### PR TITLE
Iox #350 refactor has triggered in user trigger

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,readability-*,-readability-named-parameter,-readability-avoid-const-params-in-decls,-readability-else-after-return,performance-*,hicpp-*,-hicpp-named-parameter,-hicpp-avoid-c-arrays,cppcoreguidelines-*,-hicpp-no-array-decay,-hicpp-signed-bitwise,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-array-to-pointer-decay, concurrency-*,clang-analyzer-*,cert-*,bugprone-*'
+Checks: '-*,readability-*,-readability-named-parameter,-readability-avoid-const-params-in-decls,-readability-else-after-return,performance-*,hicpp-*,-hicpp-named-parameter,-hicpp-avoid-c-arrays,cppcoreguidelines-*,-hicpp-no-array-decay,-hicpp-signed-bitwise,-hicpp-vararg,-cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-type-vararg,concurrency-*,clang-analyzer-*,cert-*,bugprone-*'
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,               value: CamelCase }
   - { key: readability-identifier-naming.EnumCase,                value: CamelCase }

--- a/iceoryx_binding_c/include/iceoryx_binding_c/user_trigger.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/user_trigger.h
@@ -42,10 +42,4 @@ void iox_user_trigger_trigger(iox_user_trigger_t const self);
 /// @return returns true if the user trigger was triggered, otherwise false
 bool iox_user_trigger_has_triggered(iox_user_trigger_t const self);
 
-/// @brief resets the user trigger triggering state. after that call
-///         iox_user_trigger_has_triggered will return false until it was
-///         triggered again
-/// @param[in] self handle to user trigger
-void iox_user_trigger_reset_trigger(iox_user_trigger_t const self);
-
 #endif

--- a/iceoryx_binding_c/source/c_user_trigger.cpp
+++ b/iceoryx_binding_c/source/c_user_trigger.cpp
@@ -46,8 +46,3 @@ bool iox_user_trigger_has_triggered(iox_user_trigger_t const self)
 {
     return self->hasTriggered();
 }
-
-void iox_user_trigger_reset_trigger(iox_user_trigger_t const self)
-{
-    self->resetTrigger();
-}

--- a/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
@@ -76,20 +76,6 @@ TEST_F(iox_user_trigger_test, canBeTriggeredWhenAttached)
     EXPECT_TRUE(iox_user_trigger_has_triggered(m_sut));
 }
 
-TEST_F(iox_user_trigger_test, resetTriggerWhenNotTriggeredIsNotTriggered)
-{
-    iox_user_trigger_reset_trigger(m_sut);
-    EXPECT_FALSE(iox_user_trigger_has_triggered(m_sut));
-}
-
-TEST_F(iox_user_trigger_test, resetTriggerWhenTriggeredIsResultsInNotTriggered)
-{
-    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, NULL);
-    iox_user_trigger_trigger(m_sut);
-    iox_user_trigger_reset_trigger(m_sut);
-    EXPECT_FALSE(iox_user_trigger_has_triggered(m_sut));
-}
-
 TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectEventId)
 {
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 88191U, NULL);

