### PR TITLE
Iox #408 improve typed and untyped api

### DIFF
--- a/doc/website/getting-started/overview.md
+++ b/doc/website/getting-started/overview.md
@@ -406,7 +406,7 @@ while (keepRunning)
             // we received no data
         }
     } else {
-        iox::popo::ChunkReceiveError& error = result.get_error();
+        iox::popo::ChunkReceiveResult& error = result.get_error();
         //handle the error
     }
 }
@@ -435,7 +435,7 @@ while (keepRunning)
             uint32_t counter = sample->counter;
         })
         .if_empty([] { /* no data received but also no error */ })
-        .or_else([](iox::popo::ChunkReceiveError) { /* handle the error */ });
+        .or_else([](iox::popo::ChunkReceiveResult) { /* handle the error */ });
 }
 
 ```
@@ -468,7 +468,7 @@ while (keepRunning)
                 /* alternatively use operator-> */
                 uint32_t counter = sample->counter;
             })
-            .or_else([](iox::popo::ChunkReceiveError) { /* handle the error */ });
+            .or_else([](iox::popo::ChunkReceiveResult) { /* handle the error */ });
     }
     // wait for new samples (either sleep or use the waitset)
 }
@@ -569,7 +569,7 @@ while (keepRunning)
             /* process the received data using counter */
         })
         .if_empty([] { /* no data received but also no error */ })
-        .or_else([](iox::popo::ChunkReceiveError) { /* handle the error */ });
+        .or_else([](iox::popo::ChunkReceiveResult) { /* handle the error */ });
 }
 ```
 
@@ -606,7 +606,7 @@ while (keepRunning)
                 // we received no data
             }
         } else {
-            iox::popo::ChunkReceiveError& error = result.get_error();
+            iox::popo::ChunkReceiveResult& error = result.get_error();
             //handle the error
         }
     }

--- a/iceoryx_binding_c/include/iceoryx_binding_c/internal/cpp2c_enum_translation.hpp
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/internal/cpp2c_enum_translation.hpp
@@ -25,7 +25,7 @@
 namespace cpp2c
 {
 iox_SubscribeState SubscribeState(const iox::SubscribeState value);
-iox_ChunkReceiveResult ChunkReceiveResult(const iox::popo::ChunkReceiveError value);
+iox_ChunkReceiveResult ChunkReceiveResult(const iox::popo::ChunkReceiveResult value);
 iox_AllocationResult AllocationResult(const iox::popo::AllocationError value);
 iox_WaitSetResult WaitSetResult(const iox::popo::WaitSetError value);
 } // namespace cpp2c

--- a/iceoryx_binding_c/source/cpp2c_enum_translation.cpp
+++ b/iceoryx_binding_c/source/cpp2c_enum_translation.cpp
@@ -39,11 +39,11 @@ iox_SubscribeState SubscribeState(const iox::SubscribeState value)
     }
 }
 
-iox_ChunkReceiveResult ChunkReceiveResult(const iox::popo::ChunkReceiveError value)
+iox_ChunkReceiveResult ChunkReceiveResult(const iox::popo::ChunkReceiveResult value)
 {
     switch (value)
     {
-    case ChunkReceiveError::TOO_MANY_CHUNKS_HELD_IN_PARALLEL:
+    case ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL:
         return ChunkReceiveResult_TOO_MANY_CHUNKS_HELD_IN_PARALLEL;
     default:
         return ChunkReceiveResult_UNDEFINED_ERROR;

--- a/iceoryx_binding_c/test/moduletests/test_cpp2c_enum_translation.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_cpp2c_enum_translation.cpp
@@ -36,13 +36,13 @@ TEST(cpp2c_enum_translation_test, SubscribeState)
 
 TEST(cpp2c_enum_translation_test, ChunkReceiveResult)
 {
-    EXPECT_EQ(cpp2c::ChunkReceiveResult(iox::popo::ChunkReceiveError::TOO_MANY_CHUNKS_HELD_IN_PARALLEL),
+    EXPECT_EQ(cpp2c::ChunkReceiveResult(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL),
               ChunkReceiveResult_TOO_MANY_CHUNKS_HELD_IN_PARALLEL);
 
     // ignore the warning since we would like to test the behavior of an invalid enum value
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
-    EXPECT_EQ(cpp2c::ChunkReceiveResult(static_cast<iox::popo::ChunkReceiveError>(-1)),
+    EXPECT_EQ(cpp2c::ChunkReceiveResult(static_cast<iox::popo::ChunkReceiveResult>(-1)),
               ChunkReceiveResult_UNDEFINED_ERROR);
 #pragma GCC diagnostic pop
 }

--- a/iceoryx_dds/test/mocks/google_mocks.hpp
+++ b/iceoryx_dds/test/mocks/google_mocks.hpp
@@ -65,7 +65,7 @@ class MockSubscriber
     MOCK_CONST_METHOD0(hasSamples, bool());
     MOCK_METHOD0(hasMissedSamples, bool());
     MOCK_METHOD0_T(take,
-                   iox::cxx::expected<iox::cxx::optional<iox::popo::Sample<const T>>, iox::popo::ChunkReceiveError>());
+                   iox::cxx::expected<iox::cxx::optional<iox::popo::Sample<const T>>, iox::popo::ChunkReceiveResult>());
     MOCK_METHOD0(releaseQueuedSamples, void());
     MOCK_METHOD1(setConditionVariable, bool(iox::popo::ConditionVariableData*));
     MOCK_METHOD0(unsetConditionVariable, bool(void));

--- a/iceoryx_examples/ice_multi_publisher/README.md
+++ b/iceoryx_examples/ice_multi_publisher/README.md
@@ -176,7 +176,7 @@ The displayed counters are monotonically increasing for each id but between diff
 
 We also handle potential errors
 ```cpp
-    .or_else([](iox::popo::ChunkReceiveError) { std::cout << "Error while receiving." << std::endl; });
+    .or_else([](iox::popo::ChunkReceiveResult) { std::cout << "Error while receiving." << std::endl; });
 ```
 
 and wait for some time before looking for data again.

--- a/iceoryx_examples/ice_multi_publisher/ice_subscriber.cpp
+++ b/iceoryx_examples/ice_multi_publisher/ice_subscriber.cpp
@@ -43,7 +43,7 @@ void receive()
                 .and_then([](iox::popo::Sample<const CounterTopic>& sample) {
                     std::cout << "Received: " << *sample.get() << std::endl;
                 })
-                .or_else([](iox::popo::ChunkReceiveError) { std::cout << "Error while receiving." << std::endl; });
+                .or_else([](iox::popo::ChunkReceiveResult) { std::cout << "Error while receiving." << std::endl; });
         };
         std::cout << "Waiting for data ... " << std::endl;
     }

--- a/iceoryx_examples/icedelivery/README.md
+++ b/iceoryx_examples/icedelivery/README.md
@@ -214,7 +214,7 @@ untypedSubscriber.take()
     {
         // ...
     })
-    .or_else([](iox::popo::ChunkReceiveError error)
+    .or_else([](iox::popo::ChunkReceiveResult error)
     {
         std::cout << "Error receiving chunk." << std::endl;
     });

--- a/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
@@ -50,7 +50,7 @@ int main()
         // API Usage #1
         //  * Retrieve a typed sample from shared memory.
         //  * Sample can be held until ready to publish.
-        //
+        //  * Data is default constructed during loan
         auto result = publisher.loan_1_0();
         if (!result.has_error())
         {
@@ -66,11 +66,10 @@ int main()
             // Do something with error
         }
 
-        // API Usage #1
-        //  * Retrieve a typed sample from shared memory and construct data using the
-        //    arguments provided.
+        // API Usage #2
+        //  * Retrieve a typed sample from shared memory and construct data in-place
         //  * Sample can be held until ready to publish.
-        //
+        //  * Data is constructed with the aruments provided.
         result = publisher.loan_1_0(ct, ct, ct);
         if (!result.has_error())
         {

--- a/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
@@ -66,7 +66,23 @@ int main()
             // Do something with error
         }
 
-        // API Usage #2
+        // API Usage #1
+        //  * Retrieve a typed sample from shared memory and construct data using the
+        //    arguments provided.
+        //  * Sample can be held until ready to publish.
+        //
+        result = publisher.loan_1_0(ct, ct, ct);
+        if (!result.has_error())
+        {
+            result.value().publish();
+        }
+        else
+        {
+            auto error = result.get_error();
+            // Do something with error
+        }
+
+        // API Usage #3
         //  * Retrieve a sample and provide the logic to immediately populate and publish it via a lambda.
         //
         publisher.loan_1_0()
@@ -82,13 +98,13 @@ int main()
             });
 
 
-        // API Usage #3
+        // API Usage #4
         //  * Basic copy-and-publish. Useful for smaller data types.
         //
         auto object = RadarObject(ct, ct, ct);
         publisher.publishCopyOf(object);
 
-        // API Usage #4
+        // API Usage #5
         //  * Provide a callable that will be used to populate the loaned sample.
         //  * The first argument of the callable must be T* and is the location that the callable should
         //      write its result to.
@@ -96,7 +112,7 @@ int main()
         publisher.publishResultOf(getRadarObject, ct);
         publisher.publishResultOf([&ct](RadarObject* object) { *object = RadarObject(ct, ct, ct); });
 
-        std::cout << "Sent five times value: " << ct << std::endl;
+        std::cout << "Sent six times value: " << ct << std::endl;
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
     }

--- a/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_typed.cpp
@@ -39,8 +39,8 @@ int main()
 
     iox::runtime::PoshRuntime::initRuntime("iox-ex-publisher-typed");
 
-    iox::popo::TypedPublisher<RadarObject> typedPublisher({"Radar", "FrontLeft", "Object"});
-    typedPublisher.offer();
+    iox::popo::TypedPublisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"});
+    publisher.offer();
 
     double ct = 0.0;
     while (!killswitch)
@@ -51,7 +51,7 @@ int main()
         //  * Retrieve a typed sample from shared memory.
         //  * Sample can be held until ready to publish.
         //
-        auto result = typedPublisher.loan();
+        auto result = publisher.loan_1_0();
         if (!result.has_error())
         {
             auto& sample = result.value();
@@ -69,7 +69,7 @@ int main()
         // API Usage #2
         //  * Retrieve a sample and provide the logic to immediately populate and publish it via a lambda.
         //
-        typedPublisher.loan()
+        publisher.loan_1_0()
             .and_then([&](auto& sample) {
                 auto object = sample.get();
                 // Do some stuff leading to eventually generating the data in the samples loaned memory...
@@ -86,15 +86,15 @@ int main()
         //  * Basic copy-and-publish. Useful for smaller data types.
         //
         auto object = RadarObject(ct, ct, ct);
-        typedPublisher.publishCopyOf(object);
+        publisher.publishCopyOf(object);
 
         // API Usage #4
         //  * Provide a callable that will be used to populate the loaned sample.
         //  * The first argument of the callable must be T* and is the location that the callable should
         //      write its result to.
         //
-        typedPublisher.publishResultOf(getRadarObject, ct);
-        typedPublisher.publishResultOf([&ct](RadarObject* object) { *object = RadarObject(ct, ct, ct); });
+        publisher.publishResultOf(getRadarObject, ct);
+        publisher.publishResultOf([&ct](RadarObject* object) { *object = RadarObject(ct, ct, ct); });
 
         std::cout << "Sent five times value: " << ct << std::endl;
 

--- a/iceoryx_examples/icedelivery/iox_publisher_with_history.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_with_history.cpp
@@ -38,8 +38,8 @@ int main()
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.historyCapacity = 10U;
 
-    iox::popo::TypedPublisher<RadarObject> typedPublisher({"Radar", "FrontLeft", "Object"}, publisherOptions);
-    typedPublisher.offer();
+    iox::popo::TypedPublisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"}, publisherOptions);
+    publisher.offer();
 
     double ct = 0.0;
     while (!killswitch)
@@ -47,13 +47,7 @@ int main()
         ++ct;
 
         // Retrieve a sample and provide the logic to immediately populate and publish it via a lambda.
-        typedPublisher.loan().and_then([&](auto& sample) {
-            auto object = sample.get();
-            // Do some stuff leading to eventually generating the data in the samples loaned memory...
-            *object = RadarObject(ct, ct, ct);
-            // ...then publish the sample
-            sample.publish();
-        });
+        publisher.loan_1_0(ct, ct, ct).and_then([&](auto& sample) { sample.publish(); });
 
         std::cout << "Sent value: " << ct << std::endl;
 

--- a/iceoryx_examples/icedelivery/iox_publisher_with_history.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_with_history.cpp
@@ -46,8 +46,8 @@ int main()
     {
         ++ct;
 
-        // Retrieve a sample and provide the logic to immediately populate and publish it via a lambda.
-        publisher.loan_1_0(ct, ct, ct).and_then([&](auto& sample) { sample.publish(); });
+        // Retrieve a sample, construct it with the given arguments and publish it via a lambda.
+        publisher.loan_1_0(ct, ct, ct).and_then([](auto& sample) { sample.publish(); });
 
         std::cout << "Sent value: " << ct << std::endl;
 

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
@@ -52,7 +52,7 @@ int main()
                     std::cout << "Got value: " << object->x << std::endl;
                 })
                 .if_empty([] { std::cout << std::endl; })
-                .or_else([](iox::popo::ChunkReceiveError) { std::cout << "Error receiving chunk." << std::endl; });
+                .or_else([](iox::popo::ChunkReceiveResult) { std::cout << "Error receiving chunk." << std::endl; });
         }
         else
         {

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
@@ -50,14 +50,10 @@ int main()
             subscriber.take_1_0()
                 .and_then([](auto& sample) { std::cout << "Got value: " << sample->x << std::endl; })
                 .or_else([](auto& result) {
-                    // only has to be called if the alternative is of interest
-                    // (i.e. if nothing has to happen when no data is received and
-                    // a possible error alternative is not checked or_else is not needed)
-                    if (result == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
-                    {
-                        std::cout << "No sample available" << std::endl;
-                    }
-                    else
+                    // only has to be called if the alternative is of interest,
+                    // i.e. if nothing has to happen when no data is received and
+                    // a possible error alternative is not checked or_else is not needed
+                    if (result != iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
                     {
                         std::cout << "Error receiving chunk." << std::endl;
                     }

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed.cpp
@@ -39,20 +39,29 @@ int main()
     // initialized subscriber
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.queueCapacity = 10U;
-    iox::popo::TypedSubscriber<RadarObject> typedSubscriber({"Radar", "FrontLeft", "Object"}, subscriberOptions);
-    typedSubscriber.subscribe();
+    iox::popo::TypedSubscriber<RadarObject> subscriber({"Radar", "FrontLeft", "Object"}, subscriberOptions);
+    subscriber.subscribe();
 
     // run until interrupted by Ctrl-C
     while (!killswitch)
     {
-        if (typedSubscriber.getSubscriptionState() == iox::SubscribeState::SUBSCRIBED)
+        if (subscriber.getSubscriptionState() == iox::SubscribeState::SUBSCRIBED)
         {
-            typedSubscriber.take()
-                .and_then([](iox::popo::Sample<const RadarObject>& object) {
-                    std::cout << "Got value: " << object->x << std::endl;
-                })
-                .if_empty([] { std::cout << std::endl; })
-                .or_else([](iox::popo::ChunkReceiveResult) { std::cout << "Error receiving chunk." << std::endl; });
+            subscriber.take_1_0()
+                .and_then([](auto& sample) { std::cout << "Got value: " << sample->x << std::endl; })
+                .or_else([](auto& result) {
+                    // only has to be called if the alternative is of interest
+                    // (i.e. if nothing has to happen when no data is received and
+                    // a possible error alternative is not checked or_else is not needed)
+                    if (result == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
+                    {
+                        std::cout << "No sample available" << std::endl;
+                    }
+                    else
+                    {
+                        std::cout << "Error receiving chunk." << std::endl;
+                    }
+                });
         }
         else
         {
@@ -62,7 +71,7 @@ int main()
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    typedSubscriber.unsubscribe();
+    subscriber.unsubscribe();
 
     return (EXIT_SUCCESS);
 }

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
@@ -48,9 +48,13 @@ int main()
         if (subscriber.getSubscriptionState() == iox::SubscribeState::SUBSCRIBED)
         {
             subscriber.take_1_0()
-                .and_then([](const void* data) {
+                .and_then([&](const void* data) {
                     auto object = static_cast<const RadarObject*>(data);
                     std::cout << "Got value: " << object->x << std::endl;
+
+                    // note that we explicitly have to release the data
+                    // and afterwards the pointer access is undefined behavior
+                    subscriber.releaseChunk(object);
                 })
                 .or_else([](auto& result) {
                     if (result != iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
@@ -53,7 +53,7 @@ int main()
                     std::cout << "Got value: " << object->x << std::endl;
                 })
                 .if_empty([] { std::cout << std::endl; })
-                .or_else([](iox::popo::ChunkReceiveError) { std::cout << "Error receiving chunk." << std::endl; });
+                .or_else([](iox::popo::ChunkReceiveResult) { std::cout << "Error receiving chunk." << std::endl; });
         }
         else
         {

--- a/iceoryx_examples/icedelivery_on_c/README.md
+++ b/iceoryx_examples/icedelivery_on_c/README.md
@@ -65,7 +65,7 @@ Let's take a look at the `receiving` function which comes with the
          if (SubscribeState_SUBSCRIBED == iox_sub_get_subscription_state(subscriber))
          {
              const void* chunk = NULL;
-             while (ChunkReceiveError_SUCCESS == iox_sub_get_chunk(subscriber, &chunk))
+             while (ChunkReceiveResult_SUCCESS == iox_sub_get_chunk(subscriber, &chunk))
              {
                  const struct RadarObject* sample = (const struct RadarObject*)(chunk);
                  printf("Got value: %.0f\n", sample->x);

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
@@ -80,6 +80,17 @@ inline cxx::optional<Sample<T>> BasePublisher<T, port_t>::loanPreviousSample() n
 }
 
 template <typename T, typename port_t>
+cxx::optional<void*> BasePublisher<T, port_t>::loanPreviousChunk() noexcept
+{
+    auto result = m_port.tryGetPreviousChunk();
+    if (result.has_value())
+    {
+        return result.value()->payload();
+    }
+    return cxx::nullopt;
+}
+
+template <typename T, typename port_t>
 inline void BasePublisher<T, port_t>::offer() noexcept
 {
     m_port.offer();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
@@ -61,11 +61,32 @@ inline cxx::expected<Sample<T>, AllocationError> BasePublisher<T, port_t>::loan(
 }
 
 template <typename T, typename port_t>
+inline cxx::expected<void*, AllocationError> BasePublisher<T, port_t>::loan_1_0(const uint32_t size) noexcept
+{
+    auto result = m_port.tryAllocateChunk(size);
+    if (result.has_error())
+    {
+        return cxx::error<AllocationError>(result.get_error());
+    }
+    else
+    {
+        return cxx::success<void*>(result.value()->payload());
+    }
+}
+
+template <typename T, typename port_t>
 inline void BasePublisher<T, port_t>::publish(Sample<T>&& sample) noexcept
 {
     auto header = mepoo::ChunkHeader::fromPayload(sample.get());
     m_port.sendChunk(header);
     sample.release(); // Must release ownership of the sample as the publisher port takes it when publishing.
+}
+
+template <typename T, typename port_t>
+inline void BasePublisher<T, port_t>::publish(const void* const chunk) noexcept
+{
+    auto header = mepoo::ChunkHeader::fromPayload(chunk);
+    m_port.sendChunk(header);
 }
 
 template <typename T, typename port_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -148,6 +148,13 @@ inline void BaseSubscriber<T, Subscriber, port_t>::invalidateTrigger(const uint6
     }
 }
 
+template <typename T, typename Subscriber, typename port_t>
+void BaseSubscriber<T, Subscriber, port_t>::releaseChunk(const void* payload) noexcept
+{
+    auto header = mepoo::ChunkHeader::fromPayload(payload);
+    m_port.get().releaseChunk(header);
+}
+
 // ============================== Sample Deleter ============================== //
 
 template <typename T, typename Subscriber, typename port_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -83,13 +83,13 @@ inline bool BaseSubscriber<T, Subscriber, port_t>::hasMissedSamples() noexcept
 }
 
 template <typename T, typename Subscriber, typename port_t>
-inline cxx::expected<cxx::optional<Sample<const T>>, ChunkReceiveError>
+inline cxx::expected<cxx::optional<Sample<const T>>, ChunkReceiveResult>
 BaseSubscriber<T, Subscriber, port_t>::take() noexcept
 {
     auto result = m_port.tryGetChunk();
     if (result.has_error())
     {
-        return cxx::error<ChunkReceiveError>(result.get_error());
+        return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     else
     {
@@ -109,13 +109,13 @@ BaseSubscriber<T, Subscriber, port_t>::take() noexcept
 }
 
 template <typename T, typename Subscriber, typename port_t>
-inline cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveError>
+inline cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveResult>
 BaseSubscriber<T, Subscriber, port_t>::takeChunk() noexcept
 {
     auto result = m_port.tryGetChunk();
     if (result.has_error())
     {
-        return cxx::error<ChunkReceiveError>(result.get_error());
+        return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     else
     {
@@ -127,7 +127,7 @@ BaseSubscriber<T, Subscriber, port_t>::takeChunk() noexcept
         else
         {
             // could move this to a tryGetChunk but then we should remove expected<optional<>> there in the call chain
-            return cxx::error<ChunkReceiveError>(ChunkReceiveError::NO_CHUNK_AVAILABLE);
+            return cxx::error<ChunkReceiveResult>(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
         }
     }
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -122,14 +122,11 @@ BaseSubscriber<T, Subscriber, port_t>::takeChunk() noexcept
         auto maybeHeader = result.value();
         if (maybeHeader.has_value())
         {
-            cxx::success<const mepoo::ChunkHeader*>(maybeHeader.value());
-        }
-        else
-        {
-            // could move this to a tryGetChunk but then we should remove expected<optional<>> there in the call chain
-            return cxx::error<ChunkReceiveResult>(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
+            return cxx::success<const mepoo::ChunkHeader*>(maybeHeader.value());
         }
     }
+    // could move this to a tryGetChunk but then we should remove expected<optional<>> there in the call chain
+    return cxx::error<ChunkReceiveResult>(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
 }
 
 template <typename T, typename Subscriber, typename port_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -147,9 +147,8 @@ inline void BaseSubscriber<T, Subscriber, port_t>::invalidateTrigger(const uint6
 }
 
 template <typename T, typename Subscriber, typename port_t>
-void BaseSubscriber<T, Subscriber, port_t>::releaseChunk(const void* payload) noexcept
+void BaseSubscriber<T, Subscriber, port_t>::releaseChunk(const mepoo::ChunkHeader* header) noexcept
 {
-    auto header = mepoo::ChunkHeader::fromPayload(payload);
     m_port.releaseChunk(header);
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -125,7 +125,8 @@ BaseSubscriber<T, Subscriber, port_t>::takeChunk() noexcept
             return cxx::success<const mepoo::ChunkHeader*>(maybeHeader.value());
         }
     }
-    // could move this to a tryGetChunk but then we should remove expected<optional<>> there in the call chain
+    ///@todo: optimization - we could move this to a tryGetChunk but then we should remove expected<optional<>> there in
+    /// the call chain
     return cxx::error<ChunkReceiveResult>(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
 }
 
@@ -149,7 +150,7 @@ template <typename T, typename Subscriber, typename port_t>
 void BaseSubscriber<T, Subscriber, port_t>::releaseChunk(const void* payload) noexcept
 {
     auto header = mepoo::ChunkHeader::fromPayload(payload);
-    m_port.get().releaseChunk(header);
+    m_port.releaseChunk(header);
 }
 
 // ============================== Sample Deleter ============================== //

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
@@ -25,7 +25,7 @@ namespace iox
 {
 namespace popo
 {
-enum class ChunkReceiveError
+enum class ChunkReceiveResult
 {
     TOO_MANY_CHUNKS_HELD_IN_PARALLEL,
     NO_CHUNK_AVAILABLE
@@ -56,8 +56,8 @@ class ChunkReceiver : public ChunkQueuePopper<typename ChunkReceiverDataType::Ch
     /// The ownerhip of the SharedChunk remains in the ChunkReceiver for being able to cleanup if the user process
     /// disappears
     /// @return optional that has a new chunk header or no value if there are no new chunks in the underlying queue,
-    /// ChunkReceiveError on error
-    cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveError> tryGet() noexcept;
+    /// ChunkReceiveResult on error
+    cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveResult> tryGet() noexcept;
 
     /// @brief Release a chunk that was obtained with get
     /// @param[in] chunkHeader, pointer to the ChunkHeader to release

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
@@ -27,7 +27,8 @@ namespace popo
 {
 enum class ChunkReceiveError
 {
-    TOO_MANY_CHUNKS_HELD_IN_PARALLEL
+    TOO_MANY_CHUNKS_HELD_IN_PARALLEL,
+    NO_CHUNK_AVAILABLE
 };
 
 /// @brief The ChunkReceiver is a building block of the shared memory communication infrastructure. It extends

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
@@ -43,7 +43,7 @@ ChunkReceiver<ChunkReceiverDataType>::getMembers() noexcept
 }
 
 template <typename ChunkReceiverDataType>
-inline cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveError>
+inline cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveResult>
 ChunkReceiver<ChunkReceiverDataType>::tryGet() noexcept
 {
     auto popRet = this->tryPop();
@@ -62,7 +62,7 @@ ChunkReceiver<ChunkReceiverDataType>::tryGet() noexcept
         {
             // release the chunk
             sharedChunk = nullptr;
-            return cxx::error<ChunkReceiveError>(ChunkReceiveError::TOO_MANY_CHUNKS_HELD_IN_PARALLEL);
+            return cxx::error<ChunkReceiveResult>(ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL);
         }
     }
     else

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/client_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/client_port_user.hpp
@@ -82,8 +82,8 @@ class ClientPortUser : public BasePort
     /// @brief Tries to get the next response from the queue. If there is a new one, the ChunkHeader of the oldest
     /// response in the queue is returned (FiFo queue)
     /// @return optional that has a new chunk header or no value if there are no new responses in the underlying queue,
-    /// ChunkReceiveError on error
-    cxx::expected<cxx::optional<const ResponseHeader*>, ChunkReceiveError> getResponse() noexcept;
+    /// ChunkReceiveResult on error
+    cxx::expected<cxx::optional<const ResponseHeader*>, ChunkReceiveResult> getResponse() noexcept;
 
     /// @brief Release a response that was obtained with getResponseChunk
     /// @param[in] chunkHeader, pointer to the ChunkHeader to release

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/server_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/server_port_user.hpp
@@ -49,8 +49,8 @@ class ServerPortUser : public BasePort
     /// @brief Tries to get the next request from the queue. If there is a new one, the ChunkHeader of the oldest
     /// request in the queue is returned (FiFo queue)
     /// @return optional that has a new chunk header or no value if there are no new requests in the underlying queue,
-    /// ChunkReceiveError on error
-    cxx::expected<cxx::optional<const RequestHeader*>, ChunkReceiveError> getRequest() noexcept;
+    /// ChunkReceiveResult on error
+    cxx::expected<cxx::optional<const RequestHeader*>, ChunkReceiveResult> getRequest() noexcept;
 
     /// @brief Release a request that was obtained with getRequest
     /// @param[in] chunkHeader, pointer to the ChunkHeader to release

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp
@@ -62,8 +62,8 @@ class SubscriberPortUser : public BasePort
     /// @brief Tries to get the next chunk from the queue. If there is a new one, the ChunkHeader of the oldest chunk in
     /// the queue is returned (FiFo queue)
     /// @return optional that has a new chunk header or no value if there are no new chunks in the underlying queue,
-    /// ChunkReceiveError on error
-    cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveError> tryGetChunk() noexcept;
+    /// ChunkReceiveResult on error
+    cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveResult> tryGetChunk() noexcept;
 
     /// @brief Release a chunk that was obtained with tryGetChunk
     /// @param[in] chunkHeader, pointer to the ChunkHeader to release

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -65,6 +65,12 @@ inline T* Sample<T>::operator->() noexcept
 }
 
 template <typename T>
+inline const T* Sample<T>::operator->() const noexcept
+{
+    return get();
+}
+
+template <typename T>
 template <typename S, typename>
 inline S& Sample<T>::operator*() noexcept
 {
@@ -72,13 +78,26 @@ inline S& Sample<T>::operator*() noexcept
 }
 
 template <typename T>
-inline Sample<T>::operator bool()
+template <typename S, typename>
+inline const S& Sample<T>::operator*() const noexcept
+{
+    return *get();
+}
+
+template <typename T>
+inline Sample<T>::operator bool() const
 {
     return get() != nullptr;
 }
 
 template <typename T>
 inline T* Sample<T>::get() noexcept
+{
+    return m_samplePtr.get();
+}
+
+template <typename T>
+inline const T* Sample<T>::get() const noexcept
 {
     return m_samplePtr.get();
 }
@@ -107,16 +126,6 @@ template <typename T>
 inline void Sample<T>::release() noexcept
 {
     m_samplePtr.release();
-}
-
-template <typename T>
-template <typename... Args>
-inline void Sample<T>::emplace(Args&&... args) noexcept
-{
-    // to discuss overwrite unchecked (requires expert use) or keept track with a bool
-    // whether it needs to be destroyed before?
-
-    new (get()) T(std::forward<Args>(args)...);
 }
 
 // ============================== Sample<const T> ========================= //

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -109,6 +109,16 @@ inline void Sample<T>::release() noexcept
     m_samplePtr.release();
 }
 
+template <typename T>
+template <typename... Args>
+inline void Sample<T>::emplace(Args&&... args) noexcept
+{
+    // to discuss overwrite unchecked (requires expert use) or keept track with a bool
+    // whether it needs to be destroyed before?
+
+    new (get()) T(std::forward<Args>(args)...);
+}
+
 // ============================== Sample<const T> ========================= //
 
 template <typename T>
@@ -157,12 +167,6 @@ template <typename S, typename>
 inline const S& Sample<const T>::operator*() noexcept
 {
     return *get();
-}
-
-template <typename T>
-inline Sample<const T>::operator bool()
-{
-    return get() != nullptr;
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -65,6 +65,19 @@ inline T* Sample<T>::operator->() noexcept
 }
 
 template <typename T>
+template <typename S, typename>
+inline S& Sample<T>::operator*() noexcept
+{
+    return *get();
+}
+
+template <typename T>
+inline Sample<T>::operator bool()
+{
+    return get() != nullptr;
+}
+
+template <typename T>
 inline T* Sample<T>::get() noexcept
 {
     return m_samplePtr.get();
@@ -137,6 +150,19 @@ template <typename T>
 inline const T* Sample<const T>::operator->() noexcept
 {
     return get();
+}
+
+template <typename T>
+template <typename S, typename>
+inline const S& Sample<const T>::operator*() noexcept
+{
+    return *get();
+}
+
+template <typename T>
+inline Sample<const T>::operator bool()
+{
+    return get() != nullptr;
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_publisher.inl
@@ -38,6 +38,12 @@ inline cxx::expected<Sample<T>, AllocationError> TypedPublisher<T, base_publishe
 }
 
 template <typename T, typename base_publisher_t>
+inline cxx::expected<Sample<T>, AllocationError> TypedPublisher<T, base_publisher_t>::loanUninitialized() noexcept
+{
+    return std::move(base_publisher_t::loan(sizeof(T)));
+}
+
+template <typename T, typename base_publisher_t>
 template <typename Callable, typename... ArgTypes>
 inline cxx::expected<AllocationError> TypedPublisher<T, base_publisher_t>::publishResultOf(Callable c,
                                                                                            ArgTypes... args) noexcept

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_publisher.inl
@@ -38,9 +38,11 @@ inline cxx::expected<Sample<T>, AllocationError> TypedPublisher<T, base_publishe
 }
 
 template <typename T, typename base_publisher_t>
-inline cxx::expected<Sample<T>, AllocationError> TypedPublisher<T, base_publisher_t>::loanUninitialized() noexcept
+template <typename... Args>
+inline cxx::expected<Sample<T>, AllocationError> TypedPublisher<T, base_publisher_t>::loan_1_0(Args&&... args) noexcept
 {
-    return std::move(base_publisher_t::loan(sizeof(T)));
+    return std::move(base_publisher_t::loan(sizeof(T)).and_then(
+        [&](auto& sample) { new (sample.get()) T(std::forward<Args>(args)...); }));
 }
 
 template <typename T, typename base_publisher_t>
@@ -48,9 +50,9 @@ template <typename Callable, typename... ArgTypes>
 inline cxx::expected<AllocationError> TypedPublisher<T, base_publisher_t>::publishResultOf(Callable c,
                                                                                            ArgTypes... args) noexcept
 {
-    static_assert(
-        cxx::is_invocable<Callable, T*, ArgTypes...>::value,
-        "TypedPublisher<T>::publishResultOf expects a valid callable with a specific signature as the first argument");
+    static_assert(cxx::is_invocable<Callable, T*, ArgTypes...>::value,
+                  "TypedPublisher<T>::publishResultOf expects a valid callable with a specific signature as the "
+                  "first argument");
     static_assert(cxx::has_signature<Callable, void(T*, ArgTypes...)>::value,
                   "callable provided to TypedPublisher<T>::publishResultOf must have signature void(T*, ArgsTypes...)");
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
@@ -34,8 +34,8 @@ inline cxx::expected<Sample<const T>, ChunkReceiveResult> TypedSubscriber<T, bas
     {
         return cxx::error<ChunkReceiveResult>(result.get_error());
     }
-    auto payloadPtr = reinterpret_cast<T*>(result.value()->payload());
-    auto samplePtr = cxx::unique_ptr<T>(reinterpret_cast<T*>(payloadPtr), BaseSubscriber::m_sampleDeleter);
+    auto payloadPtr = static_cast<T*>(result.value()->payload());
+    auto samplePtr = cxx::unique_ptr<T>(static_cast<T*>(payloadPtr), BaseSubscriber::m_sampleDeleter);
     return cxx::success<Sample<const T>>(std::move(samplePtr));
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
@@ -26,6 +26,19 @@ inline TypedSubscriber<T, base_subscriber_t>::TypedSubscriber(const capro::Servi
 {
 }
 
+template <typename T, template <typename, typename, typename> class base_subscriber_t>
+inline cxx::expected<Sample<const T>, ChunkReceiveError> TypedSubscriber<T, base_subscriber_t>::take_1_0() noexcept
+{
+    auto result = BaseSubscriber::takeChunk();
+    if (result.has_error())
+    {
+        return result.error();
+    }
+    auto payloadPtr = reinterpret_cast<T*>(result.value()->payload());
+    auto samplePtr = cxx::unique_ptr<T>(reinterpret_cast<T*>(payloadPtr), BaseSubscriber::m_sampleDeleter);
+    return cxx::success<Sample<const T>>(std::move(samplePtr));
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
@@ -32,7 +32,7 @@ inline cxx::expected<Sample<const T>, ChunkReceiveResult> TypedSubscriber<T, bas
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())
     {
-        return result.error();
+        return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     auto payloadPtr = reinterpret_cast<T*>(result.value()->payload());
     auto samplePtr = cxx::unique_ptr<T>(reinterpret_cast<T*>(payloadPtr), BaseSubscriber::m_sampleDeleter);

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
@@ -27,7 +27,7 @@ inline TypedSubscriber<T, base_subscriber_t>::TypedSubscriber(const capro::Servi
 }
 
 template <typename T, template <typename, typename, typename> class base_subscriber_t>
-inline cxx::expected<Sample<const T>, ChunkReceiveError> TypedSubscriber<T, base_subscriber_t>::take_1_0() noexcept
+inline cxx::expected<Sample<const T>, ChunkReceiveResult> TypedSubscriber<T, base_subscriber_t>::take_1_0() noexcept
 {
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -55,6 +55,13 @@ void UntypedSubscriberImpl<base_subscriber_t>::releaseQueuedChunks() noexcept
     BaseSubscriber::releaseQueuedSamples();
 }
 
+template <template <typename, typename, typename> class base_subscriber_t>
+void UntypedSubscriberImpl<base_subscriber_t>::releaseChunk(void* payload) noexcept
+{
+    auto header = mepoo::ChunkHeader::fromPayload(payload);
+    BaseSubscriber::releaseChunk(header);
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -56,7 +56,7 @@ void UntypedSubscriberImpl<base_subscriber_t>::releaseQueuedChunks() noexcept
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>
-void UntypedSubscriberImpl<base_subscriber_t>::releaseChunk(void* payload) noexcept
+void UntypedSubscriberImpl<base_subscriber_t>::releaseChunk(const void* payload) noexcept
 {
     auto header = mepoo::ChunkHeader::fromPayload(payload);
     BaseSubscriber::releaseChunk(header);

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -37,6 +37,24 @@ inline cxx::expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<base
     return result.value()->payload();
 }
 
+template <template <typename, typename, typename> class base_subscriber_t>
+bool UntypedSubscriberImpl<base_subscriber_t>::hasData() const noexcept
+{
+    return BaseSubscriber::hasSamples();
+}
+
+template <template <typename, typename, typename> class base_subscriber_t>
+bool UntypedSubscriberImpl<base_subscriber_t>::hasMissedData() noexcept
+{
+    return BaseSubscriber::hasMissedData();
+}
+
+template <template <typename, typename, typename> class base_subscriber_t>
+void UntypedSubscriberImpl<base_subscriber_t>::releaseQueuedData() noexcept
+{
+    BaseSubscriber::releaseQueuedSamples();
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -32,9 +32,9 @@ inline cxx::expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<base
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())
     {
-        return result.error();
+        return cxx::error<ChunkReceiveResult>(result.get_error());
     }
-    return result.value()->payload();
+    return cxx::success<const void*>(result.value()->payload());
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -27,7 +27,7 @@ inline UntypedSubscriberImpl<base_subscriber_t>::UntypedSubscriberImpl(const cap
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>
-inline cxx::expected<const void*, ChunkReceiveError> UntypedSubscriberImpl<base_subscriber_t>::take_1_0() noexcept
+inline cxx::expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<base_subscriber_t>::take_1_0() noexcept
 {
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -38,19 +38,19 @@ inline cxx::expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<base
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>
-bool UntypedSubscriberImpl<base_subscriber_t>::hasData() const noexcept
+bool UntypedSubscriberImpl<base_subscriber_t>::hasChunks() const noexcept
 {
     return BaseSubscriber::hasSamples();
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>
-bool UntypedSubscriberImpl<base_subscriber_t>::hasMissedData() noexcept
+bool UntypedSubscriberImpl<base_subscriber_t>::hasMissedChunks() noexcept
 {
     return BaseSubscriber::hasMissedData();
 }
 
 template <template <typename, typename, typename> class base_subscriber_t>
-void UntypedSubscriberImpl<base_subscriber_t>::releaseQueuedData() noexcept
+void UntypedSubscriberImpl<base_subscriber_t>::releaseQueuedChunks() noexcept
 {
     BaseSubscriber::releaseQueuedSamples();
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -26,6 +26,17 @@ inline UntypedSubscriberImpl<base_subscriber_t>::UntypedSubscriberImpl(const cap
 {
 }
 
+template <template <typename, typename, typename> class base_subscriber_t>
+inline cxx::expected<const void*, ChunkReceiveError> UntypedSubscriberImpl<base_subscriber_t>::take_1_0() noexcept
+{
+    auto result = BaseSubscriber::takeChunk();
+    if (result.has_error())
+    {
+        return result.error();
+    }
+    return result.value()->payload();
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
@@ -75,6 +75,13 @@ class BasePublisher : public PublisherInterface<T>
     cxx::expected<Sample<T>, AllocationError> loan(const uint32_t size) noexcept;
 
     ///
+    /// @brief loan Get a chunk from loaned shared memory.
+    /// @param size The expected size of the chunk.
+    /// @return A pointer to a chunk of memory with the requested size.
+    ///
+    cxx::expected<void*, AllocationError> loan_1_0(const uint32_t size) noexcept;
+
+    ///
     /// @brief publish Publishes the given sample and then releases its loan.
     /// @param sample The sample to publish.
     ///

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
@@ -82,11 +82,19 @@ class BasePublisher : public PublisherInterface<T>
     ///
     cxx::expected<void*, AllocationError> loan_1_0(const uint32_t size) noexcept;
 
+    // iox-#408 remove?
     ///
     /// @brief publish Publishes the given sample and then releases its loan.
     /// @param sample The sample to publish.
     ///
     void publish(Sample<T>&& sample) noexcept override;
+
+    // iox-#408 override, provide a pure virtual base and adapt tests
+    ///
+    /// @brief publish Publishes the given chunk and then releases its loan.
+    /// @param chunk The chunk to publish.
+    ///
+    void publish(const void* const chunk) noexcept;
 
     // iox-#408 remove?
     ///

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_publisher.hpp
@@ -65,6 +65,7 @@ class BasePublisher : public PublisherInterface<T>
     ///
     capro::ServiceDescription getServiceDescription() const noexcept;
 
+    // iox-#408 remove? (the typed version can use chunks and convert them to samples)
     ///
     /// @brief loan Get a sample from loaned shared memory.
     /// @param size The expected size of the sample.
@@ -87,11 +88,18 @@ class BasePublisher : public PublisherInterface<T>
     ///
     void publish(Sample<T>&& sample) noexcept override;
 
+    // iox-#408 remove?
     ///
     /// @brief previousSample Retrieve the previously loaned sample if it has not yet been claimed.
     /// @return The previously loaned sample if retrieved.
     ///
     cxx::optional<Sample<T>> loanPreviousSample() noexcept;
+
+    ///
+    /// @brief loanPreviousChunk Get the previously loanded chunk if possible.
+    /// @return A pointer to the previous chunk if available, nullopt otherwise.
+    ///
+    cxx::optional<void*> loanPreviousChunk() noexcept;
 
     ///
     /// @brief offer Offer the service to be subscribed to.

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -116,6 +116,8 @@ class BaseSubscriber
     ///
     void releaseQueuedSamples() noexcept;
 
+    void releaseChunk(const void* payload) noexcept;
+
     template <uint64_t Capacity>
     friend class WaitSet;
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -116,6 +116,11 @@ class BaseSubscriber
     ///
     void releaseQueuedSamples() noexcept;
 
+    ///
+    /// @brief releaseChunk Releases the chunk provided by the payload pointer.
+    /// @details The chunk must have been previosly provided by takeChunk and
+    ///          not have been already released.
+    ///
     void releaseChunk(const void* payload) noexcept;
 
     template <uint64_t Capacity>

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -83,12 +83,14 @@ class BaseSubscriber
     ///
     void unsubscribe() noexcept;
 
+    // iox-#408 replace
     ///
     /// @brief hasData Check if sample is available.
     /// @return True if a new sample is available.
     ///
     bool hasSamples() const noexcept;
 
+    // iox-#408 replace
     ///
     /// @brief hasMissedSamples Check if samples have been missed since the last hasMissedSamples() call.
     /// @return True if samples have been missed.
@@ -96,7 +98,7 @@ class BaseSubscriber
     ///
     bool hasMissedSamples() noexcept;
 
-    // TO_BE_REMOVED
+    // iox-#408 remove
     ///
     /// @brief take Take the a sample from the top of the receive queue.
     /// @return An expected containing populated optional if there is a sample available, otherwise empty.
@@ -111,6 +113,7 @@ class BaseSubscriber
     ///
     cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveResult> takeChunk() noexcept;
 
+    // iox-#408 replace
     ///
     /// @brief releaseQueuedSamples Releases any unread queued samples.
     ///

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -102,14 +102,14 @@ class BaseSubscriber
     /// @return An expected containing populated optional if there is a sample available, otherwise empty.
     /// @details The memory loan for the sample is automatically released when it goes out of scope.
     ///
-    cxx::expected<cxx::optional<Sample<const T>>, ChunkReceiveError> take() noexcept;
+    cxx::expected<cxx::optional<Sample<const T>>, ChunkReceiveResult> take() noexcept;
 
     ///
     /// @brief takeChunk Take the chunk from the top of the receive queue.
     /// @return The header of the chunk taken.
     /// @details No automatic cleaunp of the associated chunk is performed.
     ///
-    cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveError> takeChunk() noexcept;
+    cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveResult> takeChunk() noexcept;
 
     ///
     /// @brief releaseQueuedSamples Releases any unread queued samples.

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -120,11 +120,11 @@ class BaseSubscriber
     void releaseQueuedSamples() noexcept;
 
     ///
-    /// @brief releaseChunk Releases the chunk provided by the payload pointer.
+    /// @brief releaseChunk Releases the chunk associated with the header pointer.
     /// @details The chunk must have been previosly provided by takeChunk and
     ///          not have been already released.
     ///
-    void releaseChunk(const void* payload) noexcept;
+    void releaseChunk(const mepoo::ChunkHeader* header) noexcept;
 
     template <uint64_t Capacity>
     friend class WaitSet;

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -96,12 +96,20 @@ class BaseSubscriber
     ///
     bool hasMissedSamples() noexcept;
 
+    // TO_BE_REMOVED
     ///
     /// @brief take Take the a sample from the top of the receive queue.
     /// @return An expected containing populated optional if there is a sample available, otherwise empty.
     /// @details The memory loan for the sample is automatically released when it goes out of scope.
     ///
     cxx::expected<cxx::optional<Sample<const T>>, ChunkReceiveError> take() noexcept;
+
+    ///
+    /// @brief takeChunk Take the chunk from the top of the receive queue.
+    /// @return The header of the chunk taken.
+    /// @details No automatic cleaunp of the associated chunk is performed.
+    ///
+    cxx::expected<const mepoo::ChunkHeader*, ChunkReceiveError> takeChunk() noexcept;
 
     ///
     /// @brief releaseQueuedSamples Releases any unread queued samples.

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -140,9 +140,6 @@ class Sample<const T>
     const T* get() noexcept;
     const mepoo::ChunkHeader* getHeader() noexcept;
 
-    template <typename... Args>
-    void emplace(Args&&... args) noexcept = delete;
-
   private:
     cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
 };

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -49,6 +49,12 @@ class Sample
     T* operator->() noexcept;
 
     ///
+    /// @brief operator -> Transparent read-only access to the encapsulated type.
+    /// @return
+    ///
+    const T* operator->() const noexcept;
+
+    ///
     /// @brief operator* Provide a reference to the encapsulated type.
     /// @return A T& to the encapsulated type.
     /// @details Only available for non void type T.
@@ -58,16 +64,31 @@ class Sample
     S& operator*() noexcept;
 
     ///
+    /// @brief operator* Provide a const reference to the encapsulated type.
+    /// @return A T& to the encapsulated type.
+    /// @details Only available for non void type T.
+    ///
+    template <typename S = T,
+              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
+    const S& operator*() const noexcept;
+
+    ///
     /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.
     /// @return true if the sample is valid, false otherwise.
     ///
-    operator bool();
+    operator bool() const;
 
     ///
     /// @brief allocation Access to the memory chunk loaned to the sample.
     /// @return
     ///
     T* get() noexcept;
+
+    ///
+    /// @brief allocation Read-only access to the memory chunk loaned to the sample.
+    /// @return
+    ///
+    const T* get() const noexcept;
 
     ///
     /// @brief header Retrieve the header of the underlying memory chunk loaned to the sample.
@@ -86,15 +107,6 @@ class Sample
     /// @details This prevents the sample from automatically releasing ownership on destruction.
     ///
     void release() noexcept;
-
-    ///
-    /// @brief emplace In place construct encapsulated type with given arguments.
-    /// @param args Arguments used for construction
-    /// @details Will overwrite anything already there without calling a dtor.
-    ///          For use with uninitialized samples only.
-    ///
-    template <typename... Args>
-    void emplace(Args&&... args) noexcept;
 
   protected:
     cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -87,6 +87,15 @@ class Sample
     ///
     void release() noexcept;
 
+    ///
+    /// @brief emplace In place construct encapsulated type with given arguments.
+    /// @param args arguments used for consctruction
+    /// @details Will overwrite anything already there without calling a dtor.
+    ///          For use with uninitialized samples only.
+    ///
+    template <typename... Args>
+    void emplace(Args&&... args) noexcept;
+
   protected:
     cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
     std::reference_wrapper<PublisherInterface<T>> m_publisherRef;
@@ -115,8 +124,6 @@ class Sample<const T>
     template <typename S = T,
               typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
     const S& operator*() noexcept;
-
-    operator bool();
 
     const T* get() noexcept;
     const mepoo::ChunkHeader* getHeader() noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -49,6 +49,21 @@ class Sample
     T* operator->() noexcept;
 
     ///
+    /// @brief operator* Provide a reference to the encapsulated type.
+    /// @return A T& to the encapsulated type.
+    /// @details Only available for non void type T.
+    ///
+    template <typename S = T,
+              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
+    S& operator*() noexcept;
+
+    ///
+    /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.
+    /// @return true if the sample is valid, false otherwise.
+    ///
+    operator bool();
+
+    ///
     /// @brief allocation Access to the memory chunk loaned to the sample.
     /// @return
     ///
@@ -96,6 +111,13 @@ class Sample<const T>
     Sample(std::nullptr_t) noexcept;
 
     const T* operator->() noexcept;
+
+    template <typename S = T,
+              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
+    const S& operator*() noexcept;
+
+    operator bool();
+
     const T* get() noexcept;
     const mepoo::ChunkHeader* getHeader() noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -89,7 +89,7 @@ class Sample
 
     ///
     /// @brief emplace In place construct encapsulated type with given arguments.
-    /// @param args arguments used for consctruction
+    /// @param args Arguments used for construction
     /// @details Will overwrite anything already there without calling a dtor.
     ///          For use with uninitialized samples only.
     ///
@@ -127,6 +127,9 @@ class Sample<const T>
 
     const T* get() noexcept;
     const mepoo::ChunkHeader* getHeader() noexcept;
+
+    template <typename... Args>
+    void emplace(Args&&... args) noexcept = delete;
 
   private:
     cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
@@ -48,6 +48,15 @@ class TypedPublisher : public base_publisher_t
     using base_publisher_t::stopOffer;
 
     cxx::expected<Sample<T>, AllocationError> loan() noexcept;
+
+    ///
+    /// @brief loan Get a sample from loaned shared memory.
+    /// @return An instance of the sample that resides in shared memory or an error if unable ot allocate memory to
+    /// loan. No object of type T is constructed at this memory.
+    /// @details The loaned sample is automatically released when it goes out of scope.
+    ///
+    cxx::expected<Sample<T>, AllocationError> loanUninitialized() noexcept;
+
     ///
     /// @brief publishCopyOf Copy the provided value into a loaned shared memory chunk and publish it.
     /// @param val Value to copy.

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
@@ -55,7 +55,7 @@ class TypedPublisher : public base_publisher_t
     /// @brief loan Get a sample from loaned shared memory and consctruct the data with the given arguments.
     /// @param args Arguments used to construct the data.
     /// @return An instance of the sample that resides in shared memory or an error if unable ot allocate memory to
-    /// laon.
+    /// loan.
     /// @details The loaned sample is automatically released when it goes out of scope.
     ///
     template <typename... Args>

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_publisher.hpp
@@ -47,15 +47,19 @@ class TypedPublisher : public base_publisher_t
     using base_publisher_t::publish;
     using base_publisher_t::stopOffer;
 
+    // iox-#408 replace with loan_1_0
     cxx::expected<Sample<T>, AllocationError> loan() noexcept;
 
+
     ///
-    /// @brief loan Get a sample from loaned shared memory.
+    /// @brief loan Get a sample from loaned shared memory and consctruct the data with the given arguments.
+    /// @param args Arguments used to construct the data.
     /// @return An instance of the sample that resides in shared memory or an error if unable ot allocate memory to
-    /// loan. No object of type T is constructed at this memory.
+    /// laon.
     /// @details The loaned sample is automatically released when it goes out of scope.
     ///
-    cxx::expected<Sample<T>, AllocationError> loanUninitialized() noexcept;
+    template <typename... Args>
+    cxx::expected<Sample<T>, AllocationError> loan_1_0(Args&&... args) noexcept;
 
     ///
     /// @brief publishCopyOf Copy the provided value into a loaned shared memory chunk and publish it.

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
@@ -46,6 +46,12 @@ class TypedSubscriber : public base_subscriber_t<T, TypedSubscriber<T, base_subs
     using BaseSubscriber::subscribe;
     using BaseSubscriber::take;
     using BaseSubscriber::unsubscribe;
+
+    // the _1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
+    // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
+    // all examples)
+
+    inline cxx::expected<Sample<const T>, ChunkReceiveError> take_1_0() noexcept;
 };
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
@@ -51,7 +51,7 @@ class TypedSubscriber : public base_subscriber_t<T, TypedSubscriber<T, base_subs
     // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
     // all examples)
 
-    inline cxx::expected<Sample<const T>, ChunkReceiveError> take_1_0() noexcept;
+    inline cxx::expected<Sample<const T>, ChunkReceiveResult> take_1_0() noexcept;
 };
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
@@ -48,8 +48,8 @@ class TypedSubscriber : public base_subscriber_t<T, TypedSubscriber<T, base_subs
     using BaseSubscriber::unsubscribe;
 
     // the _1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
-    // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
-    // all examples)
+    // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
+    // all examples) iox-#408
 
     inline cxx::expected<Sample<const T>, ChunkReceiveResult> take_1_0() noexcept;
 };

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
@@ -47,9 +47,10 @@ class TypedSubscriber : public base_subscriber_t<T, TypedSubscriber<T, base_subs
     using BaseSubscriber::take;
     using BaseSubscriber::unsubscribe;
 
+    // iox-#408
     // the _1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
     // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
-    // all examples) iox-#408
+    // all examples)
 
     inline cxx::expected<Sample<const T>, ChunkReceiveResult> take_1_0() noexcept;
 };

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_publisher.hpp
@@ -37,9 +37,11 @@ class UntypedPublisherImpl : public base_publisher_t
     using base_publisher_t::getServiceDescription;
     using base_publisher_t::getUid;
     using base_publisher_t::hasSubscribers;
-    using base_publisher_t::isOffered;
-    using base_publisher_t::loan;
-    using base_publisher_t::loanPreviousSample;
+    using base_publisher_t::isOffered; // iox-#408 better hasOffered ?
+    using base_publisher_t::loan;      // iox-#408 replace
+    using base_publisher_t::loan_1_0;
+    using base_publisher_t::loanPreviousChunk;
+    using base_publisher_t::loanPreviousSample; // iox-#408 replace
     using base_publisher_t::offer;
     using base_publisher_t::publish;
     using base_publisher_t::stopOffer;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -51,6 +51,7 @@ class UntypedSubscriberImpl
     using BaseSubscriber::hasMissedSamples;
     using BaseSubscriber::hasSamples;
     using BaseSubscriber::invalidateTrigger;
+    using BaseSubscriber::releaseChunk;
     using BaseSubscriber::releaseQueuedSamples;
     using BaseSubscriber::subscribe;
     using BaseSubscriber::take;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -58,7 +58,7 @@ class UntypedSubscriberImpl
     using BaseSubscriber::unsubscribe;
 
     // the 1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
-    // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
+    // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
     // all examples)
 
     cxx::expected<const void*, ChunkReceiveResult> take_1_0() noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -55,6 +55,12 @@ class UntypedSubscriberImpl
     using BaseSubscriber::subscribe;
     using BaseSubscriber::take;
     using BaseSubscriber::unsubscribe;
+
+    // the 1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
+    // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
+    // all examples)
+
+    cxx::expected<const void*, ChunkReceiveError> take_1_0() noexcept;
 };
 
 using UntypedSubscriber = UntypedSubscriberImpl<>;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -48,13 +48,13 @@ class UntypedSubscriberImpl
     using BaseSubscriber::getServiceDescription;
     using BaseSubscriber::getSubscriptionState;
     using BaseSubscriber::getUid;
-    using BaseSubscriber::hasMissedSamples;
-    using BaseSubscriber::hasSamples;
+    using BaseSubscriber::hasMissedSamples; // iox-#408 remove
+    using BaseSubscriber::hasSamples;       // iox-#408 remove
     using BaseSubscriber::invalidateTrigger;
     using BaseSubscriber::releaseChunk;
-    using BaseSubscriber::releaseQueuedSamples;
+    using BaseSubscriber::releaseQueuedSamples; // iox-#408 remove
     using BaseSubscriber::subscribe;
-    using BaseSubscriber::take;
+    using BaseSubscriber::take; // iox-#408 replace
     using BaseSubscriber::unsubscribe;
 
     // the 1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
@@ -62,6 +62,27 @@ class UntypedSubscriberImpl
     // all examples)
 
     cxx::expected<const void*, ChunkReceiveResult> take_1_0() noexcept;
+
+    // the untyped API is supposed to deal with chunks, hence the renaming iox #408 remove comment
+    // calling it chunks looks inapproriate in the function names (use data instead of chunks?)...
+
+    ///
+    /// @brief hasData Check if chunks are available.
+    /// @return True if a new chunk is available.
+    ///
+    bool hasChunks() const noexcept;
+
+    ///
+    /// @brief hasMissedChunks Check if chunks have been missed since the last hasMissedData() call.
+    /// @return True if chunks have been missed.
+    /// @details Chunks may be missed due to overflowing receive queue.
+    ///
+    bool hasMissedChunks() noexcept;
+
+    ///
+    /// @brief releaseQueuedChunks Releases any unread queued data chunk.
+    ///
+    void releaseQueuedChunks() noexcept;
 };
 
 using UntypedSubscriber = UntypedSubscriberImpl<>;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -51,7 +51,6 @@ class UntypedSubscriberImpl
     using BaseSubscriber::hasMissedSamples; // iox-#408 remove
     using BaseSubscriber::hasSamples;       // iox-#408 remove
     using BaseSubscriber::invalidateTrigger;
-    using BaseSubscriber::releaseChunk;
     using BaseSubscriber::releaseQueuedSamples; // iox-#408 remove
     using BaseSubscriber::subscribe;
     using BaseSubscriber::take; // iox-#408 replace
@@ -85,6 +84,14 @@ class UntypedSubscriberImpl
     /// @brief releaseQueuedChunks Releases any unread queued data chunk.
     ///
     void releaseQueuedChunks() noexcept;
+
+    ///
+    /// @brief releaseChunk Releases the chunk provided by the payload pointer.
+    /// @param payload pointer to the payload of the chunk to be released
+    /// @details The chunk must have been previosly provided by take_1_0 and
+    ///          not have been already released.
+    ///
+    void releaseChunk(void* payload) noexcept;
 };
 
 using UntypedSubscriber = UntypedSubscriberImpl<>;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -57,12 +57,14 @@ class UntypedSubscriberImpl
     using BaseSubscriber::take; // iox-#408 replace
     using BaseSubscriber::unsubscribe;
 
+    // iox-#408
     // the 1_0 suffix is only used temporarily to not cause regressions in all examples and tests and keep the changes
     // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
     // all examples)
 
     cxx::expected<const void*, ChunkReceiveResult> take_1_0() noexcept;
 
+    // iox-#408
     // the untyped API is supposed to deal with chunks, hence the renaming iox #408 remove comment
     // calling it chunks looks inappropriate in the function names (use data instead of chunks?)...
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -91,7 +91,7 @@ class UntypedSubscriberImpl
     /// @details The chunk must have been previosly provided by take_1_0 and
     ///          not have been already released.
     ///
-    void releaseChunk(void* payload) noexcept;
+    void releaseChunk(const void* payload) noexcept;
 };
 
 using UntypedSubscriber = UntypedSubscriberImpl<>;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -64,10 +64,10 @@ class UntypedSubscriberImpl
     cxx::expected<const void*, ChunkReceiveResult> take_1_0() noexcept;
 
     // the untyped API is supposed to deal with chunks, hence the renaming iox #408 remove comment
-    // calling it chunks looks inapproriate in the function names (use data instead of chunks?)...
+    // calling it chunks looks inappropriate in the function names (use data instead of chunks?)...
 
     ///
-    /// @brief hasData Check if chunks are available.
+    /// @brief hasChunks Check if chunks are available.
     /// @return True if a new chunk is available.
     ///
     bool hasChunks() const noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -60,7 +60,7 @@ class UntypedSubscriberImpl
     // // as small as possible, it will replace the function without suffix in a follow-up pull request (which changes
     // all examples)
 
-    cxx::expected<const void*, ChunkReceiveError> take_1_0() noexcept;
+    cxx::expected<const void*, ChunkReceiveResult> take_1_0() noexcept;
 };
 
 using UntypedSubscriber = UntypedSubscriberImpl<>;

--- a/iceoryx_posh/source/popo/ports/client_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_user.cpp
@@ -66,7 +66,7 @@ ConnectionState ClientPortUser::getConnectionState() const noexcept
     return getMembers()->m_connectionState;
 }
 
-cxx::expected<cxx::optional<const ResponseHeader*>, ChunkReceiveError> ClientPortUser::getResponse() noexcept
+cxx::expected<cxx::optional<const ResponseHeader*>, ChunkReceiveResult> ClientPortUser::getResponse() noexcept
 {
     /// @todo
     return cxx::success<cxx::optional<const ResponseHeader*>>(cxx::nullopt_t());

--- a/iceoryx_posh/source/popo/ports/server_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_user.cpp
@@ -37,7 +37,7 @@ ServerPortUser::MemberType_t* ServerPortUser::getMembers() noexcept
 }
 
 
-cxx::expected<cxx::optional<const RequestHeader*>, ChunkReceiveError> ServerPortUser::getRequest() noexcept
+cxx::expected<cxx::optional<const RequestHeader*>, ChunkReceiveResult> ServerPortUser::getRequest() noexcept
 {
     return cxx::success<cxx::optional<const RequestHeader*>>(cxx::nullopt_t());
 }

--- a/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
@@ -61,7 +61,7 @@ SubscribeState SubscriberPortUser::getSubscriptionState() const noexcept
     return getMembers()->m_subscriptionState;
 }
 
-cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveError> SubscriberPortUser::tryGetChunk() noexcept
+cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiveResult> SubscriberPortUser::tryGetChunk() noexcept
 {
     return m_chunkReceiver.tryGet();
 }

--- a/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
@@ -180,7 +180,7 @@ class ChunkBuildingBlocks_IntegrationTest : public Test
                         }
                     }
                 })
-                .or_else([](ChunkReceiveError) {
+                .or_else([](ChunkReceiveResult) {
                     // Errors shall never occur
                     FAIL();
                 });

--- a/iceoryx_posh/test/mocks/publisher_mock.hpp
+++ b/iceoryx_posh/test/mocks/publisher_mock.hpp
@@ -76,8 +76,10 @@ class MockBasePublisher : public iox::popo::PublisherInterface<T>
     MOCK_CONST_METHOD0(getUid, iox::popo::uid_t());
     MOCK_CONST_METHOD0(getServiceDescription, iox::capro::ServiceDescription());
     MOCK_METHOD1_T(loan, iox::cxx::expected<iox::popo::Sample<T>, iox::popo::AllocationError>(uint32_t));
+    MOCK_METHOD1(loan_1_0, iox::cxx::expected<void*, iox::popo::AllocationError>(uint32_t));
     MOCK_METHOD1_T(publishMocked, void(iox::popo::Sample<T>&&));
     MOCK_METHOD0_T(loanPreviousSample, iox::cxx::optional<iox::popo::Sample<T>>());
+    MOCK_METHOD0(loanPreviousChunk, iox::cxx::optional<void*>());
     MOCK_METHOD0(offer, void(void));
     MOCK_METHOD0(stopOffer, void(void));
     MOCK_CONST_METHOD0(isOffered, bool(void));

--- a/iceoryx_posh/test/mocks/subscriber_mock.hpp
+++ b/iceoryx_posh/test/mocks/subscriber_mock.hpp
@@ -86,4 +86,5 @@ class MockBaseSubscriber
                                                     const uint64_t,
                                                     const iox::popo::Trigger::Callback<MockSubscriberPortUser>));
     MOCK_METHOD1(disableEvent, void(const iox::popo::SubscriberEvent));
+    MOCK_METHOD1(releaseChunk, void(const void*));
 };

--- a/iceoryx_posh/test/mocks/subscriber_mock.hpp
+++ b/iceoryx_posh/test/mocks/subscriber_mock.hpp
@@ -45,7 +45,7 @@ class MockSubscriberPortUser
     MOCK_CONST_METHOD0(getSubscriptionState, iox::SubscribeState());
     MOCK_METHOD0(
         tryGetChunk,
-        iox::cxx::expected<iox::cxx::optional<const iox::mepoo::ChunkHeader*>, iox::popo::ChunkReceiveError>());
+        iox::cxx::expected<iox::cxx::optional<const iox::mepoo::ChunkHeader*>, iox::popo::ChunkReceiveResult>());
     MOCK_METHOD1(releaseChunk, void(iox::mepoo::ChunkHeader*));
     MOCK_METHOD0(releaseQueuedChunks, void());
     MOCK_CONST_METHOD0(hasNewChunks, bool());
@@ -76,7 +76,7 @@ class MockBaseSubscriber
     MOCK_CONST_METHOD0(hasSamples, bool());
     MOCK_METHOD0(hasMissedSamples, bool());
     MOCK_METHOD0_T(take,
-                   iox::cxx::expected<iox::cxx::optional<iox::popo::Sample<const T>>, iox::popo::ChunkReceiveError>());
+                   iox::cxx::expected<iox::cxx::optional<iox::popo::Sample<const T>>, iox::popo::ChunkReceiveResult>());
     MOCK_METHOD0(releaseQueuedSamples, void());
     MOCK_METHOD1(invalidateTrigger, bool(const uint64_t));
     MOCK_METHOD4(

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -156,8 +156,8 @@ TEST_F(BaseSubscriberTest, ReceiveForwardsErrorsFromUnderlyingPort)
 {
     // ===== Setup ===== //
     EXPECT_CALL(sut.getMockedPort(), tryGetChunk)
-        .WillOnce(Return(ByMove(iox::cxx::error<iox::popo::ChunkReceiveError>(
-            iox::popo::ChunkReceiveError::TOO_MANY_CHUNKS_HELD_IN_PARALLEL))));
+        .WillOnce(Return(ByMove(iox::cxx::error<iox::popo::ChunkReceiveResult>(
+            iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL))));
     // ===== Test ===== //
     auto result = sut.take();
     // ===== Verify ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -160,7 +160,7 @@ TEST_F(ChunkReceiver_test, getTooMuchWithoutRelease)
 
     auto maybeChunkHeader = m_chunkReceiver.tryGet();
     EXPECT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_THAT(maybeChunkHeader.get_error(), Eq(iox::popo::ChunkReceiveError::TOO_MANY_CHUNKS_HELD_IN_PARALLEL));
+    EXPECT_THAT(maybeChunkHeader.get_error(), Eq(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL));
 }
 
 TEST_F(ChunkReceiver_test, releaseInvalidChunk)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References
- Does not close #408, will require follow-up work for cleanup, tests and remaining examples
- Closes n.a.

# Summary
Goal: keep the changes minimal but introduce the new API as discussed
Cleanup will follow in another PR directly after this one

- Changes the API of typed publisher and subscriber as discussed in #408 (variadic emplacement loan instead was discussed internally)
- Keeps the old API intact temporarily to not break all tests and examples before we agree on the final API (hence both APIs exist simultaneously for a short time)
- Changes the icedelivery example to use the 1.0 API, use this to discuss additional improvement potential
- Were overloading was not possible, the suffix _1_0 was introduced, this will change to the method without suffix when the original API is removed in the follow up
- TypedPublisher/Subscriber will be renamed (remove Typed prefix) in a follow up to keep the diff cleaner 
- tests will be adapted to the new API in the follow up
- documentation will be updated in a follow up to reflect the new API
- replacements and removals are marked with "iox-#408" in comments

Whether we want the BasePublisher and BaseSubscriber is debatable but the more I think about it the more I come to the conclusion that it is better to keep it (instead of using untyped as a base for typed and removing the current base). The reason is that this way the typed and untyped API can be changed independently in a cleaner way and it costs us not much (if anything) design-wise (in the worst case untyped just uses all base methods). BasePublisher/Subscriber will just have the common functionality.
