### PR TITLE
iox-#536 refactored creation/getter method names in units::Duration

### DIFF
--- a/iceoryx_binding_c/source/c_wait_set.cpp
+++ b/iceoryx_binding_c/source/c_wait_set.cpp
@@ -69,11 +69,7 @@ uint64_t iox_ws_timed_wait(iox_ws_t const self,
                            uint64_t* missedElements)
 {
     return event_info_vector_to_c_array(
-        self->timedWait(units::Duration::fromNanoseconds(timeout.tv_nsec)
-                        + units::Duration::fromSeconds(timeout.tv_sec)),
-        eventInfoArray,
-        eventInfoArrayCapacity,
-        missedElements);
+        self->timedWait(units::Duration(timeout)), eventInfoArray, eventInfoArrayCapacity, missedElements);
 }
 
 uint64_t iox_ws_wait(iox_ws_t const self,

--- a/iceoryx_binding_c/source/c_wait_set.cpp
+++ b/iceoryx_binding_c/source/c_wait_set.cpp
@@ -69,8 +69,8 @@ uint64_t iox_ws_timed_wait(iox_ws_t const self,
                            uint64_t* missedElements)
 {
     return event_info_vector_to_c_array(
-        self->timedWait(units::Duration::nanoseconds(static_cast<unsigned long long int>(timeout.tv_nsec))
-                        + units::Duration::seconds(static_cast<unsigned long long int>(timeout.tv_sec))),
+        self->timedWait(units::Duration::fromNanoseconds(static_cast<unsigned long long int>(timeout.tv_nsec))
+                        + units::Duration::fromSeconds(static_cast<unsigned long long int>(timeout.tv_sec))),
         eventInfoArray,
         eventInfoArrayCapacity,
         missedElements);
@@ -124,4 +124,3 @@ void iox_ws_detach_user_trigger_event(iox_ws_t const self, iox_user_trigger_t co
 {
     self->detachEvent(*userTrigger);
 }
-

--- a/iceoryx_binding_c/source/c_wait_set.cpp
+++ b/iceoryx_binding_c/source/c_wait_set.cpp
@@ -69,8 +69,8 @@ uint64_t iox_ws_timed_wait(iox_ws_t const self,
                            uint64_t* missedElements)
 {
     return event_info_vector_to_c_array(
-        self->timedWait(units::Duration::fromNanoseconds(static_cast<unsigned long long int>(timeout.tv_nsec))
-                        + units::Duration::fromSeconds(static_cast<unsigned long long int>(timeout.tv_sec))),
+        self->timedWait(units::Duration::fromNanoseconds(timeout.tv_nsec)
+                        + units::Duration::fromSeconds(timeout.tv_sec)),
         eventInfoArray,
         eventInfoArrayCapacity,
         missedElements);

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -165,7 +165,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::discoveryLoop() noexcept
         {
             discover(msg);
         }
-        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.toMilliSeconds()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.toMilliseconds()));
     }
 }
 
@@ -176,7 +176,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::forwardingLoop() noexcept
     {
         auto startTime = std::chrono::steady_clock::now();
         forEachChannel([this](channel_t channel) { this->forward(channel); });
-        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_forwardingPeriod.toMilliSeconds()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_forwardingPeriod.toMilliseconds()));
     };
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -165,7 +165,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::discoveryLoop() noexcept
         {
             discover(msg);
         }
-        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.milliSeconds()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_discoveryPeriod.toMilliSeconds()));
     }
 }
 
@@ -176,7 +176,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::forwardingLoop() noexcept
     {
         auto startTime = std::chrono::steady_clock::now();
         forEachChannel([this](channel_t channel) { this->forward(channel); });
-        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_forwardingPeriod.milliSeconds()));
+        std::this_thread::sleep_until(startTime + std::chrono::milliseconds(m_forwardingPeriod.toMilliSeconds()));
     };
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/mempool_introspection.hpp
@@ -85,7 +85,7 @@ class MemPoolIntrospection
     void copyMemPoolInfo(const MemoryManager& memoryManager, MemPoolInfoContainer& dest) noexcept;
 
   private:
-    units::Duration m_sendInterval{units::Duration::seconds(1U)};
+    units::Duration m_sendInterval{units::Duration::fromSeconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "MemPoolIntr", *this, &MemPoolIntrospection::send};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -306,7 +306,7 @@ class PortIntrospection
   private:
     PortData m_portData;
 
-    units::Duration m_sendInterval{units::Duration::seconds(1U)};
+    units::Duration m_sendInterval{units::Duration::fromSeconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "PortIntr", *this, &PortIntrospection::send};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -97,7 +97,7 @@ class ProcessIntrospection
 
     std::mutex m_mutex;
 
-    units::Duration m_sendInterval{units::Duration::seconds(1U)};
+    units::Duration m_sendInterval{units::Duration::fromSeconds(1U)};
     concurrent::PeriodicTask<cxx::MethodCallback<void>> m_publishingTask{
         concurrent::PeriodicTaskManualStart, "ProcessIntr", *this, &ProcessIntrospection::send};
 };

--- a/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
@@ -42,7 +42,7 @@ inline iox::log::LogStream& operator<<(iox::log::LogStream& logstream, const Cmd
     logstream << "Compatibility check level: " << cmdLineArgs.compatibilityCheckLevel << "\n";
     cmdLineArgs.uniqueRouDiId.and_then([&logstream](auto& id) { logstream << "Unique RouDi ID: " << id << "\n"; })
         .or_else([&logstream] { logstream << "Unique RouDi ID: < unset >\n"; });
-    logstream << "Process kill delay: " << cmdLineArgs.processKillDelay.seconds() << " s\n";
+    logstream << "Process kill delay: " << cmdLineArgs.processKillDelay.toSeconds() << " s\n";
     if (!cmdLineArgs.configFilePath.empty())
     {
         logstream << "Config file used is: " << cmdLineArgs.configFilePath;

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -159,7 +159,7 @@ void CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMo
             else
             {
                 m_processKillDelay =
-                    units::Duration::seconds(static_cast<unsigned long long int>(processKillDelayInSeconds));
+                    units::Duration::fromSeconds(static_cast<unsigned long long int>(processKillDelayInSeconds));
             }
             break;
         }
@@ -247,7 +247,7 @@ void CmdLineParser::printParameters() const noexcept
     m_uniqueRouDiId.and_then([](auto& id) { LogVerbose() << "Unique RouDi ID: " << id; }).or_else([] {
         LogVerbose() << "Unique RouDi ID: < unset >";
     });
-    LogVerbose() << "Process kill delay: " << m_processKillDelay.seconds() << " s";
+    LogVerbose() << "Process kill delay: " << m_processKillDelay.toSeconds() << " s";
 }
 
 } // namespace config

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -159,7 +159,7 @@ CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cm
             else
             {
                 m_processKillDelay =
-                    units::Duration::fromSeconds(static_cast<unsigned long long int>(processKillDelayInSeconds));
+                    units::Duration::fromSeconds(processKillDelayInSeconds);
             }
             break;
         }

--- a/iceoryx_posh/source/roudi/roudi_process.cpp
+++ b/iceoryx_posh/source/roudi/roudi_process.cpp
@@ -157,7 +157,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
             i = 0;
 
             // give processes some time to terminate before checking their state
