### PR TITLE
Iox #714 call reset in subscriber destructor

### DIFF
--- a/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
@@ -110,13 +110,11 @@ class CounterClass
         }
     }
 
-    iox::popo::Listener m_listener;
-    // when build with SANITIZE on and clang this crashes while destructing
     iox::popo::Subscriber<CounterTopic> m_subscriberLeft;
     iox::popo::Subscriber<CounterTopic> m_subscriberRight;
     iox::cxx::optional<CounterTopic> m_leftCache;
     iox::cxx::optional<CounterTopic> m_rightCache;
-    // iox::popo::Listener m_listener;
+    iox::popo::Listener m_listener;
 };
 
 int main()

--- a/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
@@ -110,11 +110,13 @@ class CounterClass
         }
     }
 
+    iox::popo::Listener m_listener;
+    // when build with SANITIZE on and clang this crashes while destructing
     iox::popo::Subscriber<CounterTopic> m_subscriberLeft;
     iox::popo::Subscriber<CounterTopic> m_subscriberRight;
     iox::cxx::optional<CounterTopic> m_leftCache;
     iox::cxx::optional<CounterTopic> m_rightCache;
-    iox::popo::Listener m_listener;
+    // iox::popo::Listener m_listener;
 };
 
 int main()

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
@@ -43,6 +43,12 @@ SubscriberImpl<T, H, BaseSubscriber_t>::take() noexcept
     return cxx::success<Sample<const T, const H>>(std::move(samplePtr));
 }
 
+template <typename T, typename H, typename BaseSubscriber_t>
+SubscriberImpl<T, H, BaseSubscriber_t>::~SubscriberImpl()
+{
+    BaseSubscriber_t::m_trigger.reset();
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber.inl
@@ -44,7 +44,7 @@ SubscriberImpl<T, H, BaseSubscriber_t>::take() noexcept
 }
 
 template <typename T, typename H, typename BaseSubscriber_t>
-SubscriberImpl<T, H, BaseSubscriber_t>::~SubscriberImpl()
+inline SubscriberImpl<T, H, BaseSubscriber_t>::~SubscriberImpl() noexcept
 {
     BaseSubscriber_t::m_trigger.reset();
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -47,6 +47,12 @@ inline void UntypedSubscriberImpl<BaseSubscriber_t>::release(const void* const u
     port().releaseChunk(chunkHeader);
 }
 
+template <typename BaseSubscriber_t>
+UntypedSubscriberImpl<BaseSubscriber_t>::~UntypedSubscriberImpl()
+{
+    BaseSubscriber_t::m_trigger.reset();
+}
+
 } // namespace popo
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -48,7 +48,7 @@ inline void UntypedSubscriberImpl<BaseSubscriber_t>::release(const void* const u
 }
 
 template <typename BaseSubscriber_t>
-UntypedSubscriberImpl<BaseSubscriber_t>::~UntypedSubscriberImpl()
+inline UntypedSubscriberImpl<BaseSubscriber_t>::~UntypedSubscriberImpl() noexcept
 {
     BaseSubscriber_t::m_trigger.reset();
 }

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
@@ -38,7 +38,7 @@ class SubscriberImpl : public BaseSubscriber_t
     SubscriberImpl& operator=(const SubscriberImpl&) = delete;
     SubscriberImpl(SubscriberImpl&& rhs) = delete;
     SubscriberImpl& operator=(SubscriberImpl&& rhs) = delete;
-    virtual ~SubscriberImpl();
+    virtual ~SubscriberImpl() noexcept;
 
     ///
     /// @brief Take the samples from the top of the receive queue.

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
@@ -38,9 +38,7 @@ class SubscriberImpl : public BaseSubscriber_t
     SubscriberImpl& operator=(const SubscriberImpl&) = delete;
     SubscriberImpl(SubscriberImpl&& rhs) = delete;
     SubscriberImpl& operator=(SubscriberImpl&& rhs) = delete;
-    virtual ~SubscriberImpl() = default;
-    // implement destructor and reset triggerHandle
-    // untyped subscriber too
+    virtual ~SubscriberImpl();
 
     ///
     /// @brief Take the samples from the top of the receive queue.

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber.hpp
@@ -39,6 +39,8 @@ class SubscriberImpl : public BaseSubscriber_t
     SubscriberImpl(SubscriberImpl&& rhs) = delete;
     SubscriberImpl& operator=(SubscriberImpl&& rhs) = delete;
     virtual ~SubscriberImpl() = default;
+    // implement destructor and reset triggerHandle
+    // untyped subscriber too
 
     ///
     /// @brief Take the samples from the top of the receive queue.

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -45,7 +45,7 @@ class UntypedSubscriberImpl : public BaseSubscriber_t
     UntypedSubscriberImpl& operator=(const UntypedSubscriberImpl&) = delete;
     UntypedSubscriberImpl(UntypedSubscriberImpl&& rhs) = delete;
     UntypedSubscriberImpl& operator=(UntypedSubscriberImpl&& rhs) = delete;
-    virtual ~UntypedSubscriberImpl() = default;
+    virtual ~UntypedSubscriberImpl();
 
     ///
     /// @brief Take the chunk from the top of the receive queue.

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -45,7 +45,7 @@ class UntypedSubscriberImpl : public BaseSubscriber_t
     UntypedSubscriberImpl& operator=(const UntypedSubscriberImpl&) = delete;
     UntypedSubscriberImpl(UntypedSubscriberImpl&& rhs) = delete;
     UntypedSubscriberImpl& operator=(UntypedSubscriberImpl&& rhs) = delete;
-    virtual ~UntypedSubscriberImpl();
+    virtual ~UntypedSubscriberImpl() noexcept;
 
     ///
     /// @brief Take the chunk from the top of the receive queue.

