### PR TITLE
iox-#14 Prepare sample for custom chunk header

### DIFF
--- a/iceoryx_dds/test/mocks/google_mocks.hpp
+++ b/iceoryx_dds/test/mocks/google_mocks.hpp
@@ -34,7 +34,6 @@
 using namespace ::testing;
 using ::testing::_;
 
-// template <typename T>
 class MockPublisher
 {
   public:
@@ -47,7 +46,6 @@ class MockPublisher
     MOCK_CONST_METHOD0(hasSubscribers, bool(void));
 };
 
-// template <typename T>
 class MockSubscriber
 {
   public:

--- a/iceoryx_dds/test/mocks/google_mocks.hpp
+++ b/iceoryx_dds/test/mocks/google_mocks.hpp
@@ -34,23 +34,20 @@
 using namespace ::testing;
 using ::testing::_;
 
-template <typename T>
+// template <typename T>
 class MockPublisher
 {
   public:
     MockPublisher(const iox::capro::ServiceDescription&, const iox::popo::PublisherOptions&){};
     virtual ~MockPublisher() = default;
     MOCK_CONST_METHOD0(getUid, iox::popo::uid_t());
-    MOCK_METHOD1_T(loan, iox::cxx::expected<iox::popo::Sample<T>, iox::popo::AllocationError>(uint32_t));
-    MOCK_METHOD1_T(publish, void(iox::popo::Sample<T>&&));
-    MOCK_METHOD0_T(loanPreviousSample, iox::cxx::optional<iox::popo::Sample<T>>());
     MOCK_METHOD0(offer, void(void));
     MOCK_METHOD0(stopOffer, void(void));
     MOCK_CONST_METHOD0(isOffered, bool(void));
     MOCK_CONST_METHOD0(hasSubscribers, bool(void));
 };
 
-template <typename T>
+// template <typename T>
 class MockSubscriber
 {
   public:
@@ -62,8 +59,6 @@ class MockSubscriber
     MOCK_METHOD0(unsubscribe, void());
     MOCK_CONST_METHOD0(hasData, bool());
     MOCK_METHOD0(hasMissedData, bool());
-    MOCK_METHOD0_T(take,
-                   iox::cxx::expected<iox::cxx::optional<iox::popo::Sample<const T>>, iox::popo::ChunkReceiveResult>());
     MOCK_METHOD0(releaseQueuedData, void());
     MOCK_METHOD1(setConditionVariable, bool(iox::popo::ConditionVariableData*));
     MOCK_METHOD0(unsetConditionVariable, bool(void));

--- a/iceoryx_dds/test/moduletests/test_dds_to_iox.cpp
+++ b/iceoryx_dds/test/moduletests/test_dds_to_iox.cpp
@@ -28,12 +28,12 @@ using namespace ::testing;
 using ::testing::_;
 
 // ======================================== Helpers ======================================== //
-using TestChannel = iox::gw::Channel<MockPublisher<void>, MockDataReader>;
+using TestChannel = iox::gw::Channel<MockPublisher, MockDataReader>;
 using TestGateway =
     iox::dds::DDS2IceoryxGateway<TestChannel, MockGenericGateway<TestChannel, iox::popo::PublisherOptions>>;
 
 // ======================================== Fixture ======================================== //
-class DDS2IceoryxGatewayTest : public DDSGatewayTestFixture<MockPublisher<void>, MockDataReader>
+class DDS2IceoryxGatewayTest : public DDSGatewayTestFixture<MockPublisher, MockDataReader>
 {
 };
 

--- a/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
+++ b/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
@@ -39,12 +39,12 @@ using ::testing::Return;
 using ::testing::SetArgPointee;
 
 // ======================================== Helpers ======================================== //
-using TestChannel = iox::gw::Channel<MockSubscriber<void>, MockDataWriter>;
+using TestChannel = iox::gw::Channel<MockSubscriber, MockDataWriter>;
 using TestGateway =
     iox::dds::Iceoryx2DDSGateway<TestChannel, MockGenericGateway<TestChannel, iox::popo::SubscriberOptions>>;
 
 // ======================================== Fixture ======================================== //
-class Iceoryx2DDSGatewayTest : public DDSGatewayTestFixture<MockSubscriber<void>, MockDataWriter>
+class Iceoryx2DDSGatewayTest : public DDSGatewayTestFixture<MockSubscriber, MockDataWriter>
 {
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher.inl
@@ -83,9 +83,9 @@ Publisher<T, base_publisher_t>::loanSample(const uint32_t size) noexcept
 template <typename T, typename base_publisher_t>
 inline void Publisher<T, base_publisher_t>::publish(Sample<T>&& sample) noexcept
 {
-    auto header = mepoo::ChunkHeader::fromPayload(sample.get());
+    auto chunkPayload = sample.release(); // release the Samples ownership of the chunk before publishing
+    auto header = mepoo::ChunkHeader::fromPayload(chunkPayload);
     port().sendChunk(header);
-    sample.release(); // Must release ownership of the sample as the publisher port takes it when publishing.
 }
 
 template <typename T, typename base_publisher_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -133,9 +133,9 @@ inline void Sample<T>::publish() noexcept
 }
 
 template <typename T>
-inline void Sample<T>::release() noexcept
+inline T* Sample<T>::release() noexcept
 {
-    m_members.sampleUniquePtr.release();
+    return m_members.sampleUniquePtr.release();
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -137,13 +137,14 @@ inline const T* Sample<T>::operator->() const noexcept
 
 template <typename T>
 template <typename S, typename>
-inline T& Sample<T>::operator*() noexcept
+inline S& Sample<T>::operator*() noexcept
 {
     return *get();
 }
 
 template <typename T>
-inline const T& Sample<T>::operator*() const noexcept
+template <typename S, typename>
+inline const S& Sample<T>::operator*() const noexcept
 {
     return *get();
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -25,37 +25,38 @@ namespace popo
 namespace internal
 {
 template <typename T>
-inline SamplePrivateData<T>::SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept
-    : samplePtr(std::move(samplePtr))
+inline SamplePrivateData<T>::SamplePrivateData(cxx::unique_ptr<T>&& sampleUniquePtr,
+                                               PublisherInterface<T>& publisher) noexcept
+    : sampleUniquePtr(std::move(sampleUniquePtr))
     , publisherRef(publisher)
 {
 }
 
 template <typename T>
-inline SamplePrivateData<const T>::SamplePrivateData(cxx::unique_ptr<const T>&& samplePtr) noexcept
-    : samplePtr(std::move(samplePtr))
+inline SamplePrivateData<const T>::SamplePrivateData(cxx::unique_ptr<const T>&& sampleUniquePtr) noexcept
+    : sampleUniquePtr(std::move(sampleUniquePtr))
 {
 }
 } // namespace internal
 
 template <typename T>
 template <typename S, typename>
-inline Sample<T>::Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept
-    : m_members({std::move(samplePtr), publisher})
+inline Sample<T>::Sample(cxx::unique_ptr<T>&& sampleUniquePtr, PublisherInterface<T>& publisher) noexcept
+    : m_members({std::move(sampleUniquePtr), publisher})
 {
 }
 
 template <typename T>
 template <typename S, typename>
-inline Sample<T>::Sample(cxx::unique_ptr<T>&& samplePtr) noexcept
-    : m_members(std::move(samplePtr))
+inline Sample<T>::Sample(cxx::unique_ptr<T>&& sampleUniquePtr) noexcept
+    : m_members(std::move(sampleUniquePtr))
 {
 }
 
 template <typename T>
 inline Sample<T>::Sample(std::nullptr_t) noexcept
 {
-    m_members.samplePtr.reset();
+    m_members.sampleUniquePtr.reset();
 }
 
 template <typename T>
@@ -94,33 +95,33 @@ template <typename T>
 template <typename S, typename>
 inline T* Sample<T>::get() noexcept
 {
-    return m_members.samplePtr.get();
+    return m_members.sampleUniquePtr.get();
 }
 
 template <typename T>
 inline const T* Sample<T>::get() const noexcept
 {
-    return m_members.samplePtr.get();
+    return m_members.sampleUniquePtr.get();
 }
 
 template <typename T>
 template <typename S, typename>
 inline mepoo::ChunkHeader* Sample<T>::getHeader() noexcept
 {
-    return mepoo::ChunkHeader::fromPayload(m_members.samplePtr.get());
+    return mepoo::ChunkHeader::fromPayload(m_members.sampleUniquePtr.get());
 }
 
 template <typename T>
 inline const mepoo::ChunkHeader* Sample<T>::getHeader() const noexcept
 {
-    return mepoo::ChunkHeader::fromPayload(m_members.samplePtr.get());
+    return mepoo::ChunkHeader::fromPayload(m_members.sampleUniquePtr.get());
 }
 
 template <typename T>
 template <typename S, typename>
 inline void Sample<T>::publish() noexcept
 {
-    if (m_members.samplePtr)
+    if (m_members.sampleUniquePtr)
     {
         m_members.publisherRef.get().publish(std::move(*this));
     }
@@ -135,7 +136,7 @@ template <typename T>
 template <typename S, typename>
 inline void Sample<T>::release() noexcept
 {
-    m_members.samplePtr.reset();
+    m_members.sampleUniquePtr.reset();
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -143,8 +143,7 @@ inline S& Sample<T>::operator*() noexcept
 }
 
 template <typename T>
-template <typename S, typename>
-inline const S& Sample<T>::operator*() const noexcept
+inline const T& Sample<T>::operator*() const noexcept
 {
     return *get();
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -133,10 +133,9 @@ inline void Sample<T>::publish() noexcept
 }
 
 template <typename T>
-template <typename S, typename>
 inline void Sample<T>::release() noexcept
 {
-    m_members.sampleUniquePtr.reset();
+    m_members.sampleUniquePtr.release();
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -24,65 +24,23 @@ namespace popo
 {
 namespace internal
 {
-// ============================== SamplePrivateData<T> ========================= //
 template <typename T>
-inline SamplePrivateData<T>::SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher)
+inline SamplePrivateData<T>::SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept
     : samplePtr(std::move(samplePtr))
     , publisherRef(publisher)
 {
 }
 
 template <typename T>
-inline SamplePrivateData<T>& SamplePrivateData<T>::operator=(SamplePrivateData<T>&& rhs)
-{
-    if (this != &rhs)
-    {
-        publisherRef = rhs.publisherRef;
-        samplePtr = std::move(rhs.samplePtr);
-        rhs.samplePtr = nullptr;
-    }
-    return *this;
-}
-
-template <typename T>
-inline SamplePrivateData<T>::SamplePrivateData(SamplePrivateData<T>&& rhs)
-    : samplePtr(std::move(rhs.samplePtr))
-    , publisherRef(std::move(rhs.publisherRef))
-{
-    rhs.samplePtr = nullptr;
-}
-
-// ============================== SamplePrivateData<const T> ========================= //
-
-template <typename T>
 inline SamplePrivateData<const T>::SamplePrivateData(cxx::unique_ptr<const T>&& samplePtr) noexcept
     : samplePtr(std::move(samplePtr))
 {
 }
-
-template <typename T>
-inline SamplePrivateData<const T>& SamplePrivateData<const T>::operator=(SamplePrivateData<const T>&& rhs)
-{
-    if (this != &rhs)
-    {
-        samplePtr = std::move(rhs.samplePtr);
-        rhs.samplePtr = nullptr;
-    }
-    return *this;
-}
-
-template <typename T>
-inline SamplePrivateData<const T>::SamplePrivateData(SamplePrivateData<const T>&& rhs)
-    : samplePtr(std::move(rhs.samplePtr))
-{
-    rhs.samplePtr = nullptr;
-}
 } // namespace internal
 
-// ============================== Sample<T> ========================= //
 template <typename T>
 template <typename S, typename>
-inline Sample<T>::Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher)
+inline Sample<T>::Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept
     : m_members({std::move(samplePtr), publisher})
 {
 }
@@ -95,31 +53,9 @@ inline Sample<T>::Sample(cxx::unique_ptr<T>&& samplePtr) noexcept
 }
 
 template <typename T>
-inline Sample<T>& Sample<T>::operator=(Sample<T>&& rhs)
-{
-    if (this != &rhs)
-    {
-        m_members = std::move(rhs.m_members);
-    }
-    return *this;
-}
-
-template <typename T>
-inline Sample<T>::Sample(Sample<T>&& rhs)
-    : m_members(std::move(rhs.m_members))
-{
-}
-
-template <typename T>
-inline Sample<T>::~Sample()
-{
-    m_members.samplePtr = nullptr;
-}
-
-template <typename T>
 inline Sample<T>::Sample(std::nullptr_t) noexcept
 {
-    m_members.samplePtr = nullptr; // The pointer will take care of cleaning up resources.
+    m_members.samplePtr.reset();
 }
 
 template <typename T>
@@ -149,7 +85,7 @@ inline const T& Sample<T>::operator*() const noexcept
 }
 
 template <typename T>
-inline Sample<T>::operator bool() const
+inline Sample<T>::operator bool() const noexcept
 {
     return get() != nullptr;
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/sample.inl
@@ -200,7 +200,7 @@ template <typename T>
 template <typename S, typename>
 inline void Sample<T>::release() noexcept
 {
-    m_members.samplePtr.release();
+    m_members.samplePtr.reset();
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
@@ -38,7 +38,7 @@ inline cxx::expected<Sample<const T>, ChunkReceiveResult> Subscriber<T, base_sub
         return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     auto payloadPtr = static_cast<T*>(result.value()->payload());
-    auto samplePtr = cxx::unique_ptr<T>(static_cast<T*>(payloadPtr), m_sampleDeleter);
+    auto samplePtr = cxx::unique_ptr<const T>(static_cast<const T*>(payloadPtr), m_sampleDeleter);
     return cxx::success<Sample<const T>>(std::move(samplePtr));
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -168,14 +168,15 @@ class Sample
     template <typename S = T, typename = ForPublisherOnly<S, T>>
     void publish() noexcept;
 
-    ///
-    /// @brief release Manually transfers ownership of the loaned memory chunk back to the mempool.
-    /// @details Only available for non-const type T.
-    ///
-    template <typename S = T, typename = ForPublisherOnly<S, T>>
+  private:
+    template <typename, typename>
+    friend class Publisher;
+
+    /// @note used by the publisher to release the chunk ownership from the `Sample` after publishing the chunk and
+    /// therefore preventing the invocation of the custom deleter
     void release() noexcept;
 
-  protected:
+  private:
     internal::SamplePrivateData<T> m_members;
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -70,18 +70,28 @@ struct SamplePrivateData<const T>
 template <typename T>
 class Sample
 {
+    template <typename S, typename TT>
+    using ForPublisherOnly = std::enable_if_t<std::is_same<S, TT>::value && !std::is_const<S>::value, S>;
+
+    template <typename S, typename TT>
+    using ForSubscriberOnly = std::enable_if_t<std::is_same<S, TT>::value && std::is_const<S>::value, S>;
+
+    template <typename S, typename TT>
+    using myFuncyEnableIf =
+        std::enable_if_t<std::is_same<S, TT>::value && !std::is_same<S, void>::value && !std::is_const<S>::value, S>;
+
   public:
     /// @brief constructor for a Sample used by the Publisher
     /// @tparam S is a dummy template parameter to enable the constructor only for non-const T
     /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
     /// @param publisher is a reference to the publisher to be able to use the `publish` and `release` methods
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher);
 
     /// @brief constructor for a Sample used by the Subscriber
     /// @tparam S is a dummy template parameter to enable the constructor only for const T
     /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForSubscriberOnly<S, T>>
     Sample(cxx::unique_ptr<T>&& samplePtr) noexcept;
 
     Sample(std::nullptr_t) noexcept;
@@ -99,7 +109,7 @@ class Sample
     /// @return a pointer to the encapsulated type.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     T* operator->() noexcept;
 
     ///
@@ -113,19 +123,14 @@ class Sample
     /// @return A T& to the encapsulated type.
     /// @details Only available for non-const type T.
     ///
-    template <
-        typename S = T,
-        typename =
-            std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     S& operator*() noexcept;
 
     ///
     /// @brief operator* Provide a const reference to the encapsulated type.
     /// @return A const T& to the encapsulated type.
     ///
-    template <typename S = T,
-              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
-    const S& operator*() const noexcept;
+    const T& operator*() const noexcept;
 
     ///
     /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.
@@ -138,7 +143,7 @@ class Sample
     /// @return a pointer to the encapsulated type.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     T* get() noexcept;
 
     ///
@@ -152,7 +157,7 @@ class Sample
     /// @return The ChunkHeader of the underlying memory chunk.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     mepoo::ChunkHeader* getHeader() noexcept;
 
     ///
@@ -166,14 +171,14 @@ class Sample
     /// release ownership to it.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     void publish() noexcept;
 
     ///
     /// @brief release Manually transfers ownership of the loaned memory chunk back to the mempool.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    template <typename S = T, typename = ForPublisherOnly<S, T>>
     void release() noexcept;
 
   protected:

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -113,14 +113,19 @@ class Sample
     /// @return A T& to the encapsulated type.
     /// @details Only available for non-const type T.
     ///
-    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
-    T& operator*() noexcept;
+    template <
+        typename S = T,
+        typename =
+            std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value && !std::is_const<S>::value, S>>
+    S& operator*() noexcept;
 
     ///
     /// @brief operator* Provide a const reference to the encapsulated type.
     /// @return A const T& to the encapsulated type.
     ///
-    const T& operator*() const noexcept;
+    template <typename S = T,
+              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
+    const S& operator*() const noexcept;
 
     ///
     /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -34,7 +34,7 @@ namespace internal
 template <typename T>
 struct SamplePrivateData
 {
-    SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept;
+    SamplePrivateData(cxx::unique_ptr<T>&& sampleUniquePtr, PublisherInterface<T>& publisher) noexcept;
 
     SamplePrivateData(SamplePrivateData&& rhs) noexcept = default;
     SamplePrivateData& operator=(SamplePrivateData&& rhs) noexcept = default;
@@ -42,7 +42,7 @@ struct SamplePrivateData
     SamplePrivateData(const SamplePrivateData&) = delete;
     SamplePrivateData& operator=(const SamplePrivateData&) = delete;
 
-    cxx::unique_ptr<T> samplePtr;
+    cxx::unique_ptr<T> sampleUniquePtr;
     std::reference_wrapper<PublisherInterface<T>> publisherRef;
 };
 
@@ -50,7 +50,7 @@ struct SamplePrivateData
 template <typename T>
 struct SamplePrivateData<const T>
 {
-    SamplePrivateData(cxx::unique_ptr<const T>&& samplePtr) noexcept;
+    SamplePrivateData(cxx::unique_ptr<const T>&& sampleUniquePtr) noexcept;
 
     SamplePrivateData(SamplePrivateData&& rhs) noexcept = default;
     SamplePrivateData& operator=(SamplePrivateData&& rhs) noexcept = default;
@@ -58,7 +58,7 @@ struct SamplePrivateData<const T>
     SamplePrivateData(const SamplePrivateData&) = delete;
     SamplePrivateData& operator=(const SamplePrivateData&) = delete;
 
-    cxx::unique_ptr<const T> samplePtr;
+    cxx::unique_ptr<const T> sampleUniquePtr;
 };
 } // namespace internal
 
@@ -78,16 +78,16 @@ class Sample
   public:
     /// @brief constructor for a Sample used by the Publisher
     /// @tparam S is a dummy template parameter to enable the constructor only for non-const T
-    /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
+    /// @param sampleUniquePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
     /// @param publisher is a reference to the publisher to be able to use the `publish` and `release` methods
     template <typename S = T, typename = ForPublisherOnly<S, T>>
-    Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept;
+    Sample(cxx::unique_ptr<T>&& sampleUniquePtr, PublisherInterface<T>& publisher) noexcept;
 
     /// @brief constructor for a Sample used by the Subscriber
     /// @tparam S is a dummy template parameter to enable the constructor only for const T
-    /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
+    /// @param sampleUniquePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
     template <typename S = T, typename = ForSubscriberOnly<S, T>>
-    Sample(cxx::unique_ptr<T>&& samplePtr) noexcept;
+    Sample(cxx::unique_ptr<T>&& sampleUniquePtr) noexcept;
 
     Sample(std::nullptr_t) noexcept;
     ~Sample() noexcept = default;

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +28,41 @@ namespace popo
 template <typename T>
 class PublisherInterface;
 
+namespace internal
+{
+/// @brief helper struct for sample
+template <typename T>
+struct SamplePrivateData
+{
+    SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher);
+
+    SamplePrivateData(SamplePrivateData&& rhs);
+    SamplePrivateData& operator=(SamplePrivateData&& rhs);
+
+    SamplePrivateData(const SamplePrivateData&) = delete;
+    SamplePrivateData& operator=(const SamplePrivateData&) = delete;
+
+    cxx::unique_ptr<T> samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
+    std::reference_wrapper<PublisherInterface<T>> publisherRef;
+};
+
+/// @brief specialization of helper struct for sample for const T
+template <typename T>
+struct SamplePrivateData<const T>
+{
+    SamplePrivateData(cxx::unique_ptr<const T>&& samplePtr) noexcept;
+
+    SamplePrivateData(SamplePrivateData&& rhs);
+    SamplePrivateData& operator=(SamplePrivateData&& rhs);
+
+    SamplePrivateData(const SamplePrivateData&) = delete;
+    SamplePrivateData& operator=(const SamplePrivateData&) = delete;
+
+    cxx::unique_ptr<const T> samplePtr{
+        [](const T* const) {}}; // Placeholder. This is overwritten on sample construction.
+};
+} // namespace internal
+
 ///
 /// @brief The Sample class is a mutable abstraction over types which are written to loaned shared memory.
 /// These samples are publishable to the iceoryx system.
@@ -35,44 +71,56 @@ template <typename T>
 class Sample
 {
   public:
+    /// @brief constructor for a Sample used by the Publisher
+    /// @tparam S is a dummy template parameter to enable the constructor only for non-const T
+    /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
+    /// @param publisher is a reference to the publisher to be able to use the `publish` and `release` methods
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher);
-    Sample(const Sample<T>&) = delete;
-    Sample<T>& operator=(const Sample<T>&) = delete;
-    Sample<T>& operator=(Sample<T>&& rhs);
-    Sample(Sample<T>&& rhs);
-    ~Sample();
+
+    /// @brief constructor for a Sample used by the Subscriber
+    /// @tparam S is a dummy template parameter to enable the constructor only for const T
+    /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && std::is_const<S>::value, S>>
+    Sample(cxx::unique_ptr<T>&& samplePtr) noexcept;
 
     Sample(std::nullptr_t) noexcept;
+    ~Sample();
+
+    Sample<T>& operator=(Sample<T>&& rhs);
+    Sample(Sample<T>&& rhs);
+
+    Sample(const Sample<T>&) = delete;
+    Sample<T>& operator=(const Sample<T>&) = delete;
+
 
     ///
     /// @brief operator -> Transparent access to the encapsulated type.
-    /// @return
+    /// @return a pointer to the encapsulated type.
+    /// @details Only available for non-const type T.
     ///
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     T* operator->() noexcept;
 
     ///
     /// @brief operator -> Transparent read-only access to the encapsulated type.
-    /// @return
+    /// @return a const pointer to the encapsulated type.
     ///
     const T* operator->() const noexcept;
 
     ///
     /// @brief operator* Provide a reference to the encapsulated type.
     /// @return A T& to the encapsulated type.
-    /// @details Only available for non void type T.
+    /// @details Only available for non-const type T.
     ///
-    template <typename S = T,
-              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
-    S& operator*() noexcept;
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
+    T& operator*() noexcept;
 
     ///
     /// @brief operator* Provide a const reference to the encapsulated type.
-    /// @return A T& to the encapsulated type.
-    /// @details Only available for non void type T.
+    /// @return A const T& to the encapsulated type.
     ///
-    template <typename S = T,
-              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
-    const S& operator*() const noexcept;
+    const T& operator*() const noexcept;
 
     ///
     /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.
@@ -81,69 +129,51 @@ class Sample
     operator bool() const;
 
     ///
-    /// @brief allocation Access to the memory chunk loaned to the sample.
-    /// @return
+    /// @brief allocation Access to the encapsulated type loaned to the sample.
+    /// @return a pointer to the encapsulated type.
+    /// @details Only available for non-const type T.
     ///
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     T* get() noexcept;
 
     ///
-    /// @brief allocation Read-only access to the memory chunk loaned to the sample.
-    /// @return
+    /// @brief allocation Read-only access to the encapsulated type loaned to the sample.
+    /// @return a const pointer to the encapsulated type.
     ///
     const T* get() const noexcept;
 
     ///
     /// @brief header Retrieve the header of the underlying memory chunk loaned to the sample.
     /// @return The ChunkHeader of the underlying memory chunk.
+    /// @details Only available for non-const type T.
     ///
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     mepoo::ChunkHeader* getHeader() noexcept;
+
+    ///
+    /// @brief header Retrieve the header of the underlying memory chunk loaned to the sample.
+    /// @return The const ChunkHeader of the underlying memory chunk.
+    ///
+    const mepoo::ChunkHeader* getHeader() const noexcept;
 
     ///
     /// @brief publish Publish the sample via the publisher from which it was loaned and automatically
     /// release ownership to it.
+    /// @details Only available for non-const type T.
     ///
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     void publish() noexcept;
 
     ///
     /// @brief release Manually release ownership of the loaned memory chunk.
-    /// @details This prevents the sample from automatically releasing ownership on destruction.
+    /// @details This prevents the sample from automatically releasing ownership on destruction and is only available
+    /// for non-const type T.
     ///
+    template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     void release() noexcept;
 
   protected:
-    cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
-    std::reference_wrapper<PublisherInterface<T>> m_publisherRef;
-};
-
-///
-/// @brief The Sample<const T> class is a non-mutable abstraction over types which are written to loaned shared memory.
-/// These samples are received from the iceoryx system via subscribers.
-///
-template <typename T>
-class Sample<const T>
-{
-  public:
-    /// Creates an empty sample.
-    Sample(cxx::unique_ptr<T>&& samplePtr) noexcept;
-    Sample(const Sample&) = delete;
-    Sample& operator=(const Sample&) = delete;
-    Sample(Sample<const T>&& rhs);
-    Sample& operator=(Sample<const T>&& rhs);
-    ~Sample();
-
-    Sample(std::nullptr_t) noexcept;
-
-    const T* operator->() noexcept;
-
-    template <typename S = T,
-              typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_same<S, void>::value, S>>
-    const S& operator*() noexcept;
-
-    const T* get() noexcept;
-    const mepoo::ChunkHeader* getHeader() noexcept;
-
-  private:
-    cxx::unique_ptr<T> m_samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
+    internal::SamplePrivateData<T> m_members;
 };
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -34,15 +34,15 @@ namespace internal
 template <typename T>
 struct SamplePrivateData
 {
-    SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher);
+    SamplePrivateData(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept;
 
-    SamplePrivateData(SamplePrivateData&& rhs);
-    SamplePrivateData& operator=(SamplePrivateData&& rhs);
+    SamplePrivateData(SamplePrivateData&& rhs) noexcept = default;
+    SamplePrivateData& operator=(SamplePrivateData&& rhs) noexcept = default;
 
     SamplePrivateData(const SamplePrivateData&) = delete;
     SamplePrivateData& operator=(const SamplePrivateData&) = delete;
 
-    cxx::unique_ptr<T> samplePtr{[](T* const) {}}; // Placeholder. This is overwritten on sample construction.
+    cxx::unique_ptr<T> samplePtr;
     std::reference_wrapper<PublisherInterface<T>> publisherRef;
 };
 
@@ -52,14 +52,13 @@ struct SamplePrivateData<const T>
 {
     SamplePrivateData(cxx::unique_ptr<const T>&& samplePtr) noexcept;
 
-    SamplePrivateData(SamplePrivateData&& rhs);
-    SamplePrivateData& operator=(SamplePrivateData&& rhs);
+    SamplePrivateData(SamplePrivateData&& rhs) noexcept = default;
+    SamplePrivateData& operator=(SamplePrivateData&& rhs) noexcept = default;
 
     SamplePrivateData(const SamplePrivateData&) = delete;
     SamplePrivateData& operator=(const SamplePrivateData&) = delete;
 
-    cxx::unique_ptr<const T> samplePtr{
-        [](const T* const) {}}; // Placeholder. This is overwritten on sample construction.
+    cxx::unique_ptr<const T> samplePtr;
 };
 } // namespace internal
 
@@ -76,17 +75,13 @@ class Sample
     template <typename S, typename TT>
     using ForSubscriberOnly = std::enable_if_t<std::is_same<S, TT>::value && std::is_const<S>::value, S>;
 
-    template <typename S, typename TT>
-    using myFuncyEnableIf =
-        std::enable_if_t<std::is_same<S, TT>::value && !std::is_same<S, void>::value && !std::is_const<S>::value, S>;
-
   public:
     /// @brief constructor for a Sample used by the Publisher
     /// @tparam S is a dummy template parameter to enable the constructor only for non-const T
     /// @param samplePtr is a `rvalue` to a `cxx::unique_ptr<T>` with to the data of the encapsulated type T
     /// @param publisher is a reference to the publisher to be able to use the `publish` and `release` methods
     template <typename S = T, typename = ForPublisherOnly<S, T>>
-    Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher);
+    Sample(cxx::unique_ptr<T>&& samplePtr, PublisherInterface<T>& publisher) noexcept;
 
     /// @brief constructor for a Sample used by the Subscriber
     /// @tparam S is a dummy template parameter to enable the constructor only for const T