-            std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.toMilliSeconds()));
+            std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.toMilliseconds()));
 
             for (auto& process : m_processList)
             {
@@ -755,7 +755,7 @@ void ProcessManager::run() noexcept
 {
     monitorProcesses();
     discoveryUpdate();
-    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.toMilliseconds()));
 }
 
 popo::PublisherPortData* ProcessManager::addIntrospectionPublisherPort(const capro::ServiceDescription& service,
@@ -815,7 +815,7 @@ void ProcessManager::monitorProcesses() noexcept
             if (timediff > runtime::PROCESS_KEEP_ALIVE_TIMEOUT)
             {
                 LogWarn() << "Application " << processIterator->getName() << " not responding (last response "
-                          << timediff.toMilliSeconds() << " milliseconds ago) --> removing it";
+                          << timediff.toMilliseconds() << " milliseconds ago) --> removing it";
 
                 // note: if we would want to use the removeProcess function, it would search for the process again
                 // (but we already found it and have an iterator to remove it)

--- a/iceoryx_posh/source/roudi/roudi_process.cpp
+++ b/iceoryx_posh/source/roudi/roudi_process.cpp
@@ -157,7 +157,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
             i = 0;
 
             // give processes some time to terminate before checking their state
-            std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.milliSeconds()));
+            std::this_thread::sleep_for(std::chrono::milliseconds(PROCESS_TERMINATED_CHECK_INTERVAL.toMilliSeconds()));
 
             for (auto& process : m_processList)
             {
@@ -204,7 +204,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
             if (processStillRunning[i])
             {
                 LogWarn() << "Process ID " << process.getPid() << " named '" << process.getName()
-                          << "' is still running after SIGTERM was sent " << processKillDelay.seconds()
+                          << "' is still running after SIGTERM was sent " << processKillDelay.toSeconds()
                           << " seconds ago. RouDi is sending SIGKILL now.";
                 processStillRunning[i] = requestShutdownOfProcess(process, ShutdownPolicy::SIG_KILL);
             }
@@ -223,7 +223,7 @@ void ProcessManager::killAllProcesses(const units::Duration processKillDelay) no
                 if (processStillRunning[i])
                 {
                     LogWarn() << "Process ID " << process.getPid() << " named '" << process.getName()
-                              << "' is still running after SIGKILL was sent " << processKillDelay.seconds()
+                              << "' is still running after SIGKILL was sent " << processKillDelay.toSeconds()
                               << " seconds ago. RouDi is ignoring this process.";
                 }
                 ++i;
@@ -755,7 +755,7 @@ void ProcessManager::run() noexcept
 {
     monitorProcesses();
     discoveryUpdate();
-    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(DISCOVERY_INTERVAL.toMilliSeconds()));
 }
 
 popo::PublisherPortData* ProcessManager::addIntrospectionPublisherPort(const capro::ServiceDescription& service,
@@ -815,7 +815,7 @@ void ProcessManager::monitorProcesses() noexcept
             if (timediff > runtime::PROCESS_KEEP_ALIVE_TIMEOUT)
             {
                 LogWarn() << "Application " << processIterator->getName() << " not responding (last response "
-                          << timediff.milliSeconds() << " milliseconds ago) --> removing it";
+                          << timediff.toMilliSeconds() << " milliseconds ago) --> removing it";
 
                 // note: if we would want to use the removeProcess function, it would search for the process again
                 // (but we already found it and have an iterator to remove it)

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -161,7 +161,7 @@ class Mepoo_IntegrationTest : public Test
 
     void PrintTiming(iox::units::Duration start)
     {
-        auto totalMillisconds = start.milliSeconds();
+        auto totalMillisconds = start.toMilliSeconds();
         auto milliseconds = totalMillisconds % 1000U;
         auto totalSeconds = totalMillisconds / 1000U;
         auto seconds = totalSeconds % 60U;

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -161,7 +161,7 @@ class Mepoo_IntegrationTest : public Test
 
     void PrintTiming(iox::units::Duration start)
     {
-        auto totalMillisconds = start.toMilliSeconds();
+        auto totalMillisconds = start.toMilliseconds();
         auto milliseconds = totalMillisconds % 1000U;
         auto totalSeconds = totalMillisconds / 1000U;
         auto seconds = totalSeconds % 60U;

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
@@ -286,7 +286,7 @@ TEST_F(CmdLineParser_test, KillDelayLongOptionLeadsToCorrectDelay)
     auto result = sut.parse(numberOfArgs, args);
 
     EXPECT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result.value().processKillDelay, Eq(Duration::seconds(73)));
+    EXPECT_THAT(result.value().processKillDelay, Eq(Duration::fromSeconds(73)));
 }
 
 TEST_F(CmdLineParser_test, KillDelayShortOptionLeadsToCorrectDelay)
@@ -304,7 +304,7 @@ TEST_F(CmdLineParser_test, KillDelayShortOptionLeadsToCorrectDelay)
     auto result = sut.parse(numberOfArgs, args);
 
     EXPECT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result.value().processKillDelay, Eq(Duration::seconds(42)));
+    EXPECT_THAT(result.value().processKillDelay, Eq(Duration::fromSeconds(42)));
 }
 
 TEST_F(CmdLineParser_test, KillDelayOptionOutOfBoundsLeadsToProgrammNotRunning)

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -265,9 +265,9 @@ TIMING_TEST_F(MemPoolIntrospection_test, thread, Repeat(5), [&] {
     introspectionAccess.setSendInterval(snapshotInterval);
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.toMilliSeconds())); // within this time, the thread should have run 6 times
+        6 * snapshotInterval.toMilliseconds())); // within this time, the thread should have run 6 times
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.toMilliSeconds())); // the thread should sleep, if not, we have 12 runs
+        6 * snapshotInterval.toMilliseconds())); // the thread should sleep, if not, we have 12 runs
     introspectionAccess.stop();
 });

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -265,9 +265,9 @@ TIMING_TEST_F(MemPoolIntrospection_test, thread, Repeat(5), [&] {
     introspectionAccess.setSendInterval(snapshotInterval);
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.milliSeconds())); // within this time, the thread should have run 6 times
+        6 * snapshotInterval.toMilliSeconds())); // within this time, the thread should have run 6 times
     introspectionAccess.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(
-        6 * snapshotInterval.milliSeconds())); // the thread should sleep, if not, we have 12 runs
+        6 * snapshotInterval.toMilliSeconds())); // the thread should sleep, if not, we have 12 runs
     introspectionAccess.stop();
 });

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/periodic_task.hpp
@@ -118,7 +118,7 @@ class PeriodicTask
   private:
     T m_callable;
     posix::ThreadName_t m_taskName;
-    units::Duration m_interval{units::Duration::milliseconds(0U)};
+    units::Duration m_interval{units::Duration::fromMilliseconds(0U)};
     /// @todo use a refactored posix::Timer object once available
     posix::Semaphore m_stop{posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U).value()};
     std::thread m_taskExecutor;

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -233,19 +233,19 @@ class Duration
     /// @brief returns the duration in nanoseconds
     /// @note If the duration in nanoseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
-    constexpr uint64_t toNanoSeconds() const noexcept;
+    constexpr uint64_t toNanoseconds() const noexcept;
 
     /// @brief returns the duration in microseconds
     /// @note If the duration in microseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
     /// @note The remaining nanoseconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t toMicroSeconds() const noexcept;
+    constexpr uint64_t toMicroseconds() const noexcept;
 
     /// @brief returns the duration in milliseconds
     /// @note If the duration in milliseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
     /// @note The remaining microseconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t toMilliSeconds() const noexcept;
+    constexpr uint64_t toMilliseconds() const noexcept;
 
     /// @brief returns the duration in seconds
     /// @note The remaining milliseconds are truncated, similar to the casting behavior of a float to an int.

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.hpp
@@ -82,7 +82,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration nanoseconds(const T value) noexcept;
+    static constexpr Duration fromNanoseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from microseconds
     /// @tparam T is an integer type for the value
@@ -90,7 +90,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration microseconds(const T value) noexcept;
+    static constexpr Duration fromMicroseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from milliseconds
     /// @tparam T is an integer type for the value
@@ -98,7 +98,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration milliseconds(const T value) noexcept;
+    static constexpr Duration fromMilliseconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from seconds
     /// @tparam T is an integer type for the value
@@ -106,7 +106,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration seconds(const T value) noexcept;
+    static constexpr Duration fromSeconds(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from minutes
     /// @tparam T is an integer type for the value
@@ -114,7 +114,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration minutes(const T value) noexcept;
+    static constexpr Duration fromMinutes(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from hours
     /// @tparam T is an integer type for the value
@@ -122,7 +122,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration hours(const T value) noexcept;
+    static constexpr Duration fromHours(const T value) noexcept;
 
     /// @brief Constructs a new Duration object from days
     /// @tparam T is an integer type for the value
@@ -130,7 +130,7 @@ class Duration
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     template <typename T>
-    static constexpr Duration days(const T value) noexcept;
+    static constexpr Duration fromDays(const T value) noexcept;
 
     // END CREATION FROM STATIC FUNCTIONS
 
@@ -233,35 +233,35 @@ class Duration
     /// @brief returns the duration in nanoseconds
     /// @note If the duration in nanoseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
-    constexpr uint64_t nanoSeconds() const noexcept;
+    constexpr uint64_t toNanoSeconds() const noexcept;
 
     /// @brief returns the duration in microseconds
     /// @note If the duration in microseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
     /// @note The remaining nanoseconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t microSeconds() const noexcept;
+    constexpr uint64_t toMicroSeconds() const noexcept;
 
     /// @brief returns the duration in milliseconds
     /// @note If the duration in milliseconds is larger than an uint64_t can represent, it will be clamped to the
     /// uint64_t max value.
     /// @note The remaining microseconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t milliSeconds() const noexcept;
+    constexpr uint64_t toMilliSeconds() const noexcept;
 
     /// @brief returns the duration in seconds
     /// @note The remaining milliseconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t seconds() const noexcept;
+    constexpr uint64_t toSeconds() const noexcept;
 
     /// @brief returns the duration in minutes
     /// @note The remaining seconds are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t minutes() const noexcept;
+    constexpr uint64_t toMinutes() const noexcept;
 
     /// @brief returns the duration in hours
     /// @note The remaining minutes are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t hours() const noexcept;
+    constexpr uint64_t toHours() const noexcept;
 
     /// @brief returns the duration in days
     /// @note The remaining hours are truncated, similar to the casting behavior of a float to an int.
-    constexpr uint64_t days() const noexcept;
+    constexpr uint64_t toDays() const noexcept;
 
     /// @brief converts duration in a timespec c struct
     struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const noexcept;

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -73,37 +73,37 @@ inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(con
 }
 
 template <typename T>
-constexpr Duration Duration::nanoseconds(const T value) noexcept
+constexpr Duration Duration::fromNanoseconds(const T value) noexcept
 {
     return operator"" _ns(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::microseconds(const T value) noexcept
+constexpr Duration Duration::fromMicroseconds(const T value) noexcept
 {
     return operator"" _us(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::milliseconds(const T value) noexcept
+constexpr Duration Duration::fromMilliseconds(const T value) noexcept
 {
     return operator"" _ms(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::seconds(const T value) noexcept
+constexpr Duration Duration::fromSeconds(const T value) noexcept
 {
     return operator"" _s(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::minutes(const T value) noexcept
+constexpr Duration Duration::fromMinutes(const T value) noexcept
 {
     return operator"" _m(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::hours(const T value) noexcept
+constexpr Duration Duration::fromHours(const T value) noexcept
 {
     return operator"" _h(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
-constexpr Duration Duration::days(const T value) noexcept
+constexpr Duration Duration::fromDays(const T value) noexcept
 {
     return operator"" _d(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
@@ -125,12 +125,12 @@ inline constexpr Duration::Duration(const struct itimerspec& value) noexcept
 
 inline constexpr Duration::Duration(const std::chrono::milliseconds& value) noexcept
 {
-    *this = Duration::milliseconds(value.count());
+    *this = Duration::fromMilliseconds(value.count());
 }
 
 inline constexpr Duration::Duration(const std::chrono::nanoseconds& value) noexcept
 {
-    *this = Duration::nanoseconds(value.count());
+    *this = Duration::fromNanoseconds(value.count());
 }
 
 inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexcept
@@ -139,7 +139,7 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
     return *this;
 }
 
-inline constexpr uint64_t Duration::nanoSeconds() const noexcept
+inline constexpr uint64_t Duration::toNanoSeconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / NANOSECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() % NANOSECS_PER_SEC};
@@ -156,7 +156,7 @@ inline constexpr uint64_t Duration::nanoSeconds() const noexcept
     return m_seconds * NANOSECS_PER_SEC + m_nanoseconds;
 }
 
-inline constexpr uint64_t Duration::microSeconds() const noexcept
+inline constexpr uint64_t Duration::toMicroSeconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MICROSECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC)
@@ -174,7 +174,7 @@ inline constexpr uint64_t Duration::microSeconds() const noexcept
     return m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC;
 }
 
-inline constexpr uint64_t Duration::milliSeconds() const noexcept
+inline constexpr uint64_t Duration::toMilliSeconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MILLISECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC)
@@ -192,22 +192,22 @@ inline constexpr uint64_t Duration::milliSeconds() const noexcept
     return m_seconds * MILLISECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MILLISEC;
 }
 
-inline constexpr uint64_t Duration::seconds() const noexcept
+inline constexpr uint64_t Duration::toSeconds() const noexcept
 {
     return m_seconds;
 }
 
-inline constexpr uint64_t Duration::minutes() const noexcept
+inline constexpr uint64_t Duration::toMinutes() const noexcept
 {
     return m_seconds / SECS_PER_MINUTE;
 }
 
-inline constexpr uint64_t Duration::hours() const noexcept
+inline constexpr uint64_t Duration::toHours() const noexcept
 {
     return m_seconds / SECS_PER_HOUR;
 }
 
-inline constexpr uint64_t Duration::days() const noexcept
+inline constexpr uint64_t Duration::toDays() const noexcept
 {
     return m_seconds / (HOURS_PER_DAY * SECS_PER_HOUR);
 }
@@ -323,7 +323,7 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
     // check if the result of the m_nanoseconds multiplication can easily be converted into a Duration
     if (m_nanoseconds <= maxBeforeOverflow)
     {
-        return durationFromSeconds + Duration::nanoseconds(m_nanoseconds * multiplicator);
+        return durationFromSeconds + Duration::fromNanoseconds(m_nanoseconds * multiplicator);
     }
 
     // when we reach this, the multiplicator must be larger than 2^32, since smaller values multiplied with the
@@ -333,7 +333,7 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
 
     // this is the easy part with the lower 32 bits
     uint64_t multiplicatorLow = static_cast<uint32_t>(multiplicator);
-    auto durationFromNanosecondsLow = Duration::nanoseconds(m_nanoseconds * multiplicatorLow);
+    auto durationFromNanosecondsLow = Duration::fromNanoseconds(m_nanoseconds * multiplicatorLow);
 
     // this is the complicated part with the upper 32 bits;
     // the m_nanoseconds are multiplied with the upper 32 bits of the multiplicator shifted by 32 bit to the right, thus
@@ -361,7 +361,7 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
     auto remainingBlockWithFullAndFractionalSeconds = nanosecondsFromHigh % ONE_FULL_BLOCK_OF_SECONDS_ONLY;
 
     auto durationFromNanosecondsHigh = Duration{fullBlocksOfSecondsOnly * SECONDS_PER_FULL_BLOCK, 0U}
-                                       + Duration::nanoseconds(remainingBlockWithFullAndFractionalSeconds << 32);
+                                       + Duration::fromNanoseconds(remainingBlockWithFullAndFractionalSeconds << 32);
 
     return durationFromSeconds + durationFromNanosecondsLow + durationFromNanosecondsHigh;
 }
@@ -423,7 +423,7 @@ Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, 
 
     if (!wouldCastFromFloatingPointProbablyOverflow<T, uint64_t>(resultNanoseconds))
     {
-        return durationFromSeconds + Duration::nanoseconds(static_cast<uint64_t>(resultNanoseconds));
+        return durationFromSeconds + Duration::fromNanoseconds(static_cast<uint64_t>(resultNanoseconds));
     }
 
     // the multiplication result of nanoseconds would exceed the value an uint64_t can represent

--- a/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/units/duration.inl
@@ -139,7 +139,7 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexc
     return *this;
 }
 
-inline constexpr uint64_t Duration::toNanoSeconds() const noexcept
+inline constexpr uint64_t Duration::toNanoseconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / NANOSECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() % NANOSECS_PER_SEC};
@@ -156,7 +156,7 @@ inline constexpr uint64_t Duration::toNanoSeconds() const noexcept
     return m_seconds * NANOSECS_PER_SEC + m_nanoseconds;
 }
 
-inline constexpr uint64_t Duration::toMicroSeconds() const noexcept
+inline constexpr uint64_t Duration::toMicroseconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MICROSECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC)
@@ -174,7 +174,7 @@ inline constexpr uint64_t Duration::toMicroSeconds() const noexcept
     return m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC;
 }
 
-inline constexpr uint64_t Duration::toMilliSeconds() const noexcept
+inline constexpr uint64_t Duration::toMilliseconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MILLISECS_PER_SEC};
     constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC)

--- a/iceoryx_utils/source/posix_wrapper/timer.cpp
+++ b/iceoryx_utils/source/posix_wrapper/timer.cpp
@@ -452,7 +452,7 @@ Timer::Timer(const units::Duration timeToWait) noexcept
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.nanoSeconds() == 0U)
+    if (m_timeToWait.toNanoSeconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
     }
