### PR TITLE
Iox #33 relative pointer & posix threads for windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -108,7 +108,7 @@ jobs:
       # we have to exclude the tests explicitly until everyone is running
       - name: Run tests, excluding timing_tests
         run: |
-          build\hoofs\test\Debug\hoofs_moduletests.exe --gtest_filter="-relativeptr*:base_relative*:Thread*:*TimingTest*"
+          build\hoofs\test\Debug\hoofs_moduletests.exe --gtest_filter="-*TimingTest*"
           build\hoofs\test\Debug\hoofs_integrationtests.exe
           build\binding_c\test\Debug\binding_c_moduletests.exe --gtest_filter="-Chunk*:iox_listener*:iox_node*:iox_pub*:BindingC_Runtime*:iox_sub*:iox_ws*:iox_types*:*TimingTest*"
           build\posh\test\Debug\posh_moduletests.exe --gtest_filter="-PoshRuntime*:IceoryxRoudiApp*:IceoryxRoudiMemoryManager*:PortManager*:ProcessIntrospection*:ProcessManager*:PosixShmMemoryProvider*:Process_test*:ParseAllMalformedInput*:*TimingTest*"

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/pthread.hpp
@@ -36,7 +36,6 @@ struct pthread_mutex_t
 using pthread_mutexattr_t = int;
 using pthread_t = std::thread::native_handle_type;
 
-int pthread_setname_np(pthread_t thread, const char* name);
 int pthread_mutexattr_destroy(pthread_mutexattr_t* attr);
 int pthread_mutexattr_init(pthread_mutexattr_t* attr);
 int pthread_mutexattr_setpshared(pthread_mutexattr_t* attr, int pshared);
@@ -49,15 +48,7 @@ int pthread_mutex_lock(pthread_mutex_t* mutex);
 int pthread_mutex_trylock(pthread_mutex_t* mutex);
 int pthread_mutex_unlock(pthread_mutex_t* mutex);
 
-inline int iox_pthread_setname_np(pthread_t thread, const char* name)
-{
-    return 0;
-}
-
-
-inline int pthread_getname_np(pthread_t thread, const char* name, size_t len)
-{
-    return 0;
-}
+int iox_pthread_setname_np(pthread_t thread, const char* name);
+int pthread_getname_np(pthread_t thread, char* name, size_t len);
 
 #endif // IOX_HOOFS_WIN_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/win/source/pthread.cpp
+++ b/iceoryx_hoofs/platform/win/source/pthread.cpp
@@ -15,10 +15,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/platform/pthread.hpp"
+#include "iceoryx_hoofs/platform/win32_errorHandling.hpp"
+#include "iceoryx_hoofs/platform/windows.hpp"
 
-int pthread_setname_np(pthread_t thread, const char* name)
+#include <cwchar>
+#include <vector>
+
+int iox_pthread_setname_np(pthread_t thread, const char* name)
 {
-    return 0;
+    DWORD threadId = Win32Call(GetThreadId, static_cast<HANDLE>(thread)).value;
+
+    std::mbstate_t state = std::mbstate_t();
+    uint64_t length = std::mbsrtowcs(nullptr, &name, 0, &state) + 1U;
+    std::vector<wchar_t> wName(length);
+    std::mbsrtowcs(wName.data(), &name, length, &state);
+
+    return Win32Call(SetThreadDescription, static_cast<HANDLE>(thread), wName.data()).error;
+}
+
+int pthread_getname_np(pthread_t thread, char* name, size_t len)
+{
+    wchar_t* wName;
+    auto result = Win32Call(GetThreadDescription, static_cast<HANDLE>(thread), &wName).error;
+    if (result == 0)
+    {
+        wcstombs(name, wName, len);
+    }
+
+    return result;
 }
 
 int pthread_mutexattr_destroy(pthread_mutexattr_t* attr)

--- a/iceoryx_hoofs/platform/win/source/pthread.cpp
+++ b/iceoryx_hoofs/platform/win/source/pthread.cpp
@@ -40,6 +40,7 @@ int pthread_getname_np(pthread_t thread, char* name, size_t len)
     if (result == 0)
     {
         wcstombs(name, wName, len);
+        LocalFree(wName);
     }
 
     return result;