@@ -95,14 +90,13 @@ class Sample
     Sample(cxx::unique_ptr<T>&& samplePtr) noexcept;
 
     Sample(std::nullptr_t) noexcept;
-    ~Sample();
+    ~Sample() noexcept = default;
 
-    Sample<T>& operator=(Sample<T>&& rhs);
-    Sample(Sample<T>&& rhs);
+    Sample<T>& operator=(Sample<T>&& rhs) noexcept = default;
+    Sample(Sample<T>&& rhs) noexcept = default;
 
     Sample(const Sample<T>&) = delete;
     Sample<T>& operator=(const Sample<T>&) = delete;
-
 
     ///
     /// @brief operator -> Transparent access to the encapsulated type.
@@ -136,7 +130,7 @@ class Sample
     /// @brief operator bool Indciates whether the sample is valid, i.e. refers to allocated memory.
     /// @return true if the sample is valid, false otherwise.
     ///
-    operator bool() const;
+    operator bool() const noexcept;
 
     ///
     /// @brief allocation Access to the encapsulated type loaned to the sample.

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -174,7 +174,7 @@ class Sample
 
     /// @note used by the publisher to release the chunk ownership from the `Sample` after publishing the chunk and
     /// therefore preventing the invocation of the custom deleter
-    void release() noexcept;
+    T* release() noexcept;
 
   private:
     internal::SamplePrivateData<T> m_members;