@@ -462,7 +462,7 @@ Timer::Timer(const units::Duration timeToWait, const std::function<void()>& call
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.nanoSeconds() == 0U)
+    if (m_timeToWait.toNanoSeconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
         return;
@@ -499,7 +499,7 @@ cxx::expected<TimerError> Timer::stop() noexcept
 cxx::expected<TimerError>
 Timer::restart(const units::Duration timeToWait, const RunMode runMode, const CatchUpPolicy catchUpPolicy) noexcept
 {
-    if (timeToWait.nanoSeconds() == 0U)
+    if (timeToWait.toNanoSeconds() == 0U)
     {
         return cxx::error<TimerError>(TimerError::TIMEOUT_IS_ZERO);
     }

--- a/iceoryx_utils/source/posix_wrapper/timer.cpp
+++ b/iceoryx_utils/source/posix_wrapper/timer.cpp
@@ -452,7 +452,7 @@ Timer::Timer(const units::Duration timeToWait) noexcept
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.toNanoSeconds() == 0U)
+    if (m_timeToWait.toNanoseconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
     }
@@ -462,7 +462,7 @@ Timer::Timer(const units::Duration timeToWait, const std::function<void()>& call
     : m_timeToWait(timeToWait)
     , m_creationTime(now().value())
 {
-    if (m_timeToWait.toNanoSeconds() == 0U)
+    if (m_timeToWait.toNanoseconds() == 0U)
     {
         m_errorValue = TimerError::TIMEOUT_IS_ZERO;
         return;
@@ -499,7 +499,7 @@ cxx::expected<TimerError> Timer::stop() noexcept
 cxx::expected<TimerError>
 Timer::restart(const units::Duration timeToWait, const RunMode runMode, const CatchUpPolicy catchUpPolicy) noexcept
 {
-    if (timeToWait.toNanoSeconds() == 0U)
+    if (timeToWait.toNanoseconds() == 0U)
     {
         return cxx::error<TimerError>(TimerError::TIMEOUT_IS_ZERO);
     }

--- a/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
@@ -187,7 +187,7 @@ cxx::expected<IpcChannelError> UnixDomainSocket::send(const std::string& msg) co
 {
     // we also support timedSend. The setsockopt call sets the timeout for all further sendto calls, so we must set
     // it to 0 to turn the timeout off
-    return timedSend(msg, units::Duration::seconds(0ULL));
+    return timedSend(msg, units::Duration::fromSeconds(0ULL));
 }
 
 cxx::expected<IpcChannelError> UnixDomainSocket::timedSend(const std::string& msg,

--- a/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
@@ -47,7 +47,7 @@ class DeadlineTimer_test : public Test
 };
 
 const Duration DeadlineTimer_test::TIMEOUT{10_ms};
-const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.toMilliSeconds();
+const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.toMilliseconds();
 
 TIMING_TEST_F(DeadlineTimer_test, ZeroTimeoutTest, Repeat(5), [&] {
     Timer sut(0_s);
@@ -120,7 +120,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfExpired, Repeat(5), [&] {
 
     TIMING_TEST_ASSERT_TRUE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().toMilliSeconds();
+    int remainingTime = sut.remainingTime().toMilliseconds();
     const int EXPECTED_REMAINING_TIME = 0; // the timer is expired the remaining wait time is Zero
     TIMING_TEST_EXPECT_TRUE(remainingTime == EXPECTED_REMAINING_TIME);
 });
@@ -131,7 +131,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfNotExpired, Repeat(5), [&]
 
     TIMING_TEST_ASSERT_FALSE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().toMilliSeconds();
+    int remainingTime = sut.remainingTime().toMilliseconds();
     const int PASSED_TIMER_TIME = SLEEPTIME; // Already 10ms passed in sleeping out of 20ms
     const int RANGE_APPROX = 2;              // 2ms arppoximation. This may be lost after arming the timer in execution.
     const int EXPECTED_REMAINING_TIME = PASSED_TIMER_TIME - RANGE_APPROX;

--- a/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_deadline_timer.cpp
@@ -47,7 +47,7 @@ class DeadlineTimer_test : public Test
 };
 
 const Duration DeadlineTimer_test::TIMEOUT{10_ms};
-const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.milliSeconds();
+const int DeadlineTimer_test::SLEEPTIME = DeadlineTimer_test::TIMEOUT.toMilliSeconds();
 
 TIMING_TEST_F(DeadlineTimer_test, ZeroTimeoutTest, Repeat(5), [&] {
     Timer sut(0_s);
@@ -120,7 +120,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfExpired, Repeat(5), [&] {
 
     TIMING_TEST_ASSERT_TRUE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().milliSeconds();
+    int remainingTime = sut.remainingTime().toMilliSeconds();
     const int EXPECTED_REMAINING_TIME = 0; // the timer is expired the remaining wait time is Zero
     TIMING_TEST_EXPECT_TRUE(remainingTime == EXPECTED_REMAINING_TIME);
 });
@@ -131,7 +131,7 @@ TIMING_TEST_F(DeadlineTimer_test, RemainingTimeCheckIfNotExpired, Repeat(5), [&]
 
     TIMING_TEST_ASSERT_FALSE(sut.hasExpired());
 
-    int remainingTime = sut.remainingTime().milliSeconds();
+    int remainingTime = sut.remainingTime().toMilliSeconds();
     const int PASSED_TIMER_TIME = SLEEPTIME; // Already 10ms passed in sleeping out of 20ms
     const int RANGE_APPROX = 2;              // 2ms arppoximation. This may be lost after arming the timer in execution.
     const int EXPECTED_REMAINING_TIME = PASSED_TIMER_TIME - RANGE_APPROX;

--- a/iceoryx_utils/test/moduletests/test_posix_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_posix_timer.cpp
@@ -76,7 +76,7 @@ TIMING_TEST_F(Timer_test, CallbackNotExecutedWhenNotStarted, Repeat(5), [&] {
     bool callbackExecuted{false};
     Timer sut(TIMEOUT, [&] { callbackExecuted = true; });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
 
     TIMING_TEST_EXPECT_ALWAYS_FALSE(callbackExecuted);
 });
@@ -94,7 +94,7 @@ TIMING_TEST_F(Timer_test, CallbackExecutedPeriodicallyAfterStart, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 11);
@@ -104,7 +104,7 @@ TIMING_TEST_F(Timer_test, PeriodicCallbackNotExecutedPrematurely, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -112,7 +112,7 @@ TIMING_TEST_F(Timer_test, OneTimeCallbackNotExecutedPrematurely, Repeat(5), [&] 
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -130,7 +130,7 @@ TIMING_TEST_F(Timer_test, StartRunModeOnceIsStoppedAfterStop, Repeat(5), [&] {
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -140,7 +140,7 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedAfterStop, Repeat(5), [&]
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -149,10 +149,10 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedInTheMiddleAfterStop, Rep
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
     sut.stop();
     auto previousCount = counter.load();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(previousCount == counter.load());
 });
@@ -170,10 +170,10 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTiming, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 10, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.toMilliSeconds()));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -183,15 +183,15 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
     sut.restart(TIMEOUT, Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
 });
 
@@ -199,11 +199,11 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTimingAndRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 2, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.toMilliSeconds()));
     counter = 0;
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
 
     auto finalCount = counter.load();
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -239,24 +239,24 @@ TEST_F(Timer_test, TimeUntilExpirationFailsWithoutCallback)
 TIMING_TEST_F(Timer_test, TimeUntilExpirationWithCallback, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    auto timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
-    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.milliSeconds() / 3);
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
+    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.toMilliSeconds() / 3);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.milliSeconds() / 3));
-    timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
-    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.milliSeconds() / 3);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
+    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.toMilliSeconds() / 3);
 });
 
 TIMING_TEST_F(Timer_test, TimeUntilExpirationZeroAfterCallbackOnceCalled, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
-    auto timeUntilExpiration = sut.timeUntilExpiration().value().milliSeconds();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
     TIMING_TEST_EXPECT_TRUE(timeUntilExpiration == 0);
 });
 
 TIMING_TEST_F(Timer_test, StoppingIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -286,14 +286,14 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningContinuously, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
 
     for (auto& sut : sutList)
     {
         sut.timer.stop();
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
 
     for (auto& sut : sutList)
     {
@@ -319,7 +319,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
 
     for (auto& sut : sutList)
     {
@@ -330,7 +330,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
 TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
     std::chrono::time_point<std::chrono::system_clock> startTime;
     {
-        Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+        Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
         sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         startTime = std::chrono::system_clock::now();
@@ -342,7 +342,7 @@ TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
 });
 
 TIMING_TEST_F(Timer_test, StartStopAndStartAgainIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -369,11 +369,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatContinuesWhenCallbackIsLong
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -382,11 +382,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateContinuesWhenCallbackIsLongerThe
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -395,11 +395,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyTerminateTerminatesWhenCallbackIsLongerTh
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
 
@@ -408,12 +408,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyChangeToTerminateChangesBehaviorToTermina
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
 
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
@@ -423,12 +423,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatSkipsCallbackWhenStillRunni
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
     // every second callback is skipped since the runtime is slightly longer therefore
     // the counter must be in that range
     TIMING_TEST_EXPECT_TRUE(40 <= counter && counter <= 70);
@@ -439,12 +439,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateCallsCallbackImmediatelyAfterFin
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
 
     // the asap timer should in theory call the callback 90 times since it is calling it right
     // after the last one finished and one callback takes 1.1 ms and we run for 100ms.
@@ -456,17 +456,17 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatCallsLessCallbacksThanASAPT
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.milliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
     int softTimerCounter = counter.load();
     sut.stop();
 
     counter.store(0);
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.milliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
     int asapTimerCounter = counter.load();
     sut.stop();
 

--- a/iceoryx_utils/test/moduletests/test_posix_timer.cpp
+++ b/iceoryx_utils/test/moduletests/test_posix_timer.cpp
@@ -76,7 +76,7 @@ TIMING_TEST_F(Timer_test, CallbackNotExecutedWhenNotStarted, Repeat(5), [&] {
     bool callbackExecuted{false};
     Timer sut(TIMEOUT, [&] { callbackExecuted = true; });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
 
     TIMING_TEST_EXPECT_ALWAYS_FALSE(callbackExecuted);
 });
@@ -94,7 +94,7 @@ TIMING_TEST_F(Timer_test, CallbackExecutedPeriodicallyAfterStart, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 11);
@@ -104,7 +104,7 @@ TIMING_TEST_F(Timer_test, PeriodicCallbackNotExecutedPrematurely, Repeat(5), [&]
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -112,7 +112,7 @@ TIMING_TEST_F(Timer_test, OneTimeCallbackNotExecutedPrematurely, Repeat(5), [&] 
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
 
@@ -130,7 +130,7 @@ TIMING_TEST_F(Timer_test, StartRunModeOnceIsStoppedAfterStop, Repeat(5), [&] {
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -140,7 +140,7 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedAfterStop, Repeat(5), [&]
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     sut.stop();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
 });
@@ -149,10 +149,10 @@ TIMING_TEST_F(Timer_test, StartRunPeriodicOnceIsStoppedInTheMiddleAfterStop, Rep
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
     sut.stop();
     auto previousCount = counter.load();
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
 
     TIMING_TEST_EXPECT_TRUE(previousCount == counter.load());
 });
@@ -170,10 +170,10 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTiming, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 10, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(20 * TIMEOUT.toMilliseconds()));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
     auto finalCount = counter.load();
 
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -183,15 +183,15 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT, [&] { counter++; });
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(4 * TIMEOUT.toMilliseconds() / 3));
     sut.restart(TIMEOUT, Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     counter = 0;
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 0);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
     TIMING_TEST_EXPECT_TRUE(counter.load() == 1);
 });
 
