### PR TITLE
Iox #349 add subscriber process to introspection

### DIFF
--- a/iceoryx_examples/icecrystal/Readme.md
+++ b/iceoryx_examples/icecrystal/Readme.md
@@ -50,15 +50,10 @@ The process view will show you the processes (incl. PID), which are currently re
 
     --port            Subscribe to port introspection data.
 
-The port view shows both publisher and subscriber ports that are created by RouDi in the shared memory. Their respective
-service description (service, instance, event) is shown to identify them uniquely. The columns `Process` and
-`used by process` display to which process the ports belong and how they are currently connected. Size in bytes of
-both sample size and chunk size (sample size + meta data) and statistical data of `Chunks [/Minute]` is provided as
-well. When a publisher port instantly provides data to a subscriber with the `subscribe()` call, the `Field` column is
-ticked. The service discovery protocol allows you to define the `Propagation scope` of the data. This can enable
-data forwarding to other machines e.g. over network or just consume them internally. When a `Callback` is
-registered on subscriber side, the box is ticked accordingly. `FiFo size / capacity` shows the consumption of chunks
-on the subscriber side and is a useful column to debug potential memleaks.
+The port view shows both publisher and subscriber ports that are created by RouDi in the shared memory. Their respective service 
+description (service, instance, event) is shown to identify them uniquely. The columns `Process` and `Node` display to which 
+process and node the ports belong. The service discovery protocol allows you to define the `Propagation scope` of the data. This 
+can enable data forwarding to other machines e.g. over network or just consume them internally.
 
     --all             Subscribe to all available introspection data.
 

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -307,10 +307,11 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     constexpr int32_t eventWidth{21};
     constexpr int32_t processNameWidth{23};
     constexpr int32_t nodeNameWidth{23};
-    constexpr int32_t sampleSizeWidth{12};
-    constexpr int32_t chunkSizeWidth{12};
-    constexpr int32_t chunksWidth{12};
-    constexpr int32_t intervalWidth{19};
+    // uncomment once this information is needed
+    // constexpr int32_t sampleSizeWidth{12};
+    // constexpr int32_t chunkSizeWidth{12};
+    // constexpr int32_t chunksWidth{12};
+    // constexpr int32_t intervalWidth{19};
     constexpr int32_t subscriptionStateWidth{14};
     // constexpr int32_t fifoWidth{17};    // uncomment once this information is needed
     constexpr int32_t scopeWidth{12};
@@ -323,10 +324,11 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", eventWidth, "Event");
     wprintw(pad, " %*s |", processNameWidth, "Process");
     wprintw(pad, " %*s |", nodeNameWidth, "Node");
-    wprintw(pad, " %*s |", sampleSizeWidth, "Sample Size");
-    wprintw(pad, " %*s |", chunkSizeWidth, "Chunk Size");
-    wprintw(pad, " %*s |", chunksWidth, "Chunks");
-    wprintw(pad, " %*s |", intervalWidth, "Last Send Interval");
+    // uncomment once this information is needed
+    // wprintw(pad, " %*s |", sampleSizeWidth, "Sample Size");
+    // wprintw(pad, " %*s |", chunkSizeWidth, "Chunk Size");
+    // wprintw(pad, " %*s |", chunksWidth, "Chunks");
+    // wprintw(pad, " %*s |", intervalWidth, "Last Send Interval");
     wprintw(pad, " %*s\n", interfaceSourceWidth, "Src. Itf.");
 
     wprintw(pad, " %*s |", serviceWidth, "");
@@ -334,14 +336,15 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", eventWidth, "");
     wprintw(pad, " %*s |", processNameWidth, "");
     wprintw(pad, " %*s |", nodeNameWidth, "");
-    wprintw(pad, " %*s |", sampleSizeWidth, "[Byte]");
-    wprintw(pad, " %*s |", chunkSizeWidth, "[Byte]");
-    wprintw(pad, " %*s |", chunksWidth, "[/Minute]");
-    wprintw(pad, " %*s |", intervalWidth, "[Milliseconds]");
+    // uncomment once this information is needed
+    // wprintw(pad, " %*s |", sampleSizeWidth, "[Byte]");
+    // wprintw(pad, " %*s |", chunkSizeWidth, "[Byte]");
+    // wprintw(pad, " %*s |", chunksWidth, "[/Minute]");
+    // wprintw(pad, " %*s |", intervalWidth, "[Milliseconds]");
     wprintw(pad, " %*s\n", interfaceSourceWidth, "");
 
     wprintw(pad, "---------------------------------------------------------------------------------------------------");