--- a/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/sample.hpp
@@ -170,9 +170,8 @@ class Sample
     void publish() noexcept;
 
     ///
-    /// @brief release Manually release ownership of the loaned memory chunk.
-    /// @details This prevents the sample from automatically releasing ownership on destruction and is only available
-    /// for non-const type T.
+    /// @brief release Manually transfers ownership of the loaned memory chunk back to the mempool.
+    /// @details Only available for non-const type T.
     ///
     template <typename S = T, typename = std::enable_if_t<std::is_same<S, T>::value && !std::is_const<S>::value, S>>
     void release() noexcept;

--- a/iceoryx_posh/test/moduletests/test_popo_sample.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_sample.cpp
@@ -18,6 +18,9 @@
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/popo/sample.hpp"
 #include "iceoryx_utils/cxx/unique_ptr.hpp"
+
+#include "mocks/chunk_mock.hpp"
+
 #include "test.hpp"
 
 using namespace ::testing;
@@ -66,7 +69,8 @@ class SampleTest : public Test
 TEST_F(SampleTest, PublishesSampleViaPublisherInterface)
 {
     // ===== Setup ===== //
-    iox::cxx::unique_ptr<DummyData> testSamplePtr{new DummyData(), [](DummyData* ptr) { delete ptr; }};
+    ChunkMock<DummyData> chunk;
+    iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), [](DummyData*) {}};
     MockPublisherInterface<DummyData> mockPublisherInterface{};
 
     auto sut = iox::popo::Sample<DummyData>(std::move(testSamplePtr), mockPublisherInterface);
