### PR TITLE
Declare dependency on libatomic in package.xml

### DIFF
--- a/iceoryx_utils/package.xml
+++ b/iceoryx_utils/package.xml
@@ -13,6 +13,7 @@
     <buildtool_depend>cmake</buildtool_depend>
 
     <depend>acl</depend>
+    <depend>libatomic</depend>
 
     <doc_depend>doxygen</doc_depend>
 


### PR DESCRIPTION
This library is used here: https://github.com/eclipse-iceoryx/iceoryx/blob/c4270c988e06619f5db040a59a56f4f9449637a4/iceoryx_utils/CMakeLists.txt#L187-L189

Here are the backing rosdep rules for `libatomic`: https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L1856-L1861

The library is somehow implicitly installed for our Ubuntu builds, but it needs an explicit dependency for RHEL: https://build.ros2.org/job/Rbin_rhel_el864__iceoryx_utils__rhel_8_x86_64__binary/5/console