### PR TITLE
Iox #489 replace introspection threads with periodic task

### DIFF
--- a/iceoryx_binding_c/source/c_user_trigger.cpp
+++ b/iceoryx_binding_c/source/c_user_trigger.cpp
@@ -49,4 +49,3 @@ void iox_user_trigger_reset_trigger(iox_user_trigger_t const self)
 {
     self->resetTrigger();
 }
-

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -73,13 +73,13 @@ class MemPoolIntrospection
     MemoryManager* m_rouDiInternalMemoryManager{nullptr}; // mempool handler needs to outlive this class (!)
     SegmentManager* m_segmentManager{nullptr};
     PublisherPort m_publisherPort{nullptr};
+    void send() noexcept;
 
   private:
     static void prepareIntrospectionSample(MemPoolIntrospectionInfo& sample,
                                            const posix::PosixGroup& readerGroup,
                                            const posix::PosixGroup& writerGroup,
                                            uint32_t id) noexcept;
-    void send() noexcept;
 
     /// @brief copy data fro internal struct into interface struct
     void copyMemPoolInfo(const MemoryManager& memoryManager, MemPoolInfoContainer& dest) noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -20,14 +20,10 @@
 #include "iceoryx_posh/internal/roudi/roudi_process.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_posh/roudi/introspection_types.hpp"
+#include "iceoryx_utils/cxx/method_callback.hpp"
+#include "iceoryx_utils/internal/concurrent/periodic_task.hpp"
 
-#include <chrono>
-#include <condition_variable>
 #include <cstdint>
-#include <iostream>
-#include <mutex>
-#include <string>
-#include <thread>
 
 namespace iox
 {
@@ -41,14 +37,6 @@ namespace roudi
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
 class MemPoolIntrospection
 {
-  private:
-    enum RunLevel
-    {
-        RUN,
-        WAIT,
-        TERMINATE
-    };
-
   public:
     /// @brief The constructor for the MemPoolIntrospection.
     ///        It starts a thread and set it into a wait condition.
@@ -68,24 +56,18 @@ class MemPoolIntrospection
     MemPoolIntrospection(MemPoolIntrospection&&) = delete;
     MemPoolIntrospection& operator=(MemPoolIntrospection&&) = delete;
 
-    /// @brief This function sets the thread into run mode, which periodically
-    ///        sends snapshots of the mempool introspecton data to the client.
-    ///        The send interval can be set by @ref setSnapshotInterval "setSnapshotInterval(...)".
-    void start() noexcept;
-
-    /// @brief This functions sets the thread into a wait state and
-    ///        the transmission of the introspection data is stopped.
-    void wait() noexcept;
+    /// @brief This function starts the periodic transmission of snapshots of the mempool introspecton data.
+    ///        The send interval can be set by @ref setSendInterval "setSendInterval(...)". By default it's 1 second.
+    void run() noexcept;
 
     /// @brief This function stops the thread which sends the introspection data.
     ///        It is not possible to start the thread again.
-    void terminate() noexcept;
+    void stop() noexcept;
 
     /// @brief This function configures the interval for the transmission of the
     ///        mempool introspection data.
-    ///
-    /// @param snapshotInterval_ms is the interval time in milliseconds
-    void setSnapshotInterval(unsigned int snapshotInterval_ms) noexcept;
+    /// @param[in] interval duration between two send invocations
+    void setSendInterval(const units::Duration interval) noexcept;
 
   protected:
     MemoryManager* m_rouDiInternalMemoryManager{nullptr}; // mempool handler needs to outlive this class (!)
@@ -93,21 +75,6 @@ class MemPoolIntrospection
     PublisherPort m_publisherPort{nullptr};
 
   private:
-    std::chrono::milliseconds m_snapShotInterval{1000};
-
-    std::atomic<RunLevel> m_runLevel{WAIT};
-    std::condition_variable m_waitConditionVar;
-    std::mutex m_mutex;
-    std::thread m_thread;
-
-    void run() noexcept;
-    void waitForRunLevelChange() noexcept;
-    void wakeUp(RunLevel newLevel = RUN) noexcept;
-
-    // wait until start command, run until wait or terminate, restart from wait
-    // is possible  terminate call leads to exit
-    void threadMain() noexcept;
-
     static void prepareIntrospectionSample(MemPoolIntrospectionInfo& sample,
                                            const posix::PosixGroup& readerGroup,
                                            const posix::PosixGroup& writerGroup,
@@ -116,6 +83,10 @@ class MemPoolIntrospection
 
     /// @brief copy data fro internal struct into interface struct
     void copyMemPoolInfo(const MemoryManager& memoryManager, MemPoolInfoContainer& dest) noexcept;
+
+  private:
+    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"MemPoolIntr", *this, &MemPoolIntrospection::send};
 };
 
 /// @brief typedef for the templated mempool introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -87,7 +87,7 @@ class MemPoolIntrospection
   private:
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
-        "MemPoolIntr", *this, &MemPoolIntrospection::send};
+        concurrent::PeriodicTaskManualStart, "MemPoolIntr", *this, &MemPoolIntrospection::send};
 };
 
 /// @brief typedef for the templated mempool introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -86,7 +86,8 @@ class MemPoolIntrospection
 
   private:
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
-    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"MemPoolIntr", *this, &MemPoolIntrospection::send};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
+        "MemPoolIntr", *this, &MemPoolIntrospection::send};
 };
 
 /// @brief typedef for the templated mempool introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.inl