--- a/iceoryx_hoofs/test/moduletests/test_posix_thread.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_thread.cpp
@@ -62,7 +62,7 @@ class Thread_test : public Test
     std::thread* m_thread;
 };
 
-#if !defined(__APPLE__) && !defined(__WIN32)
+#if !defined(__APPLE__)
 TEST_F(Thread_test, SetAndGetWithEmptyThreadNameIsWorking)
 {
     ThreadName_t emptyString = "";

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -38,6 +38,9 @@ struct Data
     uint32_t Data2 = 72;
 };
 
+static constexpr uint64_t SHARED_MEMORY_SIZE = 4096 * 32;
+static constexpr uint64_t NUMBER_OF_MEMORY_PARTITIONS = 2U;
+
 template <typename T>
 class base_relative_ptr_test : public Test
 {
@@ -57,10 +60,7 @@ class base_relative_ptr_test : public Test
         }
     }
 
-    static constexpr uint64_t ShmSize = 4096 * 32;
-    static constexpr uint64_t NUMBER_OF_MEMORY_PARTITIONS = 2U;
-
-    uint8_t memoryPartition[NUMBER_OF_MEMORY_PARTITIONS][ShmSize];
+    uint8_t memoryPartition[NUMBER_OF_MEMORY_PARTITIONS][SHARED_MEMORY_SIZE];
 };
 
 typedef testing::Types<uint8_t, int8_t, double> Types;