@@ -199,11 +199,11 @@ TIMING_TEST_F(Timer_test, RestartWithDifferentTimingAndRunMode, Repeat(5), [&] {
     std::atomic_int counter{0};
     Timer sut(TIMEOUT * 2, [&] { counter++; });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5 * TIMEOUT.toMilliseconds()));
     counter = 0;
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
 
     auto finalCount = counter.load();
     TIMING_TEST_EXPECT_TRUE(6 <= finalCount && finalCount <= 13);
@@ -239,24 +239,24 @@ TEST_F(Timer_test, TimeUntilExpirationFailsWithoutCallback)
 TIMING_TEST_F(Timer_test, TimeUntilExpirationWithCallback, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
-    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.toMilliSeconds() / 3);
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliseconds();
+    TIMING_TEST_EXPECT_TRUE(timeUntilExpiration > 2 * TIMEOUT.toMilliseconds() / 3);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliSeconds() / 3));
-    timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
-    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.toMilliSeconds() / 3);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2 * TIMEOUT.toMilliseconds() / 3));
+    timeUntilExpiration = sut.timeUntilExpiration().value().toMilliseconds();
+    TIMING_TEST_EXPECT_TRUE(1 <= timeUntilExpiration && timeUntilExpiration <= TIMEOUT.toMilliseconds() / 3);
 });
 
 TIMING_TEST_F(Timer_test, TimeUntilExpirationZeroAfterCallbackOnceCalled, Repeat(5), [&] {
     Timer sut(TIMEOUT, [] {});
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
-    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliSeconds();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
+    auto timeUntilExpiration = sut.timeUntilExpiration().value().toMilliseconds();
     TIMING_TEST_EXPECT_TRUE(timeUntilExpiration == 0);
 });
 
 TIMING_TEST_F(Timer_test, StoppingIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -286,14 +286,14 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningContinuously, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
 
     for (auto& sut : sutList)
     {
         sut.timer.stop();
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
 
     for (auto& sut : sutList)
     {
@@ -319,7 +319,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
         sut.timer.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10 * TIMEOUT.toMilliseconds()));
 
     for (auto& sut : sutList)
     {
@@ -330,7 +330,7 @@ TIMING_TEST_F(Timer_test, MultipleTimersRunningOnce, Repeat(5), [&] {
 TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
     std::chrono::time_point<std::chrono::system_clock> startTime;
     {
-        Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+        Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
         sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
         startTime = std::chrono::system_clock::now();
@@ -342,7 +342,7 @@ TIMING_TEST_F(Timer_test, DestructorIsBlocking, Repeat(5), [&] {
 });
 
 TIMING_TEST_F(Timer_test, StartStopAndStartAgainIsNonBlocking, Repeat(5), [&] {
-    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(1_ns, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
     sut.start(Timer::RunMode::ONCE, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -369,11 +369,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatContinuesWhenCallbackIsLong
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -382,11 +382,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateContinuesWhenCallbackIsLongerThe
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
     TIMING_TEST_EXPECT_FALSE(hasTerminated);
 });
 
@@ -395,11 +395,11 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyTerminateTerminatesWhenCallbackIsLongerTh
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
 
@@ -408,12 +408,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyChangeToTerminateChangesBehaviorToTermina
     auto errorHandlerGuard = iox::ErrorHandler::SetTemporaryErrorHandler(
         [&](const iox::Error, const std::function<void()>, const iox::ErrorLevel) { hasTerminated = true; });
 
-    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10)); });
+    Timer sut(TIMEOUT, [] { std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10)); });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
     sut.restart(TIMEOUT, Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::TERMINATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 10));
 
     TIMING_TEST_EXPECT_TRUE(hasTerminated);
 });
@@ -423,12 +423,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatSkipsCallbackWhenStillRunni
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliseconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 100));
     // every second callback is skipped since the runtime is slightly longer therefore
     // the counter must be in that range
     TIMING_TEST_EXPECT_TRUE(40 <= counter && counter <= 70);
@@ -439,12 +439,12 @@ TIMING_TEST_F(Timer_test, CatchUpPolicyImmediateCallsCallbackImmediatelyAfterFin
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliseconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 100));
 
     // the asap timer should in theory call the callback 90 times since it is calling it right
     // after the last one finished and one callback takes 1.1 ms and we run for 100ms.