@@ -41,13 +41,13 @@ inline MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::~MemP
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
 inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::run() noexcept
 {
-    m_sender.start(m_sendInterval);
+    m_publishingTask.start(m_sendInterval);
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
 inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::stop() noexcept
 {
-    m_sender.stop();
+    m_publishingTask.stop();
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
@@ -55,10 +55,10 @@ inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::
     const units::Duration interval) noexcept
 {
     m_sendInterval = interval;
-    if (m_sender.isActive())
+    if (m_publishingTask.isActive())
     {
-        m_sender.stop();
-        m_sender.start(m_sendInterval);
+        m_publishingTask.stop();
+        m_publishingTask.start(m_sendInterval);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.inl
@@ -22,7 +22,7 @@ namespace iox
 namespace roudi
 {
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::MemPoolIntrospection(
+inline MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::MemPoolIntrospection(
     MemoryManager& rouDiInternalMemoryManager, SegmentManager& segmentManager, PublisherPort&& publisherPort)
     : m_rouDiInternalMemoryManager(&rouDiInternalMemoryManager)
     , m_segmentManager(&segmentManager)
@@ -32,26 +32,26 @@ MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::MemPoolIntro
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::~MemPoolIntrospection()
+inline MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::~MemPoolIntrospection()
 {
     stop();
     m_publisherPort.stopOffer();
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::run() noexcept
+inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::run() noexcept
 {
     m_sender.start(m_sendInterval);
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::stop() noexcept
+inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::stop() noexcept
 {
     m_sender.stop();
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::setSendInterval(
+inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::setSendInterval(
     const units::Duration interval) noexcept
 {
     m_sendInterval = interval;
@@ -63,7 +63,7 @@ void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::setSend
 }
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::prepareIntrospectionSample(
+inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::prepareIntrospectionSample(
     MemPoolIntrospectionInfo& sample,
     const posix::PosixGroup& readerGroup,
     const posix::PosixGroup& writerGroup,
@@ -78,7 +78,7 @@ void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::prepare
 
 
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::send() noexcept
+inline void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::send() noexcept
 {
     if (m_publisherPort.hasSubscribers())
     {
@@ -138,8 +138,9 @@ void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::send() 
 
 // copy data fro internal struct into interface struct
 template <typename MemoryManager, typename SegmentManager, typename PublisherPort>
-void MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::copyMemPoolInfo(
-    const MemoryManager& memoryManager, MemPoolInfoContainer& dest) noexcept
+inline void
+MemPoolIntrospection<MemoryManager, SegmentManager, PublisherPort>::copyMemPoolInfo(const MemoryManager& memoryManager,
+                                                                                    MemPoolInfoContainer& dest) noexcept
 {
     auto numOfMemPools = memoryManager.getNumberOfMemPools();
     dest = MemPoolInfoContainer(numOfMemPools, MemPoolInfo());

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -62,12 +62,12 @@ class PortIntrospection
 
         struct PublisherInfo
         {
-            PublisherInfo() = default;
+            PublisherInfo() noexcept = default;
 
             PublisherInfo(typename PublisherPort::MemberType_t* const portData,
                           const ProcessName_t& name,
                           const capro::ServiceDescription& service,
-                          const NodeName_t& node)
+                          const NodeName_t& node) noexcept
                 : portData(portData)
                 , name(name)
                 , service(service)
@@ -92,14 +92,12 @@ class PortIntrospection
 
         struct SubscriberInfo
         {
-            SubscriberInfo()
-            {
-            }
+            SubscriberInfo() noexcept = default;
 
             SubscriberInfo(typename SubscriberPort::MemberType_t* const portData,
                            const ProcessName_t& name,
                            const capro::ServiceDescription& service,
-                           const NodeName_t& node)
+                           const NodeName_t& node) noexcept
                 : portData(portData)
                 , name(name)
                 , service(service)
@@ -115,20 +113,18 @@ class PortIntrospection
 
         struct ConnectionInfo
         {
-            ConnectionInfo()
-            {
-            }
+            ConnectionInfo() noexcept = default;
 
             ConnectionInfo(typename SubscriberPort::MemberType_t* const portData,
                            const ProcessName_t& name,
                            const capro::ServiceDescription& service,
-                           const NodeName_t& node)
+                           const NodeName_t& node) noexcept
                 : subscriberInfo(portData, name, service, node)
                 , state(ConnectionState::DEFAULT)
             {
             }
 
-            ConnectionInfo(SubscriberInfo& subscriberInfo)
+            ConnectionInfo(SubscriberInfo& subscriberInfo) noexcept
                 : subscriberInfo(subscriberInfo)
                 , state(ConnectionState::DEFAULT)
             {
@@ -138,14 +134,14 @@ class PortIntrospection
             PublisherInfo* publisherInfo{nullptr};
             ConnectionState state{ConnectionState::DEFAULT};
 
-            bool isConnected()
+            bool isConnected() const noexcept
             {
                 return publisherInfo && state == ConnectionState::CONNECTED;
             }
         };
 
       public:
-        PortData();
+        PortData() noexcept;
 
         /// @brief add a publisher port to be tracked by introspection
         /// there cannot be multiple publisher ports with the same capro id
@@ -158,7 +154,7 @@ class PortIntrospection
         bool addPublisher(typename PublisherPort::MemberType_t* const port,
                           const ProcessName_t& name,
                           const capro::ServiceDescription& service,
-                          const NodeName_t& node);
+                          const NodeName_t& node) noexcept;
 
         /// @brief add a subscriber port to be tracked by introspection
         /// multiple subscribers with the same capro id are possible as long as the names are different
@@ -170,50 +166,50 @@ class PortIntrospection
         bool addSubscriber(typename SubscriberPort::MemberType_t* const portData,
                            const ProcessName_t& name,
                            const capro::ServiceDescription& service,
-                           const NodeName_t& node);
+                           const NodeName_t& node) noexcept;
 
         /// @brief remove a publisher port from introspection
         /// @param[in] name name of the port to be added
         /// @param[in] service capro service description of the port to be added
         /// @return returns false if the port could not be removed (since it did not exist)
         ///              and true otherwise
-        bool removePublisher(const ProcessName_t& name, const capro::ServiceDescription& service);
+        bool removePublisher(const ProcessName_t& name, const capro::ServiceDescription& service) noexcept;
 
         /// @brief remove a subscriber port from introspection
         /// @param[in] name name of the port to be added
         /// @param[in] service capro service description of the port to be added
         /// @return returns false if the port could not be removed (since it did not exist)
         ///              and true otherwise
-        bool removeSubscriber(const ProcessName_t& name, const capro::ServiceDescription& service);
+        bool removeSubscriber(const ProcessName_t& name, const capro::ServiceDescription& service) noexcept;
 
         /// @brief update the state of any connection identified by the capro id of a given message
         ///        according to the message type (e.g. capro:SUB for a subscription request)
         /// @param[in] message capro message to be processed
         /// @return returns false there is no corresponding capro service and true otherwise
-        bool updateConnectionState(const capro::CaproMessage& message);
+        bool updateConnectionState(const capro::CaproMessage& message) noexcept;
 
         /// @brief prepare the topic to be send based on the internal connection state of all tracked ports
         /// @param[out] topic data structure to be prepared for sending
-        void prepareTopic(PortIntrospectionTopic& topic);
+        void prepareTopic(PortIntrospectionTopic& topic) noexcept;
 
-        void prepareTopic(PortThroughputIntrospectionTopic& topic);
+        void prepareTopic(PortThroughputIntrospectionTopic& topic) noexcept;
 
-        void prepareTopic(SubscriberPortChangingIntrospectionFieldTopic& topic);
+        void prepareTopic(SubscriberPortChangingIntrospectionFieldTopic& topic) noexcept;
 
         /// @brief compute the next connection state based on the current connection state and a capro message type
         /// @param[in] currentState current connection state (e.g. CONNECTED)
         /// @param[in] messageType capro message type
         /// @return returns the new connection state
         PortIntrospection::ConnectionState getNextState(ConnectionState currentState,
-                                                        capro::CaproMessageType messageType);
+                                                        capro::CaproMessageType messageType) noexcept;
 
         /// @brief indicates whether the logical object state has changed (i.e. the data is new)
         /// @return returns true if the data is new(e.g. new connections were established), false otherwise
-        bool isNew();
+        bool isNew() const noexcept;
 
         /// @brief sets the internal flag indicating new data
         /// @param[in] value value to be set
-        void setNew(bool value);
+        void setNew(bool value) noexcept;
 
       private:
         using PublisherContainer = FixedSizeContainer<PublisherInfo, MAX_PUBLISHERS>;
@@ -240,9 +236,9 @@ class PortIntrospection
     // end of helper classes
 
   public:
-    PortIntrospection();
+    PortIntrospection() noexcept;
 
-    ~PortIntrospection();
+    ~PortIntrospection() noexcept;
 
     // delete copy constructor and assignment operator
     PortIntrospection(PortIntrospection const&) = delete;
@@ -261,7 +257,7 @@ class PortIntrospection
     bool addPublisher(typename PublisherPort::MemberType_t* port,
                       const ProcessName_t& name,
                       const capro::ServiceDescription& service,
-                      const NodeName_t& node);
+                      const NodeName_t& node) noexcept;
 
     /// @brief add a subscriber port to be tracked by introspection
     /// multiple subscribers with the same capro id are possible as long as the names are different
@@ -273,7 +269,7 @@ class PortIntrospection
     bool addSubscriber(typename SubscriberPort::MemberType_t* port,
                        const ProcessName_t& name,
                        const capro::ServiceDescription& service,
-                       const NodeName_t& node);
+                       const NodeName_t& node) noexcept;
 
 
     /// @brief remove a publisher port from introspection
@@ -281,49 +277,49 @@ class PortIntrospection
     /// @param[in] service capro service description of the port to be added
     /// @return returns false if the port could not be removed (since it did not exist)
     ///              and true otherwise
-    bool removePublisher(const ProcessName_t& name, const capro::ServiceDescription& service);
+    bool removePublisher(const ProcessName_t& name, const capro::ServiceDescription& service) noexcept;
 
     /// @brief remove a subscriber port from introspection
     /// @param[in] name name of the port to be added
     /// @param[in] service capro service description of the port to be added
     /// @return returns false if the port could not be removed (since it did not exist)
     ///              and true otherwise
-    bool removeSubscriber(const ProcessName_t& name, const capro::ServiceDescription& service);
+    bool removeSubscriber(const ProcessName_t& name, const capro::ServiceDescription& service) noexcept;
 
     /// @brief report a capro message to introspection (since this could change the state of active connections)
     /// @param[in] message capro message to be processed
-    void reportMessage(const capro::CaproMessage& message);
+    void reportMessage(const capro::CaproMessage& message) noexcept;
 
     /// @brief register publisher port used to send introspection
     /// @param[in] publisherPort publisher port to be registered
     /// @return true if registration was successful, false otherwise
     bool registerPublisherPort(PublisherPort&& publisherPortGeneric,
                                PublisherPort&& publisherPortThroughput,
-                               PublisherPort&& publisherPortSubscriberPortsData);
+                               PublisherPort&& publisherPortSubscriberPortsData) noexcept;
 
     /// @brief set the time interval used to send new introspection data
     /// @param[in] interval duration between two send invocations
-    void setSendInterval(const units::Duration interval);
+    void setSendInterval(const units::Duration interval) noexcept;
 
 
     /// @brief start the internal send thread
-    void run();
+    void run() noexcept;
 
     /// @brief stop the internal send thread
-    void stop();
+    void stop() noexcept;
 
   protected:
     /// @brief sends the port data; this is used from the unittests
-    void sendPortData();
+    void sendPortData() noexcept;
 
     /// @brief sends the throughput data; this is used from the unittests
-    void sendThroughputData();
+    void sendThroughputData() noexcept;
 
     /// @brief sends the subscriberport changing data, this is used from the unittests
-    void sendSubscriberPortsData();
+    void sendSubscriberPortsData() noexcept;
 
     /// @brief calls the three specific send functions from above, this is used from the periodic task
-    void send();
+    void send() noexcept;
 
   protected:
     cxx::optional<PublisherPort> m_publisherPort;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -302,8 +302,8 @@ class PortIntrospection
                                PublisherPort&& publisherPortSubscriberPortsData);
 
     /// @brief set the time interval used to send new introspection data
-    /// @param[in] interval duration between two sends
-    void setSendInterval(units::Duration interval);
+    /// @param[in] interval duration between two send invocations
+    void setSendInterval(const units::Duration interval);
 
 
     /// @brief start the internal send thread
@@ -333,7 +333,7 @@ class PortIntrospection
   private:
     PortData m_portData;
 
-    units::Duration m_sendInterval{units::Duration::seconds<long double>(1.0)};
+    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"PortIntr", *this, &PortIntrospection::send};
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -62,7 +62,7 @@ class PortIntrospection
 
         struct PublisherInfo
         {
-            PublisherInfo() noexcept = default;
+            PublisherInfo() noexcept {};
 
             PublisherInfo(typename PublisherPort::MemberType_t* const portData,
                           const ProcessName_t& name,
@@ -330,7 +330,8 @@ class PortIntrospection
     PortData m_portData;
 
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
-    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{"PortIntr", *this, &PortIntrospection::send};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
+        concurrent::PeriodicTaskManualStart, "PortIntr", *this, &PortIntrospection::send};
 };
 
 /// @brief typedef for the templated port introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -334,7 +334,7 @@ class PortIntrospection
     PortData m_portData;
 
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
-    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"PortIntr", *this, &PortIntrospection::send};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{"PortIntr", *this, &PortIntrospection::send};
 };
 
 /// @brief typedef for the templated port introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -21,30 +21,30 @@ namespace iox
 namespace roudi
 {
 template <typename PublisherPort, typename SubscriberPort>
-PortIntrospection<PublisherPort, SubscriberPort>::PortIntrospection()
+inline PortIntrospection<PublisherPort, SubscriberPort>::PortIntrospection()
 {
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-PortIntrospection<PublisherPort, SubscriberPort>::PortData::PortData()
+inline PortIntrospection<PublisherPort, SubscriberPort>::PortData::PortData()
     : m_newData(true)
 {
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-PortIntrospection<PublisherPort, SubscriberPort>::~PortIntrospection()
+inline PortIntrospection<PublisherPort, SubscriberPort>::~PortIntrospection()
 {
     stop();
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::reportMessage(const capro::CaproMessage& message)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::reportMessage(const capro::CaproMessage& message)
 {
     m_portData.updateConnectionState(message);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::registerPublisherPort(
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::registerPublisherPort(
     PublisherPort&& publisherPortGeneric,
     PublisherPort&& publisherPortThroughput,
     PublisherPort&& publisherPortSubscriberPortsData)
@@ -62,7 +62,7 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::registerPublisherPort(
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::run()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::run()
 {
     cxx::Expects(m_publisherPort.has_value());
     cxx::Expects(m_publisherPortThroughput.has_value());
@@ -80,7 +80,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::run()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::send()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::send()
 {
     if (m_portData.isNew())
     {
@@ -91,7 +91,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::send()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData()
 {
     auto maybeChunkHeader = m_publisherPort->tryAllocateChunk(sizeof(PortIntrospectionFieldTopic));
     if (!maybeChunkHeader.has_error())
@@ -106,7 +106,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData()
 {
     auto maybeChunkHeader = m_publisherPortThroughput->tryAllocateChunk(sizeof(PortThroughputIntrospectionFieldTopic));
     if (!maybeChunkHeader.has_error())
@@ -122,7 +122,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData()
 {
     auto maybeChunkHeader =
         m_publisherPortSubscriberPortsData->tryAllocateChunk(sizeof(SubscriberPortChangingIntrospectionFieldTopic));
@@ -139,7 +139,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
     if (m_sender.isActive())
@@ -150,14 +150,14 @@ void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const uni
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::stop()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::stop()
 {
     m_sender.stop();
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::updateConnectionState(
-    const capro::CaproMessage& message)
+inline bool
+PortIntrospection<PublisherPort, SubscriberPort>::PortData::updateConnectionState(const capro::CaproMessage& message)
 {
     const capro::ServiceDescription& service = message.m_serviceDescription;
     capro::CaproMessageType messageType = message.m_type;
@@ -187,7 +187,7 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::updateConnectio
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addPublisher(
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addPublisher(
     typename PublisherPort::MemberType_t* const port,
     const ProcessName_t& name,
     const capro::ServiceDescription& service,
@@ -232,7 +232,7 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addPublisher(
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addSubscriber(
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addSubscriber(
     typename SubscriberPort::MemberType_t* const portData,
     const ProcessName_t& name,
     const capro::ServiceDescription& service,
@@ -276,8 +276,9 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addSubscriber(
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher(
-    const ProcessName_t& name [[gnu::unused]], const capro::ServiceDescription& service)
+inline bool
+PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher(const ProcessName_t& name [[gnu::unused]],
+                                                                            const capro::ServiceDescription& service)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -306,8 +307,9 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscriber(
-    const ProcessName_t& name, const capro::ServiceDescription& service)
+inline bool
+PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscriber(const ProcessName_t& name,
+                                                                             const capro::ServiceDescription& service)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -347,7 +349,7 @@ bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscribe
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-typename PortIntrospection<PublisherPort, SubscriberPort>::ConnectionState
+inline typename PortIntrospection<PublisherPort, SubscriberPort>::ConnectionState
 PortIntrospection<PublisherPort, SubscriberPort>::PortData::getNextState(ConnectionState currentState,
                                                                          capro::CaproMessageType messageType)
 {
@@ -403,7 +405,7 @@ PortIntrospection<PublisherPort, SubscriberPort>::PortData::getNextState(Connect
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortIntrospectionTopic& topic)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortIntrospectionTopic& topic)
 {
     auto& m_publisherList = topic.m_publisherList;
 
@@ -466,14 +468,15 @@ void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(Po
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortThroughputIntrospectionTopic& topic
-                                                                              [[gnu::unused]])
+inline void
+PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortThroughputIntrospectionTopic& topic
+                                                                         [[gnu::unused]])
 {
     /// @todo #402 re-add port throughput
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(
+inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(
     SubscriberPortChangingIntrospectionFieldTopic& topic)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -510,45 +513,45 @@ void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::isNew()
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::isNew()
 {
     return m_newData.load(std::memory_order_acquire);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::PortData::setNew(bool value)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::setNew(bool value)
 {
     m_newData.store(value, std::memory_order_release);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::addPublisher(typename PublisherPort::MemberType_t* port,
-                                                                    const ProcessName_t& name,
-                                                                    const capro::ServiceDescription& service,
-                                                                    const NodeName_t& node)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::addPublisher(typename PublisherPort::MemberType_t* port,
+                                                                           const ProcessName_t& name,
+                                                                           const capro::ServiceDescription& service,
+                                                                           const NodeName_t& node)
 {
     return m_portData.addPublisher(std::move(port), name, service, node);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::addSubscriber(typename SubscriberPort::MemberType_t* port,
-                                                                     const ProcessName_t& name,
-                                                                     const capro::ServiceDescription& service,
-                                                                     const NodeName_t& node)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::addSubscriber(typename SubscriberPort::MemberType_t* port,
+                                                                            const ProcessName_t& name,
+                                                                            const capro::ServiceDescription& service,
+                                                                            const NodeName_t& node)
 {
     return m_portData.addSubscriber(std::move(port), name, service, node);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::removePublisher(const ProcessName_t& name,
-                                                                       const capro::ServiceDescription& service)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::removePublisher(const ProcessName_t& name,
+                                                                              const capro::ServiceDescription& service)
 {
     return m_portData.removePublisher(name, service);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-bool PortIntrospection<PublisherPort, SubscriberPort>::removeSubscriber(const ProcessName_t& name,
-                                                                        const capro::ServiceDescription& service)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::removeSubscriber(const ProcessName_t& name,
+                                                                               const capro::ServiceDescription& service)
 {
     return m_portData.removeSubscriber(name, service);
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -76,7 +76,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::run()
     m_publisherPortThroughput->offer();
     m_publisherPortSubscriberPortsData->offer();
 
-    m_sender.start(m_sendInterval);
+    m_publishingTask.start(m_sendInterval);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
@@ -142,17 +142,17 @@ template <typename PublisherPort, typename SubscriberPort>
 inline void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
-    if (m_sender.isActive())
+    if (m_publishingTask.isActive())
     {
-        m_sender.stop();
-        m_sender.start(m_sendInterval);
+        m_publishingTask.stop();
+        m_publishingTask.start(m_sendInterval);
     }
 }
 
 template <typename PublisherPort, typename SubscriberPort>
 inline void PortIntrospection<PublisherPort, SubscriberPort>::stop()
 {
-    m_sender.stop();
+    m_publishingTask.stop();
 }
 
 template <typename PublisherPort, typename SubscriberPort>

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -21,24 +21,24 @@ namespace iox
 namespace roudi
 {
 template <typename PublisherPort, typename SubscriberPort>
-inline PortIntrospection<PublisherPort, SubscriberPort>::PortIntrospection()
+inline PortIntrospection<PublisherPort, SubscriberPort>::PortIntrospection() noexcept
 {
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline PortIntrospection<PublisherPort, SubscriberPort>::PortData::PortData()
+inline PortIntrospection<PublisherPort, SubscriberPort>::PortData::PortData() noexcept
     : m_newData(true)
 {
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline PortIntrospection<PublisherPort, SubscriberPort>::~PortIntrospection()
+inline PortIntrospection<PublisherPort, SubscriberPort>::~PortIntrospection() noexcept
 {
     stop();
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::reportMessage(const capro::CaproMessage& message)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::reportMessage(const capro::CaproMessage& message) noexcept
 {
     m_portData.updateConnectionState(message);
 }
@@ -47,7 +47,7 @@ template <typename PublisherPort, typename SubscriberPort>
 inline bool PortIntrospection<PublisherPort, SubscriberPort>::registerPublisherPort(
     PublisherPort&& publisherPortGeneric,
     PublisherPort&& publisherPortThroughput,
-    PublisherPort&& publisherPortSubscriberPortsData)
+    PublisherPort&& publisherPortSubscriberPortsData) noexcept
 {
     if (m_publisherPort || m_publisherPortThroughput || m_publisherPortSubscriberPortsData)
     {
@@ -62,7 +62,7 @@ inline bool PortIntrospection<PublisherPort, SubscriberPort>::registerPublisherP
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::run()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::run() noexcept
 {
     cxx::Expects(m_publisherPort.has_value());
     cxx::Expects(m_publisherPortThroughput.has_value());
@@ -80,7 +80,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::run()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::send()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::send() noexcept
 {
     if (m_portData.isNew())
     {
@@ -91,7 +91,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::send()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData() noexcept
 {
     auto maybeChunkHeader = m_publisherPort->tryAllocateChunk(sizeof(PortIntrospectionFieldTopic));
     if (!maybeChunkHeader.has_error())
@@ -106,7 +106,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData() noexcept
 {
     auto maybeChunkHeader = m_publisherPortThroughput->tryAllocateChunk(sizeof(PortThroughputIntrospectionFieldTopic));
     if (!maybeChunkHeader.has_error())
@@ -122,7 +122,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData() noexcept
 {
     auto maybeChunkHeader =
         m_publisherPortSubscriberPortsData->tryAllocateChunk(sizeof(SubscriberPortChangingIntrospectionFieldTopic));
@@ -139,7 +139,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPort
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval) noexcept
 {
     m_sendInterval = interval;
     if (m_publishingTask.isActive())
@@ -150,14 +150,14 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(co
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::stop()
+inline void PortIntrospection<PublisherPort, SubscriberPort>::stop() noexcept
 {
     m_publishingTask.stop();
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool
-PortIntrospection<PublisherPort, SubscriberPort>::PortData::updateConnectionState(const capro::CaproMessage& message)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::updateConnectionState(
+    const capro::CaproMessage& message) noexcept
 {
     const capro::ServiceDescription& service = message.m_serviceDescription;
     capro::CaproMessageType messageType = message.m_type;
@@ -191,7 +191,7 @@ inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addPubli
     typename PublisherPort::MemberType_t* const port,
     const ProcessName_t& name,
     const capro::ServiceDescription& service,
-    const NodeName_t& node)
+    const NodeName_t& node) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -236,7 +236,7 @@ inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addSubsc
     typename SubscriberPort::MemberType_t* const portData,
     const ProcessName_t& name,
     const capro::ServiceDescription& service,
-    const NodeName_t& node)
+    const NodeName_t& node) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -276,9 +276,8 @@ inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::addSubsc
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool
-PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher(const ProcessName_t& name [[gnu::unused]],
-                                                                            const capro::ServiceDescription& service)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher(
+    const ProcessName_t& name [[gnu::unused]], const capro::ServiceDescription& service) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -307,9 +306,8 @@ PortIntrospection<PublisherPort, SubscriberPort>::PortData::removePublisher(cons
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool
-PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscriber(const ProcessName_t& name,
-                                                                             const capro::ServiceDescription& service)
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscriber(
+    const ProcessName_t& name, const capro::ServiceDescription& service) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -351,7 +349,7 @@ PortIntrospection<PublisherPort, SubscriberPort>::PortData::removeSubscriber(con
 template <typename PublisherPort, typename SubscriberPort>
 inline typename PortIntrospection<PublisherPort, SubscriberPort>::ConnectionState
 PortIntrospection<PublisherPort, SubscriberPort>::PortData::getNextState(ConnectionState currentState,
-                                                                         capro::CaproMessageType messageType)
+                                                                         capro::CaproMessageType messageType) noexcept
 {
     ConnectionState nextState = currentState; // stay in currentState as default transition
 
@@ -405,7 +403,8 @@ PortIntrospection<PublisherPort, SubscriberPort>::PortData::getNextState(Connect
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortIntrospectionTopic& topic)
+inline void
+PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortIntrospectionTopic& topic) noexcept
 {
     auto& m_publisherList = topic.m_publisherList;
 
@@ -470,14 +469,14 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareT
 template <typename PublisherPort, typename SubscriberPort>
 inline void
 PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(PortThroughputIntrospectionTopic& topic
-                                                                         [[gnu::unused]])
+                                                                         [[gnu::unused]]) noexcept
 {
     /// @todo #402 re-add port throughput
 }
 
 template <typename PublisherPort, typename SubscriberPort>
 inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareTopic(
-    SubscriberPortChangingIntrospectionFieldTopic& topic)
+    SubscriberPortChangingIntrospectionFieldTopic& topic) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     for (auto& connPair : m_connectionMap)
@@ -513,13 +512,13 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::prepareT
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::isNew()
+inline bool PortIntrospection<PublisherPort, SubscriberPort>::PortData::isNew() const noexcept
 {
     return m_newData.load(std::memory_order_acquire);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::setNew(bool value)
+inline void PortIntrospection<PublisherPort, SubscriberPort>::PortData::setNew(bool value) noexcept
 {
     m_newData.store(value, std::memory_order_release);
 }
@@ -528,7 +527,7 @@ template <typename PublisherPort, typename SubscriberPort>
 inline bool PortIntrospection<PublisherPort, SubscriberPort>::addPublisher(typename PublisherPort::MemberType_t* port,
                                                                            const ProcessName_t& name,
                                                                            const capro::ServiceDescription& service,
-                                                                           const NodeName_t& node)
+                                                                           const NodeName_t& node) noexcept
 {
     return m_portData.addPublisher(std::move(port), name, service, node);
 }
@@ -537,21 +536,23 @@ template <typename PublisherPort, typename SubscriberPort>
 inline bool PortIntrospection<PublisherPort, SubscriberPort>::addSubscriber(typename SubscriberPort::MemberType_t* port,
                                                                             const ProcessName_t& name,
                                                                             const capro::ServiceDescription& service,
-                                                                            const NodeName_t& node)
+                                                                            const NodeName_t& node) noexcept
 {
     return m_portData.addSubscriber(std::move(port), name, service, node);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool PortIntrospection<PublisherPort, SubscriberPort>::removePublisher(const ProcessName_t& name,
-                                                                              const capro::ServiceDescription& service)
+inline bool
+PortIntrospection<PublisherPort, SubscriberPort>::removePublisher(const ProcessName_t& name,
+                                                                  const capro::ServiceDescription& service) noexcept
 {
     return m_portData.removePublisher(name, service);
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-inline bool PortIntrospection<PublisherPort, SubscriberPort>::removeSubscriber(const ProcessName_t& name,
-                                                                               const capro::ServiceDescription& service)
+inline bool
+PortIntrospection<PublisherPort, SubscriberPort>::removeSubscriber(const ProcessName_t& name,
+                                                                   const capro::ServiceDescription& service) noexcept
 {
     return m_portData.removeSubscriber(name, service);
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -139,7 +139,7 @@ void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPortsData()
 }
 
 template <typename PublisherPort, typename SubscriberPort>
-void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(units::Duration interval)
+void PortIntrospection<PublisherPort, SubscriberPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
     if (m_sender.isActive())

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -98,7 +98,8 @@ class ProcessIntrospection
     std::mutex m_mutex;
 
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
-    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"ProcessIntr", *this, &ProcessIntrospection::send};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
+        "ProcessIntr", *this, &ProcessIntrospection::send};
 };
 
 /// @brief typedef for the templated process introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -83,8 +83,8 @@ class ProcessIntrospection
 
     /// @brief This function configures the interval for the transmission of the
     ///        port introspection data.
-    /// @param[in] interval duration between two sends.
-    void setSendInterval(units::Duration interval);
+    /// @param[in] interval duration between two send invocations.
+    void setSendInterval(const units::Duration interval);
 
   protected:
     cxx::optional<PublisherPort> m_publisherPort;
@@ -97,7 +97,7 @@ class ProcessIntrospection
 
     std::mutex m_mutex;
 
-    units::Duration m_sendInterval{units::Duration::seconds<long double>(1.0)};
+    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_sender{"ProcessIntr", *this, &ProcessIntrospection::send};
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -36,8 +36,8 @@ template <typename PublisherPort>
 class ProcessIntrospection
 {
   public:
-    ProcessIntrospection();
-    ~ProcessIntrospection();
+    ProcessIntrospection() noexcept;
+    ~ProcessIntrospection() noexcept;
 
     // delete copy constructor and assignment operator
     ProcessIntrospection(ProcessIntrospection const&) = delete;
@@ -50,45 +50,45 @@ class ProcessIntrospection
     /// @brief This function is used to add a process to the process introspection
     /// @param[in] f_pid is the PID of the process to add
     /// @param[in] f_name is the name of the process
-    void addProcess(int f_pid, const ProcessName_t& f_name);
+    void addProcess(const int f_pid, const ProcessName_t& f_name) noexcept;
 
     /// @brief This function is used to remove process to the process introspection
     /// @param[in] f_pid is the PID of the process to remove
-    void removeProcess(int f_pid);
+    void removeProcess(const int f_pid) noexcept;
 
     /// @brief This function is used to add a node to the process introspection
     /// @param[in] f_processName is the name of the proces
     /// @param[in] f_nodeName is the name of the node to add
-    void addNode(const ProcessName_t& f_process, const NodeName_t& f_node);
+    void addNode(const ProcessName_t& f_process, const NodeName_t& f_node) noexcept;
 
     /// @brief This function is used to remove a node to the process introspection
     /// @param[in] f_processName is the name of the proces
     /// @param[in] f_nodeName is the name of the node to remove
-    void removeNode(const ProcessName_t& f_process, const NodeName_t& f_node);
+    void removeNode(const ProcessName_t& f_process, const NodeName_t& f_node) noexcept;
 
     /// @brief This functions registers the POSH publisher port which is used
     ///        to send the data to the instrospcetion client
     /// @param publisherPort is the publisher port for transmission
-    void registerPublisherPort(PublisherPort&& publisherPort);
+    void registerPublisherPort(PublisherPort&& publisherPort) noexcept;
 
     /// @brief This function starts a thread which periodically sends
     ///        the introspection data to the client. The send interval
     ///        can be set by @ref setSendInterval "setSendInterval(...)".
     ///        Before this function is called, the publisher port hast to be
     ///        registered with @ref registerPublisherPort "registerPublisherPort()".
-    void run();
+    void run() noexcept;
 
     /// @brief This function stops the thread previously started by @ref run "run()"
-    void stop();
+    void stop() noexcept;
 
     /// @brief This function configures the interval for the transmission of the
     ///        port introspection data.
     /// @param[in] interval duration between two send invocations.
-    void setSendInterval(const units::Duration interval);
+    void setSendInterval(const units::Duration interval) noexcept;
 
   protected:
     cxx::optional<PublisherPort> m_publisherPort;
-    void send();
+    void send() noexcept;
 
   private:
     using ProcessList_t = cxx::list<ProcessIntrospectionData, MAX_PROCESS_NUMBER>;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -99,7 +99,7 @@ class ProcessIntrospection
 
     units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
-        "ProcessIntr", *this, &ProcessIntrospection::send};
+        concurrent::PeriodicTaskManualStart, "ProcessIntr", *this, &ProcessIntrospection::send};
 };
 
 /// @brief typedef for the templated process introspection class that is used by RouDi for the

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
@@ -26,12 +26,12 @@ namespace iox
 namespace roudi
 {
 template <typename PublisherPort>
-inline ProcessIntrospection<PublisherPort>::ProcessIntrospection()
+inline ProcessIntrospection<PublisherPort>::ProcessIntrospection() noexcept
 {
 }
 
 template <typename PublisherPort>
-inline ProcessIntrospection<PublisherPort>::~ProcessIntrospection()
+inline ProcessIntrospection<PublisherPort>::~ProcessIntrospection() noexcept
 {
     stop();
     if (m_publisherPort.has_value())
@@ -41,7 +41,7 @@ inline ProcessIntrospection<PublisherPort>::~ProcessIntrospection()
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::addProcess(int f_pid, const ProcessName_t& f_name)
+inline void ProcessIntrospection<PublisherPort>::addProcess(const int f_pid, const ProcessName_t& f_name) noexcept
 {
     ProcessIntrospectionData procIntrData;
     procIntrData.m_pid = f_pid;
@@ -55,7 +55,7 @@ inline void ProcessIntrospection<PublisherPort>::addProcess(int f_pid, const Pro
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::removeProcess(int f_pid)
+inline void ProcessIntrospection<PublisherPort>::removeProcess(const int f_pid) noexcept
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -71,7 +71,8 @@ inline void ProcessIntrospection<PublisherPort>::removeProcess(int f_pid)
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_process, const NodeName_t& f_node)
+inline void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_process,
+                                                         const NodeName_t& f_node) noexcept
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -104,7 +105,8 @@ inline void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t& f_process, const NodeName_t& f_node)
+inline void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t& f_process,
+                                                            const NodeName_t& f_node) noexcept
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -138,7 +140,7 @@ inline void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t&
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::registerPublisherPort(PublisherPort&& publisherPort)
+inline void ProcessIntrospection<PublisherPort>::registerPublisherPort(PublisherPort&& publisherPort) noexcept
 {
     // we do not want to call this twice
     if (!m_publisherPort.has_value())
@@ -148,7 +150,7 @@ inline void ProcessIntrospection<PublisherPort>::registerPublisherPort(Publisher
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::run()
+inline void ProcessIntrospection<PublisherPort>::run() noexcept
 {
     // TODO: error handling for non debug builds
     cxx::Expects(m_publisherPort.has_value());
@@ -161,7 +163,7 @@ inline void ProcessIntrospection<PublisherPort>::run()
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::send()
+inline void ProcessIntrospection<PublisherPort>::send() noexcept
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     if (m_processListNewData)
@@ -184,13 +186,13 @@ inline void ProcessIntrospection<PublisherPort>::send()
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::stop()
+inline void ProcessIntrospection<PublisherPort>::stop() noexcept
 {
     m_publishingTask.stop();
 }
 
 template <typename PublisherPort>
-inline void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval)
+inline void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval) noexcept
 {
     m_sendInterval = interval;
     if (m_publishingTask.isActive())

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
@@ -157,7 +157,7 @@ inline void ProcessIntrospection<PublisherPort>::run()
     send();
     m_publisherPort->offer();
 
-    m_sender.start(m_sendInterval);
+    m_publishingTask.start(m_sendInterval);
 }
 
 template <typename PublisherPort>
@@ -186,17 +186,17 @@ inline void ProcessIntrospection<PublisherPort>::send()
 template <typename PublisherPort>
 inline void ProcessIntrospection<PublisherPort>::stop()
 {
-    m_sender.stop();
+    m_publishingTask.stop();
 }
 
 template <typename PublisherPort>
 inline void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
-    if (m_sender.isActive())
+    if (m_publishingTask.isActive())
     {
-        m_sender.stop();
-        m_sender.start(m_sendInterval);
+        m_publishingTask.stop();
+        m_publishingTask.start(m_sendInterval);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
@@ -190,7 +190,7 @@ void ProcessIntrospection<PublisherPort>::stop()
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::setSendInterval(units::Duration interval)
+void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
     if (m_sender.isActive())

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
@@ -26,12 +26,12 @@ namespace iox
 namespace roudi
 {
 template <typename PublisherPort>
-ProcessIntrospection<PublisherPort>::ProcessIntrospection()
+inline ProcessIntrospection<PublisherPort>::ProcessIntrospection()
 {
 }
 
 template <typename PublisherPort>
-ProcessIntrospection<PublisherPort>::~ProcessIntrospection()
+inline ProcessIntrospection<PublisherPort>::~ProcessIntrospection()
 {
     stop();
     if (m_publisherPort.has_value())
@@ -41,7 +41,7 @@ ProcessIntrospection<PublisherPort>::~ProcessIntrospection()
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::addProcess(int f_pid, const ProcessName_t& f_name)
+inline void ProcessIntrospection<PublisherPort>::addProcess(int f_pid, const ProcessName_t& f_name)
 {
     ProcessIntrospectionData procIntrData;
     procIntrData.m_pid = f_pid;
@@ -55,7 +55,7 @@ void ProcessIntrospection<PublisherPort>::addProcess(int f_pid, const ProcessNam
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::removeProcess(int f_pid)
+inline void ProcessIntrospection<PublisherPort>::removeProcess(int f_pid)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -71,7 +71,7 @@ void ProcessIntrospection<PublisherPort>::removeProcess(int f_pid)
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_process, const NodeName_t& f_node)
+inline void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_process, const NodeName_t& f_node)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -104,7 +104,7 @@ void ProcessIntrospection<PublisherPort>::addNode(const ProcessName_t& f_process
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t& f_process, const NodeName_t& f_node)
+inline void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t& f_process, const NodeName_t& f_node)
 {
     std::lock_guard<std::mutex> guard(m_mutex);
 
@@ -138,7 +138,7 @@ void ProcessIntrospection<PublisherPort>::removeNode(const ProcessName_t& f_proc
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::registerPublisherPort(PublisherPort&& publisherPort)
+inline void ProcessIntrospection<PublisherPort>::registerPublisherPort(PublisherPort&& publisherPort)
 {
     // we do not want to call this twice
     if (!m_publisherPort.has_value())
@@ -148,7 +148,7 @@ void ProcessIntrospection<PublisherPort>::registerPublisherPort(PublisherPort&& 
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::run()
+inline void ProcessIntrospection<PublisherPort>::run()
 {
     // TODO: error handling for non debug builds
     cxx::Expects(m_publisherPort.has_value());
@@ -161,7 +161,7 @@ void ProcessIntrospection<PublisherPort>::run()
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::send()
+inline void ProcessIntrospection<PublisherPort>::send()
 {
     std::lock_guard<std::mutex> guard(m_mutex);
     if (m_processListNewData)
@@ -184,13 +184,13 @@ void ProcessIntrospection<PublisherPort>::send()
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::stop()
+inline void ProcessIntrospection<PublisherPort>::stop()
 {
     m_sender.stop();
 }
 
 template <typename PublisherPort>
-void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval)
+inline void ProcessIntrospection<PublisherPort>::setSendInterval(const units::Duration interval)
 {
     m_sendInterval = interval;
     if (m_sender.isActive())

--- a/iceoryx_posh/include/iceoryx_posh/popo/user_trigger.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/user_trigger.hpp
@@ -30,7 +30,7 @@ namespace popo
 class UserTrigger
 {
   public:
-    UserTrigger() noexcept = default;
+    UserTrigger() noexcept;
     UserTrigger(const UserTrigger& rhs) = delete;
     UserTrigger(UserTrigger&& rhs) = delete;
     UserTrigger& operator=(const UserTrigger& rhs) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -206,8 +206,11 @@ class PoshRuntime
     static_assert(PROCESS_KEEP_ALIVE_INTERVAL > roudi::DISCOVERY_INTERVAL, "Keep alive interval too small");
 
     /// @note the m_keepAliveTask should always be the last member, so that it will be the first member to be destroyed
-    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_keepAliveTask{
-        PROCESS_KEEP_ALIVE_INTERVAL, "KeepAlive", *this, &PoshRuntime::sendKeepAlive};
+    concurrent::PeriodicTask<cxx::MethodCallback<void>> m_keepAliveTask{concurrent::PeriodicTaskAutoStart,
+                                                                        PROCESS_KEEP_ALIVE_INTERVAL,
+                                                                        "KeepAlive",
+                                                                        *this,
+                                                                        &PoshRuntime::sendKeepAlive};
 };
 
 } // namespace runtime

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -207,7 +207,7 @@ class PoshRuntime
 
     /// @note the m_keepAliveTask should always be the last member, so that it will be the first member to be destroyed
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_keepAliveTask{
-        "KeepAlive", PROCESS_KEEP_ALIVE_INTERVAL, *this, &PoshRuntime::sendKeepAlive};
+        PROCESS_KEEP_ALIVE_INTERVAL, "KeepAlive", *this, &PoshRuntime::sendKeepAlive};
 };
 
 } // namespace runtime

--- a/iceoryx_posh/source/popo/user_trigger.cpp
+++ b/iceoryx_posh/source/popo/user_trigger.cpp
@@ -19,6 +19,11 @@ namespace iox
 {
 namespace popo
 {
+// explicitly implemented for MSVC
+UserTrigger::UserTrigger() noexcept
+{
+}
+
 void UserTrigger::disableEvent() noexcept
 {
     m_trigger.reset();

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -47,7 +47,7 @@ RouDi::RouDi(RouDiMemoryInterface& roudiMemoryInterface,
         PublisherPortUserType(m_prcMgr.addIntrospectionPublisherPort(IntrospectionProcessService, MQ_ROUDI_NAME)));
     m_prcMgr.initIntrospection(&m_processIntrospection);
     m_processIntrospection.run();
-    m_mempoolIntrospection.start();
+    m_mempoolIntrospection.run();
 
     // since RouDi offers the introspection services, also add it to the list of processes
     m_processIntrospection.addProcess(getpid(), MQ_ROUDI_NAME);

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -21,13 +21,7 @@
 using namespace ::testing;
 using ::testing::Return;
 
-#define private public
-#define protected public
-
 #include "iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp"
-
-#undef private
-#undef protected
 
 #include "iceoryx_posh/internal/mepoo/segment_manager.hpp"
 #include "iceoryx_posh/roudi/introspection_types.hpp"
@@ -101,6 +95,9 @@ class MemPoolIntrospectionAccess
     {
         return this->m_publisherPort;
     }
+
+    using iox::roudi::MemPoolIntrospection<MePooMemoryManager_MOCK, SegmentManagerMock, MockPublisherPortUserAccess>::
+        send;
 };
 
 class MemPoolIntrospection_test : public Test

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -265,12 +265,12 @@ TIMING_TEST_F(MemPoolIntrospection_test, thread, Repeat(5), [&] {
     using namespace iox::units::duration_literals;
     iox::units::Duration snapshotInterval(100_ms);
 
-    introspectionAccess.setSnapshotInterval(snapshotInterval.milliSeconds<uint64_t>());
-    introspectionAccess.start();
+    introspectionAccess.setSendInterval(snapshotInterval);
+    introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
         6 * snapshotInterval.milliSeconds<uint64_t>())); // within this time, the thread should have run 6 times
-    introspectionAccess.wait();
+    introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
         6 * snapshotInterval.milliSeconds<uint64_t>())); // the thread should sleep, if not, we have 12 runs
-    introspectionAccess.terminate();
+    introspectionAccess.stop();
 });

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -676,7 +676,8 @@ TEST_F(PortIntrospection_test, DISABLED_thread)
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), sendChunk(_)).Times(AtLeast(4));
 
     // we use the deliverChunk call to check how often the thread calls the send method
-    m_introspectionAccess.setSendInterval(10);
+    using namespace iox::units::duration_literals;
+    m_introspectionAccess.setSendInterval(10_ms);
     m_introspectionAccess.run();
     /// @todo this time can be reduced when the sleep mechanism of the port introspection thread is replace by a trigger
     /// queue

--- a/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
@@ -18,11 +18,7 @@
 using namespace ::testing;
 using ::testing::Return;
 
-#define private public
-#define protected public
 #include "iceoryx_posh/internal/roudi/introspection/process_introspection.hpp"
-#undef private
-#undef protected
 
 #include "iceoryx_posh/internal/popo/ports/publisher_port_data.hpp"
 #include "mocks/chunk_mock.hpp"

--- a/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
@@ -169,11 +169,8 @@ TEST_F(ProcessIntrospection_test, thread)
         EXPECT_CALL(introspectionAccess.getPublisherPort().value(), offer()).Times(1);
         EXPECT_CALL(introspectionAccess.getPublisherPort().value(), sendChunk(_)).Times(Between(2, 8));
 
-        std::chrono::milliseconds& sendIntervalSleep =
-            const_cast<std::chrono::milliseconds&>(introspectionAccess.m_sendIntervalSleep);
-        sendIntervalSleep = std::chrono::milliseconds(10);
-
-        introspectionAccess.setSendInterval(10);
+        using namespace iox::units::duration_literals;
+        introspectionAccess.setSendInterval(10_ms);
         introspectionAccess.run();
 
         for (size_t i = 0; i < 3; ++i)

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
@@ -35,6 +35,7 @@ class PeriodicTask
   public:
     /// @brief Creates a periodic task. The specified callable is stored but not executed.
     /// To run the task, `void start(const units::Duration interval)` must be called.
+    /// @tparam Args are variadic template parameter for which are forwarded to the underlying callable object
     /// @param[in] taskName will be set as thread name
     /// @param[in] args are forwarded to the underlying callable object
     template <typename... Args>
@@ -42,6 +43,7 @@ class PeriodicTask
 
     /// @brief Creates a periodic task by spawning a thread. The specified callable is executed immediately on creation
     /// and then periodically after the interval duration.
+    /// @tparam Args are variadic template parameter for which are forwarded to the underlying callable object
     /// @param[in] interval is the time the thread waits between two invocations of the callable
     /// @param[in] taskName will be set as thread name
     /// @param[in] args are forwarded to the underlying callable object
@@ -61,8 +63,8 @@ class PeriodicTask
     /// @brief Spawns a thread and immediately executes the callable specified with the constructor.
     /// The execution is repeated after the specified interval is passed.
     /// @param[in] interval is the time the thread waits between two invocations of the callable
-    /// @attention If there is already a running thread, this will be stopped and started again with the new interval.
-    /// This might take some time if a slow task is executing during this call.
+    /// @attention If the PeriodicTask instance has already a running thread, this will be stopped and started again
+    /// with the new interval. This might take some time if a slow task is executing during this call.
     void start(const units::Duration interval) noexcept;
 
     /// @brief This stops the thread if it's running, otherwise does nothing. When this method returns, the thread is

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
@@ -27,7 +27,8 @@ namespace iox
 namespace concurrent
 {
 /// @brief This class periodically executes a callable specified by the template parameter.
-///        This can be a struct with a `operator()()` overload, a `cxx::function_ref<void()>` or `std::fuction<void()>`
+///        This can be a struct with a `operator()()` overload, a `cxx::function_ref<void()>` or `std::fuction<void()>`.
+/// @note Currently execution time of the callable is added to the interval.
 /// @tparam T is a callable type without function parameters
 template <typename T>
 class PeriodicTask

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
@@ -21,7 +21,7 @@ namespace concurrent
 {
 template <typename T>
 template <typename... Args>
-PeriodicTask<T>::PeriodicTask(const posix::ThreadName_t taskName, Args&&... args) noexcept
+inline PeriodicTask<T>::PeriodicTask(const posix::ThreadName_t taskName, Args&&... args) noexcept
     : m_callable(std::forward<Args>(args)...)
     , m_taskName(taskName)
 {
@@ -29,22 +29,22 @@ PeriodicTask<T>::PeriodicTask(const posix::ThreadName_t taskName, Args&&... args
 
 template <typename T>
 template <typename... Args>
-PeriodicTask<T>::PeriodicTask(const units::Duration interval,
-                              const posix::ThreadName_t taskName,
-                              Args&&... args) noexcept
+inline PeriodicTask<T>::PeriodicTask(const units::Duration interval,
+                                     const posix::ThreadName_t taskName,
+                                     Args&&... args) noexcept
     : PeriodicTask(taskName, std::forward<Args>(args)...)
 {
     start(interval);
 }
 
 template <typename T>
-PeriodicTask<T>::~PeriodicTask() noexcept
+inline PeriodicTask<T>::~PeriodicTask() noexcept
 {
     stop();
 }
 
 template <typename T>
-void PeriodicTask<T>::start(const units::Duration interval) noexcept
+inline void PeriodicTask<T>::start(const units::Duration interval) noexcept
 {
     stop();
     m_interval = interval;
@@ -53,7 +53,7 @@ void PeriodicTask<T>::start(const units::Duration interval) noexcept
 }
 
 template <typename T>
-void PeriodicTask<T>::stop() noexcept
+inline void PeriodicTask<T>::stop() noexcept
 {
     if (m_taskExecutor.joinable())
     {
@@ -63,13 +63,13 @@ void PeriodicTask<T>::stop() noexcept
 }
 
 template <typename T>
-bool PeriodicTask<T>::isActive() const noexcept
+inline bool PeriodicTask<T>::isActive() const noexcept
 {
     return m_taskExecutor.joinable();
 }
 
 template <typename T>
-void PeriodicTask<T>::run() noexcept
+inline void PeriodicTask<T>::run() noexcept
 {
     posix::SemaphoreWaitState waitState = posix::SemaphoreWaitState::NO_TIMEOUT;
     do

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
@@ -32,9 +32,7 @@ template <typename... Args>
 PeriodicTask<T>::PeriodicTask(const units::Duration interval,
                               const posix::ThreadName_t taskName,
                               Args&&... args) noexcept
-    : m_callable(std::forward<Args>(args)...)
-    , m_taskName(taskName)
-    , m_interval(interval)
+    : PeriodicTask(taskName, std::forward<Args>(args)...)
 {
     start(interval);
 }

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.inl
@@ -21,7 +21,9 @@ namespace concurrent
 {
 template <typename T>
 template <typename... Args>
-inline PeriodicTask<T>::PeriodicTask(const posix::ThreadName_t taskName, Args&&... args) noexcept
+inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskManualStart_t,
+                                     const posix::ThreadName_t taskName,
+                                     Args&&... args) noexcept
     : m_callable(std::forward<Args>(args)...)
     , m_taskName(taskName)
 {
@@ -29,10 +31,11 @@ inline PeriodicTask<T>::PeriodicTask(const posix::ThreadName_t taskName, Args&&.
 
 template <typename T>
 template <typename... Args>
-inline PeriodicTask<T>::PeriodicTask(const units::Duration interval,
+inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskAutoStart_t,
+                                     const units::Duration interval,
                                      const posix::ThreadName_t taskName,
                                      Args&&... args) noexcept
-    : PeriodicTask(taskName, std::forward<Args>(args)...)
+    : PeriodicTask(PeriodicTaskManualStart, taskName, std::forward<Args>(args)...)
 {
     start(interval);
 }

--- a/iceoryx_utils/test/moduletests/test_concurrent_periodic_task.cpp
+++ b/iceoryx_utils/test/moduletests/test_concurrent_periodic_task.cpp
@@ -105,7 +105,7 @@ TEST_F(PeriodicTask_test, MoveAssignmentIsDeleted)
 TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithObjectWithDefaultConstructor, Repeat(3), [&] {
     {
         using namespace iox::units::duration_literals;
-        concurrent::PeriodicTask<PeriodicTaskTestType> sut("Test", 10_ms);
+        concurrent::PeriodicTask<PeriodicTaskTestType> sut(10_ms, "Test");
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }
@@ -117,7 +117,7 @@ TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithObjectWithConstructorWithArgume
     constexpr uint64_t CALL_COUNTER_OFFSET{1000ULL * 1000ULL * 1000ULL * 1000ULL};
     {
         using namespace iox::units::duration_literals;
-        concurrent::PeriodicTask<PeriodicTaskTestType> sut("Test", 10_ms, CALL_COUNTER_OFFSET);
+        concurrent::PeriodicTask<PeriodicTaskTestType> sut(10_ms, "Test", CALL_COUNTER_OFFSET);
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }
@@ -130,7 +130,7 @@ TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithObjectAsReference, Repeat(3), [
     {
         using namespace iox::units::duration_literals;
         PeriodicTaskTestType testType;
-        concurrent::PeriodicTask<PeriodicTaskTestType&> sut("Test", 10_ms, testType);
+        concurrent::PeriodicTask<PeriodicTaskTestType&> sut(10_ms, "Test", testType);
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }
@@ -141,7 +141,7 @@ TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithObjectAsReference, Repeat(3), [
 TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithCxxFunctionRef, Repeat(3), [&] {
     {
         using namespace iox::units::duration_literals;
-        concurrent::PeriodicTask<cxx::function_ref<void()>> sut("Test", 10_ms, PeriodicTaskTestType::increment);
+        concurrent::PeriodicTask<cxx::function_ref<void()>> sut(10_ms, "Test", PeriodicTaskTestType::increment);
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }
@@ -152,7 +152,7 @@ TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithCxxFunctionRef, Repeat(3), [&] 
 TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithStdFunction, Repeat(3), [&] {
     {
         using namespace iox::units::duration_literals;
-        concurrent::PeriodicTask<std::function<void()>> sut("Test", 10_ms, PeriodicTaskTestType::increment);
+        concurrent::PeriodicTask<std::function<void()>> sut(10_ms, "Test", PeriodicTaskTestType::increment);
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }
@@ -165,7 +165,7 @@ TIMING_TEST_F(PeriodicTask_test, PeriodicTaskWithMethodCallback, Repeat(3), ([&]
         using namespace iox::units::duration_literals;
         PeriodicTaskTestType testType;
         concurrent::PeriodicTask<cxx::MethodCallback<void>> sut{
-            "Test", 10_ms, cxx::MethodCallback<void>{testType, &PeriodicTaskTestType::incrementMethod}};
+            10_ms, "Test", cxx::MethodCallback<void>{testType, &PeriodicTaskTestType::incrementMethod}};
 
         std::this_thread::sleep_for(SLEEP_TIME);
     }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
This PR replaces the thread in the introspection classes with a `PeriodicTask` and simplifies the code. The test time with the RouDiEnvironment will also be reduced a little bit (1s posh_modultetests and 2s in posh_integrationtests), since the stopping of the threads is not done by a polling with 100ms period.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Closes #489 and #494