@@ -73,11 +73,11 @@ TYPED_TEST_CASE(base_relative_ptr_test, Types);
 
 TYPED_TEST(base_relative_ptr_test, ConstrTests)
 {
-    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], ShmSize), true);
-    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], ShmSize), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], SHARED_MEMORY_SIZE), true);
 
     {
-        auto offset = ShmSize / 2;
+        auto offset = SHARED_MEMORY_SIZE / 2;
         void* adr = memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -94,7 +94,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        auto offset = ShmSize / 2;
+        auto offset = SHARED_MEMORY_SIZE / 2;
         void* adr = memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -103,7 +103,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        auto offset = ShmSize - 1;
+        auto offset = SHARED_MEMORY_SIZE - 1;
         void* adr = memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -119,7 +119,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        auto offset = ShmSize / 2;
+        auto offset = SHARED_MEMORY_SIZE / 2;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -128,7 +128,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        auto offset = ShmSize - 1;
+        auto offset = SHARED_MEMORY_SIZE - 1;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -142,7 +142,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        auto offset = ShmSize + 1;
+        auto offset = SHARED_MEMORY_SIZE + 1;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_NE(rp, nullptr);
@@ -151,8 +151,8 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
 TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 {
-    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], ShmSize), true);
-    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], ShmSize), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], SHARED_MEMORY_SIZE), true);
 
     {
         RelativePointer<TypeParam> rp;
@@ -179,7 +179,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
     }
 
     {
-        auto offset = ShmSize / 2;
+        auto offset = SHARED_MEMORY_SIZE / 2;
         void* adr = memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -189,7 +189,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
     }
 
     {
-        auto offset = ShmSize - 1;
+        auto offset = SHARED_MEMORY_SIZE - 1;
         void* adr = memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -207,7 +207,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
     }
 
     {
-        auto offset = ShmSize / 2;
+        auto offset = SHARED_MEMORY_SIZE / 2;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -217,7 +217,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
     }
 
     {
-        auto offset = ShmSize - 1;
+        auto offset = SHARED_MEMORY_SIZE - 1;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -233,7 +233,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
     }
 
     {
-        auto offset = ShmSize + 1;
+        auto offset = SHARED_MEMORY_SIZE + 1;
         void* adr = memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
@@ -250,7 +250,7 @@ TYPED_TEST(base_relative_ptr_test, IdAndOffset)
     EXPECT_EQ(rp1.getOffset(), reinterpret_cast<std::ptrdiff_t>(basePtr1));
     EXPECT_EQ(rp1.getId(), 1);
 
-    int offset = ShmSize / 2;
+    int offset = SHARED_MEMORY_SIZE / 2;
     auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(rp2.getOffset(), offset);
@@ -264,7 +264,7 @@ TYPED_TEST(base_relative_ptr_test, getOffset)
     EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
     EXPECT_EQ(BaseRelativePointer::getOffset(1, memoryPartition[0]), 0);
 
-    int offset = ShmSize / 2;
+    int offset = SHARED_MEMORY_SIZE / 2;
     auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(BaseRelativePointer::getOffset(1, offsetAddr1), offset);
@@ -276,7 +276,7 @@ TYPED_TEST(base_relative_ptr_test, getPtr)
     EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
     EXPECT_EQ(BaseRelativePointer::getPtr(1, 0), memoryPartition[0]);
 
-    int offset = ShmSize / 2;
+    int offset = SHARED_MEMORY_SIZE / 2;
     auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(BaseRelativePointer::getPtr(1, offset), offsetAddr1);
@@ -444,7 +444,7 @@ TYPED_TEST(base_relative_ptr_test, MemoryReMapping_SharedMemory)
 
     EXPECT_EQ(dataPointer1->Data1, reinterpret_cast<Data*>(memoryReader)->Data1);
 
-    int offset = ShmSize / 2;
+    int offset = SHARED_MEMORY_SIZE / 2;
     auto offsetAddr1 = reinterpret_cast<int*>(static_cast<uint8_t*>(memoryWriter) + offset);
     auto offsetAddr2 = reinterpret_cast<int*>(static_cast<uint8_t*>(memoryReader) + offset);
     *offsetAddr1 = 37;

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -73,12 +73,12 @@ TYPED_TEST_CASE(base_relative_ptr_test, Types);
 
 TYPED_TEST(base_relative_ptr_test, ConstrTests)
 {
-    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], SHARED_MEMORY_SIZE), true);
-    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(1, this->memoryPartition[0], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(2, this->memoryPartition[1], SHARED_MEMORY_SIZE), true);
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2;
-        void* adr = memoryPartition[0] + offset;
+        void* adr = this->memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_EQ(rp.getOffset(), offset);
@@ -87,7 +87,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        RelativePointer<TypeParam> rp(memoryPartition[0]);
+        RelativePointer<TypeParam> rp(this->memoryPartition[0]);
         EXPECT_EQ(rp.getOffset(), 0);
         EXPECT_EQ(rp.getId(), 1);
         EXPECT_NE(rp, nullptr);
@@ -95,7 +95,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2;
-        void* adr = memoryPartition[0] + offset;
+        void* adr = this->memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 1);
@@ -104,7 +104,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1;
-        void* adr = memoryPartition[0] + offset;
+        void* adr = this->memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 1);
@@ -112,7 +112,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
     }
 
     {
-        RelativePointer<TypeParam> rp(memoryPartition[1]);
+        RelativePointer<TypeParam> rp(this->memoryPartition[1]);
         EXPECT_EQ(rp.getOffset(), 0);
         EXPECT_EQ(rp.getId(), 2);
         EXPECT_NE(rp, nullptr);
@@ -120,7 +120,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 2);
@@ -129,7 +129,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 2);
@@ -143,7 +143,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_NE(rp, nullptr);
     }
