### PR TITLE
Iox #190 fixed point types for duration internal representation

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -165,7 +165,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::discoveryLoop() noexcept
         {
             discover(msg);
         }
-        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.milliSeconds<int64_t>()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.milliSeconds()));
     }
 }
 
@@ -176,8 +176,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::forwardingLoop() noexcept
     {
         auto startTime = std::chrono::steady_clock::now();
         forEachChannel([this](channel_t channel) { this->forward(channel); });
-        std::this_thread::sleep_until(startTime
-                                      + std::chrono::milliseconds(m_forwardingPeriod.milliSeconds<int64_t>()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_forwardingPeriod.milliSeconds()));
     };
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -85,7 +85,7 @@ class MemPoolIntrospection
     void copyMemPoolInfo(const MemoryManager& memoryManager, MemPoolInfoContainer& dest) noexcept;
 
   private:
-    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
+    units::Duration m_sendInterval{units::Duration::seconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "MemPoolIntr", *this, &MemPoolIntrospection::send};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -329,7 +329,7 @@ class PortIntrospection
   private:
     PortData m_portData;
 
-    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
+    units::Duration m_sendInterval{units::Duration::seconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "PortIntr", *this, &PortIntrospection::send};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -62,7 +62,9 @@ class PortIntrospection
 
         struct PublisherInfo
         {
-            PublisherInfo() noexcept {};
+            PublisherInfo() noexcept
+            {
+            }
 
             PublisherInfo(typename PublisherPort::MemberType_t* const portData,
                           const ProcessName_t& name,

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -97,7 +97,7 @@ class ProcessIntrospection
 
     std::mutex m_mutex;
 
-    units::Duration m_sendInterval{units::Duration::seconds<unsigned long long int>(1)};
+    units::Duration m_sendInterval{units::Duration::seconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "ProcessIntr", *this, &ProcessIntrospection::send};
 };

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -247,7 +247,7 @@ void CmdLineParser::printParameters() const noexcept
     m_uniqueRouDiId.and_then([](auto& id) { LogVerbose() << "Unique RouDi ID: " << id; }).or_else([] {
         LogVerbose() << "Unique RouDi ID: < unset >";
     });
-    LogVerbose() << "Process kill delay: " << m_processKillDelay.seconds<uint64_t>() << " ms";
+    LogVerbose() << "Process kill delay: " << m_processKillDelay.seconds() << " s";
 }
 
 } // namespace config

--- a/iceoryx_posh/source/roudi/roudi_process.cpp
+++ b/iceoryx_posh/source/roudi/roudi_process.cpp
@@ -157,8 +157,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
             i = 0;
 
             // give processes some time to terminate before checking their state
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.milliSeconds<int64_t>()));
+            std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.milliSeconds()));
 
             for (auto& process : m_processList)
             {
@@ -205,7 +204,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
             if (processStillRunning[i])
             {
                 LogWarn() << "Process ID " << process.getPid() << " named '" << process.getName()
-                          << "' is still running after SIGTERM was sent " << processKillDelay.seconds<int>()
+                          << "' is still running after SIGTERM was sent " << processKillDelay.seconds()
                           << " seconds ago. RouDi is sending SIGKILL now.";
                 processStillRunning[i] = requestShutdownOfProcess(process, ShutdownPolicy::SIG_KILL);
             }
@@ -224,7 +223,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
                 if (processStillRunning[i])
                 {
                     LogWarn() << "Process ID " << process.getPid() << " named '" << process.getName()
-                              << "' is still running after SIGKILL was sent " << processKillDelay.seconds<int>()
+                              << "' is still running after SIGKILL was sent " << processKillDelay.seconds()
                               << " seconds ago. RouDi is ignoring this process.";
                 }
                 ++i;
@@ -749,7 +748,7 @@ void ProcessManager::run() noexcept
 {
     monitorProcesses();
     discoveryUpdate();
-    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.milliSeconds<int64_t>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.milliSeconds()));
 }
 
 popo::PublisherPortData* ProcessManager::addIntrospectionPublisherPort(const capro::ServiceDescription& service,
@@ -801,17 +800,14 @@ void ProcessManager::monitorProcesses() noexcept
     {
         if (processIterator->isMonitored())
         {
-            auto timediff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(currentTimestamp
-                                                                                     - processIterator->getTimestamp())
-                                   .count();
+            auto timediff = units::Duration(currentTimestamp - processIterator->getTimestamp());
 
             static_assert(runtime::PROCESS_KEEP_ALIVE_TIMEOUT > runtime::PROCESS_KEEP_ALIVE_INTERVAL,
                           "keep alive timeout too small");
-            if (std::chrono::milliseconds(timediff_ms)
-                > std::chrono::milliseconds(runtime::PROCESS_KEEP_ALIVE_TIMEOUT.milliSeconds<int64_t>()))
+            if (timediff > runtime::PROCESS_KEEP_ALIVE_TIMEOUT)
             {
                 LogWarn() << "Application " << processIterator->getName() << " not responding (last response "
-                          << timediff_ms << " milliseconds ago) --> removing it";
+                          << timediff.milliSeconds() << " milliseconds ago) --> removing it";
 
                 // note: if we would want to use the removeProcess function, it would search for the process again
                 // (but we already found it and have an iterator to remove it)

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -161,9 +161,13 @@ class Mepoo_IntegrationTest : public Test
 
     void PrintTiming(iox::units::Duration start)
     {
-        std::cerr << "RouDi startup took " << start.milliSeconds<int>() << " milliseconds, "
-                  << "(which is " << start.seconds<int>() << " seconds)"
-                  << "(which is " << start.minutes<int>() << " minutes)" << std::endl;
+        auto totalMillisconds = start.milliSeconds();
+        auto millisceonds = totalMillisconds % 1000U;
+        auto totalSeconds = totalMillisconds / 1000U;
+        auto seconds = totalSeconds % 60U;
+        auto minutes = totalSeconds / 60U;
+        std::cerr << "RouDi startup took " << minutes << " minutes " << seconds << " seconds and " << millisceonds
+                  << " milliseconds" << std::endl;
     }
 
     template <uint32_t size>

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -162,11 +162,11 @@ class Mepoo_IntegrationTest : public Test
     void PrintTiming(iox::units::Duration start)
     {
         auto totalMillisconds = start.milliSeconds();
-        auto millisceonds = totalMillisconds % 1000U;
+        auto milliseconds = totalMillisconds % 1000U;
         auto totalSeconds = totalMillisconds / 1000U;
         auto seconds = totalSeconds % 60U;
         auto minutes = totalSeconds / 60U;
-        std::cerr << "RouDi startup took " << minutes << " minutes " << seconds << " seconds and " << millisceonds
+        std::cerr << "RouDi startup took " << minutes << " minutes " << seconds << " seconds and " << milliseconds
                   << " milliseconds" << std::endl;
     }
 

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_discovery.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_discovery.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,8 @@
 
 #include "test.hpp"
 
-#define private public
-#define protected public
-
 #include "iceoryx_posh/gateway/gateway_discovery.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port.hpp"
-
-#undef private
-#undef protected
 
 using namespace ::testing;
 using ::testing::Return;
@@ -30,6 +24,15 @@ using CaproMessage = iox::capro::CaproMessage;
 using BasePort = iox::popo::BasePort;
 using InterfacePort = iox::popo::InterfacePort;
 
+template <typename T>
+class GatewayDiscoveryAccess : public iox::gw::GatewayDiscovery<T>
+{
+  public:
+    GatewayDiscoveryAccess(T interfacePortImpl)
+        : iox::gw::GatewayDiscovery<T>(interfacePortImpl)
+    {
+    }
+};
 
 class InterfacePort_mock
 {
@@ -53,7 +56,8 @@ class GatewayDiscovery_test : public Test
 TEST_F(GatewayDiscovery_test, GetCaproMessage)
 {
     InterfacePort_mock interfacePortImplMock;
-    iox::gw::GatewayDiscovery<InterfacePort_mock> GatewayDiscovery(interfacePortImplMock);
+    iox::gw::GatewayDiscovery<InterfacePort_mock> GatewayDiscovery =
+        GatewayDiscoveryAccess<InterfacePort_mock>(interfacePortImplMock);
     CaproMessage msg;
     GatewayDiscovery.getCaproMessage(msg);
     EXPECT_EQ(iox::capro::CaproMessageType::ACK, msg.m_type);

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -265,9 +265,9 @@ TIMING_TEST_F(MemPoolIntrospection_test, thread, Repeat(5), [&] {
     introspectionAccess.setSendInterval(snapshotInterval);
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.milliSeconds<uint64_t>())); // within this time, the thread should have run 6 times
+        6 * snapshotInterval.milliSeconds())); // within this time, the thread should have run 6 times
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.milliSeconds<uint64_t>())); // the thread should sleep, if not, we have 12 runs
+        6 * snapshotInterval.milliSeconds())); // the thread should sleep, if not, we have 12 runs
     introspectionAccess.stop();
 });

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
@@ -118,7 +118,7 @@ class PeriodicTask
   private:
     T m_callable;
     posix::ThreadName_t m_taskName;
-    units::Duration m_interval{units::Duration::milliseconds<long double>(0.0)};
+    units::Duration m_interval{units::Duration::milliseconds(0U)};
     /// @todo use a refactored posix::Timer object once available
     posix::Semaphore m_stop{posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U).value()};
     std::thread m_taskExecutor;

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -291,21 +291,15 @@ class Duration
 
   private:
     template <typename T>