--- a/iceoryx_examples/waitset/README.md
+++ b/iceoryx_examples/waitset/README.md
@@ -370,12 +370,11 @@ class SomeClass
     static void cyclicRun(iox::popo::UserTrigger*)
     {
         std::cout << "activation callback\n";
-        trigger->resetTrigger();
     }
 };
 ```
-**Important** We need to reset the user trigger otherwise the _WaitSet_ would notify
-us immediately again since the user trigger is state based.
+**Important** The user trigger is event based and always reset after the WaitSet 
+has acquired all triggered objects.
 
 We begin as always, by creating a _WaitSet_ with the default capacity and by
 attaching the `shutdownTrigger` to 

--- a/iceoryx_examples/waitset/ice_waitset_sync.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_sync.cpp
@@ -34,14 +34,9 @@ static void sigHandler(int f_sig [[gnu::unused]])
 class SomeClass
 {
   public:
-    static void cyclicRun(iox::popo::UserTrigger* trigger)
+    static void cyclicRun(iox::popo::UserTrigger*)
     {
         std::cout << "activation callback\n";
-
-        // after every call we have to reset the trigger otherwise the waitset
-        // would immediately call us again since we still signal to the waitset that
-        // we have been triggered (waitset is state based)
-        trigger->resetTrigger();
     }
 };
 

--- a/iceoryx_examples/waitset_in_c/ice_c_waitset_sync.c
+++ b/iceoryx_examples/waitset_in_c/ice_c_waitset_sync.c
@@ -50,12 +50,9 @@ static void sigHandler(int signalValue)
 
 void cyclicRun(iox_user_trigger_t trigger)
 {
+    (void)trigger;
     printf("activation callback\n");
     fflush(stdout);
-    // after every call we have to reset the trigger otherwise the waitset
-    // would immediately call us again since we still signal to the waitset that
-    // we have been triggered (waitset is state based)
-    iox_user_trigger_reset_trigger(trigger);
 }
 
 void* cyclicTriggerCallback(void* dontCare)

--- a/iceoryx_posh/include/iceoryx_posh/popo/trigger_handle.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/trigger_handle.hpp
@@ -62,6 +62,10 @@ class TriggerHandle
     /// m_conditionVariableDataPtr != nullptr.
     bool isValid() const noexcept;
 
+    /// @brief Returns true when the TriggerHandle was triggered. The TriggerHandle wasTriggered state is set to
+    ///       false again after the underlying ConditionListener gathered all events.
+    bool wasTriggered() const noexcept;
+
     /// @brief triggers the Trigger and informs the Notifyable which verifies that the Trigger was triggered by calling
     /// the hasTriggeredCallback
     void trigger() noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/user_trigger.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/user_trigger.hpp
@@ -45,9 +45,6 @@ class UserTrigger
     /// @return true if the UserTrigger is trigger, otherwise false
     bool hasTriggered() const noexcept;
 
-    /// @brief Resets the UserTrigger state to not triggered
-    void resetTrigger() noexcept;
-
     friend class EventAttorney;
 
   private:
@@ -67,7 +64,6 @@ class UserTrigger
 
   private:
     TriggerHandle m_trigger;
-    std::atomic_bool m_wasTriggered{false};
 };
 
 } // namespace popo

--- a/iceoryx_posh/source/popo/trigger_handle.cpp
+++ b/iceoryx_posh/source/popo/trigger_handle.cpp
@@ -86,6 +86,16 @@ void TriggerHandle::trigger() noexcept
     }
 }
 
+bool TriggerHandle::wasTriggered() const noexcept
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    if (isValid())
+    {
+        return m_conditionVariableDataPtr->m_activeNotifications[m_uniqueTriggerId].load(std::memory_order_relaxed);
+    }
+    return false;
+}
+
 void TriggerHandle::reset() noexcept
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);

--- a/iceoryx_posh/source/popo/user_trigger.cpp
+++ b/iceoryx_posh/source/popo/user_trigger.cpp
@@ -33,18 +33,7 @@ void UserTrigger::disableEvent() noexcept
 
 void UserTrigger::trigger() noexcept
 {
-    m_wasTriggered.store(true, std::memory_order_relaxed);
     m_trigger.trigger();
-}
-
-bool UserTrigger::hasTriggered() const noexcept
-{
-    return m_wasTriggered.load(std::memory_order_relaxed);
-}
-
-void UserTrigger::resetTrigger() noexcept
-{
-    m_wasTriggered.store(false, std::memory_order_relaxed);
 }
 
 void UserTrigger::invalidateTrigger(const uint64_t uniqueTriggerId) noexcept
@@ -53,6 +42,11 @@ void UserTrigger::invalidateTrigger(const uint64_t uniqueTriggerId) noexcept
     {
         m_trigger.invalidate();
     }
+}
+
+bool UserTrigger::hasTriggered() const noexcept
+{
+    return m_trigger.wasTriggered();
 }
 
 WaitSetHasTriggeredCallback UserTrigger::getHasTriggeredCallbackForEvent() const noexcept

--- a/iceoryx_posh/test/moduletests/test_popo_trigger_handle.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_trigger_handle.cpp
@@ -17,6 +17,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/condition_listener.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/condition_variable_data.hpp"
 #include "iceoryx_posh/popo/trigger_handle.hpp"
+#include "testutils/watch_dog.hpp"
 
 #include "test.hpp"
 #include <thread>
@@ -32,10 +33,17 @@ class TriggerHandle_test : public Test
     {
         m_resetCallbackId = id;
     }
+
+    void SetUp()
+    {
+        m_watchdog.watchAndActOnFailure([] { std::terminate(); });
+    }
+
     uint64_t m_resetCallbackId = 0U;
     ConditionVariableData m_condVar{"Horscht"};
     TriggerHandle_test* m_self = this;
 
+    Watchdog m_watchdog{units::Duration::fromSeconds(2U)};
     TriggerHandle m_sut{m_condVar, {*this, &TriggerHandle_test::resetCallback}, 12U};
 };
 
@@ -116,3 +124,28 @@ TEST_F(TriggerHandle_test, triggerNotifiesConditionVariable)
 
     t.join();
 }
+
+TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseAfterCreation)
+{
+    EXPECT_FALSE(m_sut.wasTriggered());
+}
+
+TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseWhenHandleIsInvalid)
+{
+    m_sut.reset();
+    EXPECT_FALSE(m_sut.wasTriggered());
+}
+
+TEST_F(TriggerHandle_test, wasTriggeredReturnsTrueAfterItWasTriggered)
+{
+    m_sut.trigger();
+    EXPECT_TRUE(m_sut.wasTriggered());
+}
+
+TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseAfterItWasTriggeredAndTheListenerResetIt)
+{
+    m_sut.trigger();
+    ConditionListener(m_condVar).timedWait(units::Duration::fromSeconds(0U));
+    EXPECT_FALSE(m_sut.wasTriggered());
+}
+

--- a/iceoryx_posh/test/moduletests/test_popo_user_trigger.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_user_trigger.cpp
@@ -86,43 +86,6 @@ TEST_F(UserTrigger_test, canBeTriggeredMultipleTimesWhenAttached)
     EXPECT_TRUE(m_sut.hasTriggered());
 }
 
-TEST_F(UserTrigger_test, resetTriggerWhenNotTriggeredIsNotTriggered)
-{
-    m_sut.resetTrigger();
-
-    EXPECT_FALSE(m_sut.hasTriggered());
-}
-
-TEST_F(UserTrigger_test, resetTriggerWhenTriggeredResultsInNotTriggered)
-{
-    ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
-    m_sut.trigger();
-    m_sut.resetTrigger();
-
-    EXPECT_FALSE(m_sut.hasTriggered());
-}
-
-TEST_F(UserTrigger_test, resetTriggerAndTriggerAgainResultsInTriggered)
-{
-    ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
-    m_sut.trigger();
-    m_sut.resetTrigger();
-    m_sut.trigger();
-
-    EXPECT_TRUE(m_sut.hasTriggered());
-}
-
-TEST_F(UserTrigger_test, resetTriggerMultipleTimesWhenTriggeredResultsInNotTriggered)
-{
-    ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
-    m_sut.trigger();
-    m_sut.resetTrigger();
-    m_sut.resetTrigger();
-    m_sut.resetTrigger();
-
-    EXPECT_FALSE(m_sut.hasTriggered());
-}
-
 TEST_F(UserTrigger_test, UserTriggerGoesOutOfScopeCleansupAtWaitSet)
 {
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
The UserTrigger was previously state based and it turned event based when we used the new advanced condition variable. This makes absolutely sense and in this PR we adjusted the API and some docu to handle this new behavior.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References