@@ -151,12 +151,12 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
 TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 {
-    EXPECT_EQ(BaseRelativePointer::registerPtr(1, memoryPartition[0], SHARED_MEMORY_SIZE), true);
-    EXPECT_EQ(BaseRelativePointer::registerPtr(2, memoryPartition[1], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(1, this->memoryPartition[0], SHARED_MEMORY_SIZE), true);
+    EXPECT_EQ(BaseRelativePointer::registerPtr(2, this->memoryPartition[1], SHARED_MEMORY_SIZE), true);
 
     {
         RelativePointer<TypeParam> rp;
-        rp = memoryPartition[0];
+        rp = this->memoryPartition[0];
         EXPECT_EQ(rp.getOffset(), 0);
         EXPECT_EQ(rp.getId(), 1);
         EXPECT_NE(rp, nullptr);
@@ -164,7 +164,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         RelativePointer<TypeParam> rp;
-        rp = memoryPartition[0];
+        rp = this->memoryPartition[0];
         BaseRelativePointer basePointer(rp);
         RelativePointer<TypeParam> recovered(basePointer);
 
@@ -180,7 +180,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2;
-        void* adr = memoryPartition[0] + offset;
+        void* adr = this->memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_EQ(rp.getOffset(), offset);
@@ -190,7 +190,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1;
-        void* adr = memoryPartition[0] + offset;
+        void* adr = this->memoryPartition[0] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_EQ(rp.getOffset(), offset);
@@ -200,7 +200,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         RelativePointer<TypeParam> rp;
-        rp = memoryPartition[1];
+        rp = this->memoryPartition[1];
         EXPECT_EQ(rp.getOffset(), 0);
         EXPECT_EQ(rp.getId(), 2);
         EXPECT_NE(rp, nullptr);
@@ -208,7 +208,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_EQ(rp.getOffset(), offset);
@@ -218,7 +218,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_EQ(rp.getOffset(), offset);
@@ -234,7 +234,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1;
-        void* adr = memoryPartition[1] + offset;
+        void* adr = this->memoryPartition[1] + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_NE(rp, nullptr);
@@ -243,15 +243,15 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
 TYPED_TEST(base_relative_ptr_test, IdAndOffset)
 {
-    void* basePtr1 = memoryPartition[0];
+    void* basePtr1 = this->memoryPartition[0];
 
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
     EXPECT_EQ(rp1.getOffset(), reinterpret_cast<std::ptrdiff_t>(basePtr1));
     EXPECT_EQ(rp1.getId(), 1);
 
     int offset = SHARED_MEMORY_SIZE / 2;
-    auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
+    auto offsetAddr1 = reinterpret_cast<TypeParam*>(this->memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(rp2.getOffset(), offset);
     EXPECT_EQ(rp2.getId(), 1);
@@ -260,81 +260,81 @@ TYPED_TEST(base_relative_ptr_test, IdAndOffset)
 
 TYPED_TEST(base_relative_ptr_test, getOffset)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(BaseRelativePointer::getOffset(1, memoryPartition[0]), 0);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(BaseRelativePointer::getOffset(1, this->memoryPartition[0]), 0);
 
     int offset = SHARED_MEMORY_SIZE / 2;
-    auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
+    auto offsetAddr1 = reinterpret_cast<TypeParam*>(this->memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(BaseRelativePointer::getOffset(1, offsetAddr1), offset);
 }
 
 TYPED_TEST(base_relative_ptr_test, getPtr)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(BaseRelativePointer::getPtr(1, 0), memoryPartition[0]);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(BaseRelativePointer::getPtr(1, 0), this->memoryPartition[0]);
 
     int offset = SHARED_MEMORY_SIZE / 2;
-    auto offsetAddr1 = reinterpret_cast<TypeParam*>(memoryPartition[0] + offset);
+    auto offsetAddr1 = reinterpret_cast<TypeParam*>(this->memoryPartition[0] + offset);
     RelativePointer<TypeParam> rp2(offsetAddr1, 1);
     EXPECT_EQ(BaseRelativePointer::getPtr(1, offset), offsetAddr1);
 }
 
 TYPED_TEST(base_relative_ptr_test, registerPtr)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
 
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), false);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), false);
     EXPECT_EQ(rp1.unregisterPtr(1), true);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
 }
 
 TYPED_TEST(base_relative_ptr_test, unRegisterPointerTest_Valid)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
 
-    rp1.registerPtr(1, memoryPartition[0]);
+    rp1.registerPtr(1, this->memoryPartition[0]);
     EXPECT_EQ(rp1.unregisterPtr(1), true);
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
 }
 
 TYPED_TEST(base_relative_ptr_test, unregisterPointerAll)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
