### PR TITLE
iox-#325 introduce DualAccessTransactionTray

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -256,12 +256,7 @@ inline void ChunkDistributor<ChunkDistributorDataType>::clearHistory() noexcept
 template <typename ChunkDistributorDataType>
 inline void ChunkDistributor<ChunkDistributorDataType>::cleanup() noexcept
 {
-    if (getMembers()->tryLock())
-    {
-        clearHistory();
-        getMembers()->unlock();
-    }
-    else
+    if (!getMembers()->tryLock())
     {
         /// @todo currently we have a deadlock / mutex destroy vulnerability if the ThreadSafePolicy is used
         /// and a sending application dies when having the lock for sending. If the RouDi daemon wants to
@@ -271,6 +266,10 @@ inline void ChunkDistributor<ChunkDistributorDataType>::cleanup() noexcept
                      nullptr,
                      ErrorLevel::FATAL);
     }
+
+    getMembers()->unlock();
+    // the mutex is locked in this method
+    clearHistory();
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp
@@ -31,7 +31,7 @@ class ThreadSafePolicy
     bool tryLock() const noexcept;
 
   private:
-    mutable posix::mutex m_mutex{true}; // recursive lock
+    mutable posix::mutex m_mutex{false};
 };
 
 class SingleThreadedPolicy