-    wprintw(pad, "----------------------------------------------------------------------------\n");
+    wprintw(pad, "--------------------------------\n");
 
     bool needsLineBreak{false};
     uint32_t currentLine{0U};
@@ -378,10 +381,11 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
 
     for (auto& publisherPort : publisherPortData)
     {
-        std::string m_sampleSize{"n/a"};
-        std::string m_chunkSize{"n/a"};
-        std::string m_chunksPerMinute{"n/a"};
-        std::string sendInterval{"n/a"};
+        // uncomment once this information is needed
+        // std::string m_sampleSize{"n/a"};
+        // std::string m_chunkSize{"n/a"};
+        // std::string m_chunksPerMinute{"n/a"};
+        // std::string sendInterval{"n/a"};
 
         currentLine = 0;
         do
@@ -392,10 +396,11 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
             wprintw(pad, " %s |", printEntry(eventWidth, publisherPort.portData->m_caproEventMethodID).c_str());
             wprintw(pad, " %s |", printEntry(processNameWidth, publisherPort.portData->m_name).c_str());
             wprintw(pad, " %s |", printEntry(nodeNameWidth, publisherPort.portData->m_node).c_str());
-            wprintw(pad, " %s |", printEntry(sampleSizeWidth, m_sampleSize).c_str());
-            wprintw(pad, " %s |", printEntry(chunkSizeWidth, m_chunkSize).c_str());
-            wprintw(pad, " %s |", printEntry(chunksWidth, m_chunksPerMinute).c_str());
-            wprintw(pad, " %s |", printEntry(intervalWidth, sendInterval).c_str());
+            // uncomment once this information is needed
+            // wprintw(pad, " %s |", printEntry(sampleSizeWidth, m_sampleSize).c_str());
+            // wprintw(pad, " %s |", printEntry(chunkSizeWidth, m_chunkSize).c_str());
+            // wprintw(pad, " %s |", printEntry(chunksWidth, m_chunksPerMinute).c_str());
+            // wprintw(pad, " %s |", printEntry(intervalWidth, sendInterval).c_str());
             wprintw(
                 pad,
                 " %s\n",

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -415,6 +415,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", serviceWidth, "Service");
     wprintw(pad, " %*s |", instanceWidth, "Instance");
     wprintw(pad, " %*s |", eventWidth, "Event");
+    wprintw(pad, " %*s |", processNameWidth, "Process");
     wprintw(pad, " %*s |", nodeNameWidth, "Node");
     wprintw(pad, " %*s |", subscriptionStateWidth, "Subscription");
     wprintw(pad, " %*s |", fifoWidth, "FiFo");
@@ -423,6 +424,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", serviceWidth, "");
     wprintw(pad, " %*s |", instanceWidth, "");
     wprintw(pad, " %*s |", eventWidth, "");
+    wprintw(pad, " %*s |", processNameWidth, "");
     wprintw(pad, " %*s |", nodeNameWidth, "");
     wprintw(pad, " %*s |", subscriptionStateWidth, "State");
     wprintw(pad, " %*s |", fifoWidth, "size / capacity");
@@ -458,6 +460,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
             wprintw(pad, " %s |", printEntry(serviceWidth, subscriber.portData->m_caproServiceID).c_str());
             wprintw(pad, " %s |", printEntry(instanceWidth, subscriber.portData->m_caproInstanceID).c_str());
             wprintw(pad, " %s |", printEntry(eventWidth, subscriber.portData->m_caproEventMethodID).c_str());
+            wprintw(pad, " %s |", printEntry(processNameWidth, subscriber.portData->m_name).c_str());
             wprintw(pad, " %s |", printEntry(nodeNameWidth, subscriber.portData->m_node).c_str());
             wprintw(pad,
                     " %s |",
@@ -490,6 +493,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
         wprintw(pad, " %*s |", serviceWidth, "");
         wprintw(pad, " %*s |", instanceWidth, "");
         wprintw(pad, " %*s |", eventWidth, "");
+        wprintw(pad, " %*s |", processNameWidth, "");
         wprintw(pad, " %*s |", nodeNameWidth, "");
         wprintw(pad, " %*s |", subscriptionStateWidth, "");
         wprintw(pad, " %*s |", fifoWidth, "");

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -312,7 +312,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     constexpr int32_t chunksWidth{12};
     constexpr int32_t intervalWidth{19};
     constexpr int32_t subscriptionStateWidth{14};
-    constexpr int32_t fifoWidth{17};
+    // constexpr int32_t fifoWidth{17};    // uncomment once this information is needed
     constexpr int32_t scopeWidth{12};
     constexpr int32_t interfaceSourceWidth{8};
 
@@ -418,7 +418,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", processNameWidth, "Process");
     wprintw(pad, " %*s |", nodeNameWidth, "Node");
     wprintw(pad, " %*s |", subscriptionStateWidth, "Subscription");
-    wprintw(pad, " %*s |", fifoWidth, "FiFo");
+    // wprintw(pad, " %*s |", fifoWidth, "FiFo"); // uncomment once this information is needed
     wprintw(pad, " %*s\n", scopeWidth, "Propagation");
 
     wprintw(pad, " %*s |", serviceWidth, "");
@@ -427,7 +427,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
     wprintw(pad, " %*s |", processNameWidth, "");
     wprintw(pad, " %*s |", nodeNameWidth, "");
     wprintw(pad, " %*s |", subscriptionStateWidth, "State");
-    wprintw(pad, " %*s |", fifoWidth, "size / capacity");
+    // wprintw(pad, " %*s |", fifoWidth, "size / capacity"); // uncomment once this information is needed
     wprintw(pad, " %*s\n", scopeWidth, "scope");
 
     wprintw(pad, "---------------------------------------------------------------------------------------------------");
@@ -467,19 +467,20 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
                     printEntry(subscriptionStateWidth,
                                subscriptionStateToString(subscriber.subscriberPortChangingData->subscriptionState))
                         .c_str());
-            if (currentLine == 0)
-            {
-                std::string fifoSize{"n/a"};     // std::to_string(subscriber.subscriberPortChangingData->fifoSize))
-                std::string fifoCapacity{"n/a"}; // std::to_string(subscriber.subscriberPortChangingData->fifoCapacity))
-                wprintw(pad,
-                        " %s / %s |",
-                        printEntry(((fifoWidth / 2) - 1), fifoSize).c_str(),
-                        printEntry(((fifoWidth / 2) - 1), fifoCapacity).c_str());
-            }
-            else
-            {
-                wprintw(pad, " %*s |", fifoWidth, "");
-            }
+            // uncomment once this information is needed
+            // if (currentLine == 0)
+            //{
+            // std::string fifoSize{"n/a"};     // std::to_string(subscriber.subscriberPortChangingData->fifoSize))
+            // std::string fifoCapacity{"n/a"}; // std::to_string(subscriber.subscriberPortChangingData->fifoCapacity))
+            // wprintw(pad,
+            //" %s / %s |",
+            // printEntry(((fifoWidth / 2) - 1), fifoSize).c_str(),
+            // printEntry(((fifoWidth / 2) - 1), fifoCapacity).c_str());
+            //}
+            // else
+            //{
+            // wprintw(pad, " %*s |", fifoWidth, "");
+            //}
             wprintw(pad,
                     " %s\n",
                     printEntry(scopeWidth,
@@ -496,7 +497,7 @@ void IntrospectionApp::printPortIntrospectionData(const std::vector<ComposedPubl
         wprintw(pad, " %*s |", processNameWidth, "");
         wprintw(pad, " %*s |", nodeNameWidth, "");
         wprintw(pad, " %*s |", subscriptionStateWidth, "");
-        wprintw(pad, " %*s |", fifoWidth, "");
+        // wprintw(pad, " %*s |", fifoWidth, ""); // uncomment once this information is needed
         wprintw(pad, " %*s", scopeWidth, "");
         wprintw(pad, "\n");
     }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
This PR adds a column in the Subscriber Ports table for the process and removes all columns whose entries are not calculated. These columns are commented out so that they can easily be restored once the respective information is needed (and calculated).

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partly closes #349 
