### PR TITLE
Iox #381 Fix flooding the command line and resource leak

### DIFF
--- a/iceoryx_posh/source/runtime/message_queue_interface.cpp
+++ b/iceoryx_posh/source/runtime/message_queue_interface.cpp
@@ -158,20 +158,9 @@ bool MqBase::openMessageQueue(const posix::IpcChannelSide channelSide) noexcept
     m_mq.destroy();
 
     m_channelSide = channelSide;
-
-    posix::IpcChannelError receivedError{posix::IpcChannelError::UNDEFINED};
-    // In case the server is not present yet (ENOENT), we try again
-    do
-    {
-        IpcChannelType::create(
-            m_interfaceName, posix::IpcChannelMode::BLOCKING, m_channelSide, m_maxMessageSize, m_maxMessages)
-            .and_then([this, &receivedError](auto& mq) {
-                this->m_mq = std::move(mq);
-                receivedError = posix::IpcChannelError::UNDEFINED;
-            })
-            .or_else([&receivedError](posix::IpcChannelError& error) { receivedError = error; });
-
-    } while (receivedError == posix::IpcChannelError::NO_SUCH_CHANNEL);
+    IpcChannelType::create(
+        m_interfaceName, posix::IpcChannelMode::BLOCKING, m_channelSide, m_maxMessageSize, m_maxMessages)
+        .and_then([this](auto& mq) { this->m_mq = std::move(mq); });
 
     return m_mq.isInitialized();
 }

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -132,7 +132,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @brief creates the unix domain socket
     /// @param mode blocking or non_blocking
     /// @return int with the socket file descriptor, IpcChannelError if error occured
-    cxx::expected<int32_t, IpcChannelError> createSocket(const IpcChannelMode mode) noexcept;
+    cxx::expected<IpcChannelError> initalizeSocket(const IpcChannelMode mode) noexcept;
 
     /// @brief create an IpcChannelError from the provides error code
     /// @return IpcChannelError if error occured
@@ -143,7 +143,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @brief Tries to close the given file descriptor
     /// @param[in] file descriptor that shall be closed
     /// @return IpcChannelError if error occured
-    cxx::expected<IpcChannelError> closeFileDescriptor(const int32_t fileDescriptor) noexcept;
+    cxx::expected<IpcChannelError> closeFileDescriptor() noexcept;
 
   private:
     UdsName_t m_name;

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -141,8 +141,9 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     static bool isNameValid(const UdsName_t& name) noexcept;
 
     /// @brief Tries to close the given file descriptor
+    /// @param[in] file descriptor that shall be closed
     /// @return IpcChannelError if error occured
-    cxx::expected<IpcChannelError> closeFd(int32_t fileDescriptor);
+    cxx::expected<IpcChannelError> closeFileDescriptor(const int32_t fileDescriptor) noexcept;
 
   private:
     UdsName_t m_name;

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -46,7 +46,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     static constexpr int32_t ERROR_CODE = -1;
     static constexpr int32_t INVALID_FD = -1;
 
-    using UdsName_t = cxx::string<LONGEST_VALID_NAME>; 
+    using UdsName_t = cxx::string<LONGEST_VALID_NAME>;
 
     /// @brief for calling private constructor in create method
     friend class DesignPattern::Creation<UnixDomainSocket, IpcChannelError>;
@@ -72,8 +72,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @param NoPathPrefix signalling that this method does not add a path prefix
     /// @param name of the unix domain socket to unlink
     /// @return true if the unix domain socket could be unlinked, false otherwise, IpcChannelError if error occured
-    static cxx::expected<bool, IpcChannelError> unlinkIfExists(const NoPathPrefix_t,
-                                                               const UdsName_t& name) noexcept;
+    static cxx::expected<bool, IpcChannelError> unlinkIfExists(const NoPathPrefix_t, const UdsName_t& name) noexcept;
 
     /// @brief close the unix domain socket.
     cxx::expected<IpcChannelError> destroy() noexcept;
@@ -140,6 +139,10 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     cxx::error<IpcChannelError> createErrorFromErrnum(const int32_t errnum) const noexcept;
 
     static bool isNameValid(const UdsName_t& name) noexcept;
+
+    /// @brief Tries to close the given filedescriptor
+    /// @return SmartC object
+    iox::cxx::SmartC<int(int), int, int> closeFd(int32_t fileDescriptor);
 
   private:
     UdsName_t m_name;

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -129,9 +129,9 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
                      const uint64_t maxMsgNumber = 10U) noexcept;
 
 
-    /// @brief creates the unix domain socket
+    /// @brief initializes the unix domain socket
     /// @param mode blocking or non_blocking
-    /// @return int with the socket file descriptor, IpcChannelError if error occured
+    /// @return IpcChannelError if error occured
     cxx::expected<IpcChannelError> initalizeSocket(const IpcChannelMode mode) noexcept;
 
     /// @brief create an IpcChannelError from the provides error code

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -140,8 +140,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
 
     static bool isNameValid(const UdsName_t& name) noexcept;
 
-    /// @brief Tries to close the given file descriptor
-    /// @param[in] file descriptor that shall be closed
+    /// @brief Tries to close the file descriptor
     /// @return IpcChannelError if error occured
     cxx::expected<IpcChannelError> closeFileDescriptor() noexcept;
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/unix_domain_socket.hpp
@@ -140,9 +140,9 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
 
     static bool isNameValid(const UdsName_t& name) noexcept;
 
