### PR TITLE
Iox #759 improve helix qac parsing coverage

### DIFF
--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/variant.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/variant.inl
@@ -209,7 +209,7 @@ inline const typename internal::get_type_at_index<0, TypeIndex, Types...>::type*
 variant<Types...>::get_at_index() const noexcept
 {
     using T = typename internal::get_type_at_index<0, TypeIndex, Types...>::type;
-    return const_cast<const T*>(const_cast<variant*>(this)->get_at_index<TypeIndex>());
+    return const_cast<const T*>(const_cast<variant*>(this)->template get_at_index<TypeIndex>());
 }
 
 template <typename... Types>

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/variant.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/variant.inl
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 by Perforce All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
linked to iox-#759 

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
small workaround that should not impact compilation, but does allow for Helix QAC to parse this bit of code properly.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #759 