@@ -456,17 +456,17 @@ TIMING_TEST_F(Timer_test, CatchUpPolicySkipToNextBeatCallsLessCallbacksThanASAPT
     Timer sut(TIMEOUT, [&] {
         ++counter;
         // wait slightly longer then the timeout so that the effect is better measurable
-        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliSeconds() * 1100));
+        std::this_thread::sleep_for(std::chrono::microseconds(TIMEOUT.toMilliseconds() * 1100));
     });
 
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::SKIP_TO_NEXT_BEAT);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 100));
     int softTimerCounter = counter.load();
     sut.stop();
 
     counter.store(0);
     sut.start(Timer::RunMode::PERIODIC, Timer::CatchUpPolicy::IMMEDIATE);
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliSeconds() * 100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT.toMilliseconds() * 100));
     int asapTimerCounter = counter.load();
     sut.stop();
 

--- a/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
+++ b/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
@@ -74,7 +74,7 @@ class Semaphore_test : public TestWithParam<CreateSemaphore*>
         }
     }
 
-    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).nanoSeconds()};
+    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).toNanoSeconds()};
 
     iox::posix::Semaphore* sut{nullptr};
     iox::posix::Semaphore* syncSemaphore = [] {
@@ -321,7 +321,7 @@ TIMING_TEST_P(Semaphore_test, TimedWaitWithTimeout, Repeat(3), [&] {
     std::atomic_bool timedWaitFinish{false};
 
     std::thread t([&] {
-        auto ts = Duration::nanoseconds(TIMING_TEST_TIMEOUT).timespec(TimeSpecReference::Epoch);
+        auto ts = Duration::fromNanoseconds(TIMING_TEST_TIMEOUT).timespec(TimeSpecReference::Epoch);
         syncSemaphore->post();
         sut->wait();
         auto call = sut->timedWait(&ts, false);
@@ -347,7 +347,7 @@ TIMING_TEST_P(Semaphore_test, TimedWaitWithoutTimeout, Repeat(3), [&] {
     std::atomic_bool timedWaitFinish{false};
 
     std::thread t([&] {
-        auto ts = Duration::nanoseconds(TIMING_TEST_TIMEOUT).timespec(TimeSpecReference::Epoch);
+        auto ts = Duration::fromNanoseconds(TIMING_TEST_TIMEOUT).timespec(TimeSpecReference::Epoch);
         syncSemaphore->post();
         sut->wait();
         auto call = sut->timedWait(&ts, false);

--- a/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
+++ b/iceoryx_utils/test/moduletests/test_semaphore_module.cpp
@@ -74,7 +74,7 @@ class Semaphore_test : public TestWithParam<CreateSemaphore*>
         }
     }
 
-    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).toNanoSeconds()};
+    static constexpr unsigned long long TIMING_TEST_TIMEOUT{(100_ms).toNanoseconds()};
 
     iox::posix::Semaphore* sut{nullptr};
     iox::posix::Semaphore* syncSemaphore = [] {

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -67,7 +67,7 @@ TEST(Duration_test, ConstructDurationWithZeroTime)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
@@ -78,7 +78,7 @@ TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
@@ -89,7 +89,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
@@ -100,7 +100,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
@@ -112,7 +112,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
 
     auto sut = createDuration(SECONDS, MORE_THAN_ONE_SECOND_NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
@@ -125,7 +125,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
 
     auto sut = createDuration(SECONDS, MAX_NANOSECONDS_FOR_CTOR);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
@@ -146,7 +146,7 @@ TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanosecond
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromTimespecWithZeroValue)
@@ -319,68 +319,68 @@ TEST(Duration_test, ConstructFromChronoMillisecondsZero)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{0U};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsLessThanOneSecond)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{44U};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsMax)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut(std::chrono::milliseconds(-1));
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsZero)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{0U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsLessThanOneSecond)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{424242U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{NANOSECS_PER_SECOND + 42U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsMax)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoNanosecondsIsZero)
 {
     Duration sut(std::chrono::nanoseconds(-1));
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 // END CONSTRUCTOR TESTS
@@ -392,7 +392,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsZero)
     constexpr uint64_t EXPECTED_MILLISECONDS{0U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsLessThanOneSecond)
@@ -400,7 +400,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsLessThanOneSecond)
     constexpr uint64_t EXPECTED_MILLISECONDS{73U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
@@ -408,7 +408,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
     constexpr uint64_t EXPECTED_MILLISECONDS{1073U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsMax)
@@ -416,14 +416,14 @@ TEST(Duration_test, AssignFromChronoMillisecondsMax)
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, AssignFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut = 22_ns;
     sut = std::chrono::milliseconds(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 // END ASSIGNMENT TESTS
@@ -435,7 +435,7 @@ TEST(Duration_test, CreateDurationFromDaysLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{2U * HOURS_PER_DAY * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
     auto sut = 2_d;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursLiteral)
@@ -443,7 +443,7 @@ TEST(Duration_test, CreateDurationFromHoursLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{3U * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
     auto sut = 3_h;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesLiteral)
@@ -451,7 +451,7 @@ TEST(Duration_test, CreateDurationFromMinutesLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{4U * SECONDS_PER_MINUTE * NANOSECS_PER_SECOND};
     auto sut = 4_m;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsLiteral)
@@ -459,7 +459,7 @@ TEST(Duration_test, CreateDurationFromSecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{5U * NANOSECS_PER_SECOND};
     auto sut = 5_s;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
@@ -467,7 +467,7 @@ TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{6U * NANOSECS_PER_MILLISECOND};
     auto sut = 6_ms;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
@@ -475,7 +475,7 @@ TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{7U * NANOSECS_PER_MICROSECOND};
     auto sut = 7_us;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
@@ -483,7 +483,7 @@ TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{8U};
     auto sut = 8_ns;
 
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 // END CREATION FROM LITERAL TESTS
@@ -495,8 +495,8 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithZeroDays)
     auto sut1 = Duration::fromDays(0);
     auto sut2 = Duration::fromDays(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithMultipleDays)
@@ -505,8 +505,8 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithMultipleDays)
     auto sut1 = Duration::fromDays(2);
     auto sut2 = Duration::fromDays(2U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturation)
@@ -537,7 +537,7 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithMaxDaysResultsInSaturation
 TEST(Duration_test, CreateDurationFromDaysFunctionWithNegativeValuesIsZero)
 {
     auto sut = Duration::fromDays(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithZeroHours)
@@ -545,8 +545,8 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithZeroHours)
     auto sut1 = Duration::fromHours(0);
     auto sut2 = Duration::fromHours(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithMultipleHours)
@@ -555,8 +555,8 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithMultipleHours)
     auto sut1 = Duration::fromHours(3);
     auto sut2 = Duration::fromHours(3U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSaturation)
@@ -586,7 +586,7 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithMaxHoursResultsInSaturati
 TEST(Duration_test, CreateDurationFromHoursFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromHours(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithZeroMinuts)
@@ -594,8 +594,8 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithZeroMinuts)
     auto sut1 = Duration::fromMinutes(0);
     auto sut2 = Duration::fromMinutes(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMultipleMinutes)
@@ -604,8 +604,8 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMultipleMinutes)
     auto sut1 = Duration::fromMinutes(4);
     auto sut2 = Duration::fromMinutes(4U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInSaturation)
@@ -635,7 +635,7 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMaxMinutesResultsInSatu
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromMinutes(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithZeroSeconds)
@@ -643,8 +643,8 @@ TEST(Duration_test, CreateDurationFromSecondsFunctionWithZeroSeconds)
     auto sut1 = Duration::fromSeconds(0);
     auto sut2 = Duration::fromSeconds(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunction)
@@ -653,8 +653,8 @@ TEST(Duration_test, CreateDurationFromSecondsFunction)
     auto sut1 = Duration::fromSeconds(5);
     auto sut2 = Duration::fromSeconds(5U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
@@ -674,7 +674,7 @@ TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromSeconds(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithZeroMilliseconds)
@@ -682,8 +682,8 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithZeroMilliseconds)
     auto sut1 = Duration::fromMilliseconds(0);
     auto sut2 = Duration::fromMilliseconds(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMultipleMilliseconds)
@@ -692,8 +692,8 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMultipleMillisecon
     auto sut1 = Duration::fromMilliseconds(6);
     auto sut2 = Duration::fromMilliseconds(6U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
@@ -717,7 +717,7 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromMilliseconds(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithZeroMicroseconds)
@@ -725,8 +725,8 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithZeroMicroseconds)
     auto sut1 = Duration::fromMicroseconds(0);
     auto sut2 = Duration::fromMicroseconds(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMultipleMicroseconds)
@@ -735,8 +735,8 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMultipleMicrosecon
     auto sut1 = Duration::fromMicroseconds(7);
     auto sut2 = Duration::fromMicroseconds(7U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
@@ -760,7 +760,7 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromMicroseconds(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithZeroNanoseconds)
@@ -768,8 +768,8 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithZeroNanoseconds)
     auto sut1 = Duration::fromNanoseconds(0);
     auto sut2 = Duration::fromNanoseconds(0U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithMultipleNanoseconds)
@@ -778,8 +778,8 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithMultipleNanoseconds
     auto sut1 = Duration::fromNanoseconds(8);
     auto sut2 = Duration::fromNanoseconds(8U);
 
-    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoseconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunction)
@@ -801,7 +801,7 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunction)
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero)
 {
     auto sut = Duration::fromNanoseconds(-1);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(0U));
 }
 
 // END CREATION FROM STATIC FUNCTION TESTS