-    RelativePointer<TypeParam> rp2(memoryPartition[1], 9999);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp2(this->memoryPartition[1], 9999);
 
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(rp2.registerPtr(9999, memoryPartition[1]), true);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(rp2.registerPtr(9999, this->memoryPartition[1]), true);
     BaseRelativePointer::unregisterAll();
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(rp2.registerPtr(9999, memoryPartition[1]), true);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(rp2.registerPtr(9999, this->memoryPartition[1]), true);
 }
 
 TYPED_TEST(base_relative_ptr_test, registerPtrWithId)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
-    RelativePointer<TypeParam> rp2(memoryPartition[1], 10000);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp2(this->memoryPartition[1], 10000);
 
-    EXPECT_EQ(rp1.registerPtr(1, memoryPartition[0]), true);
-    EXPECT_EQ(rp2.registerPtr(10000, memoryPartition[1]), false);
+    EXPECT_EQ(rp1.registerPtr(1, this->memoryPartition[0]), true);
+    EXPECT_EQ(rp2.registerPtr(10000, this->memoryPartition[1]), false);
 }
 
 TYPED_TEST(base_relative_ptr_test, basePointerValid)
 {
-    void* basePtr1 = memoryPartition[0];
+    void* basePtr1 = this->memoryPartition[0];
 
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
     EXPECT_EQ(rp1.getBasePtr(1), nullptr);
-    rp1.registerPtr(1, memoryPartition[0]);
+    rp1.registerPtr(1, this->memoryPartition[0]);
     EXPECT_EQ(basePtr1, rp1.getBasePtr(1));
 }
 
 TYPED_TEST(base_relative_ptr_test, assignmentOperator)
 {
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
     RelativePointer<TypeParam> rp2 = rp1;
 
     EXPECT_EQ(rp1.getBasePtr(), rp2.getBasePtr());
@@ -344,9 +344,9 @@ TYPED_TEST(base_relative_ptr_test, assignmentOperator)
 
 TYPED_TEST(base_relative_ptr_test, pointerOperator)
 {
-    auto baseAddr = reinterpret_cast<TypeParam*>(memoryPartition[0]);
+    auto baseAddr = reinterpret_cast<TypeParam*>(this->memoryPartition[0]);
     *baseAddr = static_cast<TypeParam>(88);
-    RelativePointer<TypeParam> rp1(memoryPartition[0], 1);
+    RelativePointer<TypeParam> rp1(this->memoryPartition[0], 1);
 
     EXPECT_EQ(*rp1, *baseAddr);
     *baseAddr = static_cast<TypeParam>(99);
@@ -437,8 +437,8 @@ TYPED_TEST(base_relative_ptr_test, memoryRemapping)
 
 TYPED_TEST(base_relative_ptr_test, MemoryReMapping_SharedMemory)
 {
-    void* memoryWriter = memoryPartition[0];
-    void* memoryReader = memoryPartition[0];
+    void* memoryWriter = this->memoryPartition[0];
+    void* memoryReader = this->memoryPartition[0];
 
     Data* dataPointer1 = new (memoryWriter) Data(12, 21);
 

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -143,7 +143,7 @@ TYPED_TEST(base_relative_ptr_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1;
-        void* adr = this->memoryPartition[1] + offset;
+        void* adr = static_cast<uint8_t*>(this->memoryPartition[1]) + offset;
         RelativePointer<TypeParam> rp(adr);
         EXPECT_NE(rp, nullptr);
     }
@@ -234,7 +234,7 @@ TYPED_TEST(base_relative_ptr_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1;
-        void* adr = this->memoryPartition[1] + offset;
+        void* adr = static_cast<uint8_t*>(this->memoryPartition[1]) + offset;
         RelativePointer<TypeParam> rp;
         rp = adr;
         EXPECT_NE(rp, nullptr);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
The relative ptr tests had to be refactored so that they use local memory since shared memory is not required to verify the class. Additionally, there was a shared memory leak in the relative ptr tests which was fixed by that.

The relative ptr tests are suboptimal and need to be refactored but this is out of scope in this PR.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #33 