-    inline constexpr Duration
-    multiplySeconds(const uint64_t seconds,
-                    const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
+    inline constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
+
     template <typename T>
     inline constexpr Duration
-    multiplySeconds(const uint64_t seconds,
-                    const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
+    multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
+
     template <typename T>
     inline constexpr Duration
-    multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
-    template <typename T>
-    inline constexpr Duration
-    multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
+    multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
     static constexpr uint32_t SECS_PER_MINUTE{60U};
     static constexpr uint32_t SECS_PER_HOUR{3600U};

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <numeric>
 
 namespace iox
 {

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -207,24 +207,24 @@ class Duration
 
     // BEGIN ARITHMETIC
 
-    /// @brief creates Duration object by adding right
+    /// @brief Creates Duration object by adding right
     /// @param[in] right is the second summand
     /// @return a new Duration object
     constexpr Duration operator+(const Duration& right) const noexcept;
 
-    /// @brief creates Duration object by subtracting right
+    /// @brief Creates Duration object by subtracting right
     /// @param[in] right is the subtrahend
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     constexpr Duration operator-(const Duration& right) const noexcept;
 
-    /// @brief creates Duration object by multiplication
+    /// @brief Creates Duration object by multiplication
     /// @tparam T is an arithmetic type for the multiplicator
     /// @param[in] right is the multiplicator
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    /// @note there is no explicit division operator, if you want a fraction of of a Duration, either multiply with the
-    /// inverse of the divisor
+    /// @note There is no explicit division operator! This can be achieved by multiplication with the inverse of the
+    /// divisor.
     template <typename T>
     constexpr Duration operator*(const T& right) const noexcept;
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -38,43 +38,22 @@ class Duration;
 inline namespace duration_literals
 {
 /// @brief constructs a new Duration object in nanoseconds
-constexpr Duration operator"" _ns(long double);
-
-/// @brief constructs a new Duration object in nanoseconds
 constexpr Duration operator"" _ns(unsigned long long int); // PRQA S 48
-
-/// @brief constructs a new Duration object in microseconds
-constexpr Duration operator"" _us(long double);
 
 /// @brief constructs a new Duration object in microseconds
 constexpr Duration operator"" _us(unsigned long long int); // PRQA S 48
 
 /// @brief constructs a new Duration object in milliseconds
-constexpr Duration operator"" _ms(long double);
-
-/// @brief constructs a new Duration object in milliseconds
 constexpr Duration operator"" _ms(unsigned long long int); // PRQA S 48
-
-/// @brief constructs a new Duration object in seconds
-constexpr Duration operator"" _s(long double);
 
 /// @brief constructs a new Duration object in seconds
 constexpr Duration operator"" _s(unsigned long long int); // PRQA S 48
 
 /// @brief constructs a new Duration object in minutes
-constexpr Duration operator"" _m(long double);
-
-/// @brief constructs a new Duration object in minutes
 constexpr Duration operator"" _m(unsigned long long int); // PRQA S 48
 
 /// @brief constructs a new Duration object in hours
-constexpr Duration operator"" _h(long double);
-
-/// @brief constructs a new Duration object in hours
 constexpr Duration operator"" _h(unsigned long long int); // PRQA S 48
-
-/// @brief constructs a new Duration object in days
-constexpr Duration operator"" _d(long double);
 
 /// @brief constructs a new Duration object in days
 constexpr Duration operator"" _d(unsigned long long int); // PRQA S 48
@@ -126,17 +105,29 @@ class Duration
     /// @brief Assigns a std::chrono::milliseconds to an duration object
     Duration& operator=(const std::chrono::milliseconds& right);
 
-    /// @brief return true if durationInSeconds is larger or equal than right
+    /// @brief Equal to operator
+    /// @return true if duration equal to right
+    constexpr bool operator==(const Duration& right) const;
+
+    /// @brief Not equal to operator
+    /// @return true if duration not equal to right
+    constexpr bool operator!=(const Duration& right) const;
+
+    /// @brief Less than operator
+    /// @return true if duration is less than right
     constexpr bool operator<(const Duration& right) const;
 
-    /// @brief return true if durationInSeconds is larger or equal than right
+    /// @brief Less than or equal to operator
+    /// @return true if duration is less than or equal to right
+    constexpr bool operator<=(const Duration& right) const;
+
+    /// @brief Greater than operator
+    /// @return true if duration is greater than right
     constexpr bool operator>(const Duration& right) const;
 
-    /// @brief return true if durationInSeconds is larger or equal than right
+    /// @brief Greater than or equal to operator
+    /// @return true if duration is greater than or equal to right
     constexpr bool operator>=(const Duration& right) const;
-
-    /// @brief returns true if right is larger or equal than durationInSeconds
-    constexpr bool operator<=(const Duration& right) const;
 
     /// @brief creates Duration object by adding right and durationInSeconds
     constexpr Duration operator+(const Duration& right) const;
@@ -194,26 +185,18 @@ class Duration
     /// @brief converts time in a timespec c struct
     struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const;
 
-    //@ brief Make operators accessible, that have to be defined outside the class
-    // template <typename T>
-    // friend constexpr Duration operator*(const T& left, const Duration& right);
-    // template <typename T>
-    // friend constexpr Duration operator/(const T& left, const Duration& right);
+    template <typename T>
+    friend constexpr Duration operator*(const T& left, const Duration& right);
+    template <typename T>
+    friend constexpr Duration operator/(const T& left, const Duration& right);
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t);
-    friend constexpr Duration duration_literals::operator"" _ns(long double);
     friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _us(long double);
     friend constexpr Duration duration_literals::operator"" _us(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _ms(long double);
     friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _s(long double);
-    friend constexpr Duration duration_literals::operator"" _s(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _m(long double);
-    friend constexpr Duration duration_literals::operator"" _m(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _h(long double);
-    friend constexpr Duration duration_literals::operator"" _h(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _d(long double);
-    friend constexpr Duration duration_literals::operator"" _d(unsigned long long int); // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _s(unsigned long long int);  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _m(unsigned long long int);  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _h(unsigned long long int);  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _d(unsigned long long int);  // PRQA S 48
 
   private:
     /// @brief constructor needs to be private to ensure a unit safe usage of duration
@@ -221,7 +204,7 @@ class Duration
     long double durationInSeconds{0.0};
 };
 
-/// @brief creates Duration object multplying T with durationInSeconds
+/// @brief creates Duration object multiplying T with durationInSeconds
 template <typename T>
 constexpr Duration operator*(const T& left, const Duration& right);
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -221,6 +221,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     /// @note There is no explicit division operator! This can be achieved by multiplication with the inverse of the
     /// divisor.
+    /// @note Multiplication with NaN and +Inf results in a saturated max duration
     template <typename T>
     constexpr Duration operator*(const T& rhs) const noexcept;
 
@@ -305,26 +306,26 @@ class Duration
     /// @note this is protected to be able to use it in unit tests
     constexpr Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
 
+    /// @note this is factory method is necessary to build with msvc due to issues calling a protected constexpr ctor
+    /// from public methods
     static constexpr Duration createDuration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
 
-    inline static constexpr Duration max();
+    static constexpr Duration max() noexcept;
 
   private:
     template <typename T, typename String>
-    inline static constexpr unsigned long long int positiveValueOrClampToZero(const T value, const String fromMethod);
+    static constexpr unsigned long long int positiveValueOrClampToZero(const T value, const String fromMethod) noexcept;
 
     template <typename T>
-    inline constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
+    constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
     template <typename From, typename To>
-    inline constexpr bool wouldCastFromFloatingPointProbablyOverflow(const From floatingPoint) const noexcept;
+    constexpr bool wouldCastFromFloatingPointProbablyOverflow(const From floatingPoint) const noexcept;
 
     template <typename T>
-    inline constexpr Duration multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const
-        noexcept;
+    constexpr Duration multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
     template <typename T>
-    inline constexpr Duration multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const
-        noexcept;
+    constexpr Duration multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
   private:
     SECONDS_TYPE m_seconds{0U};

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -304,9 +304,22 @@ class Duration
     multiplyNanoseconds(const uint32_t nanoseconds,
                         const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
 
+    static constexpr uint32_t SECS_PER_MINUTE{60U};
+    static constexpr uint32_t SECS_PER_HOUR{3600U};
+    static constexpr uint32_t HOURS_PER_DAY{24U};
+
+    static constexpr uint32_t MILLISECS_PER_SEC{1000U};
+    static constexpr uint32_t MICROSECS_PER_SEC{MILLISECS_PER_SEC * 1000U};
+
+    static constexpr uint32_t NANOSECS_PER_MICROSEC{1000U};
+    static constexpr uint32_t NANOSECS_PER_MILLISEC{NANOSECS_PER_MICROSEC * 1000U};
+    static constexpr uint32_t NANOSECS_PER_SEC{NANOSECS_PER_MILLISEC * 1000U};
+
+    static_assert(NANOSECS_PER_SEC == 1000U * MICROSECS_PER_SEC, "Mismatch in calculation for conversion constants!");
+
   private:
-    uint64_t m_seconds{0};
-    uint32_t m_nanoseconds{0};
+    uint64_t m_seconds{0U};
+    uint32_t m_nanoseconds{0U};
 };
 
 /// @brief creates Duration object by multiplying object T with a duration

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -80,7 +80,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as nanoseconds
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration nanoseconds(const T value) noexcept;
 
@@ -88,7 +88,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as microseconds
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration microseconds(const T value) noexcept;
 
@@ -96,7 +96,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as milliseconds
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration milliseconds(const T value) noexcept;
 
@@ -104,7 +104,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as seconds
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration seconds(const T value) noexcept;
 
@@ -112,7 +112,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as minutes
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration minutes(const T value) noexcept;
 
@@ -120,7 +120,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as hours
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration hours(const T value) noexcept;
 
@@ -128,7 +128,7 @@ class Duration
     /// @tparam T is an integer type for the value
     /// @param[in] value as days
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
     static constexpr Duration days(const T value) noexcept;
 
@@ -151,18 +151,18 @@ class Duration
 
     /// @brief Construct a Duration object from std::chrono::milliseconds
     /// @param[in] value as milliseconds
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     constexpr explicit Duration(const std::chrono::milliseconds& value) noexcept;
 
     /// @brief Construct a Duration object from std::chrono::nanoseconds
     /// @param[in] value as nanoseconds
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     constexpr explicit Duration(const std::chrono::nanoseconds& value) noexcept;
 
     /// @brief Assigns a std::chrono::milliseconds to an duration object
     /// @param[in] rhs is the right hand side of the assignment
     /// @return a reference to the Duration object with the assigned millisecond value
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     Duration& operator=(const std::chrono::milliseconds& rhs) noexcept;
 
     // END CONSTRUCTORS AND ASSIGNMENT
@@ -211,17 +211,18 @@ class Duration
     /// @brief Creates Duration object by subtraction
     /// @param[in] rhs is the subtrahend
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     constexpr Duration operator-(const Duration& rhs) const noexcept;
 
     /// @brief Creates Duration object by multiplication
     /// @tparam T is an arithmetic type for the multiplicator
     /// @param[in] rhs is the multiplicator
     /// @return a new Duration object
-    /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
+    /// @note A duration of 0 will always result in 0, no matter if multiplied with NaN or +Inf
     /// @note There is no explicit division operator! This can be achieved by multiplication with the inverse of the
     /// divisor.
-    /// @note Multiplication with NaN and +Inf results in a saturated max duration
+    /// @note Multiplication of a non-zero duration with NaN and +Inf results in a saturated max duration
     template <typename T>
     constexpr Duration operator*(const T& rhs) const noexcept;
 
@@ -311,6 +312,7 @@ class Duration
     static constexpr Duration createDuration(const Seconds_t seconds, const Nanoseconds_t nanoseconds) noexcept;
 
     static constexpr Duration max() noexcept;
+    static constexpr Duration zero() noexcept;
 
   private:
     template <typename T, typename String>
@@ -337,7 +339,7 @@ class Duration
 /// @param[in] lhs is the multiplicator
 /// @param[in] rhs is the multiplicant
 /// @return a new Duration object
-/// @attention since negative durations are not allowed, the duration will be capped to 0
+/// @attention Since negative durations are not allowed, the duration will be clamped to 0
 template <typename T>
 constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -223,15 +223,10 @@ class Duration
     /// @param[in] right is the multiplicator
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
+    /// @note there is no explicit division operator, if you want a fraction of of a Duration, either multiply with the
+    /// inverse of the divisor
     template <typename T>
     constexpr Duration operator*(const T& right) const noexcept;
-
-    /// @brief creates Duration object by division
-    /// @tparam T is an arithmetic type for the divisor
-    /// @param[in] right is the divisor
-    /// @return a new Duration object
-    template <typename T>
-    constexpr Duration operator/(const T& right) const noexcept;
 
     // END ARITHMETIC
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -234,24 +234,36 @@ class Duration
     // BEGIN CONVERSION
 
     /// @brief returns the duration in nanoseconds
+    /// @note If the duration in nanoseconds is larger than an uint64_t can represent, it will be clamped to the
+    /// uint64_t max value.
     constexpr uint64_t nanoSeconds() const noexcept;
 
     /// @brief returns the duration in microseconds
+    /// @note If the duration in microseconds is larger than an uint64_t can represent, it will be clamped to the
+    /// uint64_t max value.
+    /// @note The remaining nanoseconds are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t microSeconds() const noexcept;
 
     /// @brief returns the duration in milliseconds
+    /// @note If the duration in milliseconds is larger than an uint64_t can represent, it will be clamped to the
+    /// uint64_t max value.
+    /// @note The remaining microseconds are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t milliSeconds() const noexcept;
 
     /// @brief returns the duration in seconds
+    /// @note The remaining milliseconds are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t seconds() const noexcept;
 
     /// @brief returns the duration in minutes
+    /// @note The remaining seconds are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t minutes() const noexcept;
 
     /// @brief returns the duration in hours
+    /// @note The remaining minutes are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t hours() const noexcept;
 
     /// @brief returns the duration in days
+    /// @note The remaining hours are truncated, similar to the casting behavior of a float to an int.
     constexpr uint64_t days() const noexcept;
 
     /// @brief converts duration in a timespec c struct

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -136,11 +136,6 @@ class Duration
 
     // BEGIN CONSTRUCTORS AND ASSIGNMENT
 
-    /// @brief Constructs a Duration from seconds and nanoseconds
-    /// @param[in] seconds portion of the duration
-    /// @param[in] nanoseconds portion of the duration
-    constexpr Duration(const uint64_t seconds, const uint32_t nanoseconds) noexcept;
-
     /// @brief Construct a Duration object from timeval
     /// @param[in] value as timeval
     constexpr explicit Duration(const struct timeval& value) noexcept;
@@ -289,6 +284,29 @@ class Duration
 
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
+    static constexpr uint32_t SECS_PER_MINUTE{60U};
+    static constexpr uint32_t SECS_PER_HOUR{3600U};
+    static constexpr uint32_t HOURS_PER_DAY{24U};
+
+    static constexpr uint32_t MILLISECS_PER_SEC{1000U};
+    static constexpr uint32_t MICROSECS_PER_SEC{MILLISECS_PER_SEC * 1000U};
+
+    static constexpr uint32_t NANOSECS_PER_MICROSEC{1000U};
+    static constexpr uint32_t NANOSECS_PER_MILLISEC{NANOSECS_PER_MICROSEC * 1000U};
+    static constexpr uint32_t NANOSECS_PER_SEC{NANOSECS_PER_MILLISEC * 1000U};
+
+  protected:
+    using SECONDS_TYPE = uint64_t;
+    using NANOSECONDS_TYPE = uint32_t;
+
+    /// @brief Constructs a Duration from seconds and nanoseconds
+    /// @param[in] seconds portion of the duration
+    /// @param[in] nanoseconds portion of the duration
+    /// @note this is protected to be able to use it in unit tests
+    constexpr Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
+
+    inline static constexpr Duration max();
+
   private:
     template <typename T>
     inline constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
@@ -301,22 +319,9 @@ class Duration
     inline constexpr Duration
     multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
-    static constexpr uint32_t SECS_PER_MINUTE{60U};
-    static constexpr uint32_t SECS_PER_HOUR{3600U};
-    static constexpr uint32_t HOURS_PER_DAY{24U};
-
-    static constexpr uint32_t MILLISECS_PER_SEC{1000U};
-    static constexpr uint32_t MICROSECS_PER_SEC{MILLISECS_PER_SEC * 1000U};
-
-    static constexpr uint32_t NANOSECS_PER_MICROSEC{1000U};
-    static constexpr uint32_t NANOSECS_PER_MILLISEC{NANOSECS_PER_MICROSEC * 1000U};
-    static constexpr uint32_t NANOSECS_PER_SEC{NANOSECS_PER_MILLISEC * 1000U};
-
-    static_assert(NANOSECS_PER_SEC == 1000U * MICROSECS_PER_SEC, "Mismatch in calculation for conversion constants!");
-
   private:
-    uint64_t m_seconds{0U};
-    uint32_t m_nanoseconds{0U};
+    SECONDS_TYPE m_seconds{0U};
+    NANOSECONDS_TYPE m_nanoseconds{0U};
 };
 
 /// @brief creates Duration object by multiplying object T with a duration

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -38,25 +38,25 @@ class Duration;
 inline namespace duration_literals
 {
 /// @brief Constructs a new Duration object from nanoseconds
-constexpr Duration operator"" _ns(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _ns(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from microseconds
-constexpr Duration operator"" _us(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _us(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from milliseconds
-constexpr Duration operator"" _ms(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _ms(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from seconds
-constexpr Duration operator"" _s(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _s(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from minutes
-constexpr Duration operator"" _m(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _m(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from hours
-constexpr Duration operator"" _h(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _h(unsigned long long int) noexcept; // PRQA S 48
 
 /// @brief Constructs a new Duration object from days
-constexpr Duration operator"" _d(unsigned long long int); // PRQA S 48
+constexpr Duration operator"" _d(unsigned long long int) noexcept; // PRQA S 48
 } // namespace duration_literals
 
 /// @code
@@ -81,7 +81,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration nanoseconds(const T value);
+    static constexpr Duration nanoseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from microseconds
     /// @tparam T is an integer type for the value
@@ -89,7 +89,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration microseconds(const T value);
+    static constexpr Duration microseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from milliseconds
     /// @tparam T is an integer type for the value
@@ -97,7 +97,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration milliseconds(const T value);
+    static constexpr Duration milliseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from seconds
     /// @tparam T is an integer type for the value
@@ -105,7 +105,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration seconds(const T value);
+    static constexpr Duration seconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from minutes
     /// @tparam T is an integer type for the value
@@ -113,7 +113,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration minutes(const T value);
+    static constexpr Duration minutes(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from hours
     /// @tparam T is an integer type for the value
@@ -121,7 +121,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration hours(const T value);
+    static constexpr Duration hours(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from days
     /// @tparam T is an integer type for the value
@@ -129,7 +129,7 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration days(const T value);
+    static constexpr Duration days(const T value) noexcept;
 
     // END CREATION FROM STATIC FUNCTIONS
 
@@ -138,36 +138,36 @@ class Duration
     /// @brief Constructs a Duration from seconds and nanoseconds
     /// @param[in] seconds portion of the duration
     /// @param[in] nanoseconds portion of the duration
-    constexpr Duration(const uint64_t seconds, const uint32_t nanoseconds);
+    constexpr Duration(const uint64_t seconds, const uint32_t nanoseconds) noexcept;
 
     /// @brief Construct a Duration object from timeval
     /// @param[in] value as timeval
-    constexpr explicit Duration(const struct timeval& value);
+    constexpr explicit Duration(const struct timeval& value) noexcept;
 
     /// @brief Construct a Duration object from timespec
     /// @param[in] value as timespec
-    constexpr explicit Duration(const struct timespec& value);
+    constexpr explicit Duration(const struct timespec& value) noexcept;
 
     /// @brief Construct a Duration object from itimerspec
     /// @param[in] value as itimerspec
     /// @note only it_interval from the itimerspec is used
-    constexpr explicit Duration(const struct itimerspec& value);
+    constexpr explicit Duration(const struct itimerspec& value) noexcept;
 
     /// @brief Construct a Duration object from std::chrono::milliseconds
     /// @param[in] value as milliseconds
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    constexpr explicit Duration(const std::chrono::milliseconds& value);
+    constexpr explicit Duration(const std::chrono::milliseconds& value) noexcept;
 
     /// @brief Construct a Duration object from std::chrono::nanoseconds
     /// @param[in] value as nanoseconds
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    constexpr explicit Duration(const std::chrono::nanoseconds& value);
+    constexpr explicit Duration(const std::chrono::nanoseconds& value) noexcept;
 
     /// @brief Assigns a std::chrono::milliseconds to an duration object
     /// @param[in] right hand side of the assignment
     /// @return a reference to the Duration object with the assigned millisecond value
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    Duration& operator=(const std::chrono::milliseconds& right);
+    Duration& operator=(const std::chrono::milliseconds& right) noexcept;
 
     // END CONSTRUCTORS AND ASSIGNMENT
 
@@ -176,32 +176,32 @@ class Duration
     /// @brief Equal to operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration equal to right
-    constexpr bool operator==(const Duration& right) const;
+    constexpr bool operator==(const Duration& right) const noexcept;
 
     /// @brief Not equal to operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration not equal to right
-    constexpr bool operator!=(const Duration& right) const;
+    constexpr bool operator!=(const Duration& right) const noexcept;
 
     /// @brief Less than operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration is less than right
-    constexpr bool operator<(const Duration& right) const;
+    constexpr bool operator<(const Duration& right) const noexcept;
 
     /// @brief Less than or equal to operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration is less than or equal to right
-    constexpr bool operator<=(const Duration& right) const;
+    constexpr bool operator<=(const Duration& right) const noexcept;
 
     /// @brief Greater than operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration is greater than right
-    constexpr bool operator>(const Duration& right) const;
+    constexpr bool operator>(const Duration& right) const noexcept;
 
     /// @brief Greater than or equal to operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration is greater than or equal to right
-    constexpr bool operator>=(const Duration& right) const;
+    constexpr bool operator>=(const Duration& right) const noexcept;
 
     // END COMPARISON
 
@@ -210,13 +210,13 @@ class Duration
     /// @brief creates Duration object by adding right
     /// @param[in] right is the second summand
     /// @return a new Duration object
-    constexpr Duration operator+(const Duration& right) const;
+    constexpr Duration operator+(const Duration& right) const noexcept;
 
     /// @brief creates Duration object by subtracting right
     /// @param[in] right is the subtrahend
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    constexpr Duration operator-(const Duration& right) const;
+    constexpr Duration operator-(const Duration& right) const noexcept;
 
     /// @brief creates Duration object by multiplication
     /// @tparam T is an arithmetic type for the multiplicator
@@ -224,14 +224,14 @@ class Duration
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    constexpr Duration operator*(const T& right) const;
+    constexpr Duration operator*(const T& right) const noexcept;
 
     /// @brief creates Duration object by division
     /// @tparam T is an arithmetic type for the divisor
     /// @param[in] right is the divisor
     /// @return a new Duration object
     template <typename T>
-    constexpr Duration operator/(const T& right) const;
+    constexpr Duration operator/(const T& right) const noexcept;
 
     // END ARITHMETIC
 
@@ -239,70 +239,72 @@ class Duration
 
     /// @brief returns the duration in nanoseconds
     template <typename T>
-    constexpr T nanoSeconds() const;
+    constexpr T nanoSeconds() const noexcept;
 
     /// @brief returns the duration in microseconds
     template <typename T>
-    constexpr T microSeconds() const;
+    constexpr T microSeconds() const noexcept;
 
     /// @brief returns the duration in milliseconds
     template <typename T>
-    constexpr T milliSeconds() const;
+    constexpr T milliSeconds() const noexcept;
 
     /// @brief returns the duration in seconds
     template <typename T>
-    constexpr T seconds() const;
+    constexpr T seconds() const noexcept;
 
     /// @brief returns the duration in minutes
     template <typename T>
-    constexpr T minutes() const;
+    constexpr T minutes() const noexcept;
 
     /// @brief returns the duration in hours
     template <typename T>
-    constexpr T hours() const;
+    constexpr T hours() const noexcept;
 
     /// @brief returns the duration in days
     template <typename T>
-    constexpr T days() const;
+    constexpr T days() const noexcept;
 
     /// @brief converts duration in a timespec c struct
-    struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const;
+    struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const noexcept;
 
     /// @brief converts duration in a timeval c struct
     ///     timeval::tv_sec = seconds since the Epoch (01.01.1970)
     ///     timeval::tv_usec = microseconds
-    constexpr operator struct timeval() const;
+    constexpr operator struct timeval() const noexcept;
 
     // END CONVERSION
 
-    friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _us(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int); // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _s(unsigned long long int);  // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _m(unsigned long long int);  // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _h(unsigned long long int);  // PRQA S 48
-    friend constexpr Duration duration_literals::operator"" _d(unsigned long long int);  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int) noexcept; // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _us(unsigned long long int) noexcept; // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int) noexcept; // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _s(unsigned long long int) noexcept;  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _m(unsigned long long int) noexcept;  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _h(unsigned long long int) noexcept;  // PRQA S 48
+    friend constexpr Duration duration_literals::operator"" _d(unsigned long long int) noexcept;  // PRQA S 48
 
     template <typename T>
-    friend constexpr Duration operator*(const T& left, const Duration& right);
+    friend constexpr Duration operator*(const T& left, const Duration& right) noexcept;
 
-    friend std::ostream& operator<<(std::ostream& stream, const Duration& t);
+    friend std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
   private:
     template <typename T>
     inline constexpr Duration
-    multiplySeconds(const uint64_t seconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+    multiplySeconds(const uint64_t seconds,
+                    const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept;
     template <typename T>
-    inline constexpr Duration multiplySeconds(const uint64_t seconds,
-                                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+    inline constexpr Duration
+    multiplySeconds(const uint64_t seconds,
+                    const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept;
     template <typename T>
     inline constexpr Duration
     multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept;
     template <typename T>
     inline constexpr Duration
     multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+                        const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept;
 
     static constexpr uint32_t SECS_PER_MINUTE{60U};
     static constexpr uint32_t SECS_PER_HOUR{3600U};
@@ -329,10 +331,10 @@ class Duration
 /// @return a new Duration object
 /// @attention since negative durations are not allowed, the duration will be capped to 0
 template <typename T>
-constexpr Duration operator*(const T& left, const Duration& right);
+constexpr Duration operator*(const T& left, const Duration& right) noexcept;
 
 /// @brief stream operator for the Duration class
-std::ostream& operator<<(std::ostream& stream, const Duration& t);
+std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
 } // namespace units
 } // namespace iox

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 #include <chrono>
 #include <iostream>
-#include <time.h>
+#include <cmath>
 
 namespace iox
 {
@@ -37,25 +37,25 @@ class Duration;
 
 inline namespace duration_literals
 {
-/// @brief constructs a new Duration object in nanoseconds
+/// @brief Constructs a new Duration object from nanoseconds
 constexpr Duration operator"" _ns(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in microseconds
+/// @brief Constructs a new Duration object from microseconds
 constexpr Duration operator"" _us(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in milliseconds
+/// @brief Constructs a new Duration object from milliseconds
 constexpr Duration operator"" _ms(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in seconds
+/// @brief Constructs a new Duration object from seconds
 constexpr Duration operator"" _s(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in minutes
+/// @brief Constructs a new Duration object from minutes
 constexpr Duration operator"" _m(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in hours
+/// @brief Constructs a new Duration object from hours
 constexpr Duration operator"" _h(unsigned long long int); // PRQA S 48
 
-/// @brief constructs a new Duration object in days
+/// @brief Constructs a new Duration object from days
 constexpr Duration operator"" _d(unsigned long long int); // PRQA S 48
 } // namespace duration_literals
 
@@ -63,89 +63,153 @@ constexpr Duration operator"" _d(unsigned long long int); // PRQA S 48
 ///   #include <iostream>
 ///   // ...
 ///   using namespace units;
-///   auto timeInDays = 12_d;
-///   auto timeInSeconds = 1.5_s;
-///   std::cout << timeInDays << std::endl;
-///   std::cout << timeInDays.nanoSeconds<int>() << " ns" << std::endl;
-///   std::cout << timeInSeconds.minutes<float>() << " min" << std::endl;
+///   using namespace units::duration_literals;
+///   auto someDays = 2 * 7_d + 5_ns;
+///   auto someSeconds = 42_s + 500_ms;
+///   std::cout << someDays << std::endl;
+///   std::cout << someDays.nanoSeconds<uint64_t>() << " ns" << std::endl;
+///   std::cout << someSeconds.milliSeconds<int64_t>() << " ms" << std::endl;
 /// @endcode
 class Duration
 {
   public:
+    /// @brief Constructs a new Duration object from nanoseconds
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as nanoseconds
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration nanoseconds(const T ns);
+    static constexpr Duration nanoseconds(const T value);
+    /// @brief Constructs a new Duration object from microseconds
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as microseconds
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration microseconds(const T us);
+    static constexpr Duration microseconds(const T value);
+    /// @brief Constructs a new Duration object from milliseconds
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as milliseconds
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration milliseconds(const T ms);
+    static constexpr Duration milliseconds(const T value);
+    /// @brief Constructs a new Duration object from seconds
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as seconds
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration seconds(const T seconds);
+    static constexpr Duration seconds(const T value);
+    /// @brief Constructs a new Duration object from minutes
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as minutes
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration minutes(const T min);
+    static constexpr Duration minutes(const T value);
+    /// @brief Constructs a new Duration object from hours
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as hours
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration hours(const T hours);
+    static constexpr Duration hours(const T value);
+    /// @brief Constructs a new Duration object from days
+    /// @tparam T is an integer type for the value
+    /// @param[in] value as days
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
-    static constexpr Duration days(const T days);
+    static constexpr Duration days(const T value);
+
+    /// @brief Constructs a Duration from seconds and nanoseconds
+    /// @param[in] seconds portion of the duration
+    /// @param[in] nanoseconds portion of the duration
+    constexpr Duration(const uint64_t seconds, const uint32_t nanoseconds);
 
     /// @brief Construct a Duration object from timeval
+    /// @param[in] value as timeval
     constexpr explicit Duration(const struct timeval& value);
 
     /// @brief Construct a Duration object from timespec
+    /// @param[in] value as timespec
     constexpr explicit Duration(const struct timespec& value);
 
     /// @brief Construct a Duration object from itimerspec
+    /// @param[in] value as itimespec
+    /// @note only it_interval from the itimerspec is used
     constexpr explicit Duration(const struct itimerspec& value);
 
     /// @brief Construct a Duration object from std::chrono::milliseconds
+    /// @param[in] value as milliseconds
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     constexpr explicit Duration(const std::chrono::milliseconds& value);
 
     /// @brief Construct a Duration object from std::chrono::nanoseconds
+    /// @param[in] value as nanoseconds
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     constexpr explicit Duration(const std::chrono::nanoseconds& value);
 
     /// @brief Assigns a std::chrono::milliseconds to an duration object
+    /// @param[in] right hand side of the assignment
+    /// @return a reference to the Duration object with the assigned millisecond value
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     Duration& operator=(const std::chrono::milliseconds& right);
 
     /// @brief Equal to operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration equal to right
     constexpr bool operator==(const Duration& right) const;
 
     /// @brief Not equal to operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration not equal to right
     constexpr bool operator!=(const Duration& right) const;
 
     /// @brief Less than operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration is less than right
     constexpr bool operator<(const Duration& right) const;
 
     /// @brief Less than or equal to operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration is less than or equal to right
     constexpr bool operator<=(const Duration& right) const;
 
     /// @brief Greater than operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration is greater than right
     constexpr bool operator>(const Duration& right) const;
 
     /// @brief Greater than or equal to operator
+    /// @param[in] right hand side of the comparison
     /// @return true if duration is greater than or equal to right
     constexpr bool operator>=(const Duration& right) const;
 
-    /// @brief creates Duration object by adding right and durationInSeconds
+    /// @brief creates Duration object by adding right
+    /// @param[in] right is the second summand
+    /// @return a new Duration object
     constexpr Duration operator+(const Duration& right) const;
 
-    /// @brief creates Duration object by subtracting right and durationInSeconds
+    /// @brief creates Duration object by subtracting right
+    /// @param[in] right is the subtrahend
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     constexpr Duration operator-(const Duration& right) const;
 
-    /// @brief creates Duration object by multiplying right and durationInSeconds
-    constexpr Duration operator*(const Duration& right) const;
-
-    /// @brief creates Duration object by dividing right and durationInSeconds
-    constexpr Duration operator/(const Duration& right) const;
-
-    /// @brief creates Duration object multplying durationInSeconds with T
+    /// @brief creates Duration object by multiplication
+    /// @tparam T is an arithmetic type for the multiplicator
+    /// @param[in] right is the multiplicator
+    /// @return a new Duration object
+    /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     constexpr Duration operator*(const T& right) const;
 
-    /// @brief creates Duration object dividing durationInSeconds through T
+    /// @brief creates Duration object by division
+    /// @tparam T is an arithmetic type for the divisor
+    /// @param[in] right is the divisor
+    /// @return a new Duration object
     template <typename T>
     constexpr Duration operator/(const T& right) const;
 
@@ -187,8 +251,6 @@ class Duration
 
     template <typename T>
     friend constexpr Duration operator*(const T& left, const Duration& right);
-    template <typename T>
-    friend constexpr Duration operator/(const T& left, const Duration& right);
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t);
     friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int); // PRQA S 48
     friend constexpr Duration duration_literals::operator"" _us(unsigned long long int); // PRQA S 48
@@ -199,18 +261,28 @@ class Duration
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int);  // PRQA S 48
 
   private:
-    /// @brief constructor needs to be private to ensure a unit safe usage of duration
-    constexpr explicit Duration(const long double durationInSeconds);
-    long double durationInSeconds{0.0};
+    template<typename T>
+    inline constexpr Duration multiplicateSeconds(const uint64_t seconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+    template<typename T>
+    inline constexpr Duration multiplicateSeconds(const uint64_t seconds, const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+    template<typename T>
+    inline constexpr Duration multiplicateNanoseconds(const uint32_t nanoseconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+    template<typename T>
+    inline constexpr Duration multiplicateNanoseconds(const uint32_t nanoseconds, const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+
+  private:
+    uint64_t m_seconds{0};
+    uint32_t m_nanoseconds{0};
 };
 
-/// @brief creates Duration object multiplying T with durationInSeconds
+/// @brief creates Duration object by multiplying object T with a duration
+/// @tparam T is an arithmetic type for the multiplicator
+/// @param[in] left is the multiplicator
+/// @param[in] right is the multiplicant
+/// @return a new Duration object
+/// @attention since negative durations are not allowed, the duration will be capped to 0
 template <typename T>
 constexpr Duration operator*(const T& left, const Duration& right);
-
-/// @brief creates Duration object dividing T through durationInSeconds
-template <typename T>
-constexpr Duration operator/(const T& left, const Duration& right);
 
 /// @brief stream operator for the Duration class
 std::ostream& operator<<(std::ostream& stream, const Duration& t);

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -308,6 +308,9 @@ class Duration
     inline static constexpr Duration max();
 
   private:
+    template <typename T, typename String>
+    inline static constexpr unsigned long long int positiveValueOrClampToZero(const T value, const String fromMethod);
+
     template <typename T>
     inline constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
     template <typename From, typename To>

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -234,32 +234,25 @@ class Duration
     // BEGIN CONVERSION
 
     /// @brief returns the duration in nanoseconds
-    template <typename T>
-    constexpr T nanoSeconds() const noexcept;
+    constexpr uint64_t nanoSeconds() const noexcept;
 
     /// @brief returns the duration in microseconds
-    template <typename T>
-    constexpr T microSeconds() const noexcept;
+    constexpr uint64_t microSeconds() const noexcept;
 
     /// @brief returns the duration in milliseconds
-    template <typename T>
-    constexpr T milliSeconds() const noexcept;
+    constexpr uint64_t milliSeconds() const noexcept;
 
     /// @brief returns the duration in seconds
-    template <typename T>
-    constexpr T seconds() const noexcept;
+    constexpr uint64_t seconds() const noexcept;
 
     /// @brief returns the duration in minutes
-    template <typename T>
-    constexpr T minutes() const noexcept;
+    constexpr uint64_t minutes() const noexcept;
 
     /// @brief returns the duration in hours
-    template <typename T>
-    constexpr T hours() const noexcept;
+    constexpr uint64_t hours() const noexcept;
 
     /// @brief returns the duration in days
-    template <typename T>
-    constexpr T days() const noexcept;
+    constexpr uint64_t days() const noexcept;
 
     /// @brief converts duration in a timespec c struct
     struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const noexcept;

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -164,69 +164,69 @@ class Duration
     constexpr explicit Duration(const std::chrono::nanoseconds& value) noexcept;
 
     /// @brief Assigns a std::chrono::milliseconds to an duration object
-    /// @param[in] right hand side of the assignment
+    /// @param[in] rhs is the right hand side of the assignment
     /// @return a reference to the Duration object with the assigned millisecond value
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    Duration& operator=(const std::chrono::milliseconds& right) noexcept;
+    Duration& operator=(const std::chrono::milliseconds& rhs) noexcept;
 
     // END CONSTRUCTORS AND ASSIGNMENT
 
     // BEGIN COMPARISON
 
     /// @brief Equal to operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration equal to right
-    constexpr bool operator==(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration equal to rhs
+    constexpr bool operator==(const Duration& rhs) const noexcept;
 
     /// @brief Not equal to operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration not equal to right
-    constexpr bool operator!=(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration not equal to rhs
+    constexpr bool operator!=(const Duration& rhs) const noexcept;
 
     /// @brief Less than operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration is less than right
-    constexpr bool operator<(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration is less than rhs
+    constexpr bool operator<(const Duration& rhs) const noexcept;
 
     /// @brief Less than or equal to operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration is less than or equal to right
-    constexpr bool operator<=(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration is less than or equal to rhs
+    constexpr bool operator<=(const Duration& rhs) const noexcept;
 
     /// @brief Greater than operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration is greater than right
-    constexpr bool operator>(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration is greater than rhs
+    constexpr bool operator>(const Duration& rhs) const noexcept;
 
     /// @brief Greater than or equal to operator
-    /// @param[in] right hand side of the comparison
-    /// @return true if duration is greater than or equal to right
-    constexpr bool operator>=(const Duration& right) const noexcept;
+    /// @param[in] rhs is the right hand side of the comparison
+    /// @return true if duration is greater than or equal to rhs
+    constexpr bool operator>=(const Duration& rhs) const noexcept;
 
     // END COMPARISON
 
     // BEGIN ARITHMETIC
 
-    /// @brief Creates Duration object by adding right
-    /// @param[in] right is the second summand
+    /// @brief Creates Duration object by addition
+    /// @param[in] rhs is the second summand
     /// @return a new Duration object
-    constexpr Duration operator+(const Duration& right) const noexcept;
+    constexpr Duration operator+(const Duration& rhs) const noexcept;
 
-    /// @brief Creates Duration object by subtracting right
-    /// @param[in] right is the subtrahend
+    /// @brief Creates Duration object by subtraction
+    /// @param[in] rhs is the subtrahend
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
-    constexpr Duration operator-(const Duration& right) const noexcept;
+    constexpr Duration operator-(const Duration& rhs) const noexcept;
 
     /// @brief Creates Duration object by multiplication
     /// @tparam T is an arithmetic type for the multiplicator
-    /// @param[in] right is the multiplicator
+    /// @param[in] rhs is the multiplicator
     /// @return a new Duration object
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     /// @note There is no explicit division operator! This can be achieved by multiplication with the inverse of the
     /// divisor.
     template <typename T>
-    constexpr Duration operator*(const T& right) const noexcept;
+    constexpr Duration operator*(const T& rhs) const noexcept;
 
     // END ARITHMETIC
 
@@ -279,7 +279,7 @@ class Duration
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int) noexcept;  // PRQA S 48
 
     template <typename T>
-    friend constexpr Duration operator*(const T& left, const Duration& right) noexcept;
+    friend constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
@@ -287,19 +287,19 @@ class Duration
     template <typename T>
     inline constexpr Duration
     multiplySeconds(const uint64_t seconds,
-                    const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept;
+                    const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
     template <typename T>
     inline constexpr Duration
     multiplySeconds(const uint64_t seconds,
-                    const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept;
+                    const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
     template <typename T>
     inline constexpr Duration
     multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept;
+                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
     template <typename T>
     inline constexpr Duration
     multiplyNanoseconds(const uint32_t nanoseconds,
-                        const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept;
+                        const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
     static constexpr uint32_t SECS_PER_MINUTE{60U};
     static constexpr uint32_t SECS_PER_HOUR{3600U};
@@ -321,12 +321,12 @@ class Duration
 
 /// @brief creates Duration object by multiplying object T with a duration
 /// @tparam T is an arithmetic type for the multiplicator
-/// @param[in] left is the multiplicator
-/// @param[in] right is the multiplicant
+/// @param[in] lhs is the multiplicator
+/// @param[in] rhs is the multiplicant
 /// @return a new Duration object
 /// @attention since negative durations are not allowed, the duration will be capped to 0
 template <typename T>
-constexpr Duration operator*(const T& left, const Duration& right) noexcept;
+constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
 /// @brief stream operator for the Duration class
 std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -297,18 +297,18 @@ class Duration
     static constexpr uint32_t NANOSECS_PER_SEC{NANOSECS_PER_MILLISEC * 1000U};
 
   protected:
-    using SECONDS_TYPE = uint64_t;
-    using NANOSECONDS_TYPE = uint32_t;
+    using Seconds_t = uint64_t;
+    using Nanoseconds_t = uint32_t;
 
     /// @brief Constructs a Duration from seconds and nanoseconds
     /// @param[in] seconds portion of the duration
     /// @param[in] nanoseconds portion of the duration
     /// @note this is protected to be able to use it in unit tests
-    constexpr Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
+    constexpr Duration(const Seconds_t seconds, const Nanoseconds_t nanoseconds) noexcept;
 
     /// @note this is factory method is necessary to build with msvc due to issues calling a protected constexpr ctor
     /// from public methods
-    static constexpr Duration createDuration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
+    static constexpr Duration createDuration(const Seconds_t seconds, const Nanoseconds_t nanoseconds) noexcept;
 
     static constexpr Duration max() noexcept;
 
@@ -328,8 +328,8 @@ class Duration
     constexpr Duration multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
 
   private:
-    SECONDS_TYPE m_seconds{0U};
-    NANOSECONDS_TYPE m_nanoseconds{0U};
+    Seconds_t m_seconds{0U};
+    Nanoseconds_t m_nanoseconds{0U};
 };
 
 /// @brief creates Duration object by multiplying object T with a duration

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -149,7 +149,7 @@ class Duration
     constexpr explicit Duration(const struct timespec& value);
 
     /// @brief Construct a Duration object from itimerspec
-    /// @param[in] value as itimespec
+    /// @param[in] value as itimerspec
     /// @note only it_interval from the itimerspec is used
     constexpr explicit Duration(const struct itimerspec& value);
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -310,6 +310,8 @@ class Duration
   private:
     template <typename T>
     inline constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;
+    template <typename From, typename To>
+    inline constexpr bool wouldCastFromFloatingPointProbablyOverflow(const From floatingPoint) const noexcept;
 
     template <typename T>
     inline constexpr Duration

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -19,8 +19,8 @@
 #include "iceoryx_utils/platform/time.hpp" // required for QNX
 
 #include <chrono>
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
 namespace iox
 {
@@ -73,6 +73,8 @@ constexpr Duration operator"" _d(unsigned long long int); // PRQA S 48
 class Duration
 {
   public:
+    // BEGIN CREATION FROM STATIC FUNCTIONS
+
     /// @brief Constructs a new Duration object from nanoseconds
     /// @tparam T is an integer type for the value
     /// @param[in] value as nanoseconds
@@ -80,6 +82,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration nanoseconds(const T value);
+
     /// @brief Constructs a new Duration object from microseconds
     /// @tparam T is an integer type for the value
     /// @param[in] value as microseconds
@@ -87,6 +90,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration microseconds(const T value);
+
     /// @brief Constructs a new Duration object from milliseconds
     /// @tparam T is an integer type for the value
     /// @param[in] value as milliseconds
@@ -94,6 +98,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration milliseconds(const T value);
+
     /// @brief Constructs a new Duration object from seconds
     /// @tparam T is an integer type for the value
     /// @param[in] value as seconds
@@ -101,6 +106,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration seconds(const T value);
+
     /// @brief Constructs a new Duration object from minutes
     /// @tparam T is an integer type for the value
     /// @param[in] value as minutes
@@ -108,6 +114,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration minutes(const T value);
+
     /// @brief Constructs a new Duration object from hours
     /// @tparam T is an integer type for the value
     /// @param[in] value as hours
@@ -115,6 +122,7 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration hours(const T value);
+
     /// @brief Constructs a new Duration object from days
     /// @tparam T is an integer type for the value
     /// @param[in] value as days
@@ -122,6 +130,10 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     template <typename T>
     static constexpr Duration days(const T value);
+
+    // END CREATION FROM STATIC FUNCTIONS
+
+    // BEGIN CONSTRUCTORS AND ASSIGNMENT
 
     /// @brief Constructs a Duration from seconds and nanoseconds
     /// @param[in] seconds portion of the duration
@@ -157,6 +169,10 @@ class Duration
     /// @attention since negative durations are not allowed, the duration will be capped to 0
     Duration& operator=(const std::chrono::milliseconds& right);
 
+    // END CONSTRUCTORS AND ASSIGNMENT
+
+    // BEGIN COMPARISON
+
     /// @brief Equal to operator
     /// @param[in] right hand side of the comparison
     /// @return true if duration equal to right
@@ -187,6 +203,10 @@ class Duration
     /// @return true if duration is greater than or equal to right
     constexpr bool operator>=(const Duration& right) const;
 
+    // END COMPARISON
+
+    // BEGIN ARITHMETIC
+
     /// @brief creates Duration object by adding right
     /// @param[in] right is the second summand
     /// @return a new Duration object
@@ -212,6 +232,10 @@ class Duration
     /// @return a new Duration object
     template <typename T>
     constexpr Duration operator/(const T& right) const;
+
+    // END ARITHMETIC
+
+    // BEGIN CONVERSION
 
     /// @brief returns the duration in nanoseconds
     template <typename T>
@@ -241,17 +265,16 @@ class Duration
     template <typename T>
     constexpr T days() const;
 
+    /// @brief converts duration in a timespec c struct
+    struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const;
+
     /// @brief converts duration in a timeval c struct
     ///     timeval::tv_sec = seconds since the Epoch (01.01.1970)
     ///     timeval::tv_usec = microseconds
     constexpr operator struct timeval() const;
 
-    /// @brief converts time in a timespec c struct
-    struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const;
+    // END CONVERSION
 
-    template <typename T>
-    friend constexpr Duration operator*(const T& left, const Duration& right);
-    friend std::ostream& operator<<(std::ostream& stream, const Duration& t);
     friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int); // PRQA S 48
     friend constexpr Duration duration_literals::operator"" _us(unsigned long long int); // PRQA S 48
     friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int); // PRQA S 48
@@ -260,15 +283,26 @@ class Duration
     friend constexpr Duration duration_literals::operator"" _h(unsigned long long int);  // PRQA S 48
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int);  // PRQA S 48
 
+    template <typename T>
+    friend constexpr Duration operator*(const T& left, const Duration& right);
+
+    friend std::ostream& operator<<(std::ostream& stream, const Duration& t);
+
   private:
-    template<typename T>
-    inline constexpr Duration multiplicateSeconds(const uint64_t seconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
-    template<typename T>
-    inline constexpr Duration multiplicateSeconds(const uint64_t seconds, const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
-    template<typename T>
-    inline constexpr Duration multiplicateNanoseconds(const uint32_t nanoseconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
-    template<typename T>
-    inline constexpr Duration multiplicateNanoseconds(const uint32_t nanoseconds, const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+    template <typename T>
+    inline constexpr Duration
+    multiplySeconds(const uint64_t seconds, const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+    template <typename T>
+    inline constexpr Duration multiplySeconds(const uint64_t seconds,
+                                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
+    template <typename T>
+    inline constexpr Duration
+    multiplyNanoseconds(const uint32_t nanoseconds,
+                        const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const;
+    template <typename T>
+    inline constexpr Duration
+    multiplyNanoseconds(const uint32_t nanoseconds,
+                        const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const;
 
   private:
     uint64_t m_seconds{0};

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -305,6 +305,8 @@ class Duration
     /// @note this is protected to be able to use it in unit tests
     constexpr Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
 
+    static constexpr Duration createDuration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept;
+
     inline static constexpr Duration max();
 
   private:
@@ -317,12 +319,12 @@ class Duration
     inline constexpr bool wouldCastFromFloatingPointProbablyOverflow(const From floatingPoint) const noexcept;
 
     template <typename T>
-    inline constexpr Duration
-    multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept;
+    inline constexpr Duration multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const
+        noexcept;
 
     template <typename T>
-    inline constexpr Duration
-    multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept;
+    inline constexpr Duration multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const
+        noexcept;
 
   private:
     SECONDS_TYPE m_seconds{0U};

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -27,9 +27,10 @@ constexpr Duration Duration::nanoseconds(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _ns(value);
+    return operator"" _ns(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::microseconds(const T value)
@@ -38,9 +39,10 @@ constexpr Duration Duration::microseconds(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _us(value);
+    return operator"" _us(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::milliseconds(const T value)
@@ -49,9 +51,10 @@ constexpr Duration Duration::milliseconds(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _ms(value);
+    return operator"" _ms(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::seconds(const T value)
@@ -60,9 +63,10 @@ constexpr Duration Duration::seconds(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _s(value);
+    return operator"" _s(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::minutes(const T value)
@@ -71,9 +75,10 @@ constexpr Duration Duration::minutes(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _m(value);
+    return operator"" _m(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::hours(const T value)
@@ -82,9 +87,10 @@ constexpr Duration Duration::hours(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _h(value);
+    return operator"" _h(static_cast<unsigned long long int>(value));
 }
 template <typename T>
 constexpr Duration Duration::days(const T value)
@@ -93,9 +99,10 @@ constexpr Duration Duration::days(const T value)
 
     if (value < 0)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
         return Duration{0U, 0U};
     }
-    return operator"" _d(value);
+    return operator"" _d(static_cast<unsigned long long int>(value));
 }
 
 
@@ -127,20 +134,12 @@ inline constexpr Duration::Duration(const struct itimerspec& value)
 
 inline constexpr Duration::Duration(const std::chrono::milliseconds& value)
 {
-    auto milliseconds = value.count();
-    if (milliseconds > 0)
-    {
-        *this = operator"" _ms(static_cast<unsigned long long int>(milliseconds));
-    }
+    *this = Duration::milliseconds(value.count());
 }
 
 inline constexpr Duration::Duration(const std::chrono::nanoseconds& value)
 {
-    auto nanoseconds = value.count();
-    if (nanoseconds > 0)
-    {
-        *this = operator"" _ns(static_cast<unsigned long long int>(nanoseconds));
-    }
+    *this = Duration::nanoseconds(value.count());
 }
 
 inline Duration& Duration::operator=(const std::chrono::milliseconds& right)
@@ -271,6 +270,7 @@ inline constexpr Duration Duration::operator-(const Duration& right) const
 {
     if (*this <= right)
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of subtraction would be negative, clamping to zero!" << std::endl;
         return Duration(0U, 0U);
     }
     auto seconds = m_seconds - right.m_seconds;
@@ -336,6 +336,8 @@ inline constexpr Duration Duration::operator*(const T& right) const
 
     if (right < static_cast<T>(0))
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would be negative, clamping to zero!"
+                  << std::endl;
         return Duration{0U, 0U};
     }
 
@@ -351,6 +353,7 @@ inline constexpr Duration Duration::operator/(const T& right) const
 
     if (right < static_cast<T>(0))
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of division would be negative, clamping to zero!" << std::endl;
         return Duration{0U, 0U};
     }
 
@@ -414,6 +417,8 @@ inline constexpr Duration operator*(const T& left, const Duration& right)
 
     if (left < static_cast<T>(0))
     {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would be negative, clamping to zero!"
+                  << std::endl;
         return Duration{0U, 0U};
     }
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -142,9 +142,9 @@ inline constexpr Duration::Duration(const std::chrono::nanoseconds& value) noexc
     *this = Duration::nanoseconds(value.count());
 }
 
-inline Duration& Duration::operator=(const std::chrono::milliseconds& right) noexcept
+inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexcept
 {
-    *this = Duration(right);
+    *this = Duration(rhs);
     return *this;
 }
 
@@ -222,42 +222,42 @@ inline constexpr Duration::operator timeval() const noexcept
     return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / NANOSECS_PER_MICROSEC)};
 }
 
-inline constexpr bool Duration::operator==(const Duration& right) const noexcept
+inline constexpr bool Duration::operator==(const Duration& rhs) const noexcept
 {
-    return (m_seconds == right.m_seconds) && (m_nanoseconds == right.m_nanoseconds);
+    return (m_seconds == rhs.m_seconds) && (m_nanoseconds == rhs.m_nanoseconds);
 }
 
-inline constexpr bool Duration::operator!=(const Duration& right) const noexcept
+inline constexpr bool Duration::operator!=(const Duration& rhs) const noexcept
 {
-    return !(*this == right);
+    return !(*this == rhs);
 }
 
-inline constexpr bool Duration::operator<(const Duration& right) const noexcept
+inline constexpr bool Duration::operator<(const Duration& rhs) const noexcept
 {
-    return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds < right.m_nanoseconds));
+    return (m_seconds < rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds < rhs.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator<=(const Duration& right) const noexcept
+inline constexpr bool Duration::operator<=(const Duration& rhs) const noexcept
 {
-    return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds <= right.m_nanoseconds));
+    return (m_seconds < rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds <= rhs.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator>(const Duration& right) const noexcept
+inline constexpr bool Duration::operator>(const Duration& rhs) const noexcept
 {
-    return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds > right.m_nanoseconds));
+    return (m_seconds > rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds > rhs.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator>=(const Duration& right) const noexcept
+inline constexpr bool Duration::operator>=(const Duration& rhs) const noexcept
 {
-    return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds >= right.m_nanoseconds));
+    return (m_seconds > rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds >= rhs.m_nanoseconds));
 }
 
-inline constexpr Duration Duration::operator+(const Duration& right) const noexcept
+inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcept
 {
     /// @todo decide if we want an overflow or saturation
 
-    auto seconds = m_seconds + right.m_seconds;
-    auto nanoseconds = m_nanoseconds + right.m_nanoseconds;
+    auto seconds = m_seconds + rhs.m_seconds;
+    auto nanoseconds = m_nanoseconds + rhs.m_nanoseconds;
     if (nanoseconds >= NANOSECS_PER_SEC)
     {
         ++seconds;
@@ -266,22 +266,22 @@ inline constexpr Duration Duration::operator+(const Duration& right) const noexc
     return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration Duration::operator-(const Duration& right) const noexcept
+inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcept
 {
-    if (*this <= right)
+    if (*this <= rhs)
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of subtraction would be negative, clamping to zero!" << std::endl;
         return Duration(0U, 0U);
     }
-    auto seconds = m_seconds - right.m_seconds;
+    auto seconds = m_seconds - rhs.m_seconds;
     uint32_t nanoseconds{0U};
-    if (m_nanoseconds >= right.m_nanoseconds)
+    if (m_nanoseconds >= rhs.m_nanoseconds)
     {
-        nanoseconds = m_nanoseconds - right.m_nanoseconds;
+        nanoseconds = m_nanoseconds - rhs.m_nanoseconds;
     }
     else
     {
-        nanoseconds = NANOSECS_PER_SEC - right.m_nanoseconds - m_nanoseconds;
+        nanoseconds = NANOSECS_PER_SEC - rhs.m_nanoseconds - m_nanoseconds;
         --seconds;
     }
     return Duration{seconds, nanoseconds};
@@ -290,20 +290,20 @@ inline constexpr Duration Duration::operator-(const Duration& right) const noexc
 template <typename T>
 inline constexpr Duration
 Duration::multiplySeconds(const uint64_t seconds,
-                          const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept
+                          const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept
 {
-    // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
-    // operator*(...) takes care of negative values for right
-    return Duration(seconds * static_cast<uint64_t>(right), 0U);
+    // specialization is needed to prevent a clang warning if `rhs` is a signed integer and not casted to unsigned
+    // operator*(...) takes care of negative values for rhs
+    return Duration(seconds * static_cast<uint64_t>(rhs), 0U);
 }
 
 template <typename T>
 inline constexpr Duration
 Duration::multiplySeconds(const uint64_t seconds,
-                          const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept
+                          const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept
 {
-    // operator*(...) takes care of negative values for right
-    auto result = seconds * right;
+    // operator*(...) takes care of negative values for rhs
+    auto result = seconds * rhs;
     double resultSeconds{0.0};
     double secondsFraction = modf(result, &resultSeconds);
     return Duration(static_cast<uint64_t>(resultSeconds), 0U)
@@ -313,28 +313,28 @@ Duration::multiplySeconds(const uint64_t seconds,
 template <typename T>
 inline constexpr Duration
 Duration::multiplyNanoseconds(const uint32_t nanoseconds,
-                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept
+                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& rhs) const noexcept
 {
-    // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
-    // operator*(...) takes care of negative values for right
-    return Duration::nanoseconds(nanoseconds * static_cast<uint64_t>(right));
+    // specialization is needed to prevent a clang warning if `rhs` is a signed integer and not casted to unsigned
+    // operator*(...) takes care of negative values for rhs
+    return Duration::nanoseconds(nanoseconds * static_cast<uint64_t>(rhs));
 }
 
 template <typename T>
 inline constexpr Duration
 Duration::multiplyNanoseconds(const uint32_t nanoseconds,
-                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept
+                              const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept
 {
-    // operator*(...) takes care of negative values for right
-    return Duration::nanoseconds(static_cast<uint64_t>(nanoseconds * right));
+    // operator*(...) takes care of negative values for rhs
+    return Duration::nanoseconds(static_cast<uint64_t>(nanoseconds * rhs));
 }
 
 template <typename T>
-inline constexpr Duration Duration::operator*(const T& right) const noexcept
+inline constexpr Duration Duration::operator*(const T& rhs) const noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
-    if (right < static_cast<T>(0))
+    if (rhs < static_cast<T>(0))
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would be negative, clamping to zero!"
                   << std::endl;
@@ -343,7 +343,7 @@ inline constexpr Duration Duration::operator*(const T& right) const noexcept
 
     /// @todo decide if we want an overflow or saturation
 
-    return multiplySeconds<T>(m_seconds, right) + multiplyNanoseconds<T>(m_nanoseconds, right);
+    return multiplySeconds<T>(m_seconds, rhs) + multiplyNanoseconds<T>(m_nanoseconds, rhs);
 }
 
 inline namespace duration_literals
@@ -392,18 +392,18 @@ inline constexpr Duration operator"" _d(unsigned long long int value) noexcept /
 } // namespace duration_literals
 
 template <typename T>
-inline constexpr Duration operator*(const T& left, const Duration& right) noexcept
+inline constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
-    if (left < static_cast<T>(0))
+    if (lhs < static_cast<T>(0))
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would be negative, clamping to zero!"
                   << std::endl;
         return Duration{0U, 0U};
     }
 
-    return right * left;
+    return rhs * lhs;
 }
 
 } // namespace units

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -243,7 +243,7 @@ inline constexpr bool Duration::operator<(const Duration& rhs) const noexcept
 
 inline constexpr bool Duration::operator<=(const Duration& rhs) const noexcept
 {
-    return (m_seconds < rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds <= rhs.m_nanoseconds));
+    return !(*this > rhs);
 }
 
 inline constexpr bool Duration::operator>(const Duration& rhs) const noexcept
@@ -253,7 +253,7 @@ inline constexpr bool Duration::operator>(const Duration& rhs) const noexcept
 
 inline constexpr bool Duration::operator>=(const Duration& rhs) const noexcept
 {
-    return (m_seconds > rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds >= rhs.m_nanoseconds));
+    return !(*this < rhs);
 }
 
 inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcept

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -23,36 +23,50 @@ namespace units
 template <typename T>
 constexpr Duration Duration::nanoseconds(const T ns)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _ns(ns);
 }
 template <typename T>
 constexpr Duration Duration::microseconds(const T us)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _us(us);
 }
 template <typename T>
 constexpr Duration Duration::milliseconds(const T ms)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _ms(ms);
 }
 template <typename T>
 constexpr Duration Duration::seconds(const T seconds)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _s(seconds);
 }
 template <typename T>
 constexpr Duration Duration::minutes(const T min)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _m(min);
 }
 template <typename T>
 constexpr Duration Duration::hours(const T hours)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _h(hours);
 }
 template <typename T>
 constexpr Duration Duration::days(const T days)
 {
+    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
+                  "only unsigned integer are supported");
     return operator"" _d(days);
 }
 inline constexpr Duration::Duration(const struct timeval& value)
@@ -140,9 +154,24 @@ inline constexpr Duration::operator timeval() const
     return {this->seconds<SEC_TYPE>(), this->microSeconds<USEC_TYPE>() - this->seconds<USEC_TYPE>() * 1000000};
 }
 
+inline constexpr bool Duration::operator==(const Duration& right) const
+{
+    return durationInSeconds == right.durationInSeconds;
+}
+
+inline constexpr bool Duration::operator!=(const Duration& right) const
+{
+    return !(*this == right);
+}
+
 inline constexpr bool Duration::operator<(const Duration& right) const
 {
     return durationInSeconds < right.durationInSeconds;
+}
+
+inline constexpr bool Duration::operator<=(const Duration& right) const
+{
+    return durationInSeconds <= right.durationInSeconds;
 }
 
 inline constexpr bool Duration::operator>(const Duration& right) const
@@ -153,11 +182,6 @@ inline constexpr bool Duration::operator>(const Duration& right) const
 inline constexpr bool Duration::operator>=(const Duration& right) const
 {
     return durationInSeconds >= right.durationInSeconds;
-}
-
-inline constexpr bool Duration::operator<=(const Duration& right) const
-{
-    return durationInSeconds <= right.durationInSeconds;
 }
 
 inline constexpr Duration Duration::operator+(const Duration& right) const
@@ -194,19 +218,9 @@ inline constexpr Duration Duration::operator/(const T& right) const
 
 inline namespace duration_literals
 {
-inline constexpr Duration operator"" _ns(long double value)
-{
-    return Duration{value / 1000000000.0};
-}
-
 inline constexpr Duration operator"" _ns(unsigned long long int value) // PRQA S 48
 {
     return Duration{static_cast<long double>(value) / 1000000000.0};
-}
-
-inline constexpr Duration operator"" _us(long double value)
-{
-    return Duration{value / 1000000.0};
 }
 
 inline constexpr Duration operator"" _us(unsigned long long int value) // PRQA S 48
@@ -214,19 +228,9 @@ inline constexpr Duration operator"" _us(unsigned long long int value) // PRQA S
     return Duration{static_cast<long double>(value) / 1000000.0};
 }
 
-inline constexpr Duration operator"" _ms(long double value)
-{
-    return Duration{value / 1000.0};
-}
-
 inline constexpr Duration operator"" _ms(unsigned long long int value) // PRQA S 48
 {
     return Duration{static_cast<long double>(value) / 1000.0};
-}
-
-inline constexpr Duration operator"" _s(long double value)
-{
-    return Duration{value};
 }
 
 inline constexpr Duration operator"" _s(unsigned long long int value) // PRQA S 48
@@ -234,29 +238,14 @@ inline constexpr Duration operator"" _s(unsigned long long int value) // PRQA S 
     return Duration{static_cast<long double>(value)};
 }
 
-inline constexpr Duration operator"" _m(long double value)
-{
-    return Duration{value * 60.0};
-}
-
 inline constexpr Duration operator"" _m(unsigned long long int value) // PRQA S 48
 {
     return Duration{static_cast<long double>(value) * 60.0};
 }
 
-inline constexpr Duration operator"" _h(long double value)
-{
-    return Duration{value * 3600.0};
-}
-
 inline constexpr Duration operator"" _h(unsigned long long int value) // PRQA S 48
 {
     return Duration{static_cast<long double>(value) * 3600.0};
-}
-
-inline constexpr Duration operator"" _d(long double value)
-{
-    return Duration{value * 24.0 * 3600.0};
 }
 
 inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 48
@@ -269,13 +258,13 @@ inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 
 template <typename T>
 inline constexpr Duration operator*(const T& left, const Duration& right)
 {
-    return Duration::seconds(static_cast<long double>(left) * right.seconds<long double>());
+    return Duration(static_cast<long double>(left) * right.seconds<long double>());
 }
 
 template <typename T>
 inline constexpr Duration operator/(const T& left, const Duration& right)
 {
-    return Duration::seconds(static_cast<long double>(left) / right.seconds<long double>());
+    return Duration(static_cast<long double>(left) / right.seconds<long double>());
 }
 
 } // namespace units

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -233,6 +233,13 @@ inline constexpr Duration::operator timeval() const noexcept
 {
     using SEC_TYPE = decltype(timeval::tv_sec);
     using USEC_TYPE = decltype(timeval::tv_usec);
+    static_assert(sizeof(uint64_t) >= sizeof(SEC_TYPE), "casting might alter result");
+    if (m_seconds > static_cast<uint64_t>(std::numeric_limits<SEC_TYPE>::max()))
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
+                  << std::endl;
+        return {std::numeric_limits<SEC_TYPE>::max(), MICROSECS_PER_SEC - 1U};
+    }
     return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / NANOSECS_PER_MICROSEC)};
 }
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -21,7 +21,7 @@ namespace iox
 namespace units
 {
 template <typename T>
-constexpr Duration Duration::nanoseconds(const T value)
+constexpr Duration Duration::nanoseconds(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -33,7 +33,7 @@ constexpr Duration Duration::nanoseconds(const T value)
     return operator"" _ns(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::microseconds(const T value)
+constexpr Duration Duration::microseconds(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -45,7 +45,7 @@ constexpr Duration Duration::microseconds(const T value)
     return operator"" _us(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::milliseconds(const T value)
+constexpr Duration Duration::milliseconds(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -57,7 +57,7 @@ constexpr Duration Duration::milliseconds(const T value)
     return operator"" _ms(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::seconds(const T value)
+constexpr Duration Duration::seconds(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -69,7 +69,7 @@ constexpr Duration Duration::seconds(const T value)
     return operator"" _s(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::minutes(const T value)
+constexpr Duration Duration::minutes(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -81,7 +81,7 @@ constexpr Duration Duration::minutes(const T value)
     return operator"" _m(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::hours(const T value)
+constexpr Duration Duration::hours(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -93,7 +93,7 @@ constexpr Duration Duration::hours(const T value)
     return operator"" _h(static_cast<unsigned long long int>(value));
 }
 template <typename T>
-constexpr Duration Duration::days(const T value)
+constexpr Duration Duration::days(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -106,7 +106,7 @@ constexpr Duration Duration::days(const T value)
 }
 
 
-inline constexpr Duration::Duration(const uint64_t seconds, const uint32_t nanoseconds)
+inline constexpr Duration::Duration(const uint64_t seconds, const uint32_t nanoseconds) noexcept
     : m_seconds(seconds)
     , m_nanoseconds(nanoseconds)
 {
@@ -117,39 +117,39 @@ inline constexpr Duration::Duration(const uint64_t seconds, const uint32_t nanos
     }
 }
 
-inline constexpr Duration::Duration(const struct timeval& value)
+inline constexpr Duration::Duration(const struct timeval& value) noexcept
     : Duration(static_cast<uint64_t>(value.tv_sec), static_cast<uint32_t>(value.tv_usec) * NANOSECS_PER_MICROSEC)
 {
 }
 
-inline constexpr Duration::Duration(const struct timespec& value)
+inline constexpr Duration::Duration(const struct timespec& value) noexcept
     : Duration(static_cast<uint64_t>(value.tv_sec), static_cast<uint32_t>(value.tv_nsec))
 {
 }
 
-inline constexpr Duration::Duration(const struct itimerspec& value)
+inline constexpr Duration::Duration(const struct itimerspec& value) noexcept
     : Duration(value.it_interval)
 {
 }
 
-inline constexpr Duration::Duration(const std::chrono::milliseconds& value)
+inline constexpr Duration::Duration(const std::chrono::milliseconds& value) noexcept
 {
     *this = Duration::milliseconds(value.count());
 }
 
-inline constexpr Duration::Duration(const std::chrono::nanoseconds& value)
+inline constexpr Duration::Duration(const std::chrono::nanoseconds& value) noexcept
 {
     *this = Duration::nanoseconds(value.count());
 }
 
-inline Duration& Duration::operator=(const std::chrono::milliseconds& right)
+inline Duration& Duration::operator=(const std::chrono::milliseconds& right) noexcept
 {
     *this = Duration(right);
     return *this;
 }
 
 template <typename T>
-inline constexpr T Duration::nanoSeconds() const
+inline constexpr T Duration::nanoSeconds() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -158,7 +158,7 @@ inline constexpr T Duration::nanoSeconds() const
 }
 
 template <typename T>
-inline constexpr T Duration::microSeconds() const
+inline constexpr T Duration::microSeconds() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -167,7 +167,7 @@ inline constexpr T Duration::microSeconds() const
 }
 
 template <typename T>
-inline constexpr T Duration::milliSeconds() const
+inline constexpr T Duration::milliSeconds() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -176,7 +176,7 @@ inline constexpr T Duration::milliSeconds() const
 }
 
 template <typename T>
-inline constexpr T Duration::seconds() const
+inline constexpr T Duration::seconds() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -186,7 +186,7 @@ inline constexpr T Duration::seconds() const
 }
 
 template <typename T>
-inline constexpr T Duration::minutes() const
+inline constexpr T Duration::minutes() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -196,7 +196,7 @@ inline constexpr T Duration::minutes() const
 }
 
 template <typename T>
-inline constexpr T Duration::hours() const
+inline constexpr T Duration::hours() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -206,7 +206,7 @@ inline constexpr T Duration::hours() const
 }
 
 template <typename T>
-inline constexpr T Duration::days() const
+inline constexpr T Duration::days() const noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
 
@@ -215,44 +215,44 @@ inline constexpr T Duration::days() const
     return static_cast<T>(m_seconds / (HOURS_PER_DAY * SECS_PER_HOUR));
 }
 
-inline constexpr Duration::operator timeval() const
+inline constexpr Duration::operator timeval() const noexcept
 {
     using SEC_TYPE = decltype(timeval::tv_sec);
     using USEC_TYPE = decltype(timeval::tv_usec);
     return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / NANOSECS_PER_MICROSEC)};
 }
 
-inline constexpr bool Duration::operator==(const Duration& right) const
+inline constexpr bool Duration::operator==(const Duration& right) const noexcept
 {
     return (m_seconds == right.m_seconds) && (m_nanoseconds == right.m_nanoseconds);
 }
 
-inline constexpr bool Duration::operator!=(const Duration& right) const
+inline constexpr bool Duration::operator!=(const Duration& right) const noexcept
 {
     return !(*this == right);
 }
 
-inline constexpr bool Duration::operator<(const Duration& right) const
+inline constexpr bool Duration::operator<(const Duration& right) const noexcept
 {
     return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds < right.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator<=(const Duration& right) const
+inline constexpr bool Duration::operator<=(const Duration& right) const noexcept
 {
     return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds <= right.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator>(const Duration& right) const
+inline constexpr bool Duration::operator>(const Duration& right) const noexcept
 {
     return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds > right.m_nanoseconds));
 }
 
-inline constexpr bool Duration::operator>=(const Duration& right) const
+inline constexpr bool Duration::operator>=(const Duration& right) const noexcept
 {
     return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds >= right.m_nanoseconds));
 }
 
-inline constexpr Duration Duration::operator+(const Duration& right) const
+inline constexpr Duration Duration::operator+(const Duration& right) const noexcept
 {
     /// @todo decide if we want an overflow or saturation
 
@@ -266,7 +266,7 @@ inline constexpr Duration Duration::operator+(const Duration& right) const
     return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration Duration::operator-(const Duration& right) const
+inline constexpr Duration Duration::operator-(const Duration& right) const noexcept
 {
     if (*this <= right)
     {
@@ -290,7 +290,7 @@ inline constexpr Duration Duration::operator-(const Duration& right) const
 template <typename T>
 inline constexpr Duration
 Duration::multiplySeconds(const uint64_t seconds,
-                          const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
+                          const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept
 {
     // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
     // operator*(...) takes care of negative values for right
@@ -300,7 +300,7 @@ Duration::multiplySeconds(const uint64_t seconds,
 template <typename T>
 inline constexpr Duration
 Duration::multiplySeconds(const uint64_t seconds,
-                          const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
+                          const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept
 {
     // operator*(...) takes care of negative values for right
     auto result = seconds * right;
@@ -313,7 +313,7 @@ Duration::multiplySeconds(const uint64_t seconds,
 template <typename T>
 inline constexpr Duration
 Duration::multiplyNanoseconds(const uint32_t nanoseconds,
-                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
+                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const noexcept
 {
     // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
     // operator*(...) takes care of negative values for right
@@ -323,14 +323,14 @@ Duration::multiplyNanoseconds(const uint32_t nanoseconds,
 template <typename T>
 inline constexpr Duration
 Duration::multiplyNanoseconds(const uint32_t nanoseconds,
-                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
+                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const noexcept
 {
     // operator*(...) takes care of negative values for right
     return Duration::nanoseconds(static_cast<uint64_t>(nanoseconds * right));
 }
 
 template <typename T>
-inline constexpr Duration Duration::operator*(const T& right) const
+inline constexpr Duration Duration::operator*(const T& right) const noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
@@ -347,7 +347,7 @@ inline constexpr Duration Duration::operator*(const T& right) const
 }
 
 template <typename T>
-inline constexpr Duration Duration::operator/(const T& right) const
+inline constexpr Duration Duration::operator/(const T& right) const noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
@@ -367,43 +367,43 @@ inline constexpr Duration Duration::operator/(const T& right) const
 
 inline namespace duration_literals
 {
-inline constexpr Duration operator"" _ns(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept // PRQA S 48
 {
     auto seconds = static_cast<uint64_t>(value / Duration::NANOSECS_PER_SEC);
     auto nanoseconds = static_cast<uint32_t>(value % Duration::NANOSECS_PER_SEC);
     return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration operator"" _us(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _us(unsigned long long int value) noexcept // PRQA S 48
 {
     auto seconds = static_cast<uint64_t>(value / Duration::MICROSECS_PER_SEC);
     auto nanoseconds = static_cast<uint32_t>((value % Duration::MICROSECS_PER_SEC) * Duration::NANOSECS_PER_MICROSEC);
     return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration operator"" _ms(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept // PRQA S 48
 {
     auto seconds = static_cast<uint64_t>(value / Duration::MILLISECS_PER_SEC);
     auto nanoseconds = static_cast<uint32_t>((value % Duration::MILLISECS_PER_SEC) * Duration::NANOSECS_PER_MILLISEC);
     return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration operator"" _s(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _s(unsigned long long int value) noexcept // PRQA S 48
 {
     return Duration{static_cast<uint64_t>(value), 0U};
 }
 
-inline constexpr Duration operator"" _m(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _m(unsigned long long int value) noexcept // PRQA S 48
 {
     return Duration{static_cast<uint64_t>(value * Duration::SECS_PER_MINUTE), 0U};
 }
 
-inline constexpr Duration operator"" _h(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _h(unsigned long long int value) noexcept // PRQA S 48
 {
     return Duration{static_cast<uint64_t>(value * Duration::SECS_PER_HOUR), 0U};
 }
 
-inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 48
+inline constexpr Duration operator"" _d(unsigned long long int value) noexcept // PRQA S 48
 {
     return Duration{static_cast<uint64_t>(value * Duration::HOURS_PER_DAY * Duration::SECS_PER_HOUR), 0U};
 }
@@ -411,7 +411,7 @@ inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 
 } // namespace duration_literals
 
 template <typename T>
-inline constexpr Duration operator*(const T& left, const Duration& right)
+inline constexpr Duration operator*(const T& left, const Duration& right) noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -141,8 +141,8 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
 
 inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 {
-    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / NANOSECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() % NANOSECS_PER_SEC};
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / NANOSECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() % NANOSECS_PER_SEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
         createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
 
@@ -158,8 +158,8 @@ inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 
 inline constexpr uint64_t Duration::microSeconds() const noexcept
 {
-    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / MICROSECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<Seconds_t>::max() % MICROSECS_PER_SEC)
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MICROSECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC)
                                                             * NANOSECS_PER_MICROSEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
         createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
@@ -176,8 +176,8 @@ inline constexpr uint64_t Duration::microSeconds() const noexcept
 
 inline constexpr uint64_t Duration::milliSeconds() const noexcept
 {
-    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / MILLISECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<Seconds_t>::max() % MILLISECS_PER_SEC)
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MILLISECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC)
                                                             * NANOSECS_PER_MILLISEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
         createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -52,6 +52,11 @@ inline constexpr Duration Duration::max() noexcept
     return Duration{std::numeric_limits<Seconds_t>::max(), NANOSECS_PER_SEC - 1U};
 }
 
+inline constexpr Duration Duration::zero() noexcept
+{
+    return Duration{0U, 0U};
+}
+
 template <typename T, typename String>
 inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value,
                                                                              const String fromMethod) noexcept
@@ -275,7 +280,7 @@ inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcep
     if (*this < rhs)
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of subtraction would be negative, clamping to zero!" << std::endl;
-        return Duration(0U, 0U);
+        return Duration::zero();
     }
     auto seconds = m_seconds - rhs.m_seconds;
     Nanoseconds_t nanoseconds{0U};
@@ -432,14 +437,14 @@ inline constexpr Duration Duration::operator*(const T& rhs) const noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
-    if (rhs <= static_cast<T>(0))
+    if (rhs <= static_cast<T>(0) || *this == Duration::zero())
     {
         if (rhs < static_cast<T>(0))
         {
             std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would be negative, clamping to zero!"
                       << std::endl;
         }
-        return Duration{0U, 0U};
+        return Duration::zero();
     }
 
     return multiplyWith<T>(rhs);

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -21,7 +21,8 @@ namespace iox
 namespace units
 {
 template <typename T, typename String>
-inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value, const String fromMethod) noexcept
+inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value,
+                                                                             const String fromMethod) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
@@ -70,18 +71,18 @@ constexpr Duration Duration::days(const T value) noexcept
     return operator"" _d(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 
-inline constexpr Duration::Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept
+inline constexpr Duration::Duration(const Seconds_t seconds, const Nanoseconds_t nanoseconds) noexcept
     : m_seconds(seconds)
     , m_nanoseconds(nanoseconds)
 {
     if (nanoseconds >= NANOSECS_PER_SEC)
     {
         auto additionalSeconds = nanoseconds / NANOSECS_PER_SEC;
-        if (std::numeric_limits<SECONDS_TYPE>::max() - additionalSeconds < m_seconds)
+        if (std::numeric_limits<Seconds_t>::max() - additionalSeconds < m_seconds)
         {
             std::clog << __PRETTY_FUNCTION__
                       << ": Applied values are out of range and would overflow, clamping to max value!" << std::endl;
-            m_seconds = std::numeric_limits<SECONDS_TYPE>::max();
+            m_seconds = std::numeric_limits<Seconds_t>::max();
             m_nanoseconds = NANOSECS_PER_SEC - 1U;
         }
         else
@@ -94,17 +95,16 @@ inline constexpr Duration::Duration(const SECONDS_TYPE seconds, const NANOSECOND
 
 inline constexpr Duration Duration::max() noexcept
 {
-    return Duration{std::numeric_limits<SECONDS_TYPE>::max(), NANOSECS_PER_SEC - 1U};
+    return Duration{std::numeric_limits<Seconds_t>::max(), NANOSECS_PER_SEC - 1U};
 }
 
 inline constexpr Duration::Duration(const struct timeval& value) noexcept
-    : Duration(static_cast<SECONDS_TYPE>(value.tv_sec),
-               static_cast<NANOSECONDS_TYPE>(value.tv_usec) * NANOSECS_PER_MICROSEC)
+    : Duration(static_cast<Seconds_t>(value.tv_sec), static_cast<Nanoseconds_t>(value.tv_usec) * NANOSECS_PER_MICROSEC)
 {
 }
 
 inline constexpr Duration::Duration(const struct timespec& value) noexcept
-    : Duration(static_cast<SECONDS_TYPE>(value.tv_sec), static_cast<NANOSECONDS_TYPE>(value.tv_nsec))
+    : Duration(static_cast<Seconds_t>(value.tv_sec), static_cast<Nanoseconds_t>(value.tv_nsec))
 {
 }
 
@@ -129,17 +129,15 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
     return *this;
 }
 
-inline constexpr Duration Duration::createDuration(const SECONDS_TYPE seconds,
-                                                   const NANOSECONDS_TYPE nanoseconds) noexcept
+inline constexpr Duration Duration::createDuration(const Seconds_t seconds, const Nanoseconds_t nanoseconds) noexcept
 {
     return Duration(seconds, nanoseconds);
 }
 
 inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 {
-    constexpr SECONDS_TYPE MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max() / NANOSECS_PER_SEC};
-    constexpr NANOSECONDS_TYPE MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max()
-                                                               % NANOSECS_PER_SEC};
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / NANOSECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() % NANOSECS_PER_SEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
         createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
 
@@ -155,9 +153,9 @@ inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 
 inline constexpr uint64_t Duration::microSeconds() const noexcept
 {
-    constexpr SECONDS_TYPE MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max() / MICROSECS_PER_SEC};
-    constexpr NANOSECONDS_TYPE MAX_NANOSECONDS_BEFORE_OVERFLOW{
-        (std::numeric_limits<SECONDS_TYPE>::max() % MICROSECS_PER_SEC) * NANOSECS_PER_MICROSEC};
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / MICROSECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<Seconds_t>::max() % MICROSECS_PER_SEC)
+                                                            * NANOSECS_PER_MICROSEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
@@ -172,9 +170,9 @@ inline constexpr uint64_t Duration::microSeconds() const noexcept
 
 inline constexpr uint64_t Duration::milliSeconds() const noexcept
 {
-    constexpr SECONDS_TYPE MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max() / MILLISECS_PER_SEC};
-    constexpr NANOSECONDS_TYPE MAX_NANOSECONDS_BEFORE_OVERFLOW{
-        (std::numeric_limits<SECONDS_TYPE>::max() % MILLISECS_PER_SEC) * NANOSECS_PER_MILLISEC};
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Seconds_t>::max() / MILLISECS_PER_SEC};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<Seconds_t>::max() % MILLISECS_PER_SEC)
+                                                            * NANOSECS_PER_MILLISEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
@@ -211,8 +209,8 @@ inline constexpr Duration::operator timeval() const noexcept
 {
     using SEC_TYPE = decltype(timeval::tv_sec);
     using USEC_TYPE = decltype(timeval::tv_usec);
-    static_assert(sizeof(SECONDS_TYPE) >= sizeof(SEC_TYPE), "casting might alter result");
-    if (m_seconds > static_cast<SECONDS_TYPE>(std::numeric_limits<SEC_TYPE>::max()))
+    static_assert(sizeof(Seconds_t) >= sizeof(SEC_TYPE), "casting might alter result");
+    if (m_seconds > static_cast<Seconds_t>(std::numeric_limits<SEC_TYPE>::max()))
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
                   << std::endl;
@@ -278,7 +276,7 @@ inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcep
         return Duration(0U, 0U);
     }
     auto seconds = m_seconds - rhs.m_seconds;
-    NANOSECONDS_TYPE nanoseconds{0U};
+    Nanoseconds_t nanoseconds{0U};
     if (m_nanoseconds >= rhs.m_nanoseconds)
     {
         nanoseconds = m_nanoseconds - rhs.m_nanoseconds;
@@ -297,11 +295,11 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
 {
     // operator*(...) takes care of negative values and 0 for rhs
 
-    static_assert(sizeof(T) <= sizeof(SECONDS_TYPE),
+    static_assert(sizeof(T) <= sizeof(Seconds_t),
                   "only integer types with less or equal to size of uint64_t are allowed for multiplication");
-    const auto multiplicator = static_cast<SECONDS_TYPE>(rhs);
+    const auto multiplicator = static_cast<Seconds_t>(rhs);
 
-    auto maxBeforeOverflow = std::numeric_limits<SECONDS_TYPE>::max() / multiplicator;
+    auto maxBeforeOverflow = std::numeric_limits<Seconds_t>::max() / multiplicator;
 
     // check if the result of the m_seconds multiplication would already overflow
     if (m_seconds > maxBeforeOverflow)
@@ -369,8 +367,8 @@ inline constexpr bool Duration::wouldCastFromFloatingPointProbablyOverflow(const
     // depending on the internal representation this could be either the last value to not cause an overflow
     // or the first one which causes an overflow;
     // to be safe, this is handled like causing an overflow which would result in undefined behavior when casting to
-    // SECONDS_TYPE
-    constexpr To SECONDS_BEFORE_LIKELY_OVERFLOW = static_cast<To>(std::numeric_limits<SECONDS_TYPE>::max());
+    // Seconds_t
+    constexpr To SECONDS_BEFORE_LIKELY_OVERFLOW = static_cast<To>(std::numeric_limits<Seconds_t>::max());
     return floatingPoint >= SECONDS_BEFORE_LIKELY_OVERFLOW;
 }
 
@@ -388,20 +386,20 @@ inline constexpr Duration Duration::fromFloatingPointSeconds(const T floatingPoi
     double secondsFull{0.0};
     double secondsFraction = modf(floatingPointSeconds, &secondsFull);
 
-    if (wouldCastFromFloatingPointProbablyOverflow<T, SECONDS_TYPE>(secondsFull))
+    if (wouldCastFromFloatingPointProbablyOverflow<T, Seconds_t>(secondsFull))
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of multiplication would overflow, clamping to max value!"
                   << std::endl;
         return Duration::max();
     }
 
-    return Duration{static_cast<SECONDS_TYPE>(secondsFull),
-                    static_cast<NANOSECONDS_TYPE>(secondsFraction * NANOSECS_PER_SEC)};
+    return Duration{static_cast<Seconds_t>(secondsFull),
+                    static_cast<Nanoseconds_t>(secondsFraction * NANOSECS_PER_SEC)};
 }
 
 template <typename T>
-inline constexpr Duration Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const
-    noexcept
+inline constexpr Duration
+Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept
 {
     // operator*(...) takes care of negative values for rhs
 
@@ -449,37 +447,37 @@ inline namespace duration_literals
 {
 inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept // PRQA S 48
 {
-    auto seconds = static_cast<Duration::SECONDS_TYPE>(value / Duration::NANOSECS_PER_SEC);
-    auto nanoseconds = static_cast<Duration::NANOSECONDS_TYPE>(value % Duration::NANOSECS_PER_SEC);
+    auto seconds = static_cast<Duration::Seconds_t>(value / Duration::NANOSECS_PER_SEC);
+    auto nanoseconds = static_cast<Duration::Nanoseconds_t>(value % Duration::NANOSECS_PER_SEC);
     return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _us(unsigned long long int value) noexcept // PRQA S 48
 {
-    auto seconds = static_cast<Duration::SECONDS_TYPE>(value / Duration::MICROSECS_PER_SEC);
-    auto nanoseconds = static_cast<Duration::NANOSECONDS_TYPE>((value % Duration::MICROSECS_PER_SEC)
-                                                               * Duration::NANOSECS_PER_MICROSEC);
+    auto seconds = static_cast<Duration::Seconds_t>(value / Duration::MICROSECS_PER_SEC);
+    auto nanoseconds =
+        static_cast<Duration::Nanoseconds_t>((value % Duration::MICROSECS_PER_SEC) * Duration::NANOSECS_PER_MICROSEC);
     return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept // PRQA S 48
 {
-    auto seconds = static_cast<Duration::SECONDS_TYPE>(value / Duration::MILLISECS_PER_SEC);
-    auto nanoseconds = static_cast<Duration::NANOSECONDS_TYPE>((value % Duration::MILLISECS_PER_SEC)
-                                                               * Duration::NANOSECS_PER_MILLISEC);
+    auto seconds = static_cast<Duration::Seconds_t>(value / Duration::MILLISECS_PER_SEC);
+    auto nanoseconds =
+        static_cast<Duration::Nanoseconds_t>((value % Duration::MILLISECS_PER_SEC) * Duration::NANOSECS_PER_MILLISEC);
     return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _s(unsigned long long int value) noexcept // PRQA S 48
 {
-    constexpr Duration::SECONDS_TYPE MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Duration::SECONDS_TYPE>::max()};
+    constexpr Duration::Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Duration::Seconds_t>::max()};
     if (value > MAX_SECONDS_BEFORE_OVERFLOW)
     {
         std::clog << __PRETTY_FUNCTION__ << ": Amount of seconds would overflow Duration, clamping to max value!"
                   << std::endl;
         return Duration::max();
     }
-    return Duration{static_cast<Duration::SECONDS_TYPE>(value), 0U};
+    return Duration{static_cast<Duration::Seconds_t>(value), 0U};
 }
 
 inline constexpr Duration operator"" _m(unsigned long long int value) noexcept // PRQA S 48
@@ -491,7 +489,7 @@ inline constexpr Duration operator"" _m(unsigned long long int value) noexcept /
                   << std::endl;
         return Duration::max();
     }
-    return Duration{static_cast<Duration::SECONDS_TYPE>(value * Duration::SECS_PER_MINUTE), 0U};
+    return Duration{static_cast<Duration::Seconds_t>(value * Duration::SECS_PER_MINUTE), 0U};
 }
 
 inline constexpr Duration operator"" _h(unsigned long long int value) noexcept // PRQA S 48
@@ -503,7 +501,7 @@ inline constexpr Duration operator"" _h(unsigned long long int value) noexcept /
                   << std::endl;
         return Duration::max();
     }
-    return Duration{static_cast<Duration::SECONDS_TYPE>(value * Duration::SECS_PER_HOUR), 0U};
+    return Duration{static_cast<Duration::Seconds_t>(value * Duration::SECS_PER_HOUR), 0U};
 }
 
 inline constexpr Duration operator"" _d(unsigned long long int value) noexcept // PRQA S 48
@@ -516,7 +514,7 @@ inline constexpr Duration operator"" _d(unsigned long long int value) noexcept /
                   << std::endl;
         return Duration::max();
     }
-    return Duration{static_cast<Duration::SECONDS_TYPE>(value * SECS_PER_DAY), 0U};
+    return Duration{static_cast<Duration::Seconds_t>(value * SECS_PER_DAY), 0U};
 }
 
 } // namespace duration_literals

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -129,12 +129,19 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
     return *this;
 }
 
+inline constexpr Duration Duration::createDuration(const SECONDS_TYPE seconds,
+                                                   const NANOSECONDS_TYPE nanoseconds) noexcept
+{
+    return Duration(seconds, nanoseconds);
+}
+
 inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 {
     constexpr SECONDS_TYPE MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max() / NANOSECS_PER_SEC};
     constexpr NANOSECONDS_TYPE MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<SECONDS_TYPE>::max()
                                                                % NANOSECS_PER_SEC};
-    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
+        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
     {
@@ -393,8 +400,8 @@ inline constexpr Duration Duration::fromFloatingPointSeconds(const T floatingPoi
 }
 
 template <typename T>
-inline constexpr Duration
-Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const noexcept
+inline constexpr Duration Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, T>& rhs) const
+    noexcept
 {
     // operator*(...) takes care of negative values for rhs
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -346,25 +346,6 @@ inline constexpr Duration Duration::operator*(const T& right) const noexcept
     return multiplySeconds<T>(m_seconds, right) + multiplyNanoseconds<T>(m_nanoseconds, right);
 }
 
-template <typename T>
-inline constexpr Duration Duration::operator/(const T& right) const noexcept
-{
-    static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
-
-    if (right < static_cast<T>(0))
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Result of division would be negative, clamping to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-
-    auto result = m_seconds / right;
-    double seconds{0.0};
-    double secondsFraction = modf(result, &seconds);
-    auto nanoseconds =
-        static_cast<uint64_t>(secondsFraction * NANOSECS_PER_SEC) + static_cast<uint64_t>(m_nanoseconds / right);
-    return Duration(static_cast<uint64_t>(seconds), 0U) + Duration::nanoseconds(nanoseconds);
-}
-
 inline namespace duration_literals
 {
 inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept // PRQA S 48

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,61 +21,102 @@ namespace iox
 namespace units
 {
 template <typename T>
-constexpr Duration Duration::nanoseconds(const T ns)
+constexpr Duration Duration::nanoseconds(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _ns(ns);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _ns(value);
 }
 template <typename T>
-constexpr Duration Duration::microseconds(const T us)
+constexpr Duration Duration::microseconds(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _us(us);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _us(value);
 }
 template <typename T>
-constexpr Duration Duration::milliseconds(const T ms)
+constexpr Duration Duration::milliseconds(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _ms(ms);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _ms(value);
 }
 template <typename T>
-constexpr Duration Duration::seconds(const T seconds)
+constexpr Duration Duration::seconds(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _s(seconds);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _s(value);
 }
 template <typename T>
-constexpr Duration Duration::minutes(const T min)
+constexpr Duration Duration::minutes(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _m(min);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _m(value);
 }
 template <typename T>
-constexpr Duration Duration::hours(const T hours)
+constexpr Duration Duration::hours(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _h(hours);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _h(value);
 }
 template <typename T>
-constexpr Duration Duration::days(const T days)
+constexpr Duration Duration::days(const T value)
 {
-    static_assert(std::numeric_limits<T>::is_integer && std::is_unsigned<T>::value,
-                  "only unsigned integer are supported");
-    return operator"" _d(days);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    if (value < 0)
+    {
+        return Duration{0U, 0U};
+    }
+    return operator"" _d(value);
 }
+
+
+inline constexpr Duration::Duration(const uint64_t seconds, const uint32_t nanoseconds)
+    : m_seconds(seconds)
+    , m_nanoseconds(nanoseconds)
+{
+    if(nanoseconds >= 1000000000U)
+    {
+        m_seconds += nanoseconds / 1000000000U;
+        m_nanoseconds = m_nanoseconds % 1000000000U;
+    }
+}
+
 inline constexpr Duration::Duration(const struct timeval& value)
-    : Duration(static_cast<long double>(value.tv_sec) + static_cast<long double>(value.tv_usec) / 1000000.0)
+    : Duration(static_cast<uint64_t>(value.tv_sec), static_cast<uint32_t>(value.tv_usec) * 1000U)
 {
 }
 
 inline constexpr Duration::Duration(const struct timespec& value)
-    : Duration(static_cast<long double>(value.tv_sec) + static_cast<long double>(value.tv_nsec) / 1000000000.0)
+    : Duration(static_cast<uint64_t>(value.tv_sec), static_cast<uint32_t>(value.tv_nsec))
 {
 }
 
@@ -85,78 +126,106 @@ inline constexpr Duration::Duration(const struct itimerspec& value)
 }
 
 inline constexpr Duration::Duration(const std::chrono::milliseconds& value)
-    : Duration(static_cast<long double>(value.count()) / 1000.0)
 {
+    auto milliseconds = value.count();
+    if (milliseconds > 0)
+    {
+        *this = operator"" _ms(static_cast<unsigned long long int>(milliseconds));
+    }
 }
 
 inline constexpr Duration::Duration(const std::chrono::nanoseconds& value)
-    : Duration(static_cast<long double>(value.count()) / 1000000000.0)
 {
+    auto nanoseconds = value.count();
+    if (nanoseconds > 0)
+    {
+        *this = operator"" _ns(static_cast<unsigned long long int>(nanoseconds));
+    }
 }
 
 inline Duration& Duration::operator=(const std::chrono::milliseconds& right)
 {
-    durationInSeconds = static_cast<long double>(right.count()) / 1000.0;
+    *this = Duration(right);
     return *this;
-}
-
-inline constexpr Duration::Duration(const long double durationInSeconds)
-    : durationInSeconds(durationInSeconds >= 0.0 ? durationInSeconds : 0.0)
-{
 }
 
 template <typename T>
 inline constexpr T Duration::nanoSeconds() const
 {
-    return static_cast<T>(durationInSeconds * 1000000000.0);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    return static_cast<T>(m_seconds * 1000000000U + m_nanoseconds);
 }
 
 template <typename T>
 inline constexpr T Duration::microSeconds() const
 {
-    return static_cast<T>(durationInSeconds * 1000000.0);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    return static_cast<T>(m_seconds * 1000000U + m_nanoseconds / 1000U);
 }
 
 template <typename T>
 inline constexpr T Duration::milliSeconds() const
 {
-    return static_cast<T>(durationInSeconds * 1000.0);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    return static_cast<T>(m_seconds * 1000U + m_nanoseconds / 1000000U);
 }
 
 template <typename T>
 inline constexpr T Duration::seconds() const
 {
-    return static_cast<T>(durationInSeconds);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
+    return static_cast<T>(m_seconds);
 }
 
 template <typename T>
 inline constexpr T Duration::minutes() const
 {
-    return static_cast<T>(durationInSeconds / 60.0);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
+    return static_cast<T>(m_seconds / 60U);
 }
 
 template <typename T>
 inline constexpr T Duration::hours() const
 {
-    return static_cast<T>(durationInSeconds / 3600.0);
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
+    return static_cast<T>(m_seconds / 3600U);
 }
 
 template <typename T>
 inline constexpr T Duration::days() const
 {
-    return static_cast<T>(durationInSeconds / (24.0 * 3600.0));
+    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+
+    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
+    return static_cast<T>(m_seconds / (24U * 3600U));
 }
 
 inline constexpr Duration::operator timeval() const
 {
     using SEC_TYPE = decltype(timeval::tv_sec);
     using USEC_TYPE = decltype(timeval::tv_usec);
-    return {this->seconds<SEC_TYPE>(), this->microSeconds<USEC_TYPE>() - this->seconds<USEC_TYPE>() * 1000000};
+    return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / 1000U)};
 }
 
 inline constexpr bool Duration::operator==(const Duration& right) const
 {
-    return durationInSeconds == right.durationInSeconds;
+    return (m_seconds == right.m_seconds) && (m_nanoseconds == right.m_nanoseconds);
 }
 
 inline constexpr bool Duration::operator!=(const Duration& right) const
@@ -166,91 +235,174 @@ inline constexpr bool Duration::operator!=(const Duration& right) const
 
 inline constexpr bool Duration::operator<(const Duration& right) const
 {
-    return durationInSeconds < right.durationInSeconds;
+    return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds < right.m_nanoseconds));
 }
 
 inline constexpr bool Duration::operator<=(const Duration& right) const
 {
-    return durationInSeconds <= right.durationInSeconds;
+    return (m_seconds < right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds <= right.m_nanoseconds));
 }
 
 inline constexpr bool Duration::operator>(const Duration& right) const
 {
-    return durationInSeconds > right.durationInSeconds;
+    return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds > right.m_nanoseconds));
 }
 
 inline constexpr bool Duration::operator>=(const Duration& right) const
 {
-    return durationInSeconds >= right.durationInSeconds;
+    return (m_seconds > right.m_seconds) || ((m_seconds == right.m_seconds) && (m_nanoseconds >= right.m_nanoseconds));
 }
 
 inline constexpr Duration Duration::operator+(const Duration& right) const
 {
-    return Duration{durationInSeconds + right.durationInSeconds};
+    /// @todo decide if we want an overflow or saturation
+
+    auto seconds = m_seconds + right.m_seconds;
+    auto nanoseconds = m_nanoseconds + right.m_nanoseconds;
+    if (nanoseconds >= 1000000000U)
+    {
+        ++seconds;
+        nanoseconds -= 1000000000U;
+    }
+    return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration Duration::operator-(const Duration& right) const
 {
-    return Duration{durationInSeconds - right.durationInSeconds};
+    if (*this <= right)
+    {
+        return Duration(0U, 0U);
+    }
+    auto seconds = m_seconds - right.m_seconds;
+    uint32_t nanoseconds{0};
+    if (m_nanoseconds >= right.m_nanoseconds)
+    {
+        nanoseconds = m_nanoseconds - right.m_nanoseconds;
+    }
+    else
+    {
+        nanoseconds = 1000000000U - right.m_nanoseconds - m_nanoseconds;
+        --seconds;
+    }
+    return Duration{seconds, nanoseconds};
 }
 
-inline constexpr Duration Duration::operator*(const Duration& right) const
+template <typename T>
+inline constexpr Duration
+Duration::multiplicateSeconds(const uint64_t seconds,
+                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
 {
-    return Duration{durationInSeconds * right.durationInSeconds};
+    // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
+    // operator*(...) takes care of negative values for right
+    return Duration(seconds * static_cast<uint64_t>(right), 0U);
 }
 
-inline constexpr Duration Duration::operator/(const Duration& right) const
+template <typename T>
+inline constexpr Duration
+Duration::multiplicateSeconds(const uint64_t seconds,
+                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
 {
-    return Duration{durationInSeconds / right.durationInSeconds};
+    // operator*(...) takes care of negative values for right
+    auto result = seconds * right;
+    double resultSeconds{0.0};
+    double secondsFraction = modf(result, &resultSeconds);
+    return Duration(static_cast<uint64_t>(resultSeconds), 0U)
+           + Duration::nanoseconds(static_cast<uint64_t>(secondsFraction * 1000000000U));
+}
+
+template <typename T>
+inline constexpr Duration
+Duration::multiplicateNanoseconds(const uint32_t nanoseconds,
+                                  const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
+{
+    // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
+    // operator*(...) takes care of negative values for right
+    return Duration::nanoseconds(nanoseconds * static_cast<uint64_t>(right));
+}
+
+template <typename T>
+inline constexpr Duration
+Duration::multiplicateNanoseconds(const uint32_t nanoseconds,
+                                  const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
+{
+    // operator*(...) takes care of negative values for right
+    return Duration::nanoseconds(static_cast<uint64_t>(nanoseconds * right));
 }
 
 template <typename T>
 inline constexpr Duration Duration::operator*(const T& right) const
 {
-    return Duration{durationInSeconds * static_cast<long double>(right)};
+    static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
+
+    if (right < static_cast<T>(0))
+    {
+        return Duration{0U, 0U};
+    }
+
+    /// @todo decide if we want an overflow or saturation
+
+    return multiplicateSeconds<T>(m_seconds, right) + multiplicateNanoseconds<T>(m_nanoseconds, right);
 }
 
 template <typename T>
 inline constexpr Duration Duration::operator/(const T& right) const
 {
-    return Duration{durationInSeconds / static_cast<long double>(right)};
+    static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
+
+    if (right < static_cast<T>(0))
+    {
+        return Duration{0U, 0U};
+    }
+
+    auto result = m_seconds / right;
+    double seconds{0.0};
+    double secondsFraction = modf(result, &seconds);
+    auto nanoseconds =
+        static_cast<uint64_t>(secondsFraction * 1000000000U) + static_cast<uint64_t>(m_nanoseconds / right);
+    return Duration(static_cast<uint64_t>(seconds), 0U) + Duration::nanoseconds(nanoseconds);
 }
 
 inline namespace duration_literals
 {
 inline constexpr Duration operator"" _ns(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) / 1000000000.0};
+    auto seconds = static_cast<uint64_t>(value / 1000000000U);
+    auto nanoseconds = static_cast<uint32_t>(value % 1000000000U);
+    return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _us(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) / 1000000.0};
+    auto seconds = static_cast<uint64_t>(value / 1000000U);
+    auto nanoseconds = static_cast<uint32_t>(value % 1000000U) * 1000U;
+    return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _ms(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) / 1000.0};
+    auto seconds = static_cast<uint64_t>(value / 1000U);
+    auto nanoseconds = static_cast<uint32_t>(value % 1000U) * 1000000U;
+    return Duration{seconds, nanoseconds};
 }
 
 inline constexpr Duration operator"" _s(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value)};
+    return Duration{static_cast<uint64_t>(value), 0U};
 }
 
 inline constexpr Duration operator"" _m(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) * 60.0};
+    return Duration{static_cast<uint64_t>(value * 60U), 0U};
 }
 
 inline constexpr Duration operator"" _h(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) * 3600.0};
+    return Duration{static_cast<uint64_t>(value * 3600U), 0U};
 }
 
 inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 48
 {
-    return Duration{static_cast<long double>(value) * 24.0 * 3600.0};
+    return Duration{static_cast<uint64_t>(value * 24U * 3600U), 0U};
 }
 
 } // namespace duration_literals
@@ -258,13 +410,14 @@ inline constexpr Duration operator"" _d(unsigned long long int value) // PRQA S 
 template <typename T>
 inline constexpr Duration operator*(const T& left, const Duration& right)
 {
-    return Duration(static_cast<long double>(left) * right.seconds<long double>());
-}
+    static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
-template <typename T>
-inline constexpr Duration operator/(const T& left, const Duration& right)
-{
-    return Duration(static_cast<long double>(left) / right.seconds<long double>());
+    if (left < static_cast<T>(0))
+    {
+        return Duration{0U, 0U};
+    }
+
+    return right * left;
 }
 
 } // namespace units

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -301,7 +301,7 @@ inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcep
 
 inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcept
 {
-    if (*this <= rhs)
+    if (*this < rhs)
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of subtraction would be negative, clamping to zero!" << std::endl;
         return Duration(0U, 0U);
@@ -314,7 +314,7 @@ inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcep
     }
     else
     {
-        nanoseconds = NANOSECS_PER_SEC - rhs.m_nanoseconds - m_nanoseconds;
+        nanoseconds = NANOSECS_PER_SEC - rhs.m_nanoseconds + m_nanoseconds;
         --seconds;
     }
     return Duration{seconds, nanoseconds};

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -177,41 +177,53 @@ inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 
 inline constexpr uint64_t Duration::microSeconds() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    constexpr uint64_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MICROSECS_PER_SEC};
+    constexpr uint64_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC) * NANOSECS_PER_MICROSEC};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
+
+    if (*this > MAX_DURATION_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
+        << std::endl;
+        return std::numeric_limits<uint64_t>::max();
+    }
+
     return m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC;
 }
 
 inline constexpr uint64_t Duration::milliSeconds() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
+    constexpr uint64_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MILLISECS_PER_SEC};
+    constexpr uint64_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC) * NANOSECS_PER_MILLISEC};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
+
+    if (*this > MAX_DURATION_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
+        << std::endl;
+        return std::numeric_limits<uint64_t>::max();
+    }
+
     return m_seconds * MILLISECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MILLISEC;
 }
 
 inline constexpr uint64_t Duration::seconds() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
     return m_seconds;
 }
 
 inline constexpr uint64_t Duration::minutes() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
     return m_seconds / SECS_PER_MINUTE;
 }
 
 inline constexpr uint64_t Duration::hours() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
     return m_seconds / SECS_PER_HOUR;
 }
 
 inline constexpr uint64_t Duration::days() const noexcept
 {
-    /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
     return m_seconds / (HOURS_PER_DAY * SECS_PER_HOUR);
 }
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -20,91 +20,55 @@ namespace iox
 {
 namespace units
 {
-template <typename T>
-constexpr Duration Duration::nanoseconds(const T value) noexcept
+template <typename T, typename String>
+inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value, const String fromMethod)
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
+    static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
     if (value < 0)
     {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
+        std::clog << fromMethod << ": Clamping negative value '" << value << "' to zero!" << std::endl;
+        return 0U;
     }
-    return operator"" _ns(static_cast<unsigned long long int>(value));
+
+    return static_cast<unsigned long long int>(value);
+}
+
+template <typename T>
+constexpr Duration Duration::nanoseconds(const T value) noexcept
+{
+    return operator"" _ns(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::microseconds(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _us(static_cast<unsigned long long int>(value));
+    return operator"" _us(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::milliseconds(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _ms(static_cast<unsigned long long int>(value));
+    return operator"" _ms(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::seconds(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _s(static_cast<unsigned long long int>(value));
+    return operator"" _s(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::minutes(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _m(static_cast<unsigned long long int>(value));
+    return operator"" _m(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::hours(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _h(static_cast<unsigned long long int>(value));
+    return operator"" _h(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::days(const T value) noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    if (value < 0)
-    {
-        std::clog << __PRETTY_FUNCTION__ << ": Clampling negative value '" << value << "' to zero!" << std::endl;
-        return Duration{0U, 0U};
-    }
-    return operator"" _d(static_cast<unsigned long long int>(value));
+    return operator"" _d(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
-
 
 inline constexpr Duration::Duration(const SECONDS_TYPE seconds, const NANOSECONDS_TYPE nanoseconds) noexcept
     : m_seconds(seconds)

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -159,81 +159,60 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
     return *this;
 }
 
-template <typename T>
-inline constexpr T Duration::nanoSeconds() const noexcept
+inline constexpr uint64_t Duration::nanoSeconds() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
-    constexpr uint64_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<T>::max() / NANOSECS_PER_SEC};
-    constexpr uint64_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<T>::max() % NANOSECS_PER_SEC};
+    constexpr uint64_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / NANOSECS_PER_SEC};
+    constexpr uint64_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() % NANOSECS_PER_SEC};
     constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
     {
         std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
                   << std::endl;
-        return std::numeric_limits<T>::max();
+        return std::numeric_limits<uint64_t>::max();
     }
 
-    return static_cast<T>(m_seconds * NANOSECS_PER_SEC + m_nanoseconds);
+    return m_seconds * NANOSECS_PER_SEC + m_nanoseconds;
 }
 
-template <typename T>
-inline constexpr T Duration::microSeconds() const noexcept
+inline constexpr uint64_t Duration::microSeconds() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    return static_cast<T>(m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC);
+    return m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC;
 }
 
-template <typename T>
-inline constexpr T Duration::milliSeconds() const noexcept
+inline constexpr uint64_t Duration::milliSeconds() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
-    return static_cast<T>(m_seconds * MILLISECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MILLISEC);
+    return m_seconds * MILLISECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MILLISEC;
 }
 
-template <typename T>
-inline constexpr T Duration::seconds() const noexcept
+inline constexpr uint64_t Duration::seconds() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
     // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
-    return static_cast<T>(m_seconds);
+    return m_seconds;
 }
 
-template <typename T>
-inline constexpr T Duration::minutes() const noexcept
+inline constexpr uint64_t Duration::minutes() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
     // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
-    return static_cast<T>(m_seconds / SECS_PER_MINUTE);
+    return m_seconds / SECS_PER_MINUTE;
 }
 
-template <typename T>
-inline constexpr T Duration::hours() const noexcept
+inline constexpr uint64_t Duration::hours() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
     // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
-    return static_cast<T>(m_seconds / SECS_PER_HOUR);
+    return m_seconds / SECS_PER_HOUR;
 }
 
-template <typename T>
-inline constexpr T Duration::days() const noexcept
+inline constexpr uint64_t Duration::days() const noexcept
 {
-    static_assert(std::numeric_limits<T>::is_integer, "only integer are supported");
-
     /// @todo decide if we want an overflow or saturation if the result is out of range for T
     // since currently only integers are supported, the nanoseconds would be rounded off and can be omitted
-    return static_cast<T>(m_seconds / (HOURS_PER_DAY * SECS_PER_HOUR));
+    return m_seconds / (HOURS_PER_DAY * SECS_PER_HOUR);
 }
 
 inline constexpr Duration::operator timeval() const noexcept

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -103,7 +103,7 @@ inline constexpr Duration::Duration(const uint64_t seconds, const uint32_t nanos
     : m_seconds(seconds)
     , m_nanoseconds(nanoseconds)
 {
-    if(nanoseconds >= 1000000000U)
+    if (nanoseconds >= 1000000000U)
     {
         m_seconds += nanoseconds / 1000000000U;
         m_nanoseconds = m_nanoseconds % 1000000000U;
@@ -289,8 +289,8 @@ inline constexpr Duration Duration::operator-(const Duration& right) const
 
 template <typename T>
 inline constexpr Duration
-Duration::multiplicateSeconds(const uint64_t seconds,
-                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
+Duration::multiplySeconds(const uint64_t seconds,
+                          const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
 {
     // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
     // operator*(...) takes care of negative values for right
@@ -299,8 +299,8 @@ Duration::multiplicateSeconds(const uint64_t seconds,
 
 template <typename T>
 inline constexpr Duration
-Duration::multiplicateSeconds(const uint64_t seconds,
-                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
+Duration::multiplySeconds(const uint64_t seconds,
+                          const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
 {
     // operator*(...) takes care of negative values for right
     auto result = seconds * right;
@@ -312,8 +312,8 @@ Duration::multiplicateSeconds(const uint64_t seconds,
 
 template <typename T>
 inline constexpr Duration
-Duration::multiplicateNanoseconds(const uint32_t nanoseconds,
-                                  const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
+Duration::multiplyNanoseconds(const uint32_t nanoseconds,
+                              const std::enable_if_t<!std::is_floating_point<T>::value, T>& right) const
 {
     // specialization is needed to prevent a clang warning if `right` is a signed integer and not casted to unsigned
     // operator*(...) takes care of negative values for right
@@ -322,8 +322,8 @@ Duration::multiplicateNanoseconds(const uint32_t nanoseconds,
 
 template <typename T>
 inline constexpr Duration
-Duration::multiplicateNanoseconds(const uint32_t nanoseconds,
-                                  const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
+Duration::multiplyNanoseconds(const uint32_t nanoseconds,
+                              const std::enable_if_t<std::is_floating_point<T>::value, T>& right) const
 {
     // operator*(...) takes care of negative values for right
     return Duration::nanoseconds(static_cast<uint64_t>(nanoseconds * right));
@@ -341,7 +341,7 @@ inline constexpr Duration Duration::operator*(const T& right) const
 
     /// @todo decide if we want an overflow or saturation
 
-    return multiplicateSeconds<T>(m_seconds, right) + multiplicateNanoseconds<T>(m_nanoseconds, right);
+    return multiplySeconds<T>(m_seconds, right) + multiplyNanoseconds<T>(m_nanoseconds, right);
 }
 
 template <typename T>

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -21,7 +21,7 @@ namespace iox
 namespace units
 {
 template <typename T, typename String>
-inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value, const String fromMethod)
+inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value, const String fromMethod) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
@@ -92,7 +92,7 @@ inline constexpr Duration::Duration(const SECONDS_TYPE seconds, const NANOSECOND
     }
 }
 
-inline constexpr Duration Duration::max()
+inline constexpr Duration Duration::max() noexcept
 {
     return Duration{std::numeric_limits<SECONDS_TYPE>::max(), NANOSECS_PER_SEC - 1U};
 }

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -452,22 +452,51 @@ inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept 
 
 inline constexpr Duration operator"" _s(unsigned long long int value) noexcept // PRQA S 48
 {
+    constexpr uint64_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max()};
+    if (value > MAX_SECONDS_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Amount of seconds would overflow Duration, clamping to max value!"
+                  << std::endl;
+        return Duration{std::numeric_limits<uint64_t>::max(), Duration::NANOSECS_PER_SEC - 1U};
+    }
     return Duration{static_cast<uint64_t>(value), 0U};
 }
 
 inline constexpr Duration operator"" _m(unsigned long long int value) noexcept // PRQA S 48
 {
+    constexpr uint64_t MAX_MINUTES_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / Duration::SECS_PER_MINUTE};
+    if (value > MAX_MINUTES_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Amount of minutes would overflow Duration, clamping to max value!"
+                  << std::endl;
+        return Duration{std::numeric_limits<uint64_t>::max(), Duration::NANOSECS_PER_SEC - 1U};
+    }
     return Duration{static_cast<uint64_t>(value * Duration::SECS_PER_MINUTE), 0U};
 }
 
 inline constexpr Duration operator"" _h(unsigned long long int value) noexcept // PRQA S 48
 {
+    constexpr uint64_t MAX_HOURS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / Duration::SECS_PER_HOUR};
+    if (value > MAX_HOURS_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Amount of hours would overflow Duration, clamping to max value!"
+                  << std::endl;
+        return Duration{std::numeric_limits<uint64_t>::max(), Duration::NANOSECS_PER_SEC - 1U};
+    }
     return Duration{static_cast<uint64_t>(value * Duration::SECS_PER_HOUR), 0U};
 }
 
 inline constexpr Duration operator"" _d(unsigned long long int value) noexcept // PRQA S 48
 {
-    return Duration{static_cast<uint64_t>(value * Duration::HOURS_PER_DAY * Duration::SECS_PER_HOUR), 0U};
+    constexpr uint64_t SECS_PER_DAY{Duration::HOURS_PER_DAY * Duration::SECS_PER_HOUR};
+    constexpr uint64_t MAX_DAYS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / SECS_PER_DAY};
+    if (value > MAX_DAYS_BEFORE_OVERFLOW)
+    {
+        std::clog << __PRETTY_FUNCTION__ << ": Amount of days would overflow Duration, clamping to max value!"
+                  << std::endl;
+        return Duration{std::numeric_limits<uint64_t>::max(), Duration::NANOSECS_PER_SEC - 1U};
+    }
+    return Duration{static_cast<uint64_t>(value * SECS_PER_DAY), 0U};
 }
 
 } // namespace duration_literals

--- a/iceoryx_utils/source/posix_wrapper/timer.cpp
+++ b/iceoryx_utils/source/posix_wrapper/timer.cpp
@@ -452,7 +452,7 @@ Timer::Timer(const units::Duration timeToWait) noexcept
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.nanoSeconds<uint64_t>() == 0u)
+    if (m_timeToWait.nanoSeconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
     }
@@ -462,7 +462,7 @@ Timer::Timer(const units::Duration timeToWait, const std::function<void()>& call
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.nanoSeconds<uint64_t>() == 0u)
+    if (m_timeToWait.nanoSeconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
         return;
@@ -499,7 +499,7 @@ cxx::expected<TimerError> Timer::stop() noexcept
 cxx::expected<TimerError>
 Timer::restart(const units::Duration timeToWait, const RunMode runMode, const CatchUpPolicy catchUpPolicy) noexcept
 {
-    if (timeToWait.nanoSeconds<uint64_t>() == 0u)
+    if (timeToWait.nanoSeconds() == 0U)
     {
         return cxx::error<TimerError>(TimerError::TIMEOUT_IS_ZERO);
     }

--- a/iceoryx_utils/source/units/duration.cpp
+++ b/iceoryx_utils/source/units/duration.cpp
@@ -23,21 +23,21 @@ namespace units
 {
 struct timespec Duration::timespec(const TimeSpecReference& reference) const noexcept
 {
-    using SECONDS_TYPE = decltype(std::declval<struct timespec>().tv_sec);
-    using NANOSECONDS_TYPE = decltype(std::declval<struct timespec>().tv_nsec);
+    using SEC_TYPE = decltype(std::declval<struct timespec>().tv_sec);
+    using NSEC_TYPE = decltype(std::declval<struct timespec>().tv_nsec);
 
     if (reference == TimeSpecReference::None)
     {
-        static_assert(sizeof(uint64_t) >= sizeof(SECONDS_TYPE), "casting might alter result");
-        if (this->m_seconds > static_cast<uint64_t>(std::numeric_limits<SECONDS_TYPE>::max()))
+        static_assert(sizeof(uint64_t) >= sizeof(SEC_TYPE), "casting might alter result");
+        if (this->m_seconds > static_cast<uint64_t>(std::numeric_limits<SEC_TYPE>::max()))
         {
             std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
                       << std::endl;
-            return {std::numeric_limits<SECONDS_TYPE>::max(), NANOSECS_PER_SEC - 1U};
+            return {std::numeric_limits<SEC_TYPE>::max(), NANOSECS_PER_SEC - 1U};
         }
 
-        auto tv_sec = static_cast<SECONDS_TYPE>(this->m_seconds);
-        auto tv_nsec = static_cast<NANOSECONDS_TYPE>(this->m_nanoseconds);
+        auto tv_sec = static_cast<SEC_TYPE>(this->m_seconds);
+        auto tv_nsec = static_cast<NSEC_TYPE>(this->m_nanoseconds);
         return {tv_sec, tv_nsec};
     }
     else
@@ -57,16 +57,16 @@ struct timespec Duration::timespec(const TimeSpecReference& reference) const noe
         {
             auto targetTime = Duration(referenceTime) + *this;
 
-            static_assert(sizeof(uint64_t) >= sizeof(SECONDS_TYPE), "casting might alter result");
-            if (targetTime.m_seconds > static_cast<uint64_t>(std::numeric_limits<SECONDS_TYPE>::max()))
+            static_assert(sizeof(uint64_t) >= sizeof(SEC_TYPE), "casting might alter result");
+            if (targetTime.m_seconds > static_cast<uint64_t>(std::numeric_limits<SEC_TYPE>::max()))
             {
                 std::clog << __PRETTY_FUNCTION__ << ": Result of conversion would overflow, clamping to max value!"
                           << std::endl;
-                return {std::numeric_limits<SECONDS_TYPE>::max(), NANOSECS_PER_SEC - 1U};
+                return {std::numeric_limits<SEC_TYPE>::max(), NANOSECS_PER_SEC - 1U};
             }
 
-            auto tv_sec = static_cast<SECONDS_TYPE>(targetTime.m_seconds);
-            auto tv_nsec = static_cast<NANOSECONDS_TYPE>(targetTime.m_nanoseconds);
+            auto tv_sec = static_cast<SEC_TYPE>(targetTime.m_seconds);
+            auto tv_nsec = static_cast<NSEC_TYPE>(targetTime.m_nanoseconds);
             return {tv_sec, tv_nsec};
         }
     }

--- a/iceoryx_utils/source/units/duration.cpp
+++ b/iceoryx_utils/source/units/duration.cpp
@@ -21,7 +21,7 @@ namespace iox
 {
 namespace units
 {
-struct timespec Duration::timespec(const TimeSpecReference& reference) const
+struct timespec Duration::timespec(const TimeSpecReference& reference) const noexcept
 {
     if (reference == TimeSpecReference::None)
     {
@@ -52,7 +52,7 @@ struct timespec Duration::timespec(const TimeSpecReference& reference) const
     }
 }
 
-std::ostream& operator<<(std::ostream& stream, const units::Duration& t)
+std::ostream& operator<<(std::ostream& stream, const units::Duration& t) noexcept
 {
     stream << t.m_seconds << "s " << t.m_nanoseconds << "ns ";
     return stream;

--- a/iceoryx_utils/source/units/duration.cpp
+++ b/iceoryx_utils/source/units/duration.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_utils/source/units/duration.cpp
+++ b/iceoryx_utils/source/units/duration.cpp
@@ -74,7 +74,7 @@ struct timespec Duration::timespec(const TimeSpecReference& reference) const noe
 
 std::ostream& operator<<(std::ostream& stream, const units::Duration& t) noexcept
 {
-    stream << t.m_seconds << "s " << t.m_nanoseconds << "ns ";
+    stream << t.m_seconds << "s " << t.m_nanoseconds << "ns";
     return stream;
 }
 

--- a/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
@@ -47,7 +47,7 @@ class DeadlineTimer_test : public Test
 };
 
 const Duration DeadlineTimer_test::TIMEOUT{10_ms};
-const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.milliSeconds<int>();
+const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.milliSeconds();
 
 TIMING_TEST_F(DeadlineTimer_test, ZeroTimeoutTest, Repeat(5), [&] {
     Timer sut(0_s);
@@ -120,7 +120,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfExpired, Repeat(5), [&] {
 
     TIMING_TEST_ASSERT_TRUE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().milliSeconds<int>();
+    int remainingTime = sut.remainingTime().milliSeconds();
     const int EXPECTED_REMAINING_TIME = 0; // the timer is expired the remaining wait time is Zero
     TIMING_TEST_EXPECT_TRUE(remainingTime == EXPECTED_REMAINING_TIME);
 });
@@ -131,7 +131,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfNotExpired, Repeat(5), [&]
 
     TIMING_TEST_ASSERT_FALSE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().milliSeconds<int>();
+    int remainingTime = sut.remainingTime().milliSeconds();
     const int PASSED_TIMER_TIME = SLEEPTIME; // Already 10ms passed in sleeping out of 20ms
     const int RANGE_APPROX = 2;              // 2ms arppoximation. This may be lost after arming the timer in execution.
     const int EXPECTED_REMAINING_TIME = PASSED_TIMER_TIME - RANGE_APPROX;

--- a/iceoryx_utils/test/moduletests/test_ipc_channel.cpp
+++ b/iceoryx_utils/test/moduletests/test_ipc_channel.cpp
@@ -94,8 +94,9 @@ TYPED_TEST(IpcChannel_test, createNoName)
 
 TYPED_TEST(IpcChannel_test, createWithLeadingSlash)
 {
-    auto serverResult = TestFixture::IpcChannelType::create(slashName, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER);
-    EXPECT_FALSE(serverResult.has_error());  
+    auto serverResult =
+        TestFixture::IpcChannelType::create(slashName, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER);
+    EXPECT_FALSE(serverResult.has_error());
 }
 
 TYPED_TEST(IpcChannel_test, createAgain)
@@ -341,11 +342,11 @@ TYPED_TEST(IpcChannel_test, timedSend)
         {
             ASSERT_THAT(result.get_error(), Eq(IpcChannelError::TIMEOUT));
             // Do not exceed timeout
-            auto timeDiff_ms = duration_cast<milliseconds>(after - before);
-            EXPECT_LT(timeDiff_ms.count(), (maxTimeout + maxTimeoutTolerance).milliSeconds<int64_t>());
+            auto timeDiff = units::Duration(after - before);
+            EXPECT_LT(timeDiff, maxTimeout + maxTimeoutTolerance);
 
             // Check if timedSend has blocked for ~maxTimeout and has not returned immediately
-            EXPECT_GT(timeDiff_ms.count(), (maxTimeout - minTimeoutTolerance).milliSeconds<int64_t>());
+            EXPECT_GT(timeDiff, maxTimeout - minTimeoutTolerance);
 
             break;
         }
@@ -378,10 +379,10 @@ TYPED_TEST(IpcChannel_test, timedReceive)
     ASSERT_THAT(received.get_error(), Eq(IpcChannelError::TIMEOUT));
 
     // Do not exceed timeout
-    auto timeDiff_ms = duration_cast<milliseconds>(after - before);
-    EXPECT_LT(timeDiff_ms.count(), (timeout + maxTimeoutTolerance).milliSeconds<int64_t>());
+    auto timeDiff = units::Duration(after - before);
+    EXPECT_LT(timeDiff, timeout + maxTimeoutTolerance);
 
     // Check if timedReceive has blocked for ~timeout and has not returned immediately
-    EXPECT_GT(timeDiff_ms.count(), (timeout - minTimeoutTolerance).milliSeconds<int64_t>());
+    EXPECT_GT(timeDiff, timeout - minTimeoutTolerance);
 }
 #endif

--- a/iceoryx_utils/test/moduletests/test_posix_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_posix_timer.cpp
@@ -76,7 +76,7 @@ TIMING_TEST_F(Timer_test, CallbackNotExecutedWhenNotStarted, Repeat(5), [&] {
     bool callbackExecuted{false};
     Timer sut(TIMEOUT, [&] { callbackExecuted = true; });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
 
     TIMING_TEST_EXPECT_ALWAYS_FALSE(callbackExecuted);
 });
@@ -94,7 +94,7 @@ TIMING_TEST_F(Timer_test, CallbackExecutedPeriodicallyAfterStart, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 11);
@@ -104,7 +104,7 @@ TIMING_TEST_F(Timer_test, PeriodicCallbackNotExecutedPrematurely, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -112,7 +112,7 @@ TIMING_TEST_F(Timer_test, OneTimeCallbackNotExecutedPrematurely, Repeat(5), [&] 
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -130,7 +130,7 @@ TIMING_TEST_F(Timer_test, StartRunModeOnceIsStoppedAfterStop, Repeat(5), [&] {
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -140,7 +140,7 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedAfterStop, Repeat(5), [&]
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -149,10 +149,10 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedInTheMiddleAfterStop, Rep
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
     sut.stop();
     auto previousCount = counter.load();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(previousCount == counter.load());
 });
@@ -170,10 +170,10 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTiming, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 10, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.milliSeconds()));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -183,15 +183,15 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
     sut.restart(TIMEOUT, Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
 });
 
@@ -199,11 +199,11 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTimingAndRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 2, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.milliSeconds()));
     counter = 0;
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
 
     auto finalCount = counter.load();
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -239,24 +239,24 @@ TEST_F(Timer_test, TimeUntilExpirationFailsWithoutCallback)
 TIMING_TEST_F(Timer_test, TimeUntilExpirationWithCallback, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    int timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds<int>();
-    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.milliSeconds<int>() / 3);
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
+    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.milliSeconds() / 3);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds<int>() / 3));
-    timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds<int>();
-    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.milliSeconds<int>() / 3);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
+    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.milliSeconds() / 3);
 });
 
 TIMING_TEST_F(Timer_test, TimeUntilExpirationZeroAfterCallbackOnceCalled, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
-    int timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds<int>();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
     TIMING_TEST_EXPECT_TRUE(timeUntilExpiration == 0);
 });
 
 TIMING_TEST_F(Timer_test, StoppingIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -286,14 +286,14 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningContinuously, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
 
     for (auto& sut : sutList)
     {
         sut.timer.stop();
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
 
     for (auto& sut : sutList)
     {
@@ -319,7 +319,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds<int>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
 
     for (auto& sut : sutList)
     {
@@ -330,8 +330,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
 TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
     std::chrono::time_point<std::chrono::system_clock> startTime;
     {
-        Timer sut(1_ns,
-                  [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+        Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
         sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         startTime = std::chrono::system_clock::now();
@@ -343,7 +342,7 @@ TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
 });
 
 TIMING_TEST_F(Timer_test, StartStopAndStartAgainIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -370,12 +369,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatContinuesWhenCallbackIsLong
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT,
-              [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -384,12 +382,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateContinuesWhenCallbackIsLongerThe
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT,
-              [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -398,12 +395,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyTerminateTerminatesWhenCallbackIsLongerTh
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT,
-              [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
 
@@ -412,13 +408,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyChangeToTerminateChangesBehaviorToTermina
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT,
-              [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
 
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
@@ -428,12 +423,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatSkipsCallbackWhenStillRunni
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds<int>() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
     // every second callback is skipped since the runtime is slightly longer therefore
     // the counter must be in that range
     TIMING_TEST_EXPECT_TRUE(40 <= counter && counter <= 70);
@@ -444,12 +439,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateCallsCallbackImmediatelyAfterFin
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds<int>() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
 
     // the asap timer should in theory call the callback 90 times since it is calling it right
     // after the last one finished and one callback takes 1.1 ms and we run for 100ms.
@@ -461,17 +456,17 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatCallsLessCallbacksThanASAPT
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds<int>() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
     int softTimerCounter = counter.load();
     sut.stop();
 
     counter.store(0);
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds<int>() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
     int asapTimerCounter = counter.load();
     sut.stop();
 

--- a/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
+++ b/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
@@ -74,7 +74,7 @@ class Semaphore_test : public TestWithParam<CreateSemaphore*>
         }
     }
 
-    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).nanoSeconds<long>()};
+    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).nanoSeconds()};
 
     iox::posix::Semaphore* sut{nullptr};
     iox::posix::Semaphore* syncSemaphore = [] {

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -93,7 +93,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
     EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
-TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValue)
+TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
 {
     constexpr uint64_t MAX_SECONDS_FOR_CTOR{std::numeric_limits<uint64_t>::max()};
     constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<uint32_t>::max()};

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -1513,4 +1513,25 @@ TEST(Duration_test, MultiplyDurationWithMinimalDoubleResultsInZero)
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
 }
 
+TEST(Duration_test, StreamingOperator)
+{
+    std::stringstream capture;
+    auto clogBuffer = std::clog.rdbuf();
+    std::clog.rdbuf(capture.rdbuf());
+
+    capture.str("");
+    std::clog << 0_s;
+    EXPECT_STREQ(capture.str().c_str(), "0s 0ns");
+
+    capture.str("");
+    std::clog << 42_ns;
+    EXPECT_STREQ(capture.str().c_str(), "0s 42ns");
+
+    capture.str("");
+    std::clog << (13_s + 73_ms + 37_us + 42_ns);
+    EXPECT_STREQ(capture.str().c_str(), "13s 73037042ns");
+
+    std::clog.rdbuf(clogBuffer);
+}
+
 // END ARITHMETIC TESTS

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -1816,14 +1816,29 @@ TEST(Duration_test, MultiplyDurationResultsInSaturationDueToNanoseconds)
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
 }
 
+TEST(Duration_test, MultiplyZeroDurationWithNaNDoubleResultsInZeroDuration)
+{
+    EXPECT_THAT(0_s * NAN, Eq(0_s));
+}
+
 TEST(Duration_test, MultiplyMaxDurationWithNaNDoubleResultsInMaxDuration)
 {
     EXPECT_THAT(DurationFactory::max() * NAN, Eq(DurationFactory::max()));
 }
 
+TEST(Duration_test, MultiplyZeroDurationWithPosInfDoubleResultsInZeroDuration)
+{
+    EXPECT_THAT(0_s * INFINITY, Eq(0_ns));
+}
+
 TEST(Duration_test, MultiplyMaxDurationWithPosInfDoubleResultsInMaxDuration)
 {
     EXPECT_THAT(DurationFactory::max() * INFINITY, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyZeroDurationWithNegInfDoubleResultsInZeroDuration)
+{
+    EXPECT_THAT(0_s * (INFINITY * -1.0), Eq(0_ns));
 }
 
 TEST(Duration_test, MultiplyMaxDurationWithNegInfDoubleResultsInZeroDuration)

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -1512,6 +1512,17 @@ TEST(Duration_test, SubstractDurationWithTwoZeroDurationsResultsInZeroDuration)
     EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
+TEST(Duration_test, SubstractDurationWithDurationsWithSameValueResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration1 = DurationFactory{10U, 123U};
+    auto duration2 = DurationFactory{10U, 123U};
+
+    auto sut = duration1 - duration2;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
 TEST(Duration_test, SubstractDurationFromZeroDurationsResultsInZeroDuration)
 {
     constexpr Duration EXPECTED_DURATION{0_s};
@@ -1586,6 +1597,17 @@ TEST(Duration_test, SubstractDurationMoreThanOneSecondWithMoreThanOneSecondResul
     constexpr DurationFactory EXPECTED_DURATION{0U, 36U};
     auto duration1 = DurationFactory{1U, 73U};
     auto duration2 = DurationFactory{1U, 37U};
+
+    auto sut = duration1 - duration2;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, SubstractDurationWithSecondsAndNanosecondsCausingReductionOfSeconds)
+{
+    constexpr DurationFactory EXPECTED_DURATION{0U, NANOSECS_PER_SECOND - 36U};
+    auto duration1 = DurationFactory{2U, 37U};
+    auto duration2 = DurationFactory{1U, 73U};
 
     auto sut = duration1 - duration2;
 

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -785,95 +785,267 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero
 
 // BEGIN CONVERSION FUNCTION TESTS
 
-TEST(Duration_test, ConvertDays)
+TEST(Duration_test, ConvertDaysFromZeroDuration)
 {
-    auto time = 10_d;
-    EXPECT_EQ(time.days(), 10U);
-    EXPECT_EQ(time.hours(), 240U);
-    EXPECT_EQ(time.minutes(), 14400U);
-    EXPECT_EQ(time.seconds(), 864000U);
-    EXPECT_EQ(time.milliSeconds(), 864000U * KILO);
-    EXPECT_EQ(time.microSeconds(), 864000U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 864000U * GIGA);
+    auto sut = 0_s;
+    EXPECT_THAT(sut.days(), Eq(0U));
 }
 
-TEST(Duration_test, ConvertHours)
+TEST(Duration_test, ConvertDaysFromDurationLessThanOneDay)
 {
-    auto time = 2_h;
-    EXPECT_EQ(time.days(), 0U);
-    EXPECT_EQ(time.hours(), 2U);
-    EXPECT_EQ(time.minutes(), 120U);
-    EXPECT_EQ(time.seconds(), 7200U);
-    EXPECT_EQ(time.milliSeconds(), 7200U * KILO);
-    EXPECT_EQ(time.microSeconds(), 7200U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 7200U * GIGA);
+    auto sut = 3473_s;
+    EXPECT_THAT(sut.days(), Eq(0U));
 }
 
-TEST(Duration_test, ConvertMinutes)
+TEST(Duration_test, ConvertDaysFromDurationMoreThanOneDay)
 {
-    auto time = 720_m;
-    EXPECT_EQ(time.days(), 0U);
-    EXPECT_EQ(time.hours(), 12U);
-    EXPECT_EQ(time.minutes(), 720U);
-    EXPECT_EQ(time.seconds(), 43200U);
-    EXPECT_EQ(time.milliSeconds(), 43200U * KILO);
-    EXPECT_EQ(time.microSeconds(), 43200U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 43200U * GIGA);
+    auto sut = 7_d + 3066_s;
+    EXPECT_THAT(sut.days(), Eq(7U));
 }
 
-TEST(Duration_test, ConvertSeconds)
+TEST(Duration_test, ConvertDaysFromMaxDuration)
 {
-    auto time = 28800_s;
-    EXPECT_EQ(time.days(), 0U);
-    EXPECT_EQ(time.hours(), 8U);
-    EXPECT_EQ(time.minutes(), 480U);
-    EXPECT_EQ(time.seconds(), 28800U);
-    EXPECT_EQ(time.milliSeconds(), 28800U * KILO);
-    EXPECT_EQ(time.microSeconds(), 28800U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 28800U * GIGA);
+    constexpr uint64_t SECONDS_PER_DAY{60U * 60U * 24U};
+    constexpr uint64_t EXPECTED_DAYS{std::numeric_limits<uint64_t>::max() / SECONDS_PER_DAY};
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.days(), Eq(EXPECTED_DAYS));
 }
 
-TEST(Duration_test, ConvertMilliseconds)
+TEST(Duration_test, ConvertHoursFromZeroDuration)
 {
-    auto time = 28800000_ms;
-    EXPECT_EQ(time.days(), 0U);
-    EXPECT_EQ(time.hours(), 8U);
-    EXPECT_EQ(time.minutes(), 480U);
-    EXPECT_EQ(time.seconds(), 28800U);
-    EXPECT_EQ(time.milliSeconds(), 28800U * KILO);
-    EXPECT_EQ(time.microSeconds(), 28800U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 28800U * GIGA);
+    auto sut = 0_s;
+    EXPECT_THAT(sut.hours(), Eq(0U));
 }
 
-TEST(Duration_test, ConvertMicroseconds)
+TEST(Duration_test, ConvertHoursFromDurationLessThanOneHour)
 {
-    auto time = 6000000_us;
-    EXPECT_EQ(time.days(), 0U);
-    EXPECT_EQ(time.hours(), 0U);
-    EXPECT_EQ(time.minutes(), 0U);
-    EXPECT_EQ(time.seconds(), 6U);
-    EXPECT_EQ(time.milliSeconds(), 6U * KILO);
-    EXPECT_EQ(time.microSeconds(), 6U * MEGA);
-    EXPECT_EQ(time.nanoSeconds(), 6U * GIGA);
+    auto sut = 37_m;
+    EXPECT_THAT(sut.hours(), Eq(0U));
 }
 
-TEST(Duration_test, ConvertNanoseconds)
+TEST(Duration_test, ConvertHoursFromDurationMoreThanOneHour)
 {
-    auto time = 1_ns;
-    EXPECT_EQ(time.seconds(), 0U);
-    EXPECT_EQ(time.milliSeconds(), 0U);
-    EXPECT_EQ(time.microSeconds(), 0U);
-    EXPECT_EQ(time.nanoSeconds(), 1U);
+    auto sut = 73_h + 42_m;
+    EXPECT_THAT(sut.hours(), Eq(73U));
 }
 
-TEST(Duration_test, ConvertTimespecWithNoneReference)
+TEST(Duration_test, ConvertHoursFromMaxDuration)
+{
+    constexpr uint64_t SECONDS_PER_HOUR{60U * 60U};
+    constexpr uint64_t EXPECTED_HOURS{std::numeric_limits<uint64_t>::max() / SECONDS_PER_HOUR};
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.hours(), Eq(EXPECTED_HOURS));
+}
+
+TEST(Duration_test, ConvertMinutesFromZeroDuration)
+{
+    auto sut = 0_s;
+    EXPECT_THAT(sut.minutes(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMinutesFromDurationLessThanOneMinute)
+{
+    auto sut = 34_s;
+    EXPECT_THAT(sut.minutes(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMinutesFromDurationMoreThanOneMinute)
+{
+    auto sut = 13_m + 42_s;
+    EXPECT_THAT(sut.minutes(), Eq(13U));
+}
+
+TEST(Duration_test, ConvertMinutesFromMaxDuration)
+{
+    constexpr uint64_t SECONDS_PER_MINUTE{60U};
+    constexpr uint64_t EXPECTED_MINUTES{std::numeric_limits<uint64_t>::max() / SECONDS_PER_MINUTE};
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.minutes(), Eq(EXPECTED_MINUTES));
+}
+
+TEST(Duration_test, ConvertSecondsFromZeroDuration)
+{
+    auto sut = 0_s;
+    EXPECT_THAT(sut.seconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertSecondsFromDurationLessThanOneSecond)
+{
+    auto sut = 737_ms;
+    EXPECT_THAT(sut.seconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertSecondsFromDurationMoreThanOneSecond)
+{
+    auto sut = 7_s + 833_ms;
+    EXPECT_THAT(sut.seconds(), Eq(7U));
+}
+
+TEST(Duration_test, ConvertSecondsFromMaxSecondsMinusOne)
+{
+    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<uint64_t>::max() - 1U};
+    auto sut = MAX_DURATION - 1_s;
+    EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
+}
+
+TEST(Duration_test, ConvertSecondsFromMaxDuration)
+{
+    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<uint64_t>::max()};
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
+}
+
+TEST(Duration_test, ConvertMillisecondsFromZeroDuration)
+{
+    auto sut = 0_s;
+    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMillisecondsFromDurationLessThanOneMillisecond)
+{
+    auto sut = 637_us;
+    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMilliecondsFromDurationMoreThanOneMillisecond)
+{
+    auto sut = 55_ms + 633_us;
+    EXPECT_THAT(sut.milliSeconds(), Eq(55U));
+}
+
+TEST(Duration_test, ConvertMillisecondsFromDurationResultsNotYetInSaturation)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<uint64_t>::max() - 1U};
+    auto sut = Duration::milliseconds(EXPECTED_MILLISECONDS);
+    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
+}
+
+TEST(Duration_test, ConvertMillisecondsFromMaxDurationResultsInSaturation)
+{
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.milliSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+}
+
+TEST(Duration_test, ConvertMicrosecondsFromZeroDuration)
+{
+    auto sut = 0_s;
+    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMicrosecondsFromDurationLessThanOneMicrosecond)
+{
+    auto sut = 733_ns;
+    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertMicrosecondsFromDurationMoreThanOneMicrosecond)
+{
+    auto sut = 555_us + 733_ns;
+    EXPECT_THAT(sut.microSeconds(), Eq(555U));
+}
+
+TEST(Duration_test, ConvertMicrosecondsFromDurationResultsNotYetInSaturation)
+{
+    constexpr uint64_t EXPECTED_MICROSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
+    auto sut = Duration::microseconds(EXPECTED_MICROSECONDS);
+    EXPECT_THAT(sut.microSeconds(), Eq(EXPECTED_MICROSECONDS));
+}
+
+TEST(Duration_test, ConvertMicroecondsFromMaxDurationResultsInSaturation)
+{
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.microSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+}
+
+TEST(Duration_test, ConvertNanosecondsFromZeroDuration)
+{
+    auto sut = 0_s;
+    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConvertNanosecondsFromDurationOfOneNanosecond)
+{
+    auto sut = 1_ns;
+    EXPECT_THAT(sut.nanoSeconds(), Eq(1U));
+}
+
+TEST(Duration_test, ConvertNanosecondsFromDurationMultipleNanoseconds)
+{
+    auto sut = 42_ns;
+    EXPECT_THAT(sut.nanoSeconds(), Eq(42U));
+}
+
+TEST(Duration_test, ConvertNanosecondsFromDurationResultsNotYetInSaturation)
+{
+    constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
+    auto sut = Duration::nanoseconds(EXPECTED_NANOSECONDS);
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+}
+
+TEST(Duration_test, ConvertNanoecondsFromMaxDurationResultsInSaturation)
+{
+    auto sut = MAX_DURATION;
+    EXPECT_THAT(sut.nanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+}
+
+TEST(Duration_test, ConvertTimespecWithNoneReferenceFromZeroDuration)
+{
+    constexpr int64_t SECONDS{0};
+    constexpr int64_t NANOSECONDS{0};
+
+    Duration duration{SECONDS, NANOSECONDS};
+
+    struct timespec sut = duration.timespec(iox::units::TimeSpecReference::None);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
+}
+
+TEST(Duration_test, ConvertTimespecWithNoneReferenceFromDurationLessThanOneSecond)
+{
+    constexpr int64_t SECONDS{0};
+    constexpr int64_t NANOSECONDS{55};
+
+    Duration duration{SECONDS, NANOSECONDS};
+
+    struct timespec sut = duration.timespec(iox::units::TimeSpecReference::None);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
+}
+
+TEST(Duration_test, ConvertTimespecWithNoneReferenceFromDurationMoreThanOneSecond)
 {
     constexpr int64_t SECONDS{44};
     constexpr int64_t NANOSECONDS{55};
 
     Duration duration{SECONDS, NANOSECONDS};
 
-    struct timespec sut = timespec(duration.timespec(iox::units::TimeSpecReference::None));
+    struct timespec sut = duration.timespec(iox::units::TimeSpecReference::None);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
+}
+
+TEST(Duration_test, ConvertTimespecWithNoneReferenceFromDurationResultsNotYetInSaturation)
+{
+    constexpr int64_t SECONDS{std::numeric_limits<int64_t>::max()};
+    constexpr int64_t NANOSECONDS{GIGA - 1U};
+
+    Duration duration{SECONDS, NANOSECONDS};
+
+    struct timespec sut = duration.timespec(iox::units::TimeSpecReference::None);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
+}
+
+TEST(Duration_test, ConvertTimespecWithNoneReferenceFromMaxDurationResultsInSaturation)
+{
+    constexpr int64_t SECONDS{std::numeric_limits<int64_t>::max()};
+    constexpr int64_t NANOSECONDS{GIGA - 1U};
+
+    struct timespec sut = MAX_DURATION.timespec(iox::units::TimeSpecReference::None);
 
     EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
     EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
@@ -896,6 +1068,17 @@ TEST(Duration_test, ConvertTimespecWithMonotonicReference)
     EXPECT_THAT(sut.tv_sec, Gt(secondsSinceMonotonicEpoch));
 }
 
+TEST(Duration_test, ConvertTimespecWithMonotonicReferenceFromMaxDurationResultsInSaturation)
+{
+    constexpr int64_t SECONDS{std::numeric_limits<int64_t>::max()};
+    constexpr int64_t NANOSECONDS{GIGA - 1U};
+
+    struct timespec sut = MAX_DURATION.timespec(iox::units::TimeSpecReference::Monotonic);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
+}
+
 TEST(Duration_test, ConvertTimespecWithEpochReference)
 {
     constexpr int64_t SECONDS{5};
@@ -909,6 +1092,17 @@ TEST(Duration_test, ConvertTimespecWithEpochReference)
     auto secondsSinceUnixEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeSinceUnixEpoch).count();
     EXPECT_THAT(10 * SECONDS, Lt(secondsSinceUnixEpoch));
     EXPECT_THAT(sut.tv_sec, Gt(secondsSinceUnixEpoch));
+}
+
+TEST(Duration_test, ConvertTimespecWithEpochReferenceFromMaxDurationResultsInSaturation)
+{
+    constexpr int64_t SECONDS{std::numeric_limits<int64_t>::max()};
+    constexpr int64_t NANOSECONDS{GIGA - 1U};
+
+    struct timespec sut = MAX_DURATION.timespec(iox::units::TimeSpecReference::Epoch);
+
+    EXPECT_THAT(sut.tv_sec, Eq(SECONDS));
+    EXPECT_THAT(sut.tv_nsec, Eq(NANOSECONDS));
 }
 
 // END CONVERSION FUNCTION TESTS

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -58,6 +58,17 @@ TEST(Duration_test, ConstructDurationWithMoreNanosecondsThanOneSecond)
     EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, ConstructDurationWithOneNanosecondIsNotSetToZero)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{1U};
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{NANOSECONDS};
+
+    auto sut = Duration{SECONDS, NANOSECONDS};
+
+    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
 TEST(Duration_test, ConstructFromTimespec)
 {
     constexpr uint64_t SECONDS{123U};

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -97,11 +97,11 @@ TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
 {
     constexpr uint64_t MAX_SECONDS_FOR_CTOR{std::numeric_limits<uint64_t>::max()};
     constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<uint32_t>::max()};
-    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{std::numeric_limits<uint64_t>::max()};
+    constexpr Duration EXPECTED_DURATION{MAX_SECONDS_FOR_CTOR, GIGA - 1U};
 
     auto sut = Duration{MAX_SECONDS_FOR_CTOR, MAX_NANOSECONDS_FOR_CTOR};
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
 TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanoseconds)
@@ -115,78 +115,273 @@ TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanosecond
     EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
-TEST(Duration_test, ConstructFromTimespec)
+TEST(Duration_test, ConstructFromTimespecWithZeroValue)
 {
-    constexpr uint64_t SECONDS{123U};
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{0U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct timespec ts;
+    ts.tv_sec = SECONDS;
+    ts.tv_nsec = NANOSECONDS;
+
+    Duration sut{ts};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromTimespecWithValueLessThanOneSecond)
+{
+    constexpr uint64_t SECONDS{0U};
     constexpr uint64_t NANOSECONDS{456U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
 
     struct timespec value;
     value.tv_sec = SECONDS;
     value.tv_nsec = NANOSECONDS;
 
     Duration sut{value};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(SECONDS * GIGA + NANOSECONDS));
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
-TEST(Duration_test, ConstructFromItimerspec)
+TEST(Duration_test, ConstructFromTimespecWithValueMoreThanOneSecond)
 {
-    constexpr uint64_t SECONDS{135U};
-    constexpr uint64_t NANOSECONDS{246U};
+    constexpr uint64_t SECONDS{73U};
+    constexpr uint64_t NANOSECONDS{456U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
 
-    struct itimerspec value;
-    value.it_interval.tv_sec = SECONDS;
-    value.it_interval.tv_nsec = NANOSECONDS;
+    struct timespec value;
+    value.tv_sec = SECONDS;
+    value.tv_nsec = NANOSECONDS;
 
     Duration sut{value};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(SECONDS * GIGA + NANOSECONDS));
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
-TEST(Duration_test, ConstructFromTimeval)
+TEST(Duration_test, ConstructFromTimespecWithMaxValue)
+{
+    constexpr uint64_t SECONDS{std::numeric_limits<uint64_t>::max()};
+    constexpr uint64_t NANOSECONDS{GIGA - 1U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct timespec ts;
+    ts.tv_sec = SECONDS;
+    ts.tv_nsec = NANOSECONDS;
+
+    Duration sut{ts};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromITimerspecWithZeroValue)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{0U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct itimerspec its;
+    its.it_interval.tv_sec = SECONDS;
+    its.it_interval.tv_nsec = NANOSECONDS;
+
+    Duration sut{its};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromITimerspecWithValueLessThanOneSecond)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{642U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct itimerspec its;
+    its.it_interval.tv_sec = SECONDS;
+    its.it_interval.tv_nsec = NANOSECONDS;
+
+    Duration sut{its};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromITimerspecWithValueMoreThanOneSecond)
+{
+    constexpr uint64_t SECONDS{13U};
+    constexpr uint64_t NANOSECONDS{42U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct itimerspec its;
+    its.it_interval.tv_sec = SECONDS;
+    its.it_interval.tv_nsec = NANOSECONDS;
+
+    Duration sut{its};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromITimerspecWithMaxValue)
+{
+    constexpr uint64_t SECONDS{std::numeric_limits<uint64_t>::max()};
+    constexpr uint64_t NANOSECONDS{GIGA - 1U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, NANOSECONDS};
+
+    struct itimerspec its;
+    its.it_interval.tv_sec = SECONDS;
+    its.it_interval.tv_nsec = NANOSECONDS;
+
+    Duration sut{its};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromTimevalWithZeroValue)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t MICROSECONDS{0U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, MICROSECONDS * KILO};
+
+    struct timeval tv;
+    tv.tv_sec = SECONDS;
+    tv.tv_usec = MICROSECONDS;
+
+    Duration sut{tv};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromTimevalWithValueLessThanOneSecond)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t MICROSECONDS{13U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, MICROSECONDS * KILO};
+
+    struct timeval tv;
+    tv.tv_sec = SECONDS;
+    tv.tv_usec = MICROSECONDS;
+
+    Duration sut{tv};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromTimevalWithValueMoreThanOneSecond)
 {
     constexpr uint64_t SECONDS{1337U};
     constexpr uint64_t MICROSECONDS{42U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, MICROSECONDS * KILO};
 
-    struct timeval value;
-    value.tv_sec = SECONDS;
-    value.tv_usec = MICROSECONDS;
+    struct timeval tv;
+    tv.tv_sec = SECONDS;
+    tv.tv_usec = MICROSECONDS;
 
-    Duration sut{value};
-    EXPECT_THAT(sut.microSeconds(), Eq(SECONDS * MEGA + MICROSECONDS));
+    Duration sut{tv};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
-TEST(Duration_test, ConstructFromChronoMilliseconds)
+TEST(Duration_test, ConstructFromTimevalWithMaxValue)
+{
+    constexpr uint64_t SECONDS{std::numeric_limits<uint64_t>::max()};
+    constexpr uint64_t MICROSECONDS{MEGA - 1U};
+    constexpr Duration EXPECTED_DURATION{SECONDS, MICROSECONDS * KILO};
+
+    struct timeval tv;
+    tv.tv_sec = SECONDS;
+    tv.tv_usec = MICROSECONDS;
+
+    Duration sut{tv};
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, ConstructFromChronoMillisecondsZero)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{0U};
+    Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, ConstructFromChronoMillisecondsLessThanOneSecond)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{44U};
+    Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * MEGA));
+}
+
+TEST(Duration_test, ConstructFromChronoMillisecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{1001};
-    Duration result{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(result.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * MEGA));
+}
+
+TEST(Duration_test, ConstructFromChronoMillisecondsMax)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
+    Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
+    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoMillisecondsIsZero)
 {
-    Duration result(std::chrono::milliseconds(-1));
-    EXPECT_THAT(result.milliSeconds(), Eq(0U));
+    Duration sut(std::chrono::milliseconds(-1));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, ConstructFromChronoNanoseconds)
+TEST(Duration_test, ConstructFromChronoNanosecondsZero)
+{
+    constexpr uint64_t EXPECTED_NANOSECONDS{0U};
+    Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructFromChronoNanosecondsLessThanOneSecond)
+{
+    constexpr uint64_t EXPECTED_NANOSECONDS{424242U};
+    Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructFromChronoNanosecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{42U + GIGA};
-    Duration result{std::chrono::milliseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(result.milliSeconds(), Eq(EXPECTED_NANOSECONDS));
+    Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructFromChronoNanosecondsMax)
+{
+    constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<int64_t>::max()};
+    Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoNanosecondsIsZero)
 {
-    Duration result(std::chrono::nanoseconds(-1));
-    EXPECT_THAT(result.nanoSeconds(), Eq(0U));
+    Duration sut(std::chrono::nanoseconds(-1));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 // END CONSTRUCTOR TESTS
 
 // BEGIN ASSIGNMENT TESTS
 
-TEST(Duration_test, AssignFromChronoMilliseconds)
+TEST(Duration_test, AssignFromChronoMillisecondsZero)
 {
-    constexpr uint64_t EXPECTED_MILLISECONDS{1001};
+    constexpr uint64_t EXPECTED_MILLISECONDS{0U};
+    Duration sut = 0_ns;
+    sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, AssignFromChronoMillisecondsLessThanOneSecond)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{73U};
+    Duration sut = 0_ns;
+    sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * MEGA));
+}
+
+TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{1073U};
+    Duration sut = 0_ns;
+    sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * MEGA));
+}
+
+TEST(Duration_test, AssignFromChronoMillisecondsLMax)
+{
+    constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
     EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
@@ -196,7 +391,7 @@ TEST(Duration_test, AssignFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut = 22_ns;
     sut = std::chrono::milliseconds(-1);
-    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 // END ASSIGNMENT TESTS
@@ -752,7 +947,7 @@ TEST(Duration_test, MultiplyDurationLessThanOneSecondResultsInMoreNanosecondsTha
 {
     constexpr uint64_t MULTIPLICATOR{(1ULL << 32U) * 42U + 73U};
     constexpr Duration DURATION = 473_ms + 578_us + 511_ns;
-    auto EXPECTED_RESULT = Duration {85428177141U, 573034055U};
+    auto EXPECTED_RESULT = Duration{85428177141U, 573034055U};
 
     auto result = MULTIPLICATOR * DURATION;
     EXPECT_THAT(result, Eq(EXPECTED_RESULT));
@@ -764,7 +959,7 @@ TEST(Duration_test, MultiplyDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545796U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration {std::numeric_limits<uint64_t>::max(), 56194452U};
+    auto EXPECTED_RESULT = Duration{std::numeric_limits<uint64_t>::max(), 56194452U};
 
     EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
@@ -774,7 +969,7 @@ TEST(Duration_test, MultiplyDurationResultsInSaturation)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545797U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration {std::numeric_limits<uint64_t>::max(), GIGA - 1U};
+    auto EXPECTED_RESULT = Duration{std::numeric_limits<uint64_t>::max(), GIGA - 1U};
 
     EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
@@ -784,7 +979,7 @@ TEST(Duration_test, MultiplyDurationWithMinimalDoubleResultsInZero)
 {
     constexpr double MULTIPLICATOR{std::numeric_limits<double>::min()};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration {0U, 0U};
+    auto EXPECTED_RESULT = Duration{0U, 0U};
 
     EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -25,7 +25,7 @@ constexpr double tenTimesEpsilon = std::numeric_limits<double>::epsilon() * 10.;
 
 TEST(Duration_test, convertDays)
 {
-    auto time = 10.0_d;
+    auto time = 10_d;
     EXPECT_DOUBLE_EQ(time.days<double>(), 10.0);
     EXPECT_DOUBLE_EQ(time.hours<double>(), 240.0);
     EXPECT_DOUBLE_EQ(time.minutes<double>(), 14400.0);
@@ -37,14 +37,14 @@ TEST(Duration_test, convertDays)
 
 TEST(Duration_test, convertHours)
 {
-    auto time = 0.5_h;
-    EXPECT_DOUBLE_EQ(time.days<double>(), 1.0 / 48.0);
-    EXPECT_DOUBLE_EQ(time.hours<double>(), 0.5);
-    EXPECT_DOUBLE_EQ(time.minutes<double>(), 30.0);
-    EXPECT_DOUBLE_EQ(time.seconds<double>(), 1800.0);
-    EXPECT_DOUBLE_EQ(time.milliSeconds<double>(), 1800.0 * KILO);
-    EXPECT_DOUBLE_EQ(time.microSeconds<double>(), 1800.0 * MEGA);
-    EXPECT_DOUBLE_EQ(time.nanoSeconds<double>(), 1800.0 * GIGA);
+    auto time = 2_h;
+    EXPECT_DOUBLE_EQ(time.days<double>(), 1.0 / 12.0);
+    EXPECT_DOUBLE_EQ(time.hours<double>(), 2.0);
+    EXPECT_DOUBLE_EQ(time.minutes<double>(), 120.0);
+    EXPECT_DOUBLE_EQ(time.seconds<double>(), 7200.0);
+    EXPECT_DOUBLE_EQ(time.milliSeconds<double>(), 7200.0 * KILO);
+    EXPECT_DOUBLE_EQ(time.microSeconds<double>(), 7200.0 * MEGA);
+    EXPECT_DOUBLE_EQ(time.nanoSeconds<double>(), 7200.0 * GIGA);
 }
 
 TEST(Duration_test, convertMinutes)
@@ -107,17 +107,17 @@ TEST(Duration_test, convertNanoseconds)
 TEST(Duration_test, comparison)
 {
     auto time1 = 200_us;
-    auto time2 = 200.0_us;
-    EXPECT_EQ(time1.seconds<double>(), time2.seconds<double>());
+    auto time2 = 200000_ns;
+    EXPECT_EQ(time1, time2);
 
-    auto time3 = 0.21_ms;
+    auto time3 = 200_us + 1_ns;
     EXPECT_LT(time1, time3);
     EXPECT_GT(time3, time2);
 }
 
 TEST(Duration_test, timespec)
 {
-    auto time = 2.5_s;
+    auto time = 2_s + 500_ms;
     struct timespec t3;
     t3.tv_sec = 2;
     t3.tv_nsec = 500000000;
@@ -129,7 +129,7 @@ TEST(Duration_test, timespec)
 
 TEST(Duration_test, timeval)
 {
-    auto time = 2.5_s;
+    auto time = 2_s + 500_ms;
     struct timeval t1;
     t1.tv_sec = 2;
     t1.tv_usec = 500000;
@@ -141,7 +141,7 @@ TEST(Duration_test, timeval)
 
 TEST(Duration_test, addDuration)
 {
-    auto time1 = 5.2_s;
+    auto time1 = 5_s + 200_ms;
     auto time2 = 200_ms;
     auto time3 = 300000_us;
 
@@ -153,7 +153,7 @@ TEST(Duration_test, addDuration)
 
 TEST(Duration_test, subtractDuration)
 {
-    auto time1 = 5.2_s;
+    auto time1 = 5_s + 200_ms;
     auto time2 = 200_ms;
     auto time3 = 300000_us;
 
@@ -170,7 +170,7 @@ TEST(Duration_test, subtractDuration)
 
 TEST(Duration_test, multiplyDuration)
 {
-    auto time1 = 5.2_s;
+    auto time1 = 5_s + 200_ms;
     auto time2 = 200_ms;
     auto time3 = 300000_us;
 
@@ -187,7 +187,7 @@ TEST(Duration_test, multiplyDuration)
 
 TEST(Duration_test, divideDuration)
 {
-    auto time1 = 5.2_s;
+    auto time1 = 5_s + 200_ms;
     auto time2 = 200_ms;
     auto time3 = 300000_us;
 
@@ -219,7 +219,7 @@ TEST(Duration_test, constructFromTimeval)
     value.tv_usec = 42;
 
     Duration result(value);
-    EXPECT_EQ(result.microSeconds<uint64_t>(), 42 + 1000000 * 1337);
+    EXPECT_EQ(result.microSeconds<uint64_t>(), 42U + 1000000U * 1337U);
 }
 
 TEST(Duration_test, isZeroWhenConstructedFromNegativeChronoMilliSeconds)

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -24,7 +24,29 @@ constexpr uint64_t GIGA = 1000000000U;
 
 // BEGIN CONSTRUCTOR TESTS
 
-TEST(Duration_test, ConstructDurationWithLessNanosecondsThanOneSecond)
+TEST(Duration_test, ConstructDurationWithZeroTime)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{0U};
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{0U};
+
+    auto sut = Duration{SECONDS, NANOSECONDS};
+
+    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
+{
+    constexpr uint64_t SECONDS{0U};
+    constexpr uint64_t NANOSECONDS{7337U};
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{NANOSECONDS};
+
+    auto sut = Duration{SECONDS, NANOSECONDS};
+
+    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
 {
     constexpr uint64_t SECONDS{37U};
     constexpr uint64_t NANOSECONDS{73U};
@@ -46,7 +68,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
     EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
-TEST(Duration_test, ConstructDurationWithMoreNanosecondsThanOneSecond)
+TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
 {
     constexpr uint64_t SECONDS{37U};
     constexpr uint64_t NANOSECONDS{42U};
@@ -58,7 +80,31 @@ TEST(Duration_test, ConstructDurationWithMoreNanosecondsThanOneSecond)
     EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
-TEST(Duration_test, ConstructDurationWithOneNanosecondIsNotSetToZero)
+TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
+{
+    constexpr uint64_t SECONDS{37U};
+    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<uint32_t>::max()};
+    constexpr uint64_t EXPECTED_SECONDS = SECONDS + MAX_NANOSECONDS_FOR_CTOR / GIGA;
+    constexpr uint64_t REMAINING_NANOSECONDS = MAX_NANOSECONDS_FOR_CTOR % GIGA;
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{(EXPECTED_SECONDS)*GIGA + REMAINING_NANOSECONDS};
+
+    auto sut = Duration{SECONDS, MAX_NANOSECONDS_FOR_CTOR};
+
+    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValue)
+{
+    constexpr uint64_t MAX_SECONDS_FOR_CTOR{std::numeric_limits<uint64_t>::max()};
+    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<uint32_t>::max()};
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{std::numeric_limits<uint64_t>::max()};
+
+    auto sut = Duration{MAX_SECONDS_FOR_CTOR, MAX_NANOSECONDS_FOR_CTOR};
+
+    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
+TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanoseconds)
 {
     constexpr uint64_t SECONDS{0U};
     constexpr uint64_t NANOSECONDS{1U};

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -702,16 +702,4 @@ TEST(Duration_test, MultiplyDuration)
     EXPECT_THAT(time * -1.0, Eq(0_s));
 }
 
-TEST(Duration_test, DivideDuration)
-{
-    auto time = 4_s + 800_ms;
-
-    EXPECT_THAT(time / 2, Eq(2_s + 400_ms));
-    EXPECT_THAT(time / 2U, Eq(2_s + 400_ms));
-    EXPECT_THAT(time / 2.5, Eq(1_s + 920_ms));
-
-    EXPECT_THAT(time / -1, Eq(0_s));
-    EXPECT_THAT(time / -1.0, Eq(0_s));
-}
-
 // END ARITHMETIC TESTS

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -493,20 +493,34 @@ TEST(Duration_test, OperatorTimeval)
 
 // BEGIN COMPARISON TESTS
 
-TEST(Duration_test, CompareTwoEqualDurations)
+TEST(Duration_test, CompareTwoEqualDurationsForEquality)
 {
     auto time1 = 200_us;
     auto time2 = 200000_ns;
     EXPECT_TRUE(time1 == time2);
-    EXPECT_TRUE(time2 == time1);
 }
 
-TEST(Duration_test, CompareTwoNonEqualDurations)
+TEST(Duration_test, CompareTwoNonEqualDurationsForEquality)
+{
+    auto time1 = 1_s + 200_us;
+    auto time2 = 1_ns;
+    EXPECT_FALSE(time1 == time2);
+    EXPECT_FALSE(time2 == time1);
+}
+
+TEST(Duration_test, CompareTwoNonEqualDurationsForInequality)
 {
     auto time1 = 1_s + 200_us;
     auto time2 = 1_ns;
     EXPECT_TRUE(time1 != time2);
     EXPECT_TRUE(time2 != time1);
+}
+
+TEST(Duration_test, CompareTwoEqualDurationsForInequality)
+{
+    auto time1 = 200_us;
+    auto time2 = 200000_ns;
+    EXPECT_FALSE(time1 != time2);
 }
 
 TEST(Duration_test, CompareTwoEqualDurationsAreNotLessThan)

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -99,7 +99,7 @@ TEST(Duration_test, ConstructFromTimeval)
 
 TEST(Duration_test, ConstructFromChronoMilliseconds)
 {
-    constexpr uint64_t  EXPECTED_MILLISECONDS {1001};
+    constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration result{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
     EXPECT_THAT(result.milliSeconds<uint64_t>(), Eq(EXPECTED_MILLISECONDS));
 }
@@ -112,7 +112,7 @@ TEST(Duration_test, ConstructFromNegativeChronoMillisecondsIsZero)
 
 TEST(Duration_test, ConstructFromChronoNanoseconds)
 {
-    constexpr uint64_t  EXPECTED_NANOSECONDS{42U + GIGA};
+    constexpr uint64_t EXPECTED_NANOSECONDS{42U + GIGA};
     Duration result{std::chrono::milliseconds(EXPECTED_NANOSECONDS)};
     EXPECT_THAT(result.milliSeconds<uint64_t>(), Eq(EXPECTED_NANOSECONDS));
 }
@@ -129,7 +129,7 @@ TEST(Duration_test, ConstructFromNegativeChronoNanosecondsIsZero)
 
 TEST(Duration_test, AssignFromChronoMilliseconds)
 {
-    constexpr uint64_t  EXPECTED_MILLISECONDS {1001};
+    constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
     EXPECT_THAT(sut.milliSeconds<uint64_t>(), Eq(EXPECTED_MILLISECONDS));
@@ -433,16 +433,16 @@ TEST(Duration_test, ConvertTimespecWithMonotonicReference)
     constexpr int64_t SECONDS{4};
     constexpr int64_t NANOSECONDS{66};
 
-    auto timeSinceUnixEpoche = std::chrono::system_clock::now().time_since_epoch();
-    auto timeSinceMonotonicEpoche = std::chrono::steady_clock::now().time_since_epoch();
+    auto timeSinceUnixEpoch = std::chrono::system_clock::now().time_since_epoch();
+    auto timeSinceMonotonicEpoch = std::chrono::steady_clock::now().time_since_epoch();
 
     Duration duration{SECONDS, NANOSECONDS};
     struct timespec sut = timespec(duration.timespec(iox::units::TimeSpecReference::Monotonic));
 
-    auto secondsSinceUnixEpoche = std::chrono::duration_cast<std::chrono::seconds>(timeSinceUnixEpoche).count();
-    auto secondsSinceMonotonicEpoche = std::chrono::duration_cast<std::chrono::seconds>(timeSinceMonotonicEpoche).count();
-    EXPECT_THAT(sut.tv_sec, Lt(secondsSinceUnixEpoche));
-    EXPECT_THAT(sut.tv_sec, Gt(secondsSinceMonotonicEpoche));
+    auto secondsSinceUnixEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeSinceUnixEpoch).count();
+    auto secondsSinceMonotonicEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeSinceMonotonicEpoch).count();
+    EXPECT_THAT(sut.tv_sec, Lt(secondsSinceUnixEpoch));
+    EXPECT_THAT(sut.tv_sec, Gt(secondsSinceMonotonicEpoch));
 }
 
 TEST(Duration_test, ConvertTimespecWithEpochReference)
@@ -450,14 +450,14 @@ TEST(Duration_test, ConvertTimespecWithEpochReference)
     constexpr int64_t SECONDS{5};
     constexpr int64_t NANOSECONDS{77};
 
-    auto timeSinceUnixEpoche = std::chrono::system_clock::now().time_since_epoch();
+    auto timeSinceUnixEpoch = std::chrono::system_clock::now().time_since_epoch();
 
     Duration duration{SECONDS, NANOSECONDS};
     struct timespec sut = timespec(duration.timespec(iox::units::TimeSpecReference::Epoch));
 
-    auto secondsSinceUnixEpoche = std::chrono::duration_cast<std::chrono::seconds>(timeSinceUnixEpoche).count();
-    EXPECT_THAT(10 * SECONDS, Lt(secondsSinceUnixEpoche));
-    EXPECT_THAT(sut.tv_sec, Gt(secondsSinceUnixEpoche));
+    auto secondsSinceUnixEpoch = std::chrono::duration_cast<std::chrono::seconds>(timeSinceUnixEpoch).count();
+    EXPECT_THAT(10 * SECONDS, Lt(secondsSinceUnixEpoch));
+    EXPECT_THAT(sut.tv_sec, Gt(secondsSinceUnixEpoch));
 }
 
 // END CONVERSION FUNCTION TESTS

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -1760,8 +1760,8 @@ TEST(Duration_test, MultiplyDurationMoreThanOneSecondWithFloatResultsInMoreThanO
 
 TEST(Duration_test, MultiplyDurationWithFractionalFloat)
 {
-    constexpr Duration EXPECTED_DURATION{2_s + 300_ms};
-    auto duration = 4_s + 600_ms;
+    constexpr Duration EXPECTED_DURATION{2_s + 800_ms};
+    auto duration = 5_s + 600_ms;
 
     multiply(duration, 0.5, EXPECTED_DURATION);
 }

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -31,15 +31,15 @@ constexpr uint64_t NANOSECS_PER_SECOND = Duration::NANOSECS_PER_SEC;
 
 struct DurationFactory : public Duration
 {
-    constexpr DurationFactory(SECONDS_TYPE seconds, NANOSECONDS_TYPE nanoseconds)
+    constexpr DurationFactory(Seconds_t seconds, Nanoseconds_t nanoseconds)
         : Duration(seconds, nanoseconds)
     {
     }
 
     using Duration::max;
 
-    using Duration::NANOSECONDS_TYPE;
-    using Duration::SECONDS_TYPE;
+    using Duration::Nanoseconds_t;
+    using Duration::Seconds_t;
 };
 
 TEST(Duration_test, ConversionConstants)
@@ -117,7 +117,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
 TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
 {
     constexpr uint64_t SECONDS{37U};
-    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::NANOSECONDS_TYPE>::max()};
+    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::Nanoseconds_t>::max()};
     constexpr uint64_t EXPECTED_SECONDS = SECONDS + MAX_NANOSECONDS_FOR_CTOR / NANOSECS_PER_SECOND;
     constexpr uint64_t REMAINING_NANOSECONDS = MAX_NANOSECONDS_FOR_CTOR % NANOSECS_PER_SECOND;
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{(EXPECTED_SECONDS)*NANOSECS_PER_SECOND + REMAINING_NANOSECONDS};
@@ -129,8 +129,8 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
 
 TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
 {
-    constexpr uint64_t MAX_SECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()};
-    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::NANOSECONDS_TYPE>::max()};
+    constexpr uint64_t MAX_SECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::Seconds_t>::max()};
+    constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR{std::numeric_limits<DurationFactory::Nanoseconds_t>::max()};
 
     auto sut = DurationFactory{MAX_SECONDS_FOR_CTOR, MAX_NANOSECONDS_FOR_CTOR};
 
@@ -192,7 +192,7 @@ TEST(Duration_test, ConstructFromTimespecWithValueMoreThanOneSecond)
 
 TEST(Duration_test, ConstructFromTimespecWithMaxValue)
 {
-    constexpr uint64_t SECONDS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()};
+    constexpr uint64_t SECONDS{std::numeric_limits<DurationFactory::Seconds_t>::max()};
     constexpr uint64_t NANOSECONDS{NANOSECS_PER_SECOND - 1U};
 
     struct timespec ts;
@@ -247,7 +247,7 @@ TEST(Duration_test, ConstructFromITimerspecWithValueMoreThanOneSecond)
 
 TEST(Duration_test, ConstructFromITimerspecWithMaxValue)
 {
-    constexpr uint64_t SECONDS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()};
+    constexpr uint64_t SECONDS{std::numeric_limits<DurationFactory::Seconds_t>::max()};
     constexpr uint64_t NANOSECONDS{NANOSECS_PER_SECOND - 1U};
 
     struct itimerspec its;
@@ -511,7 +511,7 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithMultipleDays)
 TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturation)
 {
     constexpr uint64_t SECONDS_PER_DAY{HOURS_PER_DAY * SECONDS_PER_HOUR};
-    constexpr uint64_t MAX_DAYS_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()
+    constexpr uint64_t MAX_DAYS_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::Seconds_t>::max()
                                                 / SECONDS_PER_DAY};
     constexpr DurationFactory EXPECTED_DURATION{MAX_DAYS_BEFORE_OVERFLOW * SECONDS_PER_DAY, 0U};
     static_assert(EXPECTED_DURATION < DurationFactory::max(),
@@ -560,7 +560,7 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithMultipleHours)
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSaturation)
 {
-    constexpr uint64_t MAX_HOURS_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()
+    constexpr uint64_t MAX_HOURS_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::Seconds_t>::max()
                                                  / SECONDS_PER_HOUR};
     constexpr DurationFactory EXPECTED_DURATION{MAX_HOURS_BEFORE_OVERFLOW * SECONDS_PER_HOUR, 0U};
     static_assert(EXPECTED_DURATION < DurationFactory::max(),
@@ -609,7 +609,7 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMultipleMinutes)
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInSaturation)
 {
-    constexpr uint64_t MAX_MINUTES_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()
+    constexpr uint64_t MAX_MINUTES_BEFORE_OVERFLOW{std::numeric_limits<DurationFactory::Seconds_t>::max()
                                                    / SECONDS_PER_MINUTE};
     constexpr DurationFactory EXPECTED_DURATION{MAX_MINUTES_BEFORE_OVERFLOW * SECONDS_PER_MINUTE, 0U};
     static_assert(EXPECTED_DURATION < DurationFactory::max(),
@@ -828,7 +828,7 @@ TEST(Duration_test, ConvertDaysFromDurationMoreThanOneDay)
 TEST(Duration_test, ConvertDaysFromMaxDuration)
 {
     constexpr uint64_t SECONDS_PER_DAY{60U * 60U * 24U};
-    constexpr uint64_t EXPECTED_DAYS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() / SECONDS_PER_DAY};
+    constexpr uint64_t EXPECTED_DAYS{std::numeric_limits<DurationFactory::Seconds_t>::max() / SECONDS_PER_DAY};
     auto sut = DurationFactory::max();
     EXPECT_THAT(sut.days(), Eq(EXPECTED_DAYS));
 }
@@ -854,7 +854,7 @@ TEST(Duration_test, ConvertHoursFromDurationMoreThanOneHour)
 TEST(Duration_test, ConvertHoursFromMaxDuration)
 {
     constexpr uint64_t SECONDS_PER_HOUR{60U * 60U};
-    constexpr uint64_t EXPECTED_HOURS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() / SECONDS_PER_HOUR};
+    constexpr uint64_t EXPECTED_HOURS{std::numeric_limits<DurationFactory::Seconds_t>::max() / SECONDS_PER_HOUR};
     auto sut = DurationFactory::max();
     EXPECT_THAT(sut.hours(), Eq(EXPECTED_HOURS));
 }
@@ -880,7 +880,7 @@ TEST(Duration_test, ConvertMinutesFromDurationMoreThanOneMinute)
 TEST(Duration_test, ConvertMinutesFromMaxDuration)
 {
     constexpr uint64_t SECONDS_PER_MINUTE{60U};
-    constexpr uint64_t EXPECTED_MINUTES{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() / SECONDS_PER_MINUTE};
+    constexpr uint64_t EXPECTED_MINUTES{std::numeric_limits<DurationFactory::Seconds_t>::max() / SECONDS_PER_MINUTE};
     auto sut = DurationFactory::max();
     EXPECT_THAT(sut.minutes(), Eq(EXPECTED_MINUTES));
 }
@@ -905,14 +905,14 @@ TEST(Duration_test, ConvertSecondsFromDurationMoreThanOneSecond)
 
 TEST(Duration_test, ConvertSecondsFromMaxSecondsMinusOne)
 {
-    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() - 1U};
+    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationFactory::Seconds_t>::max() - 1U};
     auto sut = DurationFactory::max() - 1_s;
     EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
 }
 
 TEST(Duration_test, ConvertSecondsFromMaxDuration)
 {
-    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max()};
+    constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationFactory::Seconds_t>::max()};
     auto sut = DurationFactory::max();
     EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
 }
@@ -1448,10 +1448,10 @@ TEST(Duration_test, AddDurationWithDurationsMoreThanOneSecondsResultsInMoreThanO
 
 TEST(Duration_test, AddDurationResultsNotYetInSaturation)
 {
-    constexpr DurationFactory EXPECTED_DURATION{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max(),
+    constexpr DurationFactory EXPECTED_DURATION{std::numeric_limits<DurationFactory::Seconds_t>::max(),
                                                 NANOSECS_PER_SECOND - 2U};
     auto duration1 =
-        DurationFactory{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() - 1U, NANOSECS_PER_SECOND - 1U};
+        DurationFactory{std::numeric_limits<DurationFactory::Seconds_t>::max() - 1U, NANOSECS_PER_SECOND - 1U};
     auto duration2 = DurationFactory{0U, NANOSECS_PER_SECOND - 1U};
 
     auto sut1 = duration1 + duration2;
@@ -1463,8 +1463,7 @@ TEST(Duration_test, AddDurationResultsNotYetInSaturation)
 
 TEST(Duration_test, AddDurationResultsInSaturationFromNanoseconds)
 {
-    auto duration1 =
-        DurationFactory{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max(), NANOSECS_PER_SECOND - 2U};
+    auto duration1 = DurationFactory{std::numeric_limits<DurationFactory::Seconds_t>::max(), NANOSECS_PER_SECOND - 2U};
     auto duration2 = DurationFactory{0U, 2U};
 
     auto sut1 = duration1 + duration2;
@@ -1477,7 +1476,7 @@ TEST(Duration_test, AddDurationResultsInSaturationFromNanoseconds)
 TEST(Duration_test, AddDurationResultsInSaturationFromSeconds)
 {
     auto duration1 =
-        DurationFactory{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() - 2U, NANOSECS_PER_SECOND - 1U};
+        DurationFactory{std::numeric_limits<DurationFactory::Seconds_t>::max() - 2U, NANOSECS_PER_SECOND - 1U};
     auto duration2 = DurationFactory{2U, 0U};
 
     auto sut1 = duration1 + duration2;
@@ -1791,7 +1790,7 @@ TEST(Duration_test, MultiplyDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545796U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    constexpr DurationFactory EXPECTED_DURATION{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max(), 56194452U};
+    constexpr DurationFactory EXPECTED_DURATION{std::numeric_limits<DurationFactory::Seconds_t>::max(), 56194452U};
     static_assert(EXPECTED_DURATION < DurationFactory::max(),
                   "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
 

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -22,6 +22,8 @@ constexpr uint64_t KILO = 1000U;
 constexpr uint64_t MEGA = 1000000U;
 constexpr uint64_t GIGA = 1000000000U;
 
+constexpr Duration MAX_DURATION{std::numeric_limits<uint64_t>::max(), GIGA - 1U};
+
 // BEGIN CONSTRUCTOR TESTS
 
 TEST(Duration_test, ConstructDurationWithZeroTime)
@@ -379,7 +381,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
     EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * MEGA));
 }
 
-TEST(Duration_test, AssignFromChronoMillisecondsLMax)
+TEST(Duration_test, AssignFromChronoMillisecondsMax)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut = 0_ns;
@@ -464,7 +466,16 @@ TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
 
 // BEGIN CREATION FROM STATIC FUNCTION TESTS
 
-TEST(Duration_test, CreateDurationFromDaysFunction)
+TEST(Duration_test, CreateDurationFromDaysFunctionWithZeroDays)
+{
+    auto sut1 = Duration::days(0);
+    auto sut2 = Duration::days(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromDaysFunctionWithMultipleDays)
 {
     constexpr uint64_t SECONDS_PER_HOUR{3600U};
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{2U * 24U * SECONDS_PER_HOUR * GIGA};
@@ -475,13 +486,46 @@ TEST(Duration_test, CreateDurationFromDaysFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturation)
+{
+    constexpr uint64_t SECONDS_PER_DAY{60U * 60U * 24U};
+    constexpr uint64_t MAX_DAYS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / SECONDS_PER_DAY};
+    constexpr Duration EXPECTED_DURATION{MAX_DAYS_BEFORE_OVERFLOW * SECONDS_PER_DAY, 0U};
+    static_assert(EXPECTED_DURATION < MAX_DURATION,
+                  "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
+
+    auto sut1 = Duration::days(static_cast<int64_t>(MAX_DAYS_BEFORE_OVERFLOW));
+    auto sut2 = Duration::days(MAX_DAYS_BEFORE_OVERFLOW);
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, CreateDurationFromDaysFunctionWithMaxDaysResultsInSaturation)
+{
+    auto sut1 = Duration::days(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::days(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(MAX_DURATION));
+    EXPECT_THAT(sut2, Eq(MAX_DURATION));
+}
+
 TEST(Duration_test, CreateDurationFromDaysFunctionWithNegativeValuesIsZero)
 {
     auto sut = Duration::days(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, CreateDurationFromHoursFunction)
+TEST(Duration_test, CreateDurationFromHoursFunctionWithZeroHours)
+{
+    auto sut1 = Duration::hours(0);
+    auto sut2 = Duration::hours(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromHoursFunctionWithMultipleHours)
 {
     constexpr uint64_t SECONDS_PER_HOUR{3600U};
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{3U * SECONDS_PER_HOUR * GIGA};
@@ -492,13 +536,46 @@ TEST(Duration_test, CreateDurationFromHoursFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSaturation)
+{
+    constexpr uint64_t SECONDS_PER_HOUR{3600U};
+    constexpr uint64_t MAX_HOURS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / SECONDS_PER_HOUR};
+    constexpr Duration EXPECTED_DURATION{MAX_HOURS_BEFORE_OVERFLOW * SECONDS_PER_HOUR, 0U};
+    static_assert(EXPECTED_DURATION < MAX_DURATION,
+                  "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
+
+    auto sut1 = Duration::hours(static_cast<int64_t>(MAX_HOURS_BEFORE_OVERFLOW));
+    auto sut2 = Duration::hours(MAX_HOURS_BEFORE_OVERFLOW);
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, CreateDurationFromHoursFunctionWithMaxHoursResultsInSaturation)
+{
+    auto sut1 = Duration::hours(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::hours(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(MAX_DURATION));
+    EXPECT_THAT(sut2, Eq(MAX_DURATION));
+}
+
 TEST(Duration_test, CreateDurationFromHoursFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::hours(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, CreateDurationFromMinutesFunction)
+TEST(Duration_test, CreateDurationFromMinutesFunctionWithZeroMinuts)
+{
+    auto sut1 = Duration::minutes(0);
+    auto sut2 = Duration::minutes(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromMinutesFunctionWithMultipleMinutes)
 {
     constexpr uint64_t SECONDS_PER_MINUTE{60U};
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{4U * SECONDS_PER_MINUTE * GIGA};
@@ -509,10 +586,43 @@ TEST(Duration_test, CreateDurationFromMinutesFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInSaturation)
+{
+    constexpr uint64_t SECONDS_PER_MINUTE{60U};
+    constexpr uint64_t MAX_MINUTES_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / SECONDS_PER_MINUTE};
+    constexpr Duration EXPECTED_DURATION{MAX_MINUTES_BEFORE_OVERFLOW * SECONDS_PER_MINUTE, 0U};
+    static_assert(EXPECTED_DURATION < MAX_DURATION,
+                  "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
+
+    auto sut1 = Duration::minutes(static_cast<int64_t>(MAX_MINUTES_BEFORE_OVERFLOW));
+    auto sut2 = Duration::minutes(MAX_MINUTES_BEFORE_OVERFLOW);
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, CreateDurationFromMinutesFunctionWithMaxMinutesResultsInSaturation)
+{
+    auto sut1 = Duration::minutes(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::minutes(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(MAX_DURATION));
+    EXPECT_THAT(sut2, Eq(MAX_DURATION));
+}
+
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::minutes(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromSecondsFunctionWithZeroSeconds)
+{
+    auto sut1 = Duration::seconds(0);
+    auto sut2 = Duration::seconds(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunction)
@@ -526,13 +636,36 @@ TEST(Duration_test, CreateDurationFromSecondsFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
+{
+    constexpr uint64_t MAX_SECONDS_FROM_SIGNED{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_SIGNED{MAX_SECONDS_FROM_SIGNED, 0U};
+    constexpr uint64_t MAX_SECONDS_FROM_USIGNED{std::numeric_limits<uint64_t>::max()};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED{MAX_SECONDS_FROM_USIGNED, 0U};
+
+    auto sut1 = Duration::seconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::seconds(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
+}
+
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::seconds(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, CreateDurationFromMillisecondsFunction)
+TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithZeroMilliseconds)
+{
+    auto sut1 = Duration::milliseconds(0);
+    auto sut2 = Duration::milliseconds(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMultipleMilliseconds)
 {
     constexpr uint64_t NANOSECONDS_PER_MILLISECOND{MEGA};
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{6U * NANOSECONDS_PER_MILLISECOND};
@@ -543,13 +676,38 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
+{
+    constexpr uint64_t MAX_MILLISECONDS_FROM_SIGNED{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_SIGNED{MAX_MILLISECONDS_FROM_SIGNED / KILO,
+                                                         (MAX_MILLISECONDS_FROM_SIGNED % KILO) * MEGA};
+    constexpr uint64_t MAX_MILLISECONDS_FROM_USIGNED{std::numeric_limits<uint64_t>::max()};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED{MAX_MILLISECONDS_FROM_USIGNED / KILO,
+                                                           (MAX_MILLISECONDS_FROM_USIGNED % KILO) * MEGA};
+
+    auto sut1 = Duration::milliseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::milliseconds(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
+}
+
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::milliseconds(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, CreateDurationFromMicrosecondsFunction)
+TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithZeroMicroseconds)
+{
+    auto sut1 = Duration::microseconds(0);
+    auto sut2 = Duration::microseconds(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMultipleMicroseconds)
 {
     constexpr uint64_t NANOSECONDS_PER_MICROSECOND{KILO};
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{7U * NANOSECONDS_PER_MICROSECOND};
@@ -560,13 +718,38 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunction)
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
+TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
+{
+    constexpr uint64_t MAX_MICROSECONDS_FROM_SIGNED{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_SIGNED{MAX_MICROSECONDS_FROM_SIGNED / MEGA,
+                                                         (MAX_MICROSECONDS_FROM_SIGNED % MEGA) * KILO};
+    constexpr uint64_t MAX_MICROSECONDS_FROM_USIGNED{std::numeric_limits<uint64_t>::max()};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED{MAX_MICROSECONDS_FROM_USIGNED / MEGA,
+                                                           (MAX_MICROSECONDS_FROM_USIGNED % MEGA) * KILO};
+
+    auto sut1 = Duration::microseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::microseconds(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
+}
+
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::microseconds(-1);
     EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
-TEST(Duration_test, CreateDurationFromNanosecondsFunction)
+TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithZeroNanoseconds)
+{
+    auto sut1 = Duration::nanoseconds(0);
+    auto sut2 = Duration::nanoseconds(0U);
+
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+}
+
+TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithMultipleNanoseconds)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{8U};
     auto sut1 = Duration::nanoseconds(8);
@@ -574,6 +757,22 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunction)
 
     EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
     EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+}
+
+TEST(Duration_test, CreateDurationFromNanosecondsFunction)
+{
+    constexpr uint64_t MAX_NANOSECONDS_FROM_SIGNED{static_cast<uint64_t>(std::numeric_limits<int64_t>::max())};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_SIGNED{MAX_NANOSECONDS_FROM_SIGNED / GIGA,
+                                                         MAX_NANOSECONDS_FROM_SIGNED % GIGA};
+    constexpr uint64_t MAX_NANOSECONDS_FROM_USIGNED{std::numeric_limits<uint64_t>::max()};
+    constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED{MAX_NANOSECONDS_FROM_USIGNED / GIGA,
+                                                           MAX_NANOSECONDS_FROM_USIGNED % GIGA};
+
+    auto sut1 = Duration::nanoseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::nanoseconds(std::numeric_limits<uint64_t>::max());
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero)
@@ -959,30 +1158,31 @@ TEST(Duration_test, MultiplyDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545796U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration{std::numeric_limits<uint64_t>::max(), 56194452U};
+    constexpr Duration EXPECTED_DURATION{std::numeric_limits<uint64_t>::max(), 56194452U};
+    static_assert(EXPECTED_DURATION < MAX_DURATION,
+                  "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
 
-    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
-    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
 }
 
 TEST(Duration_test, MultiplyDurationResultsInSaturation)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545797U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration{std::numeric_limits<uint64_t>::max(), GIGA - 1U};
 
-    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
-    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(MAX_DURATION));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(MAX_DURATION));
 }
 
 TEST(Duration_test, MultiplyDurationWithMinimalDoubleResultsInZero)
 {
     constexpr double MULTIPLICATOR{std::numeric_limits<double>::min()};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
-    auto EXPECTED_RESULT = Duration{0U, 0U};
+    auto EXPECTED_DURATION = Duration{0U, 0U};
 
-    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_RESULT));
-    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
 }
 
 // END ARITHMETIC TESTS

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -32,7 +32,7 @@ TEST(Duration_test, ConstructDurationWithZeroTime)
 
     auto sut = Duration{SECONDS, NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
@@ -43,7 +43,7 @@ TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
 
     auto sut = Duration{SECONDS, NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
@@ -54,7 +54,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
 
     auto sut = Duration{SECONDS, NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
@@ -65,7 +65,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
 
     auto sut = Duration{SECONDS, NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
@@ -77,7 +77,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
 
     auto sut = Duration{SECONDS, MORE_THAN_ONE_SECOND_NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
@@ -90,7 +90,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
 
     auto sut = Duration{SECONDS, MAX_NANOSECONDS_FOR_CTOR};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
@@ -101,7 +101,7 @@ TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
 
     auto sut = Duration{MAX_SECONDS_FOR_CTOR, MAX_NANOSECONDS_FOR_CTOR};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanoseconds)
@@ -112,7 +112,7 @@ TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanosecond
 
     auto sut = Duration{SECONDS, NANOSECONDS};
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromTimespec)
@@ -125,7 +125,7 @@ TEST(Duration_test, ConstructFromTimespec)
     value.tv_nsec = NANOSECONDS;
 
     Duration sut{value};
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(SECONDS * GIGA + NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(SECONDS * GIGA + NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromItimerspec)
@@ -138,7 +138,7 @@ TEST(Duration_test, ConstructFromItimerspec)
     value.it_interval.tv_nsec = NANOSECONDS;
 
     Duration sut{value};
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(SECONDS * GIGA + NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(SECONDS * GIGA + NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromTimeval)
@@ -151,33 +151,33 @@ TEST(Duration_test, ConstructFromTimeval)
     value.tv_usec = MICROSECONDS;
 
     Duration sut{value};
-    EXPECT_THAT(sut.microSeconds<uint64_t>(), Eq(SECONDS * MEGA + MICROSECONDS));
+    EXPECT_THAT(sut.microSeconds(), Eq(SECONDS * MEGA + MICROSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoMilliseconds)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration result{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(result.milliSeconds<uint64_t>(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(result.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoMillisecondsIsZero)
 {
     Duration result(std::chrono::milliseconds(-1));
-    EXPECT_THAT(result.milliSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(result.milliSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConstructFromChronoNanoseconds)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{42U + GIGA};
     Duration result{std::chrono::milliseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(result.milliSeconds<uint64_t>(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(result.milliSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoNanosecondsIsZero)
 {
     Duration result(std::chrono::nanoseconds(-1));
-    EXPECT_THAT(result.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(result.nanoSeconds(), Eq(0U));
 }
 
 // END CONSTRUCTOR TESTS
@@ -189,14 +189,14 @@ TEST(Duration_test, AssignFromChronoMilliseconds)
     constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.milliSeconds<uint64_t>(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, AssignFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut = 22_ns;
     sut = std::chrono::milliseconds(-1);
-    EXPECT_THAT(sut.milliSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
 }
 
 // END ASSIGNMENT TESTS
@@ -209,7 +209,7 @@ TEST(Duration_test, CreateDurationFromDaysLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{2U * 24U * SECONDS_PER_HOUR * GIGA};
     auto sut = 2_d;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursLiteral)
@@ -218,7 +218,7 @@ TEST(Duration_test, CreateDurationFromHoursLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{3U * SECONDS_PER_HOUR * GIGA};
     auto sut = 3_h;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesLiteral)
@@ -227,7 +227,7 @@ TEST(Duration_test, CreateDurationFromMinutesLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{4U * SECONDS_PER_MINUTE * GIGA};
     auto sut = 4_m;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsLiteral)
@@ -236,7 +236,7 @@ TEST(Duration_test, CreateDurationFromSecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{5U * NANOSECONDS_PER_SECOND};
     auto sut = 5_s;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
@@ -245,7 +245,7 @@ TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{6U * NANOSECONDS_PER_MILLISECOND};
     auto sut = 6_ms;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
@@ -254,7 +254,7 @@ TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{7U * NANOSECONDS_PER_MICROSECOND};
     auto sut = 7_us;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
@@ -262,7 +262,7 @@ TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{8U};
     auto sut = 8_ns;
 
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 // END CREATION FROM LITERAL TESTS
@@ -276,14 +276,14 @@ TEST(Duration_test, CreateDurationFromDaysFunction)
     auto sut1 = Duration::days(2);
     auto sut2 = Duration::days(2U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithNegativeValuesIsZero)
 {
     auto sut = Duration::days(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunction)
@@ -293,14 +293,14 @@ TEST(Duration_test, CreateDurationFromHoursFunction)
     auto sut1 = Duration::hours(3);
     auto sut2 = Duration::hours(3U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::hours(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunction)
@@ -310,14 +310,14 @@ TEST(Duration_test, CreateDurationFromMinutesFunction)
     auto sut1 = Duration::minutes(4);
     auto sut2 = Duration::minutes(4U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::minutes(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunction)
@@ -327,14 +327,14 @@ TEST(Duration_test, CreateDurationFromSecondsFunction)
     auto sut1 = Duration::seconds(5);
     auto sut2 = Duration::seconds(5U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::seconds(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunction)
@@ -344,14 +344,14 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunction)
     auto sut1 = Duration::milliseconds(6);
     auto sut2 = Duration::milliseconds(6U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::milliseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunction)
@@ -361,14 +361,14 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunction)
     auto sut1 = Duration::microseconds(7);
     auto sut2 = Duration::microseconds(7U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::microseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunction)
@@ -377,14 +377,14 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunction)
     auto sut1 = Duration::nanoseconds(8);
     auto sut2 = Duration::nanoseconds(8U);
 
-    EXPECT_THAT(sut1.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds<uint64_t>(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::nanoseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds<uint64_t>(), Eq(0U));
+    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
 }
 
 // END CREATION FROM STATIC FUNCTION TESTS
@@ -394,82 +394,82 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero
 TEST(Duration_test, ConvertDays)
 {
     auto time = 10_d;
-    EXPECT_EQ(time.days<uint64_t>(), 10U);
-    EXPECT_EQ(time.hours<uint64_t>(), 240U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 14400U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 864000U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 864000U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 864000U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 864000U * GIGA);
+    EXPECT_EQ(time.days(), 10U);
+    EXPECT_EQ(time.hours(), 240U);
+    EXPECT_EQ(time.minutes(), 14400U);
+    EXPECT_EQ(time.seconds(), 864000U);
+    EXPECT_EQ(time.milliSeconds(), 864000U * KILO);
+    EXPECT_EQ(time.microSeconds(), 864000U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 864000U * GIGA);
 }
 
 TEST(Duration_test, ConvertHours)
 {
     auto time = 2_h;
-    EXPECT_EQ(time.days<uint64_t>(), 0U);
-    EXPECT_EQ(time.hours<uint64_t>(), 2U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 120U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 7200U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 7200U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 7200U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 7200U * GIGA);
+    EXPECT_EQ(time.days(), 0U);
+    EXPECT_EQ(time.hours(), 2U);
+    EXPECT_EQ(time.minutes(), 120U);
+    EXPECT_EQ(time.seconds(), 7200U);
+    EXPECT_EQ(time.milliSeconds(), 7200U * KILO);
+    EXPECT_EQ(time.microSeconds(), 7200U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 7200U * GIGA);
 }
 
 TEST(Duration_test, ConvertMinutes)
 {
     auto time = 720_m;
-    EXPECT_EQ(time.days<uint64_t>(), 0U);
-    EXPECT_EQ(time.hours<uint64_t>(), 12U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 720U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 43200U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 43200U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 43200U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 43200U * GIGA);
+    EXPECT_EQ(time.days(), 0U);
+    EXPECT_EQ(time.hours(), 12U);
+    EXPECT_EQ(time.minutes(), 720U);
+    EXPECT_EQ(time.seconds(), 43200U);
+    EXPECT_EQ(time.milliSeconds(), 43200U * KILO);
+    EXPECT_EQ(time.microSeconds(), 43200U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 43200U * GIGA);
 }
 
 TEST(Duration_test, ConvertSeconds)
 {
     auto time = 28800_s;
-    EXPECT_EQ(time.days<uint64_t>(), 0U);
-    EXPECT_EQ(time.hours<uint64_t>(), 8U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 480U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 28800U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 28800U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 28800U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 28800U * GIGA);
+    EXPECT_EQ(time.days(), 0U);
+    EXPECT_EQ(time.hours(), 8U);
+    EXPECT_EQ(time.minutes(), 480U);
+    EXPECT_EQ(time.seconds(), 28800U);
+    EXPECT_EQ(time.milliSeconds(), 28800U * KILO);
+    EXPECT_EQ(time.microSeconds(), 28800U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 28800U * GIGA);
 }
 
 TEST(Duration_test, ConvertMilliseconds)
 {
     auto time = 28800000_ms;
-    EXPECT_EQ(time.days<uint64_t>(), 0U);
-    EXPECT_EQ(time.hours<uint64_t>(), 8U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 480U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 28800U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 28800U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 28800U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 28800U * GIGA);
+    EXPECT_EQ(time.days(), 0U);
+    EXPECT_EQ(time.hours(), 8U);
+    EXPECT_EQ(time.minutes(), 480U);
+    EXPECT_EQ(time.seconds(), 28800U);
+    EXPECT_EQ(time.milliSeconds(), 28800U * KILO);
+    EXPECT_EQ(time.microSeconds(), 28800U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 28800U * GIGA);
 }
 
 TEST(Duration_test, ConvertMicroseconds)
 {
     auto time = 6000000_us;
-    EXPECT_EQ(time.days<uint64_t>(), 0U);
-    EXPECT_EQ(time.hours<uint64_t>(), 0U);
-    EXPECT_EQ(time.minutes<uint64_t>(), 0U);
-    EXPECT_EQ(time.seconds<uint64_t>(), 6U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 6U * KILO);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 6U * MEGA);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 6U * GIGA);
+    EXPECT_EQ(time.days(), 0U);
+    EXPECT_EQ(time.hours(), 0U);
+    EXPECT_EQ(time.minutes(), 0U);
+    EXPECT_EQ(time.seconds(), 6U);
+    EXPECT_EQ(time.milliSeconds(), 6U * KILO);
+    EXPECT_EQ(time.microSeconds(), 6U * MEGA);
+    EXPECT_EQ(time.nanoSeconds(), 6U * GIGA);
 }
 
 TEST(Duration_test, ConvertNanoseconds)
 {
     auto time = 1_ns;
-    EXPECT_EQ(time.seconds<uint64_t>(), 0U);
-    EXPECT_EQ(time.milliSeconds<uint64_t>(), 0U);
-    EXPECT_EQ(time.microSeconds<uint64_t>(), 0U);
-    EXPECT_EQ(time.nanoSeconds<uint64_t>(), 1U);
+    EXPECT_EQ(time.seconds(), 0U);
+    EXPECT_EQ(time.milliSeconds(), 0U);
+    EXPECT_EQ(time.microSeconds(), 0U);
+    EXPECT_EQ(time.nanoSeconds(), 1U);
 }
 
 TEST(Duration_test, ConvertTimespecWithNoneReference)
@@ -703,13 +703,13 @@ TEST(Duration_test, AddDuration)
     auto time2 = 200_ms;
     auto time3 = 700000_us;
 
-    EXPECT_THAT(time1.milliSeconds<uint64_t>(), Eq(5200U));
+    EXPECT_THAT(time1.milliSeconds(), Eq(5200U));
 
     auto result = time1 + time2;
-    EXPECT_EQ(result.milliSeconds<uint64_t>(), 5400U);
+    EXPECT_EQ(result.milliSeconds(), 5400U);
 
     result = result + time3;
-    EXPECT_EQ(result.microSeconds<uint64_t>(), 6100000U);
+    EXPECT_EQ(result.microSeconds(), 6100000U);
 }
 
 TEST(Duration_test, SubtractDuration)
@@ -718,18 +718,18 @@ TEST(Duration_test, SubtractDuration)
     auto time2 = 200_ms;
     auto time3 = 300000_us;
 
-    EXPECT_THAT(time1.milliSeconds<uint64_t>(), Eq(5200U));
+    EXPECT_THAT(time1.milliSeconds(), Eq(5200U));
 
     auto result = time1 - time2;
-    EXPECT_EQ(result.milliSeconds<uint64_t>(), 5000U);
+    EXPECT_EQ(result.milliSeconds(), 5000U);
 
     result = result - time3;
-    EXPECT_EQ(result.microSeconds<uint64_t>(), 4700000U);
+    EXPECT_EQ(result.microSeconds(), 4700000U);
 
     auto time4 = 10_s;
 
     result = result - time4;
-    EXPECT_EQ(result.milliSeconds<uint64_t>(), 0U);
+    EXPECT_EQ(result.milliSeconds(), 0U);
 }
 
 TEST(Duration_test, MultiplyDuration)

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -1356,6 +1356,20 @@ TEST(Duration_test, CompareDurationIsNotGreaterThanOrEqualToOther)
 
 // BEGIN ARITHMETIC TESTS
 
+TEST(Duration_test, AddDurationDoesNotChangeOriginalObject)
+{
+    constexpr Duration EXPECTED_DURATION{13_s + 42_ns};
+
+    auto sut1 = EXPECTED_DURATION;
+    auto result1 [[gnu::unused]] = sut1 + 15_s;
+
+    auto sut2 = EXPECTED_DURATION;
+    auto result2 [[gnu::unused]] = 15_s + sut1;
+
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
+}
+
 TEST(Duration_test, AddDurationWithTwoZeroDurationsResultsInZeroDuration)
 {
     constexpr Duration EXPECTED_DURATION{0_s};
@@ -1439,7 +1453,6 @@ TEST(Duration_test, AddDurationWithDurationsResultsNotYetInSaturation)
     auto duration1 =
         DurationFactory{std::numeric_limits<DurationFactory::SECONDS_TYPE>::max() - 1U, NANOSECS_PER_SECOND - 1U};
     auto duration2 = DurationFactory{0U, NANOSECS_PER_SECOND - 1U};
-    ;
 
     auto sut1 = duration1 + duration2;
     auto sut2 = duration2 + duration1;
@@ -1451,7 +1464,6 @@ TEST(Duration_test, AddDurationWithDurationsResultsNotYetInSaturation)
 TEST(Duration_test, AddDurationWithDurationsResultsInSaturation)
 {
     auto duration = DurationFactory{0U, 1U};
-    ;
 
     auto sut1 = duration + DurationFactory::max();
     auto sut2 = DurationFactory::max() + duration;
@@ -1480,20 +1492,165 @@ TEST(Duration_test, SubtractDuration)
     EXPECT_EQ(result.milliSeconds(), 0U);
 }
 
-TEST(Duration_test, MultiplyDuration)
+TEST(Duration_test, MultiplyDurationDoesNotChangeOriginalObject)
 {
-    auto time = 5_s + 800_ms;
+    constexpr Duration EXPECTED_DURATION{13_s + 42_ns};
 
-    EXPECT_THAT(time * 2, Eq(11_s + 600_ms));
-    EXPECT_THAT(time * 2U, Eq(11_s + 600_ms));
-    EXPECT_THAT(time * 2.95, Eq(17_s + 110_ms));
+    auto sut1 = EXPECTED_DURATION;
+    auto result1 [[gnu::unused]] = sut1 * 0;
 
-    EXPECT_THAT(2 * time, Eq(11_s + 600_ms));
-    EXPECT_THAT(2U * time, Eq(11_s + 600_ms));
-    EXPECT_THAT(2.95 * time, Eq(17_s + 110_ms));
+    auto sut2 = EXPECTED_DURATION;
+    auto result2 [[gnu::unused]] = sut2 * 0;
 
-    EXPECT_THAT(time * -1, Eq(0_s));
-    EXPECT_THAT(time * -1.0, Eq(0_s));
+    EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
+}
+
+template <typename T>
+void multiply(Duration duration, T multiplicator, const Duration expectedDuration)
+{
+    auto sut1 = duration * multiplicator;
+    auto sut2 = multiplicator * duration;
+
+    EXPECT_THAT(sut1, Eq(expectedDuration));
+    EXPECT_THAT(sut2, Eq(expectedDuration));
+}
+
+TEST(Duration_test, MultiplyZeroDurationWithZeroSignedMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 0_s;
+
+    multiply(duration, 0, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyZeroDurationWithZeroUnsignedMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 0_s;
+
+    multiply(duration, 0U, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyZeroDurationWithZeroFloatMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 0_s;
+
+    multiply(duration, 0.0, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationWithZeroSignedMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 1_s + 12_ns;
+
+    multiply(duration, 0, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationWithZeroUnsignedMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 1_s + 12_ns;
+
+    multiply(duration, 0U, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationWithZeroFloatMultiplicatorResultsInZeroDuration)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 1_s + 12_ns;
+
+    multiply(duration, 0.0, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithSignedResultsInLessThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{36_ns};
+    auto duration = 12_ns;
+
+    multiply(duration, 3, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithUnsignedResultsInLessThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{36_ns};
+    auto duration = 12_ns;
+
+    multiply(duration, 3U, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithFloatResultsInLessThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{42_ns};
+    auto duration = 12_ns;
+
+    multiply(duration, 3.5, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithSignedResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{1_s + 800_ms};
+    auto duration = 600_ms;
+
+    multiply(duration, 3, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithUnsignedResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{1_s + 800_ms};
+    auto duration = 600_ms;
+
+    multiply(duration, 3U, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationLessThanOneSecondWithFloatResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{2_s + 100_ms};
+    auto duration = 600_ms;
+
+    multiply(duration, 3.5, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationMoreThanOneSecondWithSignedResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{13_s + 800_ms};
+    auto duration = 4_s + 600_ms;
+
+    multiply(duration, 3, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationMoreThanOneSecondWithUnsignedResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{13_s + 800_ms};
+    auto duration = 4_s + 600_ms;
+
+    multiply(duration, 3U, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationMoreThanOneSecondWithFloatResultsInMoreThanOneSecond)
+{
+    constexpr Duration EXPECTED_DURATION{16_s + 100_ms};
+    auto duration = 4_s + 600_ms;
+
+    multiply(duration, 3.5, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationWithFractionalFloat)
+{
+    constexpr Duration EXPECTED_DURATION{2_s + 300_ms};
+    auto duration = 4_s + 600_ms;
+
+    multiply(duration, 0.5, EXPECTED_DURATION);
+}
+
+TEST(Duration_test, MultiplyDurationWithNegativMultiplicatorResultsInZero)
+{
+    constexpr Duration EXPECTED_DURATION{0_s};
+    auto duration = 4_s + 600_ms;
+
+    multiply(duration, -1, EXPECTED_DURATION);
+    multiply(duration, -1.0, EXPECTED_DURATION);
 }
 
 TEST(Duration_test, MultiplyDurationLessThanOneSecondResultsInMoreNanosecondsThan64BitCanRepresent)
@@ -1520,13 +1677,47 @@ TEST(Duration_test, MultiplyDurationResultsNotYetInSaturation)
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
 }
 
-TEST(Duration_test, MultiplyDurationResultsInSaturation)
+TEST(Duration_test, MultiplyDurationResultsInSaturationDueToSeconds)
+{
+    constexpr uint64_t MULTIPLICATOR{1343535617188545797U};
+    constexpr Duration DURATION = 14_s;
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyDurationResultsInSaturationDueToNanoseconds)
 {
     constexpr uint64_t MULTIPLICATOR{1343535617188545797U};
     constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
 
     EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyMaxDurationWithNaNDoubleResultsInMaxDuration)
+{
+    EXPECT_THAT(DurationFactory::max() * NAN, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyMaxDurationWithPosInfDoubleResultsInMaxDuration)
+{
+    EXPECT_THAT(DurationFactory::max() * INFINITY, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyMaxDurationWithNegInfDoubleResultsInZeroDuration)
+{
+    EXPECT_THAT(DurationFactory::max() * (INFINITY * -1.0), Eq(0_ns));
+}
+
+TEST(Duration_test, MultiplyDurationWithMinimalFloatResultsInZero)
+{
+    constexpr float MULTIPLICATOR{std::numeric_limits<float>::min()};
+    constexpr Duration DURATION = 13_s + 730_ms + 37_ns;
+    auto EXPECTED_DURATION = DurationFactory{0U, 0U};
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_DURATION));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
 }
 
 TEST(Duration_test, MultiplyDurationWithMinimalDoubleResultsInZero)
@@ -1537,6 +1728,52 @@ TEST(Duration_test, MultiplyDurationWithMinimalDoubleResultsInZero)
 
     EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(EXPECTED_DURATION));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, MultiplyMaxDurationWithFloatOneResultsInMaxDuration)
+{
+    EXPECT_THAT(DurationFactory::max() * 1.0, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyMaxDurationWithDoubleOneResultsInMaxDuration)
+{
+    EXPECT_THAT(DurationFactory::max() * 1.0, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyDurationWithFloatResultsInSaturationDueToSeconds)
+{
+    constexpr float MULTIPLICATOR{1343535617188545797.0};
+    constexpr Duration DURATION = 14_s;
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyDurationWithDoubleResultsInSaturationDueToSeconds)
+{
+    constexpr double MULTIPLICATOR{1343535617188545797.0};
+    constexpr Duration DURATION = 14_s;
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyDurationWithFloatResultsInSaturationDueToNanoseconds)
+{
+    constexpr float MULTIPLICATOR{1343535617188545797.0};
+    constexpr Duration DURATION = 13_s + 930_ms + 37_ns;
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
+}
+
+TEST(Duration_test, MultiplyDurationWithDoubleResultsInSaturationDueToNanoseconds)
+{
+    constexpr double MULTIPLICATOR{1343535617188545797.0};
+    constexpr Duration DURATION = 13_s + 930_ms + 37_ns;
+
+    EXPECT_THAT(MULTIPLICATOR * DURATION, Eq(DurationFactory::max()));
+    EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationFactory::max()));
 }
 
 TEST(Duration_test, StreamingOperator)

--- a/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
+++ b/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
@@ -43,7 +43,7 @@ void PerformBenchmark(Return (&f)(), const char* functionName, const iox::units:
         }
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(duration.milliSeconds<uint64_t>()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(duration.milliSeconds()));
     keepRunning = false;
     t.join();
 

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -54,8 +54,8 @@ void IntrospectionApp::printHelp() noexcept
                  "  -h, --help        Display help and exit.\n"
                  "  -t, --time <ms>   Update period (in milliseconds) for the display of introspection data\n"
                  "                    [min: "
-              << MIN_UPDATE_PERIOD.milliSeconds<uint32_t>() << ", max: " << MAX_UPDATE_PERIOD.milliSeconds<uint32_t>()
-              << ", default: " << DEFAULT_UPDATE_PERIOD.milliSeconds<uint32_t>()
+              << MIN_UPDATE_PERIOD.milliSeconds() << ", max: " << MAX_UPDATE_PERIOD.milliSeconds()
+              << ", default: " << DEFAULT_UPDATE_PERIOD.milliSeconds()
               << "]\n"
                  "  -v, --version     Display latest official iceoryx release version and exit.\n"
                  "\nSubscription:\n"
@@ -350,9 +350,11 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
         {
             stream << std::left << std::setw(maxSize) << data.substr(0U, static_cast<size_t>(maxSize));
         }
-        else if (stringSize > static_cast<size_t>(maxSize) + (currentLine - 1U) * static_cast<size_t>(maxSize - indentation))
+        else if (stringSize
+                 > static_cast<size_t>(maxSize) + (currentLine - 1U) * static_cast<size_t>(maxSize - indentation))
         {
-            const auto startPosition = static_cast<size_t>(maxSize) + (currentLine - 1U) * static_cast<size_t>(maxSize - indentation);
+            const auto startPosition =
+                static_cast<size_t>(maxSize) + (currentLine - 1U) * static_cast<size_t>(maxSize - indentation);
 
             stream << indentationString << std::left << std::setw(maxSize - indentation)
                    << data.substr(startPosition, static_cast<size_t>(maxSize - indentation));
@@ -362,7 +364,8 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
             stream << std::left << std::setw(maxSize) << "";
         }
 
-        needsLineBreak |= (stringSize > static_cast<size_t>(maxSize) + (currentLine) * static_cast<size_t>(maxSize - indentation));
+        needsLineBreak |=
+            (stringSize > static_cast<size_t>(maxSize) + (currentLine) * static_cast<size_t>(maxSize - indentation));
 
         return stream.str();
     };
@@ -518,7 +521,7 @@ bool IntrospectionApp::waitForSubscription(Subscriber& port)
            !subscribed && numberOfLoopsTillTimeout > 0)
     {
         numberOfLoopsTillTimeout--;
-        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.milliSeconds<int64_t>()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.milliSeconds()));
     }
 
     return subscribed;
@@ -585,10 +588,11 @@ std::vector<ComposedSubscriberPortData> IntrospectionApp::composeSubscriberPortD
     { // should be the same, else it will be soon
         for (const auto& port : portData->m_subscriberList)
         {
-            subscriberPortData.push_back(
-                {port,
-                 (port.m_publisherIndex != -1) ? &portData->m_publisherList[static_cast<uint64_t>(port.m_publisherIndex)] : nullptr,
-                 subscriberPortChangingData->subscriberPortChangingDataList[i++]});
+            subscriberPortData.push_back({port,
+                                          (port.m_publisherIndex != -1)
+                                              ? &portData->m_publisherList[static_cast<uint64_t>(port.m_publisherIndex)]
+                                              : nullptr,
+                                          subscriberPortChangingData->subscriberPortChangingDataList[i++]});
         }
     }
 
@@ -769,13 +773,13 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
         refreshTerminal();
 
         // Watch user input for updatePeriodMs
-        auto tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds<uint64_t>());
+        auto tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds());
         auto tWaitBegin = std::chrono::system_clock::now();
         while (tWaitRemaining.count() >= 0)
         {
             waitForUserInput(static_cast<int32_t>(tWaitRemaining.count()));
             auto tWaitElapsed = std::chrono::system_clock::now() - tWaitBegin;
-            tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds<uint64_t>())
+            tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds())
                              - std::chrono::duration_cast<std::chrono::milliseconds>(tWaitElapsed);
         }
     }
@@ -787,5 +791,3 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
 } // namespace introspection
 } // namespace client
 } // namespace iox
-
-

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -96,10 +96,16 @@ void IntrospectionApp::parseCmdLineArguments(int argc,
 
         case 't':
         {
-            /// @todo Calling milliseconds() should not be ambiguous, extend units::Duration?
-            iox::units::Duration l_rate =
-                iox::units::Duration::milliseconds(static_cast<long double>(std::atoi(optarg)));
-            updatePeriodMs = bounded(l_rate, MIN_UPDATE_PERIOD, MAX_UPDATE_PERIOD);
+            uint64_t newUpdatePeriodMs;
+            if (cxx::convert::fromString(optarg, newUpdatePeriodMs))
+            {
+                iox::units::Duration rate = iox::units::Duration::milliseconds(newUpdatePeriodMs);
+                updatePeriodMs = bounded(rate, MIN_UPDATE_PERIOD, MAX_UPDATE_PERIOD);
+            }
+            else
+            {
+                std::cout << "Invalid argument for `t`! Will be ignored!";
+            }
             break;
         }
 
@@ -781,3 +787,5 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
 } // namespace introspection
 } // namespace client
 } // namespace iox
+
+


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This replaces the `long double` internal representation of `units::Duration` with `uint64_t` for seconds and `uint32_t` for nanoseconds.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [ ] All checkboxes in the PR checklist are checked or crossed out
1. [ ] Merge

## References

- Closes #190