@@ -921,94 +921,94 @@ TEST(Duration_test, ConvertSecondsFromMaxDuration)
 TEST(Duration_test, ConvertMillisecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromDurationLessThanOneMillisecond)
 {
     auto sut = 637_us;
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMilliecondsFromDurationMoreThanOneMillisecond)
 {
     auto sut = 55_ms + 633_us;
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(55U));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(55U));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<uint64_t>::max() - 1U};
     auto sut = Duration::fromMilliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.toMilliSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toMilliseconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationLessThanOneMicrosecond)
 {
     auto sut = 733_ns;
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationMoreThanOneMicrosecond)
 {
     auto sut = 555_us + 733_ns;
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(555U));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(555U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_MICROSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
     auto sut = Duration::fromMicroseconds(EXPECTED_MICROSECONDS);
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(EXPECTED_MICROSECONDS));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(EXPECTED_MICROSECONDS));
 }
 
 TEST(Duration_test, ConvertMicroecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroseconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationOfOneNanosecond)
 {
     auto sut = 1_ns;
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(1U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(1U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationMultipleNanoseconds)
 {
     auto sut = 42_ns;
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(42U));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(42U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
     auto sut = Duration::fromNanoseconds(EXPECTED_NANOSECONDS);
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConvertNanoecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.toNanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toNanoseconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertTimespecWithNoneReferenceFromZeroDuration)
@@ -1783,7 +1783,7 @@ TEST(Duration_test, MultiplyDurationLessThanOneSecondResultsInMoreNanosecondsTha
 
     auto result = MULTIPLICATOR * DURATION;
     EXPECT_THAT(result, Eq(EXPECTED_RESULT));
-    EXPECT_THAT(result.toNanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(result.toNanoseconds(), Eq(std::numeric_limits<uint64_t>::max()));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
 }
 

--- a/iceoryx_utils/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_utils/test/moduletests/test_unit_duration.cpp
@@ -67,7 +67,7 @@ TEST(Duration_test, ConstructDurationWithZeroTime)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
@@ -78,7 +78,7 @@ TEST(Duration_test, ConstructDurationWithResultOfLessNanosecondsThanOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
@@ -89,7 +89,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsLessThanOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
@@ -100,7 +100,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsEqualToOneSecond)
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
@@ -112,7 +112,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMoreThanOneSecond)
 
     auto sut = createDuration(SECONDS, MORE_THAN_ONE_SECOND_NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
@@ -125,7 +125,7 @@ TEST(Duration_test, ConstructDurationWithNanosecondsMaxValue)
 
     auto sut = createDuration(SECONDS, MAX_NANOSECONDS_FOR_CTOR);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructDurationWithSecondsAndNanosecondsMaxValues)
@@ -146,7 +146,7 @@ TEST(Duration_test, ConstructDurationWithOneNanosecondResultsNotInZeroNanosecond
 
     auto sut = createDuration(SECONDS, NANOSECONDS);
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromTimespecWithZeroValue)
@@ -319,68 +319,68 @@ TEST(Duration_test, ConstructFromChronoMillisecondsZero)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{0U};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsLessThanOneSecond)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{44U};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{1001};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, ConstructFromChronoMillisecondsMax)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut{std::chrono::milliseconds(EXPECTED_MILLISECONDS)};
-    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut(std::chrono::milliseconds(-1));
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsZero)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{0U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsLessThanOneSecond)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{424242U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsMoreThanOneSecond)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{NANOSECS_PER_SECOND + 42U};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromChronoNanosecondsMax)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut{std::chrono::nanoseconds(EXPECTED_NANOSECONDS)};
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConstructFromNegativeChronoNanosecondsIsZero)
 {
     Duration sut(std::chrono::nanoseconds(-1));
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 // END CONSTRUCTOR TESTS
@@ -392,7 +392,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsZero)
     constexpr uint64_t EXPECTED_MILLISECONDS{0U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsLessThanOneSecond)
@@ -400,7 +400,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsLessThanOneSecond)
     constexpr uint64_t EXPECTED_MILLISECONDS{73U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
@@ -408,7 +408,7 @@ TEST(Duration_test, AssignFromChronoMillisecondsMoreThanOneSecond)
     constexpr uint64_t EXPECTED_MILLISECONDS{1073U};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_MILLISECONDS * NANOSECS_PER_MILLISECOND));
 }
 
 TEST(Duration_test, AssignFromChronoMillisecondsMax)