-    /// @brief Tries to close the given filedescriptor
-    /// @return SmartC object
-    iox::cxx::SmartC<int(int), int, int> closeFd(int32_t fileDescriptor);
+    /// @brief Tries to close the given file descriptor
+    /// @return IpcChannelError if error occured
+    cxx::expected<IpcChannelError> closeFd(int32_t fileDescriptor);
 
   private:
     UdsName_t m_name;

--- a/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
@@ -412,112 +412,90 @@ cxx::error<IpcChannelError> UnixDomainSocket::createErrorFromErrnum(const int32_
     {
     case EACCES:
     {
-        std::cerr << "permission to create unix domain socket denied \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::ACCESS_DENIED);
     }
     case EAFNOSUPPORT:
     {
-        std::cerr << "address family not supported for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EINVAL:
     {
-        std::cerr << "provided invalid arguments for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EMFILE:
     {
-        std::cerr << "process limit reached for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::PROCESS_LIMIT);
     }
     case ENFILE:
     {
-        std::cerr << "system limit reached for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::SYSTEM_LIMIT);
     }
     case ENOBUFS:
     {
-        std::cerr << "out of memory for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::OUT_OF_MEMORY);
     }
     case ENOMEM:
     {
-        std::cerr << "out of memory for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::OUT_OF_MEMORY);
     }
     case EPROTONOSUPPORT:
     {
-        std::cerr << "protocol type not supported for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EADDRINUSE:
     {
-        std::cerr << "unix domain socket already in use \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::CHANNEL_ALREADY_EXISTS);
     }
     case EBADF:
     {
-        std::cerr << "invalid file descriptor for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_FILE_DESCRIPTOR);
     }
     case ENOTSOCK:
     {
-        std::cerr << "invalid file descriptor for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_FILE_DESCRIPTOR);
     }
     case EADDRNOTAVAIL:
     {
-        std::cerr << "interface or address error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case EFAULT:
     {
-        std::cerr << "outside address space error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ELOOP:
     {
-        std::cerr << "too many symbolic links for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENAMETOOLONG:
     {
-        std::cerr << "name too long for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENOTDIR:
     {
-        std::cerr << "not a directory error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENOENT:
     {
-        std::cerr << "directory prefix error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::NO_SUCH_CHANNEL);
     }
     case EROFS:
     {
-        std::cerr << "read only error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case EIO:
     {
-        std::cerr << "I/O for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::I_O_ERROR);
     }
     case ENOPROTOOPT:
     {
-        std::cerr << "invalid option for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case ECONNREFUSED:
     {
-        std::cerr << "No server for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::NO_SUCH_CHANNEL);
     }
     case ECONNRESET:
     {
-        std::cerr << "connection was reset by peer for \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::CONNECTION_RESET_BY_PEER);
     }
     case EWOULDBLOCK:

--- a/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
@@ -435,90 +435,112 @@ cxx::error<IpcChannelError> UnixDomainSocket::createErrorFromErrnum(const int32_
     {
     case EACCES:
     {
+        std::cerr << "permission to create unix domain socket denied \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::ACCESS_DENIED);
     }
     case EAFNOSUPPORT:
     {
+        std::cerr << "address family not supported for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EINVAL:
     {
+        std::cerr << "provided invalid arguments for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EMFILE:
     {
+        std::cerr << "process limit reached for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::PROCESS_LIMIT);
     }
     case ENFILE:
     {
+        std::cerr << "system limit reached for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::SYSTEM_LIMIT);
     }
     case ENOBUFS:
     {
+        std::cerr << "out of memory for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::OUT_OF_MEMORY);
     }
     case ENOMEM:
     {
+        std::cerr << "out of memory for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::OUT_OF_MEMORY);
     }
     case EPROTONOSUPPORT:
     {
+        std::cerr << "protocol type not supported for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case EADDRINUSE:
     {
+        std::cerr << "unix domain socket already in use \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::CHANNEL_ALREADY_EXISTS);
     }
     case EBADF:
     {
+        std::cerr << "invalid file descriptor for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_FILE_DESCRIPTOR);
     }
     case ENOTSOCK:
     {
+        std::cerr << "invalid file descriptor for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_FILE_DESCRIPTOR);
     }
     case EADDRNOTAVAIL:
     {
+        std::cerr << "interface or address error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case EFAULT:
     {
+        std::cerr << "outside address space error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ELOOP:
     {
+        std::cerr << "too many symbolic links for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENAMETOOLONG:
     {
+        std::cerr << "name too long for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENOTDIR:
     {
+        std::cerr << "not a directory error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case ENOENT:
     {
+        // no error message needed since this is a normal use case
         return cxx::error<IpcChannelError>(IpcChannelError::NO_SUCH_CHANNEL);
     }
     case EROFS:
     {
+        std::cerr << "read only error for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     case EIO:
     {
+        std::cerr << "I/O for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::I_O_ERROR);
     }
     case ENOPROTOOPT:
     {
+        std::cerr << "invalid option for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
     }
     case ECONNREFUSED:
     {
+        std::cerr << "No server for unix domain socket \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::NO_SUCH_CHANNEL);
     }
     case ECONNRESET:
     {
+        std::cerr << "connection was reset by peer for \"" << m_name << "\"" << std::endl;
         return cxx::error<IpcChannelError>(IpcChannelError::CONNECTION_RESET_BY_PEER);
     }
     case EWOULDBLOCK:


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
* Remove noisy output in `UnixDomainSocket`
* Loop till the `IpcChannelSide::Server` is created, this allows users to be able to start publisher and subscribers before RouDi is started
* Fix two resource leaks by introducting `closeFd(..)`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Partly closes #381 and #542