--- a/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_posh/popo/listener.hpp"
+#include "iceoryx_posh/popo/publisher.hpp"
+#include "iceoryx_posh/popo/subscriber.hpp"
+#include "iceoryx_posh/testing/roudi_environment/roudi_environment.hpp"
+
+
+#include "test.hpp"
+
+#include <chrono>
+#include <stdlib.h>
+#include <thread>
+
+using namespace ::testing;
+using namespace iox::popo;
+using namespace iox::cxx;
+using namespace iox::roudi;
+using namespace iox::capro;
+using namespace iox::runtime;
+using ::testing::Return;
+
+void onSampleReceivedCallback(Subscriber<int>* subscriber)
+{
+    static_cast<void>(subscriber);
+}
+
+class PubSubListener_IntegrationTest : public Test
+{
+  public:
+    PubSubListener_IntegrationTest()
+        : m_runtime(PoshRuntime::initRuntime("foo"))
+    {
+        m_listener = std::make_unique<Listener>();
+        m_subscriber = std::make_unique<Subscriber<int>>(m_serviceDescr);
+    }
+    virtual ~PubSubListener_IntegrationTest()
+    {
+    }
+
+    void SetUp()
+    {
+    }
+    void TearDown(){};
+
+    ServiceDescription m_serviceDescr{"Radar", "FrontLeft", "Counter"};
+    RouDiEnvironment m_roudiEnv;
+    PoshRuntime& m_runtime;
+    std::unique_ptr<Listener> m_listener;
+    std::unique_ptr<Subscriber<int>> m_subscriber;
+};
+
+TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDeatchingWorks)
+{
+    
+    m_listener
+        ->attachEvent(*m_subscriber,
+                      iox::popo::SubscriberEvent::DATA_RECEIVED,
+                      iox::popo::createEventCallback(onSampleReceivedCallback))
+        .or_else([](auto) { ASSERT_TRUE(false); });
+
+    m_subscriber.reset();
+
+    EXPECT_TRUE(m_listener);
+}

--- a/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
@@ -62,9 +62,9 @@ class PubSubListener_IntegrationTest : public RouDi_GTest
 
 /// @note Here we test that the trigger reset methods are called correctly in the d'tor of SubscriberImpl. They must not
 /// be called in the BaseSubscriber d'tor since the SubscriberImpl was attached to the Listener. When it goes out of
-/// scope, the trigger tries to access it but SubscriberImpl does not longer exist. This is catched by the
+/// scope, the trigger tries to access it but SubscriberImpl does not longer exist. This is caught by the
 /// UndefinedBehaviorSanitizer.
-TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDeatchingWorks)
+TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDetachingWorks)
 {
     m_listener
         ->attachEvent(*m_subscriber,
@@ -77,9 +77,9 @@ TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDeatchingWorks
 
 /// @note Here we test that the trigger reset methods are called correctly in the d'tor of UntypedSubscriberImpl. They
 /// must not be called in the BaseSubscriber d'tor since the UntypedSubscriberImpl was attached to the Listener. When it
-/// goes out of scope, the trigger tries to access it but UntypedSubscriberImpl does not longer exist. This is catched
+/// goes out of scope, the trigger tries to access it but UntypedSubscriberImpl does not longer exist. This is caught
 /// by the UndefinedBehaviorSanitizer.
-TEST_F(PubSubListener_IntegrationTest, UntypedSubscriberGoesOutOfScopeAndDeatchingWorks)
+TEST_F(PubSubListener_IntegrationTest, UntypedSubscriberGoesOutOfScopeAndDetachingWorks)
 {
     m_listener
         ->attachEvent(*m_untypedSubscriber,

--- a/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
@@ -60,6 +60,10 @@ class PubSubListener_IntegrationTest : public RouDi_GTest
 };
 } // namespace
 
+/// @note Here we test that the trigger reset methods are called correctly in the d'tor of SubscriberImpl. They must not
+/// be called in the BaseSubscriber d'tor since the SubscriberImpl was attached to the Listener. When it goes out of
+/// scope, the trigger tries to access it but SubscriberImpl does not longer exist. This is catched by the
+/// UndefinedBehaviorSanitizer.
 TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDeatchingWorks)
 {
     m_listener
@@ -71,6 +75,10 @@ TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDeatchingWorks
     m_subscriber.reset();
 }
 
+/// @note Here we test that the trigger reset methods are called correctly in the d'tor of UntypedSubscriberImpl. They
+/// must not be called in the BaseSubscriber d'tor since the UntypedSubscriberImpl was attached to the Listener. When it
+/// goes out of scope, the trigger tries to access it but UntypedSubscriberImpl does not longer exist. This is catched
+/// by the UndefinedBehaviorSanitizer.
 TEST_F(PubSubListener_IntegrationTest, UntypedSubscriberGoesOutOfScopeAndDeatchingWorks)
 {
     m_listener

--- a/iceoryx_posh/test/mocks/subscriber_mock.hpp
+++ b/iceoryx_posh/test/mocks/subscriber_mock.hpp
@@ -23,6 +23,7 @@
 #include "iceoryx_posh/popo/base_subscriber.hpp"
 #include "iceoryx_posh/popo/sample.hpp"
 #include "iceoryx_posh/popo/trigger.hpp"
+#include "iceoryx_posh/popo/trigger_handle.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
@@ -93,6 +94,7 @@ class MockBaseSubscriber
     }
 
     Port m_port;
+    iox::popo::TriggerHandle m_trigger;
 };
 
 #endif // IOX_POSH_MOCKS_SUBSCRIBER_MOCK_HPP


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
This PR fixes the runtime error described in #714 by calling `m_trigger.reset()` in the destructors of `SubscriberImpl` and `UntypedSubscriberImpl`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #714 