@@ -416,14 +416,14 @@ TEST(Duration_test, AssignFromChronoMillisecondsMax)
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<int64_t>::max()};
     Duration sut = 0_ns;
     sut = std::chrono::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, AssignFromNegativeChronoMillisecondsIsZero)
 {
     Duration sut = 22_ns;
     sut = std::chrono::milliseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 // END ASSIGNMENT TESTS
@@ -435,7 +435,7 @@ TEST(Duration_test, CreateDurationFromDaysLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{2U * HOURS_PER_DAY * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
     auto sut = 2_d;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursLiteral)
@@ -443,7 +443,7 @@ TEST(Duration_test, CreateDurationFromHoursLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{3U * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
     auto sut = 3_h;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesLiteral)
@@ -451,7 +451,7 @@ TEST(Duration_test, CreateDurationFromMinutesLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{4U * SECONDS_PER_MINUTE * NANOSECS_PER_SECOND};
     auto sut = 4_m;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsLiteral)
@@ -459,7 +459,7 @@ TEST(Duration_test, CreateDurationFromSecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{5U * NANOSECS_PER_SECOND};
     auto sut = 5_s;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
@@ -467,7 +467,7 @@ TEST(Duration_test, CreateDurationFromMillisecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{6U * NANOSECS_PER_MILLISECOND};
     auto sut = 6_ms;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
@@ -475,7 +475,7 @@ TEST(Duration_test, CreateDurationFromMicrosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{7U * NANOSECS_PER_MICROSECOND};
     auto sut = 7_us;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
@@ -483,7 +483,7 @@ TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{8U};
     auto sut = 8_ns;
 
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 // END CREATION FROM LITERAL TESTS
@@ -492,21 +492,21 @@ TEST(Duration_test, CreateDurationFromNanosecondsLiteral)
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithZeroDays)
 {
-    auto sut1 = Duration::days(0);
-    auto sut2 = Duration::days(0U);
+    auto sut1 = Duration::fromDays(0);
+    auto sut2 = Duration::fromDays(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithMultipleDays)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{2U * 24U * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
-    auto sut1 = Duration::days(2);
-    auto sut2 = Duration::days(2U);
+    auto sut1 = Duration::fromDays(2);
+    auto sut2 = Duration::fromDays(2U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturation)
@@ -518,8 +518,8 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturat
     static_assert(EXPECTED_DURATION < DurationAccessor::max(),
                   "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
 
-    auto sut1 = Duration::days(static_cast<int64_t>(MAX_DAYS_BEFORE_OVERFLOW));
-    auto sut2 = Duration::days(MAX_DAYS_BEFORE_OVERFLOW);
+    auto sut1 = Duration::fromDays(static_cast<int64_t>(MAX_DAYS_BEFORE_OVERFLOW));
+    auto sut2 = Duration::fromDays(MAX_DAYS_BEFORE_OVERFLOW);
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
@@ -527,8 +527,8 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithDaysResultsNotYetInSaturat
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithMaxDaysResultsInSaturation)
 {
-    auto sut1 = Duration::days(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::days(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromDays(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromDays(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(DurationAccessor::max()));
     EXPECT_THAT(sut2, Eq(DurationAccessor::max()));
@@ -536,27 +536,27 @@ TEST(Duration_test, CreateDurationFromDaysFunctionWithMaxDaysResultsInSaturation
 
 TEST(Duration_test, CreateDurationFromDaysFunctionWithNegativeValuesIsZero)
 {
-    auto sut = Duration::days(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromDays(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithZeroHours)
 {
-    auto sut1 = Duration::hours(0);
-    auto sut2 = Duration::hours(0U);
+    auto sut1 = Duration::fromHours(0);
+    auto sut2 = Duration::fromHours(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithMultipleHours)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{3U * SECONDS_PER_HOUR * NANOSECS_PER_SECOND};
-    auto sut1 = Duration::hours(3);
-    auto sut2 = Duration::hours(3U);
+    auto sut1 = Duration::fromHours(3);
+    auto sut2 = Duration::fromHours(3U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSaturation)
@@ -567,8 +567,8 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSatur
     static_assert(EXPECTED_DURATION < DurationAccessor::max(),
                   "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
 
-    auto sut1 = Duration::hours(static_cast<int64_t>(MAX_HOURS_BEFORE_OVERFLOW));
-    auto sut2 = Duration::hours(MAX_HOURS_BEFORE_OVERFLOW);
+    auto sut1 = Duration::fromHours(static_cast<int64_t>(MAX_HOURS_BEFORE_OVERFLOW));
+    auto sut2 = Duration::fromHours(MAX_HOURS_BEFORE_OVERFLOW);
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
@@ -576,8 +576,8 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithHoursResultsNotYetInSatur
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithMaxHoursResultsInSaturation)
 {
-    auto sut1 = Duration::hours(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::hours(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromHours(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromHours(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(DurationAccessor::max()));
     EXPECT_THAT(sut2, Eq(DurationAccessor::max()));
@@ -585,27 +585,27 @@ TEST(Duration_test, CreateDurationFromHoursFunctionWithMaxHoursResultsInSaturati
 
 TEST(Duration_test, CreateDurationFromHoursFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::hours(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromHours(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithZeroMinuts)
 {
-    auto sut1 = Duration::minutes(0);
-    auto sut2 = Duration::minutes(0U);
+    auto sut1 = Duration::fromMinutes(0);
+    auto sut2 = Duration::fromMinutes(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMultipleMinutes)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{4U * SECONDS_PER_MINUTE * NANOSECS_PER_SECOND};
-    auto sut1 = Duration::minutes(4);
-    auto sut2 = Duration::minutes(4U);
+    auto sut1 = Duration::fromMinutes(4);
+    auto sut2 = Duration::fromMinutes(4U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInSaturation)
@@ -616,8 +616,8 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInS
     static_assert(EXPECTED_DURATION < DurationAccessor::max(),
                   "EXPECTED_DURATION too large to exclude saturation! Please decrease!");
 
-    auto sut1 = Duration::minutes(static_cast<int64_t>(MAX_MINUTES_BEFORE_OVERFLOW));
-    auto sut2 = Duration::minutes(MAX_MINUTES_BEFORE_OVERFLOW);
+    auto sut1 = Duration::fromMinutes(static_cast<int64_t>(MAX_MINUTES_BEFORE_OVERFLOW));
+    auto sut2 = Duration::fromMinutes(MAX_MINUTES_BEFORE_OVERFLOW);
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION));
@@ -625,8 +625,8 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMinutesResultsNotYetInS
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithMaxMinutesResultsInSaturation)
 {
-    auto sut1 = Duration::minutes(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::minutes(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromMinutes(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromMinutes(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(DurationAccessor::max()));
     EXPECT_THAT(sut2, Eq(DurationAccessor::max()));
@@ -634,27 +634,27 @@ TEST(Duration_test, CreateDurationFromMinutesFunctionWithMaxMinutesResultsInSatu
 
 TEST(Duration_test, CreateDurationFromMinutesFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::minutes(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromMinutes(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithZeroSeconds)
 {
-    auto sut1 = Duration::seconds(0);
-    auto sut2 = Duration::seconds(0U);
+    auto sut1 = Duration::fromSeconds(0);
+    auto sut2 = Duration::fromSeconds(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunction)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{5U * NANOSECS_PER_SECOND};
-    auto sut1 = Duration::seconds(5);
-    auto sut2 = Duration::seconds(5U);
+    auto sut1 = Duration::fromSeconds(5);
+    auto sut2 = Duration::fromSeconds(5U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
@@ -664,8 +664,8 @@ TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
     constexpr uint64_t MAX_SECONDS_FROM_USIGNED{std::numeric_limits<uint64_t>::max()};
     constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED = createDuration(MAX_SECONDS_FROM_USIGNED, 0U);
 
-    auto sut1 = Duration::seconds(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::seconds(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromSeconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromSeconds(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
@@ -673,27 +673,27 @@ TEST(Duration_test, CreateDurationFromSecondsFunctionWithMaxSeconds)
 
 TEST(Duration_test, CreateDurationFromSecondsFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::seconds(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromSeconds(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithZeroMilliseconds)
 {
-    auto sut1 = Duration::milliseconds(0);
-    auto sut2 = Duration::milliseconds(0U);
+    auto sut1 = Duration::fromMilliseconds(0);
+    auto sut2 = Duration::fromMilliseconds(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMultipleMilliseconds)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{6U * NANOSECS_PER_MILLISECOND};
-    auto sut1 = Duration::milliseconds(6);
-    auto sut2 = Duration::milliseconds(6U);
+    auto sut1 = Duration::fromMilliseconds(6);
+    auto sut2 = Duration::fromMilliseconds(6U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
@@ -707,8 +707,8 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
         createDuration(MAX_MILLISECONDS_FROM_USIGNED / MILLISECS_PER_SECOND,
                        (MAX_MILLISECONDS_FROM_USIGNED % MILLISECS_PER_SECOND) * NANOSECS_PER_MILLISECOND);
 
-    auto sut1 = Duration::milliseconds(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::milliseconds(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromMilliseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromMilliseconds(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
@@ -716,27 +716,27 @@ TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithMaxMilliseconds)
 
 TEST(Duration_test, CreateDurationFromMillisecondsFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::milliseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromMilliseconds(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithZeroMicroseconds)
 {
-    auto sut1 = Duration::microseconds(0);
-    auto sut2 = Duration::microseconds(0U);
+    auto sut1 = Duration::fromMicroseconds(0);
+    auto sut2 = Duration::fromMicroseconds(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMultipleMicroseconds)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{7U * NANOSECS_PER_MICROSECOND};
-    auto sut1 = Duration::microseconds(7);
-    auto sut2 = Duration::microseconds(7U);
+    auto sut1 = Duration::fromMicroseconds(7);
+    auto sut2 = Duration::fromMicroseconds(7U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
@@ -750,8 +750,8 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
         createDuration(MAX_MICROSECONDS_FROM_USIGNED / MICROSECS_PER_SECONDS,
                        (MAX_MICROSECONDS_FROM_USIGNED % MICROSECS_PER_SECONDS) * NANOSECS_PER_MICROSECOND);
 
-    auto sut1 = Duration::microseconds(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::microseconds(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromMicroseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromMicroseconds(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
@@ -759,27 +759,27 @@ TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithMaxMicroseconds)
 
 TEST(Duration_test, CreateDurationFromMicrosecondsFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::microseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromMicroseconds(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithZeroNanoseconds)
 {
-    auto sut1 = Duration::nanoseconds(0);
-    auto sut2 = Duration::nanoseconds(0U);
+    auto sut1 = Duration::fromNanoseconds(0);
+    auto sut2 = Duration::fromNanoseconds(0U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(0U));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(0U));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithMultipleNanoseconds)
 {
     constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS{8U};
-    auto sut1 = Duration::nanoseconds(8);
-    auto sut2 = Duration::nanoseconds(8U);
+    auto sut1 = Duration::fromNanoseconds(8);
+    auto sut2 = Duration::fromNanoseconds(8U);
 
-    EXPECT_THAT(sut1.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
-    EXPECT_THAT(sut2.nanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut1.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
+    EXPECT_THAT(sut2.toNanoSeconds(), Eq(EXPECTED_DURATION_IN_NANOSECONDS));
 }
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunction)
@@ -791,8 +791,8 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunction)
     constexpr Duration EXPECTED_DURATION_FROM_MAX_UNSIGNED = createDuration(
         MAX_NANOSECONDS_FROM_USIGNED / NANOSECS_PER_SECOND, MAX_NANOSECONDS_FROM_USIGNED % NANOSECS_PER_SECOND);
 
-    auto sut1 = Duration::nanoseconds(std::numeric_limits<int64_t>::max());
-    auto sut2 = Duration::nanoseconds(std::numeric_limits<uint64_t>::max());
+    auto sut1 = Duration::fromNanoseconds(std::numeric_limits<int64_t>::max());
+    auto sut2 = Duration::fromNanoseconds(std::numeric_limits<uint64_t>::max());
 
     EXPECT_THAT(sut1, Eq(EXPECTED_DURATION_FROM_MAX_SIGNED));
     EXPECT_THAT(sut2, Eq(EXPECTED_DURATION_FROM_MAX_UNSIGNED));
@@ -800,8 +800,8 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunction)
 
 TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero)
 {
-    auto sut = Duration::nanoseconds(-1);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(0U));
+    auto sut = Duration::fromNanoseconds(-1);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(0U));
 }
 
 // END CREATION FROM STATIC FUNCTION TESTS
@@ -811,19 +811,19 @@ TEST(Duration_test, CreateDurationFromNanosecondsFunctionWithNegativeValueIsZero
 TEST(Duration_test, ConvertDaysFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.days(), Eq(0U));
+    EXPECT_THAT(sut.toDays(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertDaysFromDurationLessThanOneDay)
 {
     auto sut = 3473_s;
-    EXPECT_THAT(sut.days(), Eq(0U));
+    EXPECT_THAT(sut.toDays(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertDaysFromDurationMoreThanOneDay)
 {
     auto sut = 7_d + 3066_s;
-    EXPECT_THAT(sut.days(), Eq(7U));
+    EXPECT_THAT(sut.toDays(), Eq(7U));
 }
 
 TEST(Duration_test, ConvertDaysFromMaxDuration)
@@ -831,25 +831,25 @@ TEST(Duration_test, ConvertDaysFromMaxDuration)
     constexpr uint64_t SECONDS_PER_DAY{60U * 60U * 24U};
     constexpr uint64_t EXPECTED_DAYS{std::numeric_limits<DurationAccessor::Seconds_t>::max() / SECONDS_PER_DAY};
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.days(), Eq(EXPECTED_DAYS));
+    EXPECT_THAT(sut.toDays(), Eq(EXPECTED_DAYS));
 }
 
 TEST(Duration_test, ConvertHoursFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.hours(), Eq(0U));
+    EXPECT_THAT(sut.toHours(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertHoursFromDurationLessThanOneHour)
 {
     auto sut = 37_m;
-    EXPECT_THAT(sut.hours(), Eq(0U));
+    EXPECT_THAT(sut.toHours(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertHoursFromDurationMoreThanOneHour)
 {
     auto sut = 73_h + 42_m;
-    EXPECT_THAT(sut.hours(), Eq(73U));
+    EXPECT_THAT(sut.toHours(), Eq(73U));
 }
 
 TEST(Duration_test, ConvertHoursFromMaxDuration)
@@ -857,25 +857,25 @@ TEST(Duration_test, ConvertHoursFromMaxDuration)
     constexpr uint64_t SECONDS_PER_HOUR{60U * 60U};
     constexpr uint64_t EXPECTED_HOURS{std::numeric_limits<DurationAccessor::Seconds_t>::max() / SECONDS_PER_HOUR};
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.hours(), Eq(EXPECTED_HOURS));
+    EXPECT_THAT(sut.toHours(), Eq(EXPECTED_HOURS));
 }
 
 TEST(Duration_test, ConvertMinutesFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.minutes(), Eq(0U));
+    EXPECT_THAT(sut.toMinutes(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMinutesFromDurationLessThanOneMinute)
 {
     auto sut = 34_s;
-    EXPECT_THAT(sut.minutes(), Eq(0U));
+    EXPECT_THAT(sut.toMinutes(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMinutesFromDurationMoreThanOneMinute)
 {
     auto sut = 13_m + 42_s;
-    EXPECT_THAT(sut.minutes(), Eq(13U));
+    EXPECT_THAT(sut.toMinutes(), Eq(13U));
 }
 
 TEST(Duration_test, ConvertMinutesFromMaxDuration)
@@ -883,132 +883,132 @@ TEST(Duration_test, ConvertMinutesFromMaxDuration)
     constexpr uint64_t SECONDS_PER_MINUTE{60U};
     constexpr uint64_t EXPECTED_MINUTES{std::numeric_limits<DurationAccessor::Seconds_t>::max() / SECONDS_PER_MINUTE};
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.minutes(), Eq(EXPECTED_MINUTES));
+    EXPECT_THAT(sut.toMinutes(), Eq(EXPECTED_MINUTES));
 }
 
 TEST(Duration_test, ConvertSecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.seconds(), Eq(0U));
+    EXPECT_THAT(sut.toSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertSecondsFromDurationLessThanOneSecond)
 {
     auto sut = 737_ms;
-    EXPECT_THAT(sut.seconds(), Eq(0U));
+    EXPECT_THAT(sut.toSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertSecondsFromDurationMoreThanOneSecond)
 {
     auto sut = 7_s + 833_ms;
-    EXPECT_THAT(sut.seconds(), Eq(7U));
+    EXPECT_THAT(sut.toSeconds(), Eq(7U));
 }
 
 TEST(Duration_test, ConvertSecondsFromMaxSecondsMinusOne)
 {
     constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationAccessor::Seconds_t>::max() - 1U};
     auto sut = DurationAccessor::max() - 1_s;
-    EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
+    EXPECT_THAT(sut.toSeconds(), Eq(EXPECTED_SECONDS));
 }
 
 TEST(Duration_test, ConvertSecondsFromMaxDuration)
 {
     constexpr uint64_t EXPECTED_SECONDS{std::numeric_limits<DurationAccessor::Seconds_t>::max()};
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.seconds(), Eq(EXPECTED_SECONDS));
+    EXPECT_THAT(sut.toSeconds(), Eq(EXPECTED_SECONDS));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromDurationLessThanOneMillisecond)
 {
     auto sut = 637_us;
-    EXPECT_THAT(sut.milliSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMilliecondsFromDurationMoreThanOneMillisecond)
 {
     auto sut = 55_ms + 633_us;
-    EXPECT_THAT(sut.milliSeconds(), Eq(55U));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(55U));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_MILLISECONDS{std::numeric_limits<uint64_t>::max() - 1U};
-    auto sut = Duration::milliseconds(EXPECTED_MILLISECONDS);
-    EXPECT_THAT(sut.milliSeconds(), Eq(EXPECTED_MILLISECONDS));
+    auto sut = Duration::fromMilliseconds(EXPECTED_MILLISECONDS);
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(EXPECTED_MILLISECONDS));
 }
 
 TEST(Duration_test, ConvertMillisecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.milliSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toMilliSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationLessThanOneMicrosecond)
 {
     auto sut = 733_ns;
-    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationMoreThanOneMicrosecond)
 {
     auto sut = 555_us + 733_ns;
-    EXPECT_THAT(sut.microSeconds(), Eq(555U));
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(555U));
 }
 
 TEST(Duration_test, ConvertMicrosecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_MICROSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
-    auto sut = Duration::microseconds(EXPECTED_MICROSECONDS);
-    EXPECT_THAT(sut.microSeconds(), Eq(EXPECTED_MICROSECONDS));
+    auto sut = Duration::fromMicroseconds(EXPECTED_MICROSECONDS);
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(EXPECTED_MICROSECONDS));
 }
 
 TEST(Duration_test, ConvertMicroecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.microSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromZeroDuration)
 {
     auto sut = 0_s;
-    EXPECT_THAT(sut.microSeconds(), Eq(0U));
+    EXPECT_THAT(sut.toMicroSeconds(), Eq(0U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationOfOneNanosecond)
 {
     auto sut = 1_ns;
-    EXPECT_THAT(sut.nanoSeconds(), Eq(1U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(1U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationMultipleNanoseconds)
 {
     auto sut = 42_ns;
-    EXPECT_THAT(sut.nanoSeconds(), Eq(42U));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(42U));
 }
 
 TEST(Duration_test, ConvertNanosecondsFromDurationResultsNotYetInSaturation)
 {
     constexpr uint64_t EXPECTED_NANOSECONDS{std::numeric_limits<uint64_t>::max() - 1U};
-    auto sut = Duration::nanoseconds(EXPECTED_NANOSECONDS);
-    EXPECT_THAT(sut.nanoSeconds(), Eq(EXPECTED_NANOSECONDS));
+    auto sut = Duration::fromNanoseconds(EXPECTED_NANOSECONDS);
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(EXPECTED_NANOSECONDS));
 }
 
 TEST(Duration_test, ConvertNanoecondsFromMaxDurationResultsInSaturation)
 {
     auto sut = DurationAccessor::max();
-    EXPECT_THAT(sut.nanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(sut.toNanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
 }
 
 TEST(Duration_test, ConvertTimespecWithNoneReferenceFromZeroDuration)
@@ -1173,7 +1173,7 @@ TEST(Duration_test, OperatorTimevalFromDurationWithMoreThanOneSecond)
 TEST(Duration_test, OperatorTimevalFromDurationResultsNotYetInSaturation)
 {
     using SEC_TYPE = decltype(timeval::tv_sec);
-    auto duration = Duration::seconds(std::numeric_limits<SEC_TYPE>::max());
+    auto duration = Duration::fromSeconds(std::numeric_limits<SEC_TYPE>::max());
 
     struct timeval sut = timeval(duration);
 
@@ -1783,7 +1783,7 @@ TEST(Duration_test, MultiplyDurationLessThanOneSecondResultsInMoreNanosecondsTha
 
     auto result = MULTIPLICATOR * DURATION;
     EXPECT_THAT(result, Eq(EXPECTED_RESULT));
-    EXPECT_THAT(result.nanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
+    EXPECT_THAT(result.toNanoSeconds(), Eq(std::numeric_limits<uint64_t>::max()));
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(EXPECTED_RESULT));
 }
 

--- a/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
+++ b/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
@@ -43,7 +43,7 @@ void PerformBenchmark(Return (&f)(), const char* functionName, const iox::units:
         }
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(duration.milliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(duration.toMilliSeconds()));
     keepRunning = false;
     t.join();
 

--- a/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
+++ b/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
@@ -43,7 +43,7 @@ void PerformBenchmark(Return (&f)(), const char* functionName, const iox::units:
         }
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(duration.toMilliSeconds()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(duration.toMilliseconds()));
     keepRunning = false;
     t.join();
 

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -54,8 +54,8 @@ void IntrospectionApp::printHelp() noexcept
                  "  -h, --help        Display help and exit.\n"
                  "  -t, --time <ms>   Update period (in milliseconds) for the display of introspection data\n"
                  "                    [min: "
-              << MIN_UPDATE_PERIOD.toMilliSeconds() << ", max: " << MAX_UPDATE_PERIOD.toMilliSeconds()
-              << ", default: " << DEFAULT_UPDATE_PERIOD.toMilliSeconds()
+              << MIN_UPDATE_PERIOD.toMilliseconds() << ", max: " << MAX_UPDATE_PERIOD.toMilliseconds()
+              << ", default: " << DEFAULT_UPDATE_PERIOD.toMilliseconds()
               << "]\n"
                  "  -v, --version     Display latest official iceoryx release version and exit.\n"
                  "\nSubscription:\n"
@@ -519,7 +519,7 @@ bool IntrospectionApp::waitForSubscription(Subscriber& port)
            !subscribed && numberOfLoopsTillTimeout > 0)
     {
         numberOfLoopsTillTimeout--;
-        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.toMilliSeconds()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.toMilliseconds()));
     }
 
     return subscribed;
@@ -771,13 +771,13 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
         refreshTerminal();
 
         // Watch user input for updatePeriodMs
-        auto tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliSeconds());
+        auto tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliseconds());
         auto tWaitBegin = std::chrono::system_clock::now();
         while (tWaitRemaining.count() >= 0)
         {
             waitForUserInput(static_cast<int32_t>(tWaitRemaining.count()));
             auto tWaitElapsed = std::chrono::system_clock::now() - tWaitBegin;
-            tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliSeconds())
+            tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliseconds())
                              - std::chrono::duration_cast<std::chrono::milliseconds>(tWaitElapsed);
         }
     }

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -605,7 +605,7 @@ std::vector<ComposedSubscriberPortData> IntrospectionApp::composeSubscriberPortD
     return subscriberPortData;
 }
 
-void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodMs,
+void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
                                         const IntrospectionSelection introspectionSelection)
 {
     iox::runtime::PoshRuntime::initRuntime(iox::roudi::INTROSPECTION_APP_NAME);
@@ -771,13 +771,13 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
         refreshTerminal();
 
         // Watch user input for updatePeriodMs
-        auto tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.toMilliSeconds());
+        auto tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliSeconds());
         auto tWaitBegin = std::chrono::system_clock::now();
         while (tWaitRemaining.count() >= 0)
         {
             waitForUserInput(static_cast<int32_t>(tWaitRemaining.count()));
             auto tWaitElapsed = std::chrono::system_clock::now() - tWaitBegin;
-            tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.toMilliSeconds())
+            tWaitRemaining = std::chrono::milliseconds(updatePeriod.toMilliSeconds())
                              - std::chrono::duration_cast<std::chrono::milliseconds>(tWaitElapsed);
         }
     }

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -54,8 +54,8 @@ void IntrospectionApp::printHelp() noexcept
                  "  -h, --help        Display help and exit.\n"
                  "  -t, --time <ms>   Update period (in milliseconds) for the display of introspection data\n"
                  "                    [min: "
-              << MIN_UPDATE_PERIOD.milliSeconds() << ", max: " << MAX_UPDATE_PERIOD.milliSeconds()
-              << ", default: " << DEFAULT_UPDATE_PERIOD.milliSeconds()
+              << MIN_UPDATE_PERIOD.toMilliSeconds() << ", max: " << MAX_UPDATE_PERIOD.toMilliSeconds()
+              << ", default: " << DEFAULT_UPDATE_PERIOD.toMilliSeconds()
               << "]\n"
                  "  -v, --version     Display latest official iceoryx release version and exit.\n"
                  "\nSubscription:\n"
@@ -99,7 +99,7 @@ void IntrospectionApp::parseCmdLineArguments(int argc,
             uint64_t newUpdatePeriodMs;
             if (cxx::convert::fromString(optarg, newUpdatePeriodMs))
             {
-                iox::units::Duration rate = iox::units::Duration::milliseconds(newUpdatePeriodMs);
+                iox::units::Duration rate = iox::units::Duration::fromMilliseconds(newUpdatePeriodMs);
                 updatePeriodMs = bounded(rate, MIN_UPDATE_PERIOD, MAX_UPDATE_PERIOD);
             }
             else
@@ -519,7 +519,7 @@ bool IntrospectionApp::waitForSubscription(Subscriber& port)
            !subscribed && numberOfLoopsTillTimeout > 0)
     {
         numberOfLoopsTillTimeout--;
-        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.milliSeconds()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(WAIT_INTERVAL.toMilliSeconds()));
     }
 
     return subscribed;
@@ -771,13 +771,13 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
         refreshTerminal();
 
         // Watch user input for updatePeriodMs
-        auto tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds());
+        auto tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.toMilliSeconds());
         auto tWaitBegin = std::chrono::system_clock::now();
         while (tWaitRemaining.count() >= 0)
         {
             waitForUserInput(static_cast<int32_t>(tWaitRemaining.count()));
             auto tWaitElapsed = std::chrono::system_clock::now() - tWaitBegin;
-            tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.milliSeconds())
+            tWaitRemaining = std::chrono::milliseconds(updatePeriodMs.toMilliSeconds())
                              - std::chrono::duration_cast<std::chrono::milliseconds>(tWaitElapsed);
         }
     }


### PR DESCRIPTION
Signed-off-by: enkeyz <klarnorbert@gmail.com>

## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
Refactored creation/getter method names to be more meaningful for "units::Duration". Partly closes: https://github.com/eclipse-iceoryx/iceoryx/issues/536

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [ ] All checkboxes in the PR checklist are checked or crossed out
1. [ ] Merge

## References

- Closes **TBD**
