### PR TITLE
Iox #805 enhance posix call

### DIFF
--- a/cmake/googletest/CMakeLists.txt
+++ b/cmake/googletest/CMakeLists.txt
@@ -72,7 +72,7 @@ if(BUILD_TEST)
             WORKING_DIRECTORY "${SOURCE_DIR}"
             RESULT_VARIABLE result)
         if(result)
-            message(FATAL_ERROR "CMake step [patch] for googletest failed: ${result}")
+            message(WARNING "CMake step [patch] for googletest failed: ${result}! Build of gtest might fail")
         endif()
     endif()
 

--- a/iceoryx_examples/iceperf/mq.cpp
+++ b/iceoryx_examples/iceperf/mq.cpp
@@ -36,7 +36,8 @@ void MQ::cleanupOutdatedResources(const std::string& publisherName, const std::s
     auto publisherMqName = PREFIX + publisherName;
     iox::posix::posixCall(mq_unlink)(publisherMqName.c_str())
         .failureReturnValue(ERROR_CODE)
-        .evaluateWithIgnoredErrnos(ENOENT)
+        .ignoreErrnos(ENOENT)
+        .evaluate()
         .or_else([&](auto& r) {
             std::cout << "mq_unlink error for " << publisherMqName << ", " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
@@ -45,7 +46,8 @@ void MQ::cleanupOutdatedResources(const std::string& publisherName, const std::s
     auto subscriberMqName = PREFIX + subscriberName;
     iox::posix::posixCall(mq_unlink)(subscriberMqName.c_str())
         .failureReturnValue(ERROR_CODE)
-        .evaluateWithIgnoredErrnos(ENOENT)
+        .ignoreErrnos(ENOENT)
+        .evaluate()
         .or_else([&](auto& r) {
             std::cout << "mq_unlink error for " << subscriberMqName << ", " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
@@ -100,7 +102,8 @@ void MQ::shutdown() noexcept
 
     iox::posix::posixCall(mq_unlink)(m_subscriberMqName.c_str())
         .failureReturnValue(ERROR_CODE)
-        .evaluateWithIgnoredErrnos(ENOENT)
+        .ignoreErrnos(ENOENT)
+        .evaluate()
         .or_else([&](auto& r) {
             std::cout << "mq_unlink error for " << m_subscriberMqName << ", " << r.getHumanReadableErrnum()
                       << std::endl;
@@ -173,7 +176,8 @@ void MQ::open(const std::string& name, const iox::posix::IpcChannelSide channelS
 
         auto mqCall = iox::posix::posixCall(iox_mq_open4)(name.c_str(), openFlags, m_filemode, &m_attributes)
                           .failureReturnValue(ERROR_CODE)
-                          .evaluateWithIgnoredErrnos(ENOENT)
+                          .ignoreErrnos(ENOENT)
+                          .evaluate()
                           .or_else([&](auto& r) {
                               std::cout << "mq_open error for " << name << ", " << r.getHumanReadableErrnum()
                                         << std::endl;

--- a/iceoryx_examples/iceperf/uds.cpp
+++ b/iceoryx_examples/iceperf/uds.cpp
@@ -46,7 +46,8 @@ void UDS::cleanupOutdatedResources(const std::string& publisherName, const std::
     initSocketAddress(sockAddrPublisher, publisherSocketName);
     iox::posix::posixCall(unlink)(sockAddrPublisher.sun_path)
         .failureReturnValue(ERROR_CODE)
-        .evaluateWithIgnoredErrnos(ENOENT)
+        .ignoreErrnos(ENOENT)
+        .evaluate()
         .or_else([](auto& r) {
             std::cout << "unlink error " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
@@ -58,7 +59,8 @@ void UDS::cleanupOutdatedResources(const std::string& publisherName, const std::
 
     iox::posix::posixCall(unlink)(sockAddrSubscriber.sun_path)
         .failureReturnValue(ERROR_CODE)
-        .evaluateWithIgnoredErrnos(ENOENT)
+        .ignoreErrnos(ENOENT)
+        .evaluate()
         .or_else([](auto& r) {
             std::cout << "unlink error " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
@@ -130,7 +132,8 @@ void UDS::waitForLeader() noexcept
                                                       reinterpret_cast<struct sockaddr*>(&m_sockAddrPublisher),
                                                       sizeof(m_sockAddrPublisher))
                             .failureReturnValue(ERROR_CODE)
-                            .evaluateWithIgnoredErrnos(ENOENT)
+                            .ignoreErrnos(ENOENT)
+                            .evaluate()
                             .or_else([](auto& r) {
                                 std::cout << "send error " << r.getHumanReadableErrnum() << std::endl;
                                 exit(1);
@@ -240,7 +243,8 @@ void UDS::send(const char* buffer, uint32_t length) noexcept
                                          reinterpret_cast<struct sockaddr*>(&m_sockAddrPublisher),
                                          sizeof(m_sockAddrPublisher))
                .failureReturnValue(ERROR_CODE)
-               .evaluateWithIgnoredErrnos(ENOBUFS)
+               .ignoreErrnos(ENOBUFS)
+               .evaluate()
                .or_else([](auto& r) {
                    std::cout << std::endl << "send error " << r.getHumanReadableErrnum() << std::endl;
                    exit(1);

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
@@ -96,6 +96,22 @@ constexpr bool doesContainType() noexcept;
 template <typename T, typename CompareType, typename Next, typename... Remainder>
 constexpr bool doesContainType() noexcept;
 
+/// @brief Finalizes the recursion of doesContainValue
+/// @param T type of the value to check
+/// @return always false
+template <typename T>
+inline constexpr bool doesContainValue(const T);
+
+/// @brief Returns true if value of T is found in the ValueList, otherwise false
+/// @tparam T type of the value to check
+/// @tparam ValueList is a list of values to check for a specific value
+/// @param[in] value to look for in the ValueList
+/// @param[in] firstValueListEntry is the first variadic argument of ValueList
+/// @param[in] remainingValueListEntries are the remaining variadic arguments of ValueList
+template <typename T, typename... ValueList>
+inline constexpr bool
+doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept;
+
 /// @brief Merging two sorted containers so that the result is a sorted container
 ///        where every element is contained only once
 /// @tparam Container container type which has to support emplace_back() and size()

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -69,6 +69,19 @@ inline constexpr bool doesContainType() noexcept
     return doesContainType<T, CompareType>() || doesContainType<T, Next, Remainder...>();
 }
 
+template <typename T>
+inline constexpr bool doesContainValue(const T)
+{
+    return false;
+}
+
+template <typename T, typename... ValueList>
+inline constexpr bool
+doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept
+{
+    return (value == firstValueListEntry) ? true : doesContainValue(value, remainingValueListEntries...);
+}
+
 template <typename Container>
 inline Container uniqueMergeSortedContainers(const Container& v1, const Container& v2) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -130,7 +130,7 @@ PosixCallEvaluator<ReturnType>::ignoreErrnos(const IgnoredErrnos... ignoredErrno
 template <typename ReturnType>
 template <typename... SilentErrnos>
 inline PosixCallEvaluator<ReturnType>
-PosixCallEvaluator<ReturnType>::suppressErrorLoggingOfErrnos(const SilentErrnos... silentErrnos) const&& noexcept
+PosixCallEvaluator<ReturnType>::suppressErrorMessagesForErrnos(const SilentErrnos... silentErrnos) const&& noexcept
 {
     if (!m_details.hasSuccess)
     {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -101,49 +101,23 @@ inline PosixCallVerificator<ReturnType>::PosixCallVerificator(internal::PosixCal
 }
 
 template <typename ReturnType>
-inline PosixCallEvaluator<ReturnType>
-PosixCallVerificator<ReturnType>::successReturnValue(const ReturnType value) && noexcept
-{
-    m_details.hasSuccess = (m_details.result.value == value);
-    return PosixCallEvaluator<ReturnType>(m_details);
-}
-
-template <typename ReturnType>
 template <typename... SuccessReturnValues>
 inline PosixCallEvaluator<ReturnType>
-PosixCallVerificator<ReturnType>::successReturnValue(const ReturnType value,
-                                                     const SuccessReturnValues... remainingValues) && noexcept
+PosixCallVerificator<ReturnType>::successReturnValue(const SuccessReturnValues... successReturnValues) && noexcept
 {
-    m_details.hasSuccess = (m_details.result.value == value);
-    if (m_details.hasSuccess)
-    {
-        return PosixCallEvaluator<ReturnType>(m_details);
-    }
+    m_details.hasSuccess = algorithm::doesContainValue(m_details.result.value, successReturnValues...);
 
-    // we require an rvalue of our object
-    return std::move(*this).successReturnValue(remainingValues...);
+    return PosixCallEvaluator<ReturnType>(m_details);
 }
 
 template <typename ReturnType>
 template <typename... FailureReturnValues>
 inline PosixCallEvaluator<ReturnType>
-PosixCallVerificator<ReturnType>::failureReturnValue(const ReturnType value,
-                                                     const FailureReturnValues... remainingValues) && noexcept
+PosixCallVerificator<ReturnType>::failureReturnValue(const FailureReturnValues... failureReturnValues) && noexcept
 {
-    m_details.hasSuccess = (m_details.result.value != value);
-    if (m_details.result.value == value)
-    {
-        return PosixCallEvaluator<ReturnType>(m_details);
-    }
-    // we require an rvalue of our object
-    return std::move(*this).failureReturnValue(remainingValues...);
-}
+    using ValueType = decltype(m_details.result.value);
+    m_details.hasSuccess = !algorithm::doesContainValue(m_details.result.value, static_cast<ValueType>(failureReturnValues)...);
 
-template <typename ReturnType>
-inline PosixCallEvaluator<ReturnType>
-PosixCallVerificator<ReturnType>::failureReturnValue(const ReturnType value) && noexcept
-{
-    m_details.hasSuccess = (m_details.result.value != value);
     return PosixCallEvaluator<ReturnType>(m_details);
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -185,29 +185,6 @@ PosixCallEvaluator<ReturnType>::ignoreErrnos(const IgnoredErrnos... ignoredErrno
 }
 
 template <typename ReturnType>
-template <typename... IgnoredErrnos>
-inline cxx::expected<PosixCallResult<ReturnType>, PosixCallResult<ReturnType>>
-PosixCallEvaluator<ReturnType>::evaluateWithIgnoredErrnos(const IgnoredErrnos... ignoredErrnos) const&& noexcept
-{
-    if (!m_details.hasSuccess)
-    {
-        internal::AssignReturnValueIfItsErrno<ReturnType, std::is_convertible<ReturnType, int32_t>::value>::call(
-            m_details.result.value, m_details.result.errnum);
-    }
-
-    if (m_details.hasSuccess || internal::isErrnumIgnored(m_details.result.errnum, ignoredErrnos...))
-    {
-        return iox::cxx::success<PosixCallResult<ReturnType>>(m_details.result);
-    }
-
-    std::cerr << m_details.file << ":" << m_details.line << " { " << m_details.callingFunction << " -> "
-              << m_details.posixFunctionName << " }  :::  [ " << m_details.result.errnum << " ]  "
-              << m_details.result.getHumanReadableErrnum() << std::endl;
-
-    return iox::cxx::error<PosixCallResult<ReturnType>>(m_details.result);
-}
-
-template <typename ReturnType>
 inline cxx::expected<PosixCallResult<ReturnType>, PosixCallResult<ReturnType>>
 PosixCallEvaluator<ReturnType>::evaluate() const&& noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -33,27 +33,6 @@ createPosixCallBuilder(ReturnType (*posixCall)(FunctionArguments...),
     return PosixCallBuilder<ReturnType, FunctionArguments...>(
         posixCall, posixFunctionName, file, line, callingFunction);
 }
-
-template <typename ReturnType, bool ConvertableToErrno>
-struct AssignReturnValueIfItsErrno
-{
-    static void call(const ReturnType, int32_t&) noexcept
-    {
-    }
-};
-
-template <typename ReturnType>
-struct AssignReturnValueIfItsErrno<ReturnType, true>
-{
-    static void call(const ReturnType returnValue, int32_t& errnum) noexcept
-    {
-        // only override when failure was signaled but errno == 0 (SUCCESS)
-        if (errnum == 0)
-        {
-            errnum = static_cast<int32_t>(returnValue);
-        }
-    }
-};
 } // namespace internal
 
 template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -33,6 +33,19 @@ createPosixCallBuilder(ReturnType (*posixCall)(FunctionArguments...),
     return PosixCallBuilder<ReturnType, FunctionArguments...>(
         posixCall, posixFunctionName, file, line, callingFunction);
 }
+
+template <typename ReturnType>
+inline PosixCallDetails<ReturnType>::PosixCallDetails(const char* posixFunctionName,
+                                                      const char* file,
+                                                      int line,
+                                                      const char* callingFunction) noexcept
+    : posixFunctionName(posixFunctionName)
+    , file(file)
+    , callingFunction(callingFunction)
+    , line(line)
+{
+}
+
 } // namespace internal
 
 template <typename T>
@@ -48,7 +61,7 @@ inline PosixCallBuilder<ReturnType, FunctionArguments...>::PosixCallBuilder(Func
                                                                             const int32_t line,
                                                                             const char* callingFunction) noexcept
     : m_posixCall{posixCall}
-    , m_details{posixFunctionName, file, callingFunction, line, true, false, false, {}}
+    , m_details{posixFunctionName, file, line, callingFunction}
 {
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -34,22 +34,7 @@ createPosixCallBuilder(ReturnType (*posixCall)(FunctionArguments...),
         posixCall, posixFunctionName, file, line, callingFunction);
 }
 
-inline bool isErrnumIgnored(const int32_t)
-{
-    return false;
-}
 
-template <typename... IgnoredErrnos>
-inline bool
-isErrnumIgnored(const int32_t errnum, const int32_t firstErrno, const IgnoredErrnos... remainingErrnos) noexcept
-{
-    if (errnum == firstErrno)
-    {
-        return true;
-    }
-
-    return isErrnumIgnored(errnum, remainingErrnos...);
-}
 
 template <typename ReturnType, bool ConvertableToErrno>
 struct AssignReturnValueIfItsErrno
@@ -178,10 +163,11 @@ PosixCallEvaluator<ReturnType>::ignoreErrnos(const IgnoredErrnos... ignoredErrno
         internal::AssignReturnValueIfItsErrno<ReturnType, std::is_convertible<ReturnType, int32_t>::value>::call(
             m_details.result.value, m_details.result.errnum);
 
-        m_details.hasIgnoredErrno |= internal::isErrnumIgnored(m_details.result.errnum, ignoredErrnos...);
+        m_details.hasIgnoredErrno |= algorithm::doesContainValue(m_details.result.errnum, ignoredErrnos...);
     }
 
     return *this;
+
 }
 
 template <typename ReturnType>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -16,6 +16,7 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_HPP
 #define IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_HPP
 
+#include "iceoryx_hoofs/cxx/algorithm.hpp"
 #include "iceoryx_hoofs/cxx/attributes.hpp"
 #include "iceoryx_hoofs/cxx/expected.hpp"
 #include "iceoryx_hoofs/cxx/string.hpp"

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -69,6 +69,7 @@ PosixCallBuilder<ReturnType, FunctionArguments...> createPosixCallBuilder(Return
 template <typename ReturnType>
 struct PosixCallDetails
 {
+    PosixCallDetails(const char* posixFunctionName, const char* file, int line, const char* callingFunction) noexcept;
     const char* posixFunctionName = nullptr;
     const char* file = nullptr;
     const char* callingFunction = nullptr;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -138,22 +138,16 @@ class IOX_NO_DISCARD PosixCallVerificator
 {
   public:
     /// @brief the posix function call defines success through a single value
-    /// @param[in] value the value which defines success
-    /// @param[in] remainingValues a list of additional values which define success
+    /// @param[in] successReturnValues a list of values which define success
     /// @return the PosixCallEvaluator which evaluates the errno values
     template <typename... SuccessReturnValues>
-    PosixCallEvaluator<ReturnType> successReturnValue(const ReturnType value,
-                                                      const SuccessReturnValues... remainingValues) && noexcept;
-    PosixCallEvaluator<ReturnType> successReturnValue(const ReturnType value) && noexcept;
+    PosixCallEvaluator<ReturnType> successReturnValue(const SuccessReturnValues... successReturnValues) && noexcept;
 
     /// @brief the posix function call defines failure through a single value
-    /// @param[in] value the value which defines failure
-    /// @param[in] remainingValues a list of additional values which define failure
+    /// @param[in] failureReturnValues a list of values which define failure
     /// @return the PosixCallEvaluator which evaluates the errno values
     template <typename... FailureReturnValues>
-    PosixCallEvaluator<ReturnType> failureReturnValue(const ReturnType value,
-                                                      const FailureReturnValues... remainingValues) && noexcept;
-    PosixCallEvaluator<ReturnType> failureReturnValue(const ReturnType value) && noexcept;
+    PosixCallEvaluator<ReturnType> failureReturnValue(const FailureReturnValues... failureReturnValues) && noexcept;
 
   private:
     template <typename, typename...>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -75,6 +75,7 @@ struct PosixCallDetails
     int32_t line = 0;
     bool hasSuccess = true;
     bool hasIgnoredErrno = false;
+    bool hasSilentErrno = false;
 
     PosixCallResult<ReturnType> result;
 };
@@ -118,6 +119,13 @@ class IOX_NO_DISCARD PosixCallEvaluator
     /// @return a PosixCallEvaluator for further setup of the evaluation
     template <typename... IgnoredErrnos>
     PosixCallEvaluator<ReturnType> ignoreErrnos(const IgnoredErrnos... ignoredErrnos) const&& noexcept;
+
+    /// @brief silence specified errnos from printing error messages in the evaluation
+    /// @tparam SilentErrnos a list of int32_t variables
+    /// @param[in] silentErrnos the int32_t values of the errnos which should be silent and not cause an error log
+    /// @return a PosixCallEvaluator for further setup of the evaluation
+    template <typename... SilentErrnos>
+    PosixCallEvaluator<ReturnType> suppressErrorLoggingOfErrnos(const SilentErrnos... silentErrnos) const&& noexcept;
 
     /// @brief evaluate the result of a posix call
     /// @return returns an expected which contains in both cases a PosixCallResult<ReturnType> with the return value

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -125,7 +125,7 @@ class IOX_NO_DISCARD PosixCallEvaluator
     /// @param[in] silentErrnos the int32_t values of the errnos which should be silent and not cause an error log
     /// @return a PosixCallEvaluator for further setup of the evaluation
     template <typename... SilentErrnos>
-    PosixCallEvaluator<ReturnType> suppressErrorLoggingOfErrnos(const SilentErrnos... silentErrnos) const&& noexcept;
+    PosixCallEvaluator<ReturnType> suppressErrorMessagesForErrnos(const SilentErrnos... silentErrnos) const&& noexcept;
 
     /// @brief evaluate the result of a posix call
     /// @return returns an expected which contains in both cases a PosixCallResult<ReturnType> with the return value

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -102,6 +102,8 @@ struct PosixCallDetails
 ///
 ///        // when your posix call signals failure with one specific return value use
 ///        // .failureReturnValue(_) instead of .successReturnValue(_)
+///        // when your posix call signals failure by returning the errno value instead of setting the errno use
+///        // .returnValueMatchesErrno() instead of .successReturnValue(_)
 /// @endcode
 #define posixCall(f) internal::createPosixCallBuilder(f, #f, __FILE__, __LINE__, __PRETTY_FUNCTION__)
 
@@ -148,6 +150,10 @@ class IOX_NO_DISCARD PosixCallVerificator
     /// @return the PosixCallEvaluator which evaluates the errno values
     template <typename... FailureReturnValues>
     PosixCallEvaluator<ReturnType> failureReturnValue(const FailureReturnValues... failureReturnValues) && noexcept;
+
+    /// @brief the posix function call defines failure through return of the errno value instead of setting the errno
+    /// @return the PosixCallEvaluator which evaluates the errno values
+    PosixCallEvaluator<ReturnType> returnValueMatchesErrno() && noexcept;
 
   private:
     template <typename, typename...>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -116,15 +116,6 @@ class IOX_NO_DISCARD PosixCallEvaluator
     template <typename... IgnoredErrnos>
     PosixCallEvaluator<ReturnType> ignoreErrnos(const IgnoredErrnos... ignoredErrnos) const&& noexcept;
 
-    /// @brief evaluate the result of a posix call and ignore specified errnos
-    /// @tparam IgnoredErrnos a list of int32_t variables
-    /// @param[in] ignoredErrnos the int32_t values of the errnos which should be ignored
-    /// @return returns an expected which contains in both cases a PosixCallResult<ReturnType> with the return value
-    /// (.value) and the errno value (.errnum) of the function call
-    template <typename... IgnoredErrnos>
-    cxx::expected<PosixCallResult<ReturnType>, PosixCallResult<ReturnType>>
-    evaluateWithIgnoredErrnos(const IgnoredErrnos... ignoredErrnos) const&& noexcept;
-
     /// @brief evaluate the result of a posix call
     /// @return returns an expected which contains in both cases a PosixCallResult<ReturnType> with the return value
     /// (.value) and the errno value (.errnum) of the function call

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -68,7 +68,7 @@ cxx::expected<FileLockError> FileLock::initializeFileLock() noexcept
             std::cerr << "Unable to close file lock in error related cleanup during initialization." << std::endl;
         });
         // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
-        return cxx::error<FileLockError>(convertErrnoToFileLockError(openCall.get_error().errnum));
+        return cxx::error<FileLockError>(convertErrnoToFileLockError(lockCall.get_error().errnum));
     }
 
     return cxx::success<>();

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -59,7 +59,7 @@ cxx::expected<FileLockError> FileLock::initializeFileLock() noexcept
 
     auto lockCall = posixCall(iox_flock)(m_fd, LOCK_EX | LOCK_NB)
                         .failureReturnValue(ERROR_CODE)
-                        .suppressErrorLoggingOfErrnos(EWOULDBLOCK)
+                        .suppressErrorMessagesForErrnos(EWOULDBLOCK)
                         .evaluate();
 
     if (lockCall.has_error())

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -59,7 +59,8 @@ cxx::expected<FileLockError> FileLock::initializeFileLock() noexcept
 
     auto lockCall = posixCall(iox_flock)(m_fd, LOCK_EX | LOCK_NB)
                         .failureReturnValue(ERROR_CODE)
-                        .evaluateWithIgnoredErrnos(EWOULDBLOCK);
+                        .ignoreErrnos(EWOULDBLOCK)
+                        .evaluate();
 
     if (lockCall.has_error())
     {

--- a/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
@@ -60,7 +60,8 @@ MessageQueue::MessageQueue(const IpcChannelName_t& name,
         {
             posixCall(mq_unlink)(m_name.c_str())
                 .failureReturnValue(ERROR_CODE)
-                .evaluateWithIgnoredErrnos(ENOENT)
+                .ignoreErrnos(ENOENT)
+                .evaluate()
                 .and_then([this](auto& r) {
                     if (r.errnum != ENOENT)
                     {
@@ -136,7 +137,7 @@ cxx::expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChann
     }
 
 
-    auto mqCall = posixCall(mq_unlink)(l_name.c_str()).failureReturnValue(ERROR_CODE).evaluateWithIgnoredErrnos(ENOENT);
+    auto mqCall = posixCall(mq_unlink)(l_name.c_str()).failureReturnValue(ERROR_CODE).ignoreErrnos(ENOENT).evaluate();
 
     if (mqCall.has_error())
     {
@@ -224,7 +225,8 @@ MessageQueue::open(const IpcChannelName_t& name, const IpcChannelMode mode, cons
     mode_t umaskSaved = umask(0);
     auto mqCall = posixCall(iox_mq_open4)(l_name.c_str(), openFlags, m_filemode, &m_attributes)
                       .failureReturnValue(ERROR_CODE)
-                      .evaluateWithIgnoredErrnos(ENOENT);
+                      .ignoreErrnos(ENOENT)
+                      .evaluate();
 
     umask(umaskSaved);
 
@@ -280,7 +282,8 @@ cxx::expected<std::string, IpcChannelError> MessageQueue::timedReceive(const uni
 
     auto mqCall = posixCall(mq_timedreceive)(m_mqDescriptor, message, MAX_MESSAGE_SIZE, nullptr, &timeOut)
                       .failureReturnValue(ERROR_CODE)
-                      .evaluateWithIgnoredErrnos(TIMEOUT_ERRNO);
+                      .ignoreErrnos(TIMEOUT_ERRNO)
+                      .evaluate();
 
     if (mqCall.has_error())
     {
@@ -308,7 +311,8 @@ cxx::expected<IpcChannelError> MessageQueue::timedSend(const std::string& msg, c
 
     auto mqCall = posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
                       .failureReturnValue(ERROR_CODE)
-                      .evaluateWithIgnoredErrnos(TIMEOUT_ERRNO);
+                      .ignoreErrnos(TIMEOUT_ERRNO)
+                      .evaluate();
 
     if (mqCall.has_error())
     {

--- a/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
@@ -225,7 +225,7 @@ MessageQueue::open(const IpcChannelName_t& name, const IpcChannelMode mode, cons
     mode_t umaskSaved = umask(0);
     auto mqCall = posixCall(iox_mq_open4)(l_name.c_str(), openFlags, m_filemode, &m_attributes)
                       .failureReturnValue(ERROR_CODE)
-                      .suppressErrorLoggingOfErrnos(ENOENT)
+                      .suppressErrorMessagesForErrnos(ENOENT)
                       .evaluate();
 
     umask(umaskSaved);
@@ -275,7 +275,7 @@ cxx::expected<std::string, IpcChannelError> MessageQueue::timedReceive(const uni
 
     auto mqCall = posixCall(mq_timedreceive)(m_mqDescriptor, message, MAX_MESSAGE_SIZE, nullptr, &timeOut)
                       .failureReturnValue(ERROR_CODE)
-                      .suppressErrorLoggingOfErrnos(TIMEOUT_ERRNO)
+                      .suppressErrorMessagesForErrnos(TIMEOUT_ERRNO)
                       .evaluate();
 
     if (mqCall.has_error())
@@ -300,7 +300,7 @@ cxx::expected<IpcChannelError> MessageQueue::timedSend(const std::string& msg, c
 
     auto mqCall = posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
                       .failureReturnValue(ERROR_CODE)
-                      .suppressErrorLoggingOfErrnos(TIMEOUT_ERRNO)
+                      .suppressErrorMessagesForErrnos(TIMEOUT_ERRNO)
                       .evaluate();
 
     if (mqCall.has_error())

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -74,7 +74,7 @@ bool mutex::unlock()
 
 bool mutex::try_lock()
 {
-    auto result = posixCall(pthread_mutex_trylock)(&m_handle).successReturnValue(0).evaluateWithIgnoredErrnos(EBUSY);
+    auto result = posixCall(pthread_mutex_trylock)(&m_handle).successReturnValue(0).ignoreErrnos(EBUSY).evaluate();
     bool isBusy = !result.has_error() && result->errnum == EBUSY;
     return !isBusy && !result.has_error();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -74,7 +74,7 @@ bool mutex::unlock()
 
 bool mutex::try_lock()
 {
-    auto result = posixCall(pthread_mutex_trylock)(&m_handle).successReturnValue(0).ignoreErrnos(EBUSY).evaluate();
+    auto result = posixCall(pthread_mutex_trylock)(&m_handle).returnValueMatchesErrno().ignoreErrnos(EBUSY).evaluate();
     bool isBusy = !result.has_error() && result->errnum == EBUSY;
     return !isBusy && !result.has_error();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore.cpp
@@ -113,7 +113,7 @@ cxx::expected<SemaphoreWaitState, SemaphoreError> Semaphore::timedWait(const uni
 {
     const struct timespec timeout = abs_timeout.timespec(units::TimeSpecReference::Epoch);
     auto call =
-        posixCall(iox_sem_timedwait)(m_handlePtr, &timeout).failureReturnValue(-1).evaluateWithIgnoredErrnos(ETIMEDOUT);
+        posixCall(iox_sem_timedwait)(m_handlePtr, &timeout).failureReturnValue(-1).ignoreErrnos(ETIMEDOUT).evaluate();
 
     if (call.has_error())
     {
@@ -131,7 +131,7 @@ cxx::expected<SemaphoreWaitState, SemaphoreError> Semaphore::timedWait(const uni
 
 cxx::expected<bool, SemaphoreError> Semaphore::tryWait() const noexcept
 {
-    auto call = posixCall(iox_sem_trywait)(m_handlePtr).failureReturnValue(-1).evaluateWithIgnoredErrnos(EAGAIN);
+    auto call = posixCall(iox_sem_trywait)(m_handlePtr).failureReturnValue(-1).ignoreErrnos(EAGAIN).evaluate();
 
     if (call.has_error())
     {

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -140,7 +140,8 @@ bool SharedMemory::open(const int oflags, const mode_t permissions, const uint64
         {
             posixCall(shm_unlink)(m_name.c_str())
                 .failureReturnValue(-1)
-                .evaluateWithIgnoredErrnos(ENOENT)
+                .ignoreErrnos(ENOENT)
+                .evaluate()
                 .and_then([this](auto& r) {
                     if (r.errnum != ENOENT)
                     {

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -289,7 +289,7 @@ UnixDomainSocket::timedReceive(const units::Duration& timeout) const noexcept
 
         auto recvCall = posixCall(recvfrom)(m_sockfd, message, MAX_MESSAGE_SIZE, 0, nullptr, nullptr)
                             .failureReturnValue(ERROR_CODE)
-                            .suppressErrorLoggingOfErrnos(EAGAIN)
+                            .suppressErrorMessagesForErrnos(EAGAIN)
                             .evaluate();
         message[MAX_MESSAGE_SIZE] = 0;
 
@@ -365,7 +365,7 @@ cxx::expected<IpcChannelError> UnixDomainSocket::initalizeSocket(const IpcChanne
         auto connectCall =
             posixCall(connect)(m_sockfd, reinterpret_cast<struct sockaddr*>(&m_sockAddr), sizeof(m_sockAddr))
                 .failureReturnValue(ERROR_CODE)
-                .suppressErrorLoggingOfErrnos(ENOENT, ECONNREFUSED)
+                .suppressErrorMessagesForErrnos(ENOENT, ECONNREFUSED)
                 .evaluate();
 
         if (connectCall.has_error())

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -144,7 +144,7 @@ cxx::expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const NoPa
         return cxx::error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
     }
 
-    auto unlinkCall = posixCall(unlink)(name.c_str()).failureReturnValue(ERROR_CODE).evaluateWithIgnoredErrnos(ENOENT);
+    auto unlinkCall = posixCall(unlink)(name.c_str()).failureReturnValue(ERROR_CODE).ignoreErrnos(ENOENT).evaluate();
 
     if (!unlinkCall.has_error())
     {
@@ -228,7 +228,8 @@ cxx::expected<IpcChannelError> UnixDomainSocket::timedSend(const std::string& ms
 
     auto setsockoptCall = posixCall(setsockopt)(m_sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv))
                               .failureReturnValue(ERROR_CODE)
-                              .evaluateWithIgnoredErrnos(EWOULDBLOCK);
+                              .ignoreErrnos(EWOULDBLOCK)
+                              .evaluate();
 
     if (setsockoptCall.has_error())
     {
@@ -275,7 +276,8 @@ UnixDomainSocket::timedReceive(const units::Duration& timeout) const noexcept
     struct timeval tv = timeout;
     auto setsockoptCall = posixCall(setsockopt)(m_sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv))
                               .failureReturnValue(ERROR_CODE)
-                              .evaluateWithIgnoredErrnos(EWOULDBLOCK);
+                              .ignoreErrnos(EWOULDBLOCK)
+                              .evaluate();
 
     if (setsockoptCall.has_error())
     {
@@ -287,7 +289,8 @@ UnixDomainSocket::timedReceive(const units::Duration& timeout) const noexcept
 
         auto recvCall = posixCall(recvfrom)(m_sockfd, message, MAX_MESSAGE_SIZE, 0, nullptr, nullptr)
                             .failureReturnValue(ERROR_CODE)
-                            .evaluateWithIgnoredErrnos(EAGAIN);
+                            .ignoreErrnos(EAGAIN)
+                            .evaluate();
         message[MAX_MESSAGE_SIZE] = 0;
 
         if (recvCall.has_error())
@@ -371,7 +374,8 @@ cxx::expected<IpcChannelError> UnixDomainSocket::initalizeSocket(const IpcChanne
         auto connectCall =
             posixCall(connect)(m_sockfd, reinterpret_cast<struct sockaddr*>(&m_sockAddr), sizeof(m_sockAddr))
                 .failureReturnValue(ERROR_CODE)
-                .evaluateWithIgnoredErrnos(ENOENT, ECONNREFUSED);
+                .ignoreErrnos(ENOENT, ECONNREFUSED)
+                .evaluate();
 
         if (connectCall.has_error())
         {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
@@ -72,6 +72,41 @@ TEST_F(algorithm_test, MinOfManyElements)
     EXPECT_THAT(min(0.0123f, -91.12f, 123.92f, -1021.2f, 0.0f), Eq(-1021.2f));
 }
 
+TEST_F(algorithm_test, DoesContainValue_ValueListOfZeroDoesNotContainValue)
+{
+    EXPECT_FALSE(doesContainValue(42));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfOneDoesNotContainValue)
+{
+    EXPECT_FALSE(doesContainValue(37, 13));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfOneDoesContainValue)
+{
+    EXPECT_TRUE(doesContainValue(73, 73));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfMultipleValuesDoesNotContainValue)
+{
+    EXPECT_FALSE(doesContainValue(13, 42, 73, 7337));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfMultipleValuesDoesContainValueAtFront)
+{
+    EXPECT_TRUE(doesContainValue(37, 37, 3773, 7535));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfMultipleValuesDoesContainValueInTheMiddle)
+{
+    EXPECT_TRUE(doesContainValue(42, 13, 42, 555));
+}
+
+TEST_F(algorithm_test, DoesContainValue_ValueListOfMultipleValuesDoesContainValueAtEnd)
+{
+    EXPECT_TRUE(doesContainValue(7353, 42, 73, 7353));
+}
+
 TEST_F(algorithm_test, MergeTwoDisjunctNonEmptySortedContainers)
 {
     constexpr int64_t OFFSET = 1337;

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -487,14 +487,14 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
     EXPECT_TRUE(internal::GetCapturedStderr().empty());
 }
 
-TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValueWithFailureRetVal_GoodCase)
+TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_GoodCase)
 {
     internal::CaptureStderr();
 
-    constexpr int RETURN_VALUE = 41;
+    constexpr int RETURN_VALUE = 0;
 
     iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
-        .failureReturnValue(RETURN_VALUE - 1)
+        .returnValueMatchesErrno()
         .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
@@ -505,50 +505,14 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
     EXPECT_TRUE(internal::GetCapturedStderr().empty());
 }
 
-TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValueWithFailureRetVal_BadCase)
+TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_BadCase)
 {
     internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 42;
 
     iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
-        .failureReturnValue(RETURN_VALUE)
-        .evaluate()
-        .and_then([&](auto&) { EXPECT_TRUE(false); })
-        .or_else([&](auto& r) {
-            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
-            EXPECT_THAT(r.errnum, Eq(RETURN_VALUE));
-        });
-
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
-}
-
-TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValueWithSuccessRetVal_GoodCase)
-{
-    internal::CaptureStderr();
-
-    constexpr int RETURN_VALUE = 43;
-
-    iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
-        .successReturnValue(RETURN_VALUE)
-        .evaluate()
-        .and_then([&](auto& r) {
-            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
-            EXPECT_THAT(r.errnum, Eq(0));
-        })
-        .or_else([&](auto&) { EXPECT_TRUE(false); });
-
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
-}
-
-TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValueWithSuccessRetVal_BadCase)
-{
-    internal::CaptureStderr();
-
-    constexpr int RETURN_VALUE = 44;
-
-    iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
-        .successReturnValue(RETURN_VALUE - 1)
+        .returnValueMatchesErrno()
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -302,8 +302,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
 {
     internal::CaptureStderr();
 
-    constexpr int RETURN_VALUE = 17;
-    constexpr int ERRNO_VALUE = 18;
+    constexpr int RETURN_VALUE = 117;
+    constexpr int ERRNO_VALUE = 118;
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
@@ -324,8 +324,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
 {
     internal::CaptureStderr();
 
-    constexpr int RETURN_VALUE = 17;
-    constexpr int ERRNO_VALUE = 18;
+    constexpr int RETURN_VALUE = 217;
+    constexpr int ERRNO_VALUE = 218;
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
@@ -346,8 +346,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
 {
     internal::CaptureStderr();
 
-    constexpr int RETURN_VALUE = 17;
-    constexpr int ERRNO_VALUE = 18;
+    constexpr int RETURN_VALUE = 317;
+    constexpr int ERRNO_VALUE = 318;
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
@@ -368,8 +368,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
 {
     internal::CaptureStderr();
 
-    constexpr int RETURN_VALUE = 17;
-    constexpr int ERRNO_VALUE = 18;
+    constexpr int RETURN_VALUE = 417;
+    constexpr int ERRNO_VALUE = 418;
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
@@ -384,6 +384,130 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
         });
 
     EXPECT_FALSE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 111;
+    constexpr int ERRNO_VALUE = 112;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 113;
+    constexpr int ERRNO_VALUE = 114;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 115;
+    constexpr int ERRNO_VALUE = 116;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 16, ERRNO_VALUE + 17)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 117;
+    constexpr int ERRNO_VALUE = 118;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 119;
+    constexpr int ERRNO_VALUE = 120;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 13)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 17)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+}
+
+TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNotPrintsErrorMessage)
+{
+    internal::CaptureStderr();
+
+    constexpr int RETURN_VALUE = 121;
+    constexpr int ERRNO_VALUE = 122;
+
+    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+        .successReturnValue(1)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE)
+        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 17)
+        .evaluate()
+        .and_then([&](auto&) { EXPECT_TRUE(false); })
+        .or_else([&](auto& r) {
+            EXPECT_THAT(r.value, Eq(RETURN_VALUE));
+            EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
+        });
+
+    EXPECT_TRUE(internal::GetCapturedStderr().empty());
 }
 
 TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -141,7 +141,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_Good
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE + 1)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE)
+        .ignoreErrnos(ERRNO_VALUE)
+        .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
@@ -160,7 +161,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadC
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE + 1)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE + 1)
+        .ignoreErrnos(ERRNO_VALUE + 1)
+        .evaluate()
         .and_then([](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
@@ -182,7 +184,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_Good
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE)
+        .ignoreErrnos(ERRNO_VALUE)
+        .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
@@ -201,7 +204,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadC
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE + 1)
+        .ignoreErrnos(ERRNO_VALUE + 1)
+        .evaluate()
         .and_then([](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
@@ -223,7 +227,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
+        .ignoreErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
+        .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
@@ -242,7 +247,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 17, ERRNO_VALUE + 1337, ERRNO_VALUE - 2)
+        .ignoreErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 17, ERRNO_VALUE + 1337, ERRNO_VALUE - 2)
+        .evaluate()
         .and_then([](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
@@ -261,7 +267,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSuc
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .evaluateWithIgnoredErrnos(ERRNO_VALUE, ERRNO_VALUE - 91, ERRNO_VALUE + 137, ERRNO_VALUE + 17, ERRNO_VALUE - 29)
+        .ignoreErrnos(ERRNO_VALUE, ERRNO_VALUE - 91, ERRNO_VALUE + 137, ERRNO_VALUE + 17, ERRNO_VALUE - 29)
+        .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
@@ -280,8 +287,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucc
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .evaluateWithIgnoredErrnos(
-            ERRNO_VALUE - 918, ERRNO_VALUE + 8137, ERRNO_VALUE + 187, ERRNO_VALUE - 289, ERRNO_VALUE)
+        .ignoreErrnos(ERRNO_VALUE - 918, ERRNO_VALUE + 8137, ERRNO_VALUE + 187, ERRNO_VALUE - 289, ERRNO_VALUE)
+        .evaluate()
         .and_then([&](auto& r) {
             EXPECT_THAT(r.value, Eq(RETURN_VALUE));
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -395,7 +395,7 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
@@ -415,7 +415,7 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintsErrorMes
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
@@ -435,7 +435,7 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsError
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 16, ERRNO_VALUE + 17)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 16, ERRNO_VALUE + 17)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
@@ -455,7 +455,7 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrints
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
@@ -475,9 +475,9 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPri
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 13)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 17)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE + 13)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE + 17)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {
@@ -497,9 +497,9 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNo
 
     iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE - 10)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE)
-        .suppressErrorLoggingOfErrnos(ERRNO_VALUE + 17)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE)
+        .suppressErrorMessagesForErrnos(ERRNO_VALUE + 17)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
         .or_else([&](auto& r) {

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -156,7 +156,8 @@ bool ProcessManager::isProcessAlive(const Process& process) noexcept
     static constexpr int32_t ERROR_CODE = -1;
     auto checkCommand = posix::posixCall(kill)(static_cast<pid_t>(process.getPid()), SIGTERM)
                             .failureReturnValue(ERROR_CODE)
-                            .evaluateWithIgnoredErrnos(ESRCH)
+                            .ignoreErrnos(ESRCH)
+                            .evaluate()
                             .or_else([&](auto& r) {
                                 this->evaluateKillError(
                                     process, r.errnum, r.getHumanReadableErrnum().c_str(), ShutdownPolicy::SIG_TERM);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR refactors the posixCall to handle a common case were errnos are ignored just to suppress error logging.

Additionaly, the handling of returning the errno value instead of setting the errno is now handled explicit.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #805 
- Closes #808