@@ -77,5 +81,26 @@ TEST_F(SampleTest, PublishesSampleViaPublisherInterface)
     sut.publish();
 
     // ===== Verify ===== //
+    // ===== Cleanup ===== //
+}
+
+TEST_F(SampleTest, ReleaseSampleViaPublisherInterfaceIsSuccessful)
+{
+    // ===== Setup ===== //
+    ChunkMock<DummyData> chunk;
+    uint64_t releaseCounter{0U};
+    auto deleter = [&](DummyData*) { ++releaseCounter; };
+
+    iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), deleter};
+    MockPublisherInterface<DummyData> mockPublisherInterface{};
+
+    auto sut = iox::popo::Sample<DummyData>(std::move(testSamplePtr), mockPublisherInterface);
+
+    // ===== Test ===== //
+    sut.release();
+
+    // ===== Verify ===== //
+    EXPECT_EQ(releaseCounter, 1U);
+
     // ===== Cleanup ===== //
 }

--- a/iceoryx_posh/test/moduletests/test_popo_sample.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_sample.cpp
@@ -83,24 +83,3 @@ TEST_F(SampleTest, PublishesSampleViaPublisherInterface)
     // ===== Verify ===== //
     // ===== Cleanup ===== //
 }
-
-TEST_F(SampleTest, ReleaseSampleViaPublisherInterfaceIsSuccessful)
-{
-    // ===== Setup ===== //
-    ChunkMock<DummyData> chunk;
-    uint64_t releaseCounter{0U};
-    auto deleter = [&](DummyData*) { ++releaseCounter; };
-
-    iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), deleter};
-    MockPublisherInterface<DummyData> mockPublisherInterface{};
-
-    auto sut = iox::popo::Sample<DummyData>(std::move(testSamplePtr), mockPublisherInterface);
-
-    // ===== Test ===== //
-    sut.release();
-
-    // ===== Verify ===== //
-    EXPECT_EQ(releaseCounter, 1U);
-
-    // ===== Cleanup ===== //
-}


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

In order to add the custom chunk header to the typed publisher and subscriber, the `Sample` must also get an additional template parameter for the custom chunk header type. By default this must be `void`, to keep the current behavior. The `Sample` already had a specialization for `void T` which made it impossible to have a default type for the custom chunk header. This PR reworks the `Sample` to be able to use an additional template argument for the custom chunk header which defaults to `void`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Partly closes #14
