### PR TITLE
Iox #325 deadlock in shared mem mutex

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp
@@ -29,7 +29,7 @@ class ThreadSafePolicy
     bool tryLock() const noexcept;
 
   private:
-    mutable posix::mutex m_mutex{true}; // recursive lock
+    mutable posix::mutex m_mutex{posix::mutex::Recursive::ON, posix::mutex::Robust::ON}; // recursive lock
 };
 
 class SingleThreadedPolicy

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/receiver_handler.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/receiver_handler.hpp
@@ -35,7 +35,7 @@ class ThreadSafe
     void unlock();
 
   private:
-    mutex_t m_mutex{true}; // recursive lock
+    mutex_t m_mutex{mutex_t::Recursive::ON, mutex_t::Robust::ON};
 };
 
 class SingleThreaded

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/receiver_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/receiver_port_data.hpp
@@ -51,7 +51,7 @@ struct ReceiverPortData : public BasePortData
 
     // event callback related
     mutable std::atomic_bool m_chunkSendCallbackActive{false};
-    mutable mutex_t m_chunkSendCallbackMutex{false};
+    mutable mutex_t m_chunkSendCallbackMutex{mutex_t::Recursive::OFF, mutex_t::Robust::ON};
     iox::relative_ptr<posix::Semaphore> m_chunkSendSemaphore{nullptr};
 
     // offer semaphore that is stored in shared memory

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/locked_loffli.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/locked_loffli.hpp
@@ -33,7 +33,7 @@ class LockedLoFFLi
     uint32_t* m_freeIndices{nullptr};
 
     using mutex_t = posix::mutex;
-    mutable mutex_t m_accessMutex{false};
+    mutable mutex_t m_accessMutex{mutex_t::Recursive::OFF, mutex_t::Robust::OFF};
 
     uint32_t m_invalidIndex{0};
 
@@ -66,4 +66,3 @@ class LockedLoFFLi
 } // namespace concurrent
 } // namespace iox
 
-#endif // IOX_UTILS_CONCURRENT_LOCKED_LOFFLI_HPP

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/locked_loffli.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/locked_loffli.hpp
@@ -66,3 +66,4 @@ class LockedLoFFLi
 } // namespace concurrent
 } // namespace iox
 
+#endif // IOX_UTILS_CONCURRENT_LOCKED_LOFFLI_HPP

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/mutex.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/mutex.hpp
@@ -108,3 +108,4 @@ class mutex
 } // namespace posix
 } // namespace iox
 
+#endif // IOX_UTILS_POSIX_WRAPPER_MUTEX_HPP

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/mutex.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/mutex.hpp
@@ -68,11 +68,11 @@ class mutex
 
     /// @brief The construction of the mutex can fail, which will lead to a call to std::terminate, which is alright
     /// for the moment since we are intending to get rid of the mutex sooner or later.
-    /// @param[in] recursive Sets the recursive attribute of the mutex. If recursive is ON, a the same thread, which has
-    /// already locked the mutex, can lock the mutex without getting blocked.
+    /// @param[in] recursive Sets the recursive attribute of the mutex. If recursive is ON, the same thread, which has
+    /// already locked the mutex, can lock the mutex again without getting blocked.
     /// @param[in] robust If robust is set ON, a process or thread can exit while having the lock without causing an
-    /// invalid mutex. In the next lock call the system recognizes the mutex is locked by a dead process or thread and
-    /// allows it to restore it.
+    /// invalid mutex. In the next lock call to this mutex the system recognizes the mutex is locked by a dead process
+    /// or thread and allows the mutex to be restored.
     mutex(const Recursive recursive, const Robust robust);
 
     ~mutex();


### PR DESCRIPTION
Introduce a robust, recursive mutex.
If recursive is enabled, the same thread, which has already locked the mutex, can lock the mutex again without getting blocked.
If robust is enabled, a process or thread can exit while having the lock without causing an invalid mutex. In the next lock call to this mutex the system recognizes the mutex is locked by a dead process or thread and allows the mutex to be restored.