### PR TITLE
Iox #494 set MacOS Mojave in GitHub CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
          run: |
            $GITHUB_WORKSPACE/tools/iceoryx_build_test.sh out-of-tree examples toml-config-off clean
 
- # This job builds & runs iceoryx tests in macos-10.13
+ # This job builds & runs iceoryx tests in macos-10.14
   iceoryx-macos:
     runs-on: macos-10.14
     # Softwares installed in macos-latest instance

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,13 +51,12 @@ jobs:
          run: |
            $GITHUB_WORKSPACE/tools/iceoryx_build_test.sh out-of-tree examples toml-config-off clean
 
- # This job builds & runs iceoryx tests in macos-10.15
+ # This job builds & runs iceoryx tests in macos-10.13
   iceoryx-macos:
-    runs-on: macos-latest
+    runs-on: macos-10.14
     # Softwares installed in macos-latest instance
-    # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
+    # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.14-Readme.md
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -90,15 +89,14 @@ jobs:
 
  # This job builds & runs iceoryx tests in Windows 2019
   iceoryx-windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     # Softwares installed in windows instance
     # https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name : Checkout
         uses: actions/checkout@v2
 
       - name: Build sources
         run: |
-          cmake -Bbuild -Hiceoryx_meta -DBUILD_TEST=ON -DINTROSPECTION=OFF -DBINDING_C=ON -DEXAMPLES=ON -DBUILD_SHARED_LIBS=OFF && cmake --build build
+          cmake -Bbuild -Hiceoryx_meta -DBUILD_TEST=ON -DINTROSPECTION=OFF -DBINDING_C=ON -DEXAMPLES=ON && cmake --build build

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -10,12 +10,8 @@ on:
   pull_request:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    #runs-on: ubuntu-latest
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,9 +20,10 @@ jobs:
 
     steps:
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@0.0.26
+        uses: ros-tooling/setup-ros@0.1.2
         with:
           required-ros-distributions: foxy
+
       - name: Install Iceoryx Dependencies
         run: |
           sudo apt install -y apt-transport-https

--- a/.github/workflows/coverage_doc.yml
+++ b/.github/workflows/coverage_doc.yml
@@ -13,10 +13,8 @@ on:
 jobs:
   # This job builds & runs iceoryx tests in ubuntu-18.04
   iceoryx-coverage-doxygen-ubuntu:
-    # The type of runner that the job will run on
     runs-on: ubuntu-20.04
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install iceoryx dependencies
         # Softwares installed in ubuntu-18.04 instance
@@ -61,4 +59,3 @@ jobs:
           path: |
             ./build/doc/*.pdf
           retention-days: 30
-

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -9,12 +9,10 @@ on:
   pull_request:
     branches: [ master ]
 
-jobs:  
+jobs:
   clang-sanitize:
-    # The type of runner that the job will run on
     runs-on: ubuntu-20.04
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install iceoryx dependencies
         # Softwares installed in ubuntu-20.04 instance
@@ -28,12 +26,12 @@ jobs:
         run: |
           # build tests , dont run them
           $GITHUB_WORKSPACE/tools/iceoryx_build_test.sh build-strict build-all sanitize clang
-                    
+
       - name: Run tests
         run: |
           cd $GITHUB_WORKSPACE/build
           ../tools/run_all_tests.sh
-          
+
  # This job builds & runs iceoryx tests (with sanitizer) in macos-10.15
   clang-sanitize-macos:
     runs-on: macos-latest
@@ -66,6 +64,3 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/build
           ../tools/run_all_tests.sh asan-only
-        
-    
-    


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
According to the current https://www.ros.org/reps/rep-2000.html for ROS2 Foxy and Galactic is MacOS Mojave (10.14) needed.
We can tie the MacOS runners to that version, same with Windows. 

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Closes #494