--- a/iceoryx_utils/CMakeLists.txt
+++ b/iceoryx_utils/CMakeLists.txt
@@ -147,6 +147,7 @@ setup_package_name_and_create_files(
 
 add_library(iceoryx_utils
     source/concurrent/active_object.cpp
+    source/concurrent/dual_access_transaction_tray.cpp
     source/concurrent/loffli.cpp
     source/cxx/deadline_timer.cpp
     source/cxx/helplets.cpp

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_UTILS_CONCURRENT_DUAL_ACCESS_TRANSACTION_TRAY_HPP
+#define IOX_UTILS_CONCURRENT_DUAL_ACCESS_TRANSACTION_TRAY_HPP
+
+#include "iceoryx_utils/posix_wrapper/semaphore.hpp"
+
+#include <atomic>
+
+namespace iox
+{
+namespace concurrent
+{
+class DualAccessTransactionTray
+{
+  private:
+    /// @note not public to prevent the user from passing AccessToken::NONE to a method
+    enum class AccessToken
+    {
+        NONE,
+        LEFT,
+        RIGHT
+    };
+
+  public:
+    static constexpr AccessToken LEFT{AccessToken::LEFT};
+    static constexpr AccessToken RIGHT{AccessToken::RIGHT};
+
+    class AccessGuard
+    {
+      public:
+        AccessGuard(DualAccessTransactionTray& transactionTray, AccessToken accessToken);
+        ~AccessGuard();
+
+        AccessGuard(const AccessGuard&) = delete;
+        AccessGuard(AccessGuard&&) = delete;
+
+        AccessGuard& operator=(const AccessGuard&) = delete;
+        AccessGuard& operator=(AccessGuard&&) = delete;
+
+      private:
+        DualAccessTransactionTray& m_transactionTray;
+        AccessToken m_accessToken{AccessToken::NONE};
+    };
+
+    /// @brief Clean up a potential locking when LEFT or RIGHT terminated abnormally.
+    /// @param[in] tokenToCleanup is the DualAccessTransactionTray::LEFT or DualAccessTransactionTray::RIGHT token
+    /// @attention this should only be called if the thread with `tokenToCleanup` is not running anymore else the
+    /// invariants are broken and you might observe pink elephants and dragons
+    void cleanupAndSyncMemory(AccessToken tokenToCleanup);
+
+  private:
+    void acquireExclusiveAccess(AccessToken tokenToAcquireAccess);
+    void releaseExclusiveAccess(AccessToken tokenToBeReleased);
+
+    std::atomic<AccessToken> m_accessToken{AccessToken::NONE};
+    posix::Semaphore m_waitingLineLeft{posix::Semaphore::create(posix::CreateUnnamedSharedMemorySemaphore, 0U).value()};
+    posix::Semaphore m_waitingLineRight{
+        posix::Semaphore::create(posix::CreateUnnamedSharedMemorySemaphore, 0U).value()};
+};
+
+} // namespace concurrent
+} // namespace iox
+
+#endif // IOX_UTILS_CONCURRENT_DUAL_ACCESS_TRANSACTION_TRAY_HPP

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
@@ -43,7 +43,7 @@ class DualAccessTransactionTray
     class AccessGuard
     {
       public:
-        AccessGuard(DualAccessTransactionTray& transactionTray, AccessToken accessToken);
+        AccessGuard(DualAccessTransactionTray& transactionTray, const AccessToken accessToken) noexcept;
         ~AccessGuard();
 
         AccessGuard(const AccessGuard&) = delete;
@@ -61,11 +61,11 @@ class DualAccessTransactionTray
     /// @param[in] tokenToCleanup is the DualAccessTransactionTray::LEFT or DualAccessTransactionTray::RIGHT token
     /// @attention this should only be called if the thread with `tokenToCleanup` is not running anymore else the
     /// invariants are broken and you might observe pink elephants and dragons
-    void cleanupAndSyncMemory(AccessToken tokenToCleanup);
+    void cleanupAndSyncMemory(const AccessToken tokenToCleanup);
 
   private:
-    void acquireExclusiveAccess(AccessToken tokenToAcquireAccess);
-    void releaseExclusiveAccess(AccessToken tokenToBeReleased);
+    void acquireExclusiveAccess(const AccessToken tokenToAcquireAccess);
+    void releaseExclusiveAccess(const AccessToken tokenToBeReleased);
 
     std::atomic<AccessToken> m_accessToken{AccessToken::NONE};
     posix::Semaphore m_waitingLineLeft{posix::Semaphore::create(posix::CreateUnnamedSharedMemorySemaphore, 0U).value()};

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp
@@ -57,11 +57,12 @@ class DualAccessTransactionTray
         AccessToken m_accessToken{AccessToken::NONE};
     };
 
-    /// @brief Clean up a potential locking when LEFT or RIGHT terminated abnormally.
-    /// @param[in] tokenToCleanup is the DualAccessTransactionTray::LEFT or DualAccessTransactionTray::RIGHT token
-    /// @attention this should only be called if the thread with `tokenToCleanup` is not running anymore else the
+    /// @brief Revokes the lock from an absent participant when LEFT or RIGHT terminated abnormally.
+    /// @param[in] absentPaticipantToken is the DualAccessTransactionTray::LEFT or DualAccessTransactionTray::RIGHT
+    /// token
+    /// @attention this should only be called if the thread with `absentPaticipantToken` is not running anymore else the
     /// invariants are broken and you might observe pink elephants and dragons
-    void cleanupAndSyncMemory(const AccessToken tokenToCleanup);
+    void revokeLockFromAbsentParticipant(const AccessToken absentPaticipantToken);
 
   private:
     void acquireExclusiveAccess(const AccessToken tokenToAcquireAccess);

--- a/iceoryx_utils/source/concurrent/dual_access_transaction_tray.cpp
+++ b/iceoryx_utils/source/concurrent/dual_access_transaction_tray.cpp
@@ -20,7 +20,8 @@ namespace iox
 {
 namespace concurrent
 {
-DualAccessTransactionTray::AccessGuard::AccessGuard(DualAccessTransactionTray& transactionTray, AccessToken accessToken)
+DualAccessTransactionTray::AccessGuard::AccessGuard(DualAccessTransactionTray& transactionTray,
+                                                    const AccessToken accessToken) noexcept
     : m_transactionTray(transactionTray)
     , m_accessToken(accessToken)
 {
@@ -40,7 +41,7 @@ void DualAccessTransactionTray::cleanupAndSyncMemory(const AccessToken tokenToCl
     m_accessToken.compare_exchange_strong(expected, AccessToken::NONE, std::memory_order_acq_rel);
 }
 
-void DualAccessTransactionTray::acquireExclusiveAccess(AccessToken tokenToAcquireAccess)
+void DualAccessTransactionTray::acquireExclusiveAccess(const AccessToken tokenToAcquireAccess)
 {
     auto existingToken = m_accessToken.exchange(tokenToAcquireAccess, std::memory_order_acquire);
     if (existingToken == tokenToAcquireAccess)
@@ -67,7 +68,7 @@ void DualAccessTransactionTray::acquireExclusiveAccess(AccessToken tokenToAcquir
     }
 }
 
-void DualAccessTransactionTray::releaseExclusiveAccess(AccessToken tokenToBeReleased)
+void DualAccessTransactionTray::releaseExclusiveAccess(const AccessToken tokenToBeReleased)
 {
     AccessToken expected = tokenToBeReleased;
     auto casSuccessful = m_accessToken.compare_exchange_strong(expected, AccessToken::NONE, std::memory_order_release);

--- a/iceoryx_utils/source/concurrent/dual_access_transaction_tray.cpp
+++ b/iceoryx_utils/source/concurrent/dual_access_transaction_tray.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp"
+
+namespace iox
+{
+namespace concurrent
+{
+DualAccessTransactionTray::AccessGuard::AccessGuard(DualAccessTransactionTray& transactionTray, AccessToken accessToken)
+    : m_transactionTray(transactionTray)
+    , m_accessToken(accessToken)
+{
+    transactionTray.acquireExclusiveAccess(m_accessToken);
+}
+
+DualAccessTransactionTray::AccessGuard::~AccessGuard()
+{
+    m_transactionTray.releaseExclusiveAccess(m_accessToken);
+}
+
+void DualAccessTransactionTray::cleanupAndSyncMemory(const AccessToken tokenToCleanup)
+{
+    releaseExclusiveAccess(tokenToCleanup);
+    // just to be sure the memory is synchronized
+    AccessToken expected = tokenToCleanup;
+    m_accessToken.compare_exchange_strong(expected, AccessToken::NONE, std::memory_order_acq_rel);
+}
+
+void DualAccessTransactionTray::acquireExclusiveAccess(AccessToken tokenToAcquireAccess)
+{
+    auto existingToken = m_accessToken.exchange(tokenToAcquireAccess, std::memory_order_acquire);
+    if (existingToken == tokenToAcquireAccess)
+    {
+        // TODO return expected DOUBLE_ACQUIRE_BROKEN_INVARIANT
+        std::terminate();
+    }
+    else if (existingToken != AccessToken::NONE)
+    {
+        if (tokenToAcquireAccess == AccessToken::LEFT)
+        {
+            if (m_waitingLineLeft.wait().has_error())
+            {
+                // TODO return expected ERROR_WHILE_WAITING_FOR_SEMAPHORE
+            }
+        }
+        else
+        {
+            if (m_waitingLineRight.wait().has_error())
+            {
+                // TODO return expected ERROR_WHILE_WAITING_FOR_SEMAPHORE
+            }
+        }
+    }
+}
+
+void DualAccessTransactionTray::releaseExclusiveAccess(AccessToken tokenToBeReleased)
+{
+    AccessToken expected = tokenToBeReleased;
+    auto casSuccessful = m_accessToken.compare_exchange_strong(expected, AccessToken::NONE, std::memory_order_release);
+    if (!casSuccessful)
+    {
+        if (expected == AccessToken::NONE)
+        {
+            // TODO return expected RELEASE_ON_NONE_BROKEN_INVARIANT
+            std::terminate();
+        }
+        else if (tokenToBeReleased == AccessToken::LEFT)
+        {
+            // post can result in either EINVAL or EOVERFLOW; neither of those can be triggered by this code
+            IOX_DISCARD_RESULT(m_waitingLineRight.post());
+        }
+        else
+        {
+            // post can result in either EINVAL or EOVERFLOW; neither of those can be triggered by this code
+            IOX_DISCARD_RESULT(m_waitingLineLeft.post());
+        }
+    }
+}
+
+} // namespace concurrent
+} // namespace iox

--- a/iceoryx_utils/test/moduletests/test_concurrent_dual_access_transaction_tray.cpp
+++ b/iceoryx_utils/test/moduletests/test_concurrent_dual_access_transaction_tray.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_utils/internal/concurrent/dual_access_transaction_tray.hpp"
+
+#include "iceoryx_utils/posix_wrapper/semaphore.hpp"
+#include "test.hpp"
+
+#include <mutex>
+#include <thread>
+
+namespace
+{
+using namespace ::testing;
+using namespace iox::concurrent;
+
+TEST(DualAccessTransactionTray_test, StressNoContention)
+{
+    DualAccessTransactionTray transactionTray;
+    uint64_t counter = 0U;
+    constexpr uint64_t NUMBER_OF_LOOPS{1000000U};
+
+    auto now = std::chrono::system_clock::now();
+    auto threadSynchronization = iox::posix::Semaphore::create(iox::posix::CreateUnnamedSingleProcessSemaphore, 0U);
+    ASSERT_FALSE(threadSynchronization.has_error());
+
+    std::thread left([&] {
+        ASSERT_FALSE(threadSynchronization->post().has_error());
+        for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+        {
+            DualAccessTransactionTray::AccessGuard guard(transactionTray, DualAccessTransactionTray::LEFT);
+            ++counter;
+        }
+    });
+    left.join();
+
+    ASSERT_FALSE(threadSynchronization->wait().has_error());
+
+    for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+    {
+        DualAccessTransactionTray::AccessGuard guard(transactionTray, DualAccessTransactionTray::RIGHT);
+        ++counter;
+    }
+
+    auto finish = std::chrono::system_clock::now();
+    auto averageTimeInNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(finish - now).count() / (NUMBER_OF_LOOPS * 2);
+    std::cout << "Average locking time: " << averageTimeInNs / 1000. << "µs" << std::endl;
+
+    EXPECT_EQ(counter, 2 * NUMBER_OF_LOOPS);
+}
+
+TEST(DualAccessTransactionTray_test, StressContention)
+{
+    DualAccessTransactionTray transactionTray;
+    uint64_t counter = 0U;
+    constexpr uint64_t NUMBER_OF_LOOPS{1000000U};
+
+    auto threadSynchronization = iox::posix::Semaphore::create(iox::posix::CreateUnnamedSingleProcessSemaphore, 0U);
+    ASSERT_FALSE(threadSynchronization.has_error());
+
+    auto now = std::chrono::system_clock::now();
+    std::thread left([&] {
+        ASSERT_FALSE(threadSynchronization->post().has_error());
+        for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+        {
+            DualAccessTransactionTray::AccessGuard guard(transactionTray, DualAccessTransactionTray::LEFT);
+            ++counter;
+        }
+    });
+
+    ASSERT_FALSE(threadSynchronization->wait().has_error());
+
+    for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+    {
+        DualAccessTransactionTray::AccessGuard guard(transactionTray, DualAccessTransactionTray::RIGHT);
+        ++counter;
+    }
+
+    left.join();
+    auto finish = std::chrono::system_clock::now();
+    auto averageTimeInNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(finish - now).count() / (NUMBER_OF_LOOPS * 2);
+    std::cout << "Average locking time: " << averageTimeInNs / 1000. << "µs" << std::endl;
+
+    EXPECT_EQ(counter, 2 * NUMBER_OF_LOOPS);
+}
+
+TEST(DualAccessTransactionTray_test, StressWithMutexNoContention)
+{
+    std::mutex mtx;
+    uint64_t counter = 0U;
+    constexpr uint64_t NUMBER_OF_LOOPS{1000000U};
+
+    auto threadSynchronization = iox::posix::Semaphore::create(iox::posix::CreateUnnamedSingleProcessSemaphore, 0U);
+    ASSERT_FALSE(threadSynchronization.has_error());
+
+    auto now = std::chrono::system_clock::now();
+    std::thread left([&] {
+        ASSERT_FALSE(threadSynchronization->post().has_error());
+        for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+        {
+            std::lock_guard<std::mutex> g(mtx);
+            ++counter;
+        }
+    });
+    left.join();
+
+    ASSERT_FALSE(threadSynchronization->wait().has_error());
+
+    for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+    {
+        std::lock_guard<std::mutex> g(mtx);
+        ++counter;
+    }
+
+    auto finish = std::chrono::system_clock::now();
+    auto averageTimeInNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(finish - now).count() / (NUMBER_OF_LOOPS * 2);
+    std::cout << "Average locking time: " << averageTimeInNs / 1000. << "µs" << std::endl;
+
+    EXPECT_EQ(counter, 2 * NUMBER_OF_LOOPS);
+}
+
+TEST(DualAccessTransactionTray_test, StressWithMutexContention)
+{
+    std::mutex mtx;
+    uint64_t counter = 0U;
+    constexpr uint64_t NUMBER_OF_LOOPS{1000000U};
+
+    auto threadSynchronization = iox::posix::Semaphore::create(iox::posix::CreateUnnamedSingleProcessSemaphore, 0U);
+    ASSERT_FALSE(threadSynchronization.has_error());
+
+    auto now = std::chrono::system_clock::now();
+    std::thread left([&] {
+        ASSERT_FALSE(threadSynchronization->post().has_error());
+        for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+        {
+            std::lock_guard<std::mutex> g(mtx);
+            ++counter;
+        }
+    });
+
+    ASSERT_FALSE(threadSynchronization->wait().has_error());
+
+    for (uint64_t i = 0; i < NUMBER_OF_LOOPS; ++i)
+    {
+        std::lock_guard<std::mutex> g(mtx);
+        ++counter;
+    }
+
+    left.join();
+    auto finish = std::chrono::system_clock::now();
+    auto averageTimeInNs =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(finish - now).count() / (NUMBER_OF_LOOPS * 2);
+    std::cout << "Average locking time: " << averageTimeInNs / 1000. << "µs" << std::endl;
+
+    EXPECT_EQ(counter, 2 * NUMBER_OF_LOOPS);
+}
+} // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This is just a draft to discuss the API of the `DualAccessTransactionTray` which might replace the mutex in the `ChunkDistributor`. A better name is also welcome.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Partly closes #325 
