### PR TITLE
Iox #33 implement tests for unix domain socket

### DIFF
--- a/iceoryx_examples/waitset/ice_waitset_basic.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_basic.cpp
@@ -25,12 +25,12 @@
 #include <atomic>
 #include <iostream>
 
-std::atomic_bool shutdown{false};
+std::atomic_bool keepRunning{true};
 iox::cxx::optional<iox::popo::WaitSet<>> waitset;
 
 static void sigHandler(int sig IOX_MAYBE_UNUSED)
 {
-    shutdown = true;
+    keepRunning = false;
     if (waitset)
     {
         waitset->markForDestruction();
@@ -58,7 +58,7 @@ int main()
         std::exit(EXIT_FAILURE);
     });
 
-    while (!shutdown.load())
+    while (keepRunning.load())
     {
         // We block and wait for samples to arrive.
         auto notificationVector = waitset->wait();

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
@@ -57,12 +57,6 @@ enum class IpcChannelError : uint8_t
     UNDEFINED
 };
 
-enum class IpcChannelMode : uint8_t
-{
-    NON_BLOCKING,
-    BLOCKING
-};
-
 enum class IpcChannelSide : uint8_t
 {
     CLIENT,

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp
@@ -96,13 +96,11 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
 
   private:
     MessageQueue(const IpcChannelName_t& name,
-                 const IpcChannelMode mode,
                  const IpcChannelSide channelSide,
                  const size_t maxMsgSize = MAX_MESSAGE_SIZE,
                  const uint64_t maxMsgNumber = 10u);
 
-    cxx::expected<int32_t, IpcChannelError>
-    open(const IpcChannelName_t& name, const IpcChannelMode mode, const IpcChannelSide channelSide);
+    cxx::expected<int32_t, IpcChannelError> open(const IpcChannelName_t& name, const IpcChannelSide channelSide);
 
     cxx::expected<IpcChannelError> close();
     cxx::expected<IpcChannelError> unlink();

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -113,7 +113,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @param maxMsgSize max message size that can be transmitted
     /// @param maxMsgNumber max messages that can be queued
     UnixDomainSocket(const IpcChannelName_t& name,
-                     const IpcChannelMode mode,
                      const IpcChannelSide channelSide,
                      const size_t maxMsgSize = MAX_MESSAGE_SIZE,
                      const uint64_t maxMsgNumber = 10U) noexcept;
@@ -127,7 +126,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @param maxMsgNumber max messages that can be queued
     UnixDomainSocket(const NoPathPrefix_t,
                      const UdsName_t& name,
-                     const IpcChannelMode mode,
                      const IpcChannelSide channelSide,
                      const size_t maxMsgSize = MAX_MESSAGE_SIZE,
                      const uint64_t maxMsgNumber = 10U) noexcept;
@@ -136,7 +134,7 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @brief initializes the unix domain socket
     /// @param mode blocking or non_blocking
     /// @return IpcChannelError if error occured
-    cxx::expected<IpcChannelError> initalizeSocket(const IpcChannelMode mode) noexcept;
+    cxx::expected<IpcChannelError> initalizeSocket() noexcept;
 
     /// @brief create an IpcChannelError from the provides error code
     /// @return IpcChannelError if error occured

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -40,11 +40,10 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     static constexpr NoPathPrefix_t NoPathPrefix{};
     static constexpr char PATH_PREFIX[] = "/tmp/";
 
+    static constexpr uint64_t NULL_TERMINATOR_SIZE = 1U;
     /// @brief Max message size is on linux = 4096 and on mac os = 2048. To have
     ///  the same behavior on every platform we use 2048.
-    static constexpr size_t MAX_MESSAGE_SIZE = 2048U;
-    static constexpr size_t SHORTEST_VALID_NAME = 2U;
-    static constexpr size_t NULL_TERMINATOR_SIZE = 1;
+    static constexpr uint64_t MAX_MESSAGE_SIZE = 2048U - NULL_TERMINATOR_SIZE;
     /// @brief The name length is limited by the size of the sockaddr_un::sun_path buffer and the path prefix
     static constexpr size_t LONGEST_VALID_NAME = sizeof(sockaddr_un::sun_path) - 1;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -47,8 +47,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     static constexpr size_t NULL_TERMINATOR_SIZE = 1;
     /// @brief The name length is limited by the size of the sockaddr_un::sun_path buffer and the path prefix
     static constexpr size_t LONGEST_VALID_NAME = sizeof(sockaddr_un::sun_path) - 1;
-    static constexpr int32_t ERROR_CODE = -1;
-    static constexpr int32_t INVALID_FD = -1;
 
     using UdsName_t = cxx::string<LONGEST_VALID_NAME>;
 
@@ -147,6 +145,9 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     cxx::expected<IpcChannelError> closeFileDescriptor() noexcept;
 
   private:
+    static constexpr int32_t ERROR_CODE = -1;
+    static constexpr int32_t INVALID_FD = -1;
+
     UdsName_t m_name;
     IpcChannelSide m_channelSide;
     int32_t m_sockfd{INVALID_FD};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,7 +105,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
   private:
     /// @brief c'tor
     /// @param name for the unix domain socket
-    /// @param mode blocking or non_blocking
     /// @param channel side client or server
     /// @param maxMsgSize max message size that can be transmitted
     /// @param maxMsgNumber max messages that can be queued
@@ -117,7 +116,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     /// @brief c'tor
     /// @param NoPathPrefix signalling that this constructor does not add a path prefix
     /// @param name for the unix domain socket
-    /// @param mode blocking or non_blocking
     /// @param channel side client or server
     /// @param maxMsgSize max message size that can be transmitted
     /// @param maxMsgNumber max messages that can be queued
@@ -129,7 +127,6 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
 
 
     /// @brief initializes the unix domain socket
-    /// @param mode blocking or non_blocking
     /// @return IpcChannelError if error occured
     cxx::expected<IpcChannelError> initalizeSocket() noexcept;
 

--- a/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/socket.hpp
+++ b/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/socket.hpp
@@ -19,4 +19,13 @@
 
 #include <sys/socket.h>
 
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_socket(int domain, int type, int protocol);
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_closesocket(int sockfd);
+
 #endif // IOX_HOOFS_LINUX_PLATFORM_SOCKET_HPP

--- a/iceoryx_hoofs/platform/linux/source/socket.cpp
+++ b/iceoryx_hoofs/platform/linux/source/socket.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/platform/socket.hpp"
+
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return bind(sockfd, addr, addrlen);
+}
+
+int iox_socket(int domain, int type, int protocol)
+{
+    return socket(domain, type, protocol);
+}
+
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
+{
+    return setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
+{
+    return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return connect(sockfd, addr, addrlen);
+}
+
+int iox_closesocket(int sockfd)
+{
+    return close(sockfd);
+}

--- a/iceoryx_hoofs/platform/linux/source/socket.cpp
+++ b/iceoryx_hoofs/platform/linux/source/socket.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/platform/socket.hpp"
+#include <unistd.h>
 
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
 {

--- a/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/socket.hpp
+++ b/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/socket.hpp
@@ -19,4 +19,13 @@
 
 #include <sys/socket.h>
 
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_socket(int domain, int type, int protocol);
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_closesocket(int sockfd);
+
 #endif // IOX_HOOFS_MAC_PLATFORM_SOCKET_HPP

--- a/iceoryx_hoofs/platform/mac/source/socket.cpp
+++ b/iceoryx_hoofs/platform/mac/source/socket.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/platform/socket.hpp"
+
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return bind(sockfd, addr, addrlen);
+}
+
+int iox_socket(int domain, int type, int protocol)
+{
+    return socket(domain, type, protocol);
+}
+
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
+{
+    return setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
+{
+    return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return connect(sockfd, addr, addrlen);
+}
+
+int iox_closesocket(int sockfd)
+{
+    return close(sockfd);
+}

--- a/iceoryx_hoofs/platform/mac/source/socket.cpp
+++ b/iceoryx_hoofs/platform/mac/source/socket.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/platform/socket.hpp"
+#include <unistd.h>
 
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
 {

--- a/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/socket.hpp
+++ b/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/socket.hpp
@@ -19,4 +19,13 @@
 
 #include <sys/socket.h>
 
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_socket(int domain, int type, int protocol);
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_closesocket(int sockfd);
+
 #endif // IOX_HOOFS_QNX_PLATFORM_SOCKET_HPP

--- a/iceoryx_hoofs/platform/qnx/source/socket.cpp
+++ b/iceoryx_hoofs/platform/qnx/source/socket.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/platform/socket.hpp"
+
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return bind(sockfd, addr, addrlen);
+}
+
+int iox_socket(int domain, int type, int protocol)
+{
+    return socket(domain, type, protocol);
+}
+
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
+{
+    return setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
+{
+    return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return connect(sockfd, addr, addrlen);
+}
+
+int iox_closesocket(int sockfd)
+{
+    return close(sockfd);
+}

--- a/iceoryx_hoofs/platform/qnx/source/socket.cpp
+++ b/iceoryx_hoofs/platform/qnx/source/socket.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/platform/socket.hpp"
+#include <unistd.h>
 
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
 {

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/socket.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/socket.hpp
@@ -19,6 +19,9 @@
 
 #include "iceoryx_hoofs/platform/platform_correction.hpp"
 #include "iceoryx_hoofs/platform/types.hpp"
+#include "iceoryx_hoofs/platform/windows.hpp"
+
+#include <cstdint>
 
 #define AF_INET 0
 #define SOCK_STREAM 1
@@ -33,63 +36,13 @@ using sa_family_t = int;
 using socklen_t = int;
 using in_addr_t = uint32_t;
 
-struct in_addr
-{
-    uint32_t s_addr;
-};
-
-struct sockaddr_in
-{
-    sa_family_t sin_family;
-    in_port_t sin_port;
-    struct in_addr sin_addr;
-};
-
-struct sockaddr
-{
-    sa_family_t sa_family;
-    char sa_data[14];
-};
-
-inline in_addr_t inet_addr(const char* cp)
-{
-    return {0};
-}
-
-inline uint16_t htons(uint16_t hostshort)
-{
-    return 0;
-}
-
-inline int bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
-{
-    return 0;
-}
-
-inline int socket(int domain, int type, int protocol)
-{
-    return 0;
-}
-
-inline int setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
-{
-    return 0;
-}
-
-inline ssize_t
-sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
-{
-    return 0;
-}
-
-inline ssize_t recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
-{
-    return 0;
-}
-
-inline int connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
-{
-    return 0;
-}
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_socket(int domain, int type, int protocol);
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_closesocket(int sockfd);
 
 #endif // IOX_HOOFS_WIN_PLATFORM_SOCKET_HPP

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/socket.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/socket.hpp
@@ -23,18 +23,8 @@
 
 #include <cstdint>
 
-#define AF_INET 0
-#define SOCK_STREAM 1
-#define SOL_SOCKET 2
-#define SO_SNDTIMEO 3
-#define SO_RCVTIMEO 4
-#define AF_LOCAL 5
-#define SOCK_DGRAM 6
-
-using in_port_t = int;
+#define AF_LOCAL AF_INET
 using sa_family_t = int;
-using socklen_t = int;
-using in_addr_t = uint32_t;
 
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
 int iox_socket(int domain, int type, int protocol);

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/time.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/time.hpp
@@ -35,12 +35,6 @@
 using suseconds_t = uint64_t;
 using clockid_t = int;
 
-struct timeval
-{
-    time_t tv_sec;
-    suseconds_t tv_usec;
-};
-
 struct itimerspec
 {
     timespec it_interval;

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/windows.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/windows.hpp
@@ -21,6 +21,10 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#pragma comment(lib, "ws2_32.lib")
 
 #include "iceoryx_hoofs/platform/platform_correction.hpp"
 

--- a/iceoryx_hoofs/platform/win/source/socket.cpp
+++ b/iceoryx_hoofs/platform/win/source/socket.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/platform/socket.hpp"
+#include "iceoryx_hoofs/platform/win32_errorHandling.hpp"
+
+#include <iostream>
+
+
+struct Winsock2ApiInitializer
+{
+    Winsock2ApiInitializer()
+    {
+        WORD requestedVersion = MAKEWORD(2, 2);
+        WSADATA wsaData;
+        auto result = Win32Call(WSAStartup, requestedVersion, &wsaData).value;
+        if (result != 0)
+        {
+            std::cerr << "unable to initialize winsock2" << std::endl;
+            std::terminate();
+        }
+
+        if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2)
+        {
+            std::cerr << "required winsock2.dll version is 2.2, found " << HIBYTE(wsaData.wVersion) << "."
+                      << LOBYTE(wsaData.wVersion) << std::endl;
+            cleanupWinsock();
+            std::terminate();
+        }
+    }
+
+    ~Winsock2ApiInitializer()
+    {
+        cleanupWinsock();
+    }
+
+    void cleanupWinsock()
+    {
+        Win32Call(WSACleanup);
+    }
+};
+
+static Winsock2ApiInitializer winsock2ApiInitializer;
+
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return 0;
+}
+
+int iox_socket(int domain, int type, int protocol)
+{
+    return 0;
+}
+
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen)
+{
+    return 0;
+}
+
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return 0;
+}
+
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
+{
+    return 0;
+}
+
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
+{
+    return 0;
+}
+
+int iox_closesocket(int sockfd)
+{
+    return Win32Call(closesocket, static_cast<SOCKET>(sockfd)).value;
+}

--- a/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
@@ -36,7 +36,6 @@ MessageQueue::MessageQueue()
 }
 
 MessageQueue::MessageQueue(const IpcChannelName_t& name,
-                           const IpcChannelMode mode,
                            const IpcChannelSide channelSide,
                            const size_t maxMsgSize,
                            const uint64_t maxMsgNumber)
@@ -71,7 +70,7 @@ MessageQueue::MessageQueue(const IpcChannelName_t& name,
         }
         // fields have a different order in QNX,
         // so we need to initialize by name
-        m_attributes.mq_flags = (mode == IpcChannelMode::NON_BLOCKING) ? O_NONBLOCK : 0;
+        m_attributes.mq_flags = 0;
         m_attributes.mq_maxmsg = static_cast<long>(maxMsgNumber);
         m_attributes.mq_msgsize = static_cast<long>(maxMsgSize);
         m_attributes.mq_curmsgs = 0L;
@@ -79,7 +78,7 @@ MessageQueue::MessageQueue(const IpcChannelName_t& name,
         m_attributes.mq_recvwait = 0L;
         m_attributes.mq_sendwait = 0L;
 #endif
-        auto openResult = open(m_name, mode, channelSide);
+        auto openResult = open(m_name, channelSide);
         if (!openResult.has_error())
         {
             this->m_isInitialized = true;
@@ -204,8 +203,8 @@ cxx::expected<std::string, IpcChannelError> MessageQueue::receive() const
     return cxx::success<std::string>(std::string(&(message[0])));
 }
 
-cxx::expected<int32_t, IpcChannelError>
-MessageQueue::open(const IpcChannelName_t& name, const IpcChannelMode mode, const IpcChannelSide channelSide)
+cxx::expected<int32_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name,
+                                                           const IpcChannelSide channelSide)
 {
     IpcChannelName_t l_name;
     if (sanitizeIpcChannelName(name).and_then([&](IpcChannelName_t& name) { l_name = std::move(name); }).has_error())
@@ -215,7 +214,7 @@ MessageQueue::open(const IpcChannelName_t& name, const IpcChannelMode mode, cons
 
 
     int32_t openFlags = O_RDWR;
-    openFlags |= (mode == IpcChannelMode::NON_BLOCKING) ? O_NONBLOCK : 0;
+    openFlags |= 0;
     if (channelSide == IpcChannelSide::SERVER)
     {
         openFlags |= O_CREAT;

--- a/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/message_queue.cpp
@@ -214,7 +214,6 @@ cxx::expected<int32_t, IpcChannelError> MessageQueue::open(const IpcChannelName_
 
 
     int32_t openFlags = O_RDWR;
-    openFlags |= 0;
     if (channelSide == IpcChannelSide::SERVER)
     {
         openFlags |= O_CREAT;

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -31,6 +31,7 @@ namespace iox
 namespace posix
 {
 constexpr char UnixDomainSocket::PATH_PREFIX[];
+constexpr uint64_t UnixDomainSocket::MAX_MESSAGE_SIZE;
 
 UnixDomainSocket::UnixDomainSocket() noexcept
 {

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -283,7 +283,8 @@ UnixDomainSocket::timedReceive(const units::Duration& timeout) const noexcept
     {
         std::cerr
             << "socket: \"" << m_name
-            << "\", timedSend with a timeout != 0 is not supported on MacOS. timedSend will behave like send instead."
+            << "\", timedReceive with a timeout != 0 is not supported on MacOS. timedReceive will behave like receive "
+               "instead."
             << std::endl;
     }
 #endif

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -321,7 +321,7 @@ TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToErrorWithTimedReceive)
 }
 
 // is not supported on mac os and behaves there like receive
-#if !defined(__APPLE)
+#if !defined(__APPLE__)
 TEST_F(UnixDomainSocket_test, TimedReceiveBlocks)
 {
     auto start = std::chrono::steady_clock::now();

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -43,14 +43,12 @@ class UnixDomainSocket_test : public Test
   public:
     void SetUp()
     {
-        auto serverResult = UnixDomainSocket::create(
-            goodName, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER, MaxMsgSize, MaxMsgNumber);
+        auto serverResult = UnixDomainSocket::create(goodName, IpcChannelSide::SERVER, MaxMsgSize, MaxMsgNumber);
         ASSERT_THAT(serverResult.has_error(), Eq(false));
         server = std::move(serverResult.value());
         internal::CaptureStderr();
 
-        auto clientResult = UnixDomainSocket::create(
-            goodName, IpcChannelMode::BLOCKING, IpcChannelSide::CLIENT, MaxMsgSize, MaxMsgNumber);
+        auto clientResult = UnixDomainSocket::create(goodName, IpcChannelSide::CLIENT, MaxMsgSize, MaxMsgNumber);
         ASSERT_THAT(clientResult.has_error(), Eq(false));
         client = std::move(clientResult.value());
     }
@@ -76,14 +74,6 @@ class UnixDomainSocket_test : public Test
 
 const size_t UnixDomainSocket_test::MaxMsgSize = UnixDomainSocket::MAX_MESSAGE_SIZE;
 constexpr uint64_t UnixDomainSocket_test::MaxMsgNumber;
-
-TEST_F(UnixDomainSocket_test, NonBlockingModeNotSupported)
-{
-    auto result = UnixDomainSocket::create(
-        goodName, IpcChannelMode::NON_BLOCKING, IpcChannelSide::SERVER, MaxMsgSize, MaxMsgNumber);
-    EXPECT_TRUE(result.has_error());
-    ASSERT_THAT(result.get_error(), Eq(IpcChannelError::INVALID_ARGUMENTS));
-}
 
 TEST_F(UnixDomainSocket_test, UnlinkNonExistingWithInvalidNameLeadsToError)
 {

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -151,7 +151,7 @@ TEST_F(UnixDomainSocket_test, UnlinkTooLongSocketNameWithPathPrefixLeadsToInvali
     EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
 }
 
-TEST_F(UnixDomainSocket_test, UnlinkExistingSocketLeadsIsSuccessful)
+TEST_F(UnixDomainSocket_test, UnlinkExistingSocketIsSuccessful)
 {
     UnixDomainSocket::UdsName_t socketFileName = UnixDomainSocket::PATH_PREFIX;
     socketFileName.append(cxx::TruncateToCapacity, "iceoryx-hoofs-moduletest.socket");

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -17,20 +17,27 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
+#include "iceoryx_hoofs/platform/socket.hpp"
+#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 
 #include "test.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <thread>
 
 namespace
 {
 using namespace ::testing;
+using namespace ::testing::internal;
 using namespace iox;
 using namespace iox::posix;
 using namespace iox::units::duration_literals;
 using namespace iox::units;
 
-constexpr char invalidName[] = "x";
+using sendCall_t = std::function<cxx::expected<IpcChannelError>(const std::string&)>;
+using receiveCall_t = std::function<cxx::expected<std::string, IpcChannelError>()>;
+
 constexpr char goodName[] = "channel_test";
 
 /// @req
@@ -46,7 +53,7 @@ class UnixDomainSocket_test : public Test
         auto serverResult = UnixDomainSocket::create(goodName, IpcChannelSide::SERVER, MaxMsgSize, MaxMsgNumber);
         ASSERT_THAT(serverResult.has_error(), Eq(false));
         server = std::move(serverResult.value());
-        internal::CaptureStderr();
+        CaptureStderr();
 
         auto clientResult = UnixDomainSocket::create(goodName, IpcChannelSide::CLIENT, MaxMsgSize, MaxMsgNumber);
         ASSERT_THAT(clientResult.has_error(), Eq(false));
@@ -55,7 +62,7 @@ class UnixDomainSocket_test : public Test
 
     void TearDown()
     {
-        std::string output = internal::GetCapturedStderr();
+        std::string output = GetCapturedStderr();
         if (Test::HasFailure())
         {
             std::cout << output << std::endl;
@@ -66,6 +73,49 @@ class UnixDomainSocket_test : public Test
     {
     }
 
+    void createTestSocket(const UnixDomainSocket::UdsName_t& name)
+    {
+        static constexpr int32_t ERROR_CODE = -1;
+        struct sockaddr_un sockAddr;
+        int32_t sockfd;
+
+        memset(&sockAddr, 0, sizeof(sockAddr));
+        sockAddr.sun_family = AF_LOCAL;
+        strncpy(sockAddr.sun_path, name.c_str(), name.size());
+
+        iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0)
+            .failureReturnValue(ERROR_CODE)
+            .evaluate()
+            .and_then([&](auto& r) { sockfd = r.value; })
+            .or_else([](auto&) {
+                std::cerr << "unable to create socket\n";
+                std::terminate();
+            });
+
+        iox::posix::posixCall(iox_bind)(sockfd, reinterpret_cast<struct sockaddr*>(&sockAddr), sizeof(sockAddr))
+            .failureReturnValue(ERROR_CODE)
+            .evaluate()
+            .or_else([](auto&) {
+                std::cerr << "unable to bind socket\n";
+                std::terminate();
+            });
+    }
+
+    void signalThreadReady()
+    {
+        doWaitForThread.store(false, std::memory_order_relaxed);
+    }
+
+    void waitForThread()
+    {
+        while (doWaitForThread.load(std::memory_order_relaxed))
+        {
+            std::this_thread::yield();
+        }
+    }
+
+    const std::chrono::milliseconds WAIT_IN_MS{10};
+    std::atomic_bool doWaitForThread{true};
     static const size_t MaxMsgSize;
     static constexpr uint64_t MaxMsgNumber = 10U;
     UnixDomainSocket server;
@@ -75,27 +125,229 @@ class UnixDomainSocket_test : public Test
 const size_t UnixDomainSocket_test::MaxMsgSize = UnixDomainSocket::MAX_MESSAGE_SIZE;
 constexpr uint64_t UnixDomainSocket_test::MaxMsgNumber;
 
-TEST_F(UnixDomainSocket_test, UnlinkNonExistingWithInvalidNameLeadsToError)
+TEST_F(UnixDomainSocket_test, UnlinkEmptySocketNameLeadsToInvalidChannelNameError)
 {
-    auto ret = UnixDomainSocket::unlinkIfExists(UnixDomainSocket::NoPathPrefix, invalidName);
-    EXPECT_TRUE(ret.has_error());
-    ASSERT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+    auto ret = UnixDomainSocket::unlinkIfExists(UnixDomainSocket::NoPathPrefix, "");
+    ASSERT_TRUE(ret.has_error());
+    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
 }
 
-TEST_F(UnixDomainSocket_test, SendingOnServerLeadsToError)
+TEST_F(UnixDomainSocket_test, UnlinkEmptySocketNameWithPathPrefixLeadsToInvalidChannelNameError)
+{
+    auto ret = UnixDomainSocket::unlinkIfExists("");
+    ASSERT_TRUE(ret.has_error());
+    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+}
+
+TEST_F(UnixDomainSocket_test, UnlinkTooLongSocketNameWithPathPrefixLeadsToInvalidChannelNameError)
+{
+    UnixDomainSocket::UdsName_t longSocketName;
+    for (uint64_t i = 0U; i < UnixDomainSocket::LONGEST_VALID_NAME - strlen(UnixDomainSocket::PATH_PREFIX) + 1; ++i)
+    {
+        longSocketName.append(cxx::TruncateToCapacity, "o");
+    }
+    auto ret = UnixDomainSocket::unlinkIfExists(longSocketName);
+    ASSERT_TRUE(ret.has_error());
+    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+}
+
+TEST_F(UnixDomainSocket_test, UnlinkExistingSocketLeadsIsSuccessful)
+{
+    UnixDomainSocket::UdsName_t socketFileName = UnixDomainSocket::PATH_PREFIX;
+    socketFileName.append(cxx::TruncateToCapacity, "iceoryx-hoofs-moduletest.socket");
+    createTestSocket(socketFileName);
+    auto ret = UnixDomainSocket::unlinkIfExists(UnixDomainSocket::NoPathPrefix, socketFileName);
+    EXPECT_FALSE(ret.has_error());
+}
+
+TEST_F(UnixDomainSocket_test, UnlinkExistingSocketWithPathPrefixLeadsIsSuccessful)
+{
+    UnixDomainSocket::UdsName_t socketFileName = "iceoryx-hoofs-moduletest.socket";
+    UnixDomainSocket::UdsName_t socketFileNameWithPrefix = UnixDomainSocket::PATH_PREFIX;
+    socketFileNameWithPrefix.append(cxx::TruncateToCapacity, socketFileName);
+    createTestSocket(socketFileNameWithPrefix);
+    auto ret = UnixDomainSocket::unlinkIfExists(socketFileName);
+    EXPECT_FALSE(ret.has_error());
+}
+
+void sendOnServerLeadsToError(const sendCall_t& send)
 {
     cxx::string<10> message{"Foo"};
-    Duration duration{1_ms};
-    auto result = server.timedSend(message, duration);
+    auto result = send(message);
     EXPECT_TRUE(result.has_error());
     ASSERT_THAT(result.get_error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
 }
 
-TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToError)
+TEST_F(UnixDomainSocket_test, TimedSendOnServerLeadsToError)
 {
-    Duration duration{1_ms};
-    auto result = client.timedReceive(duration);
+    sendOnServerLeadsToError([&](auto& msg) { return server.timedSend(msg, 1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SendOnServerLeadsToError)
+{
+    sendOnServerLeadsToError([&](auto& msg) { return server.send(msg); });
+}
+
+void successfulSendAndReceive(const std::string& message, const sendCall_t& send, const receiveCall_t& receive)
+{
+    ASSERT_FALSE(send(message).has_error());
+
+    auto receivedMessage = receive();
+    ASSERT_FALSE(receivedMessage.has_error());
+    EXPECT_EQ(message, *receivedMessage);
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfNonEmptyMessageWithSendAndReceive)
+{
+    successfulSendAndReceive(
+        "what's hypnotoads eye color?",
+        [&](auto& msg) { return client.send(msg); },
+        [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfNonEmptyMessageWithTimedSendAndReceive)
+{
+    successfulSendAndReceive(
+        "the earth is a disc on the back of hypnotoad",
+        [&](auto& msg) { return client.timedSend(msg, 1_ms); },
+        [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfNonEmptyMessageWithTimedSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        "it is not the sun that rises, it is hypnotoad who is opening its eyes",
+        [&](auto& msg) { return client.timedSend(msg, 1_ms); },
+        [&]() { return server.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfNonEmptyMessageWithSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        "what is the most beautiful color in the world? it's hypnotoad.",
+        [&](auto& msg) { return client.send(msg); },
+        [&]() { return server.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfEmptyMessageWithSendAndReceive)
+{
+    successfulSendAndReceive(
+        "", [&](auto& msg) { return client.send(msg); }, [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfEmptyMessageWithTimedSendAndReceive)
+{
+    successfulSendAndReceive(
+        "", [&](auto& msg) { return client.timedSend(msg, 1_ms); }, [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfEmptyMessageWithTimedSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        "", [&](auto& msg) { return client.timedSend(msg, 1_ms); }, [&]() { return server.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfEmptyMessageWithSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        "", [&](auto& msg) { return client.send(msg); }, [&]() { return server.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfMaxLengthMessageWithSendAndReceive)
+{
+    successfulSendAndReceive(
+        std::string(UnixDomainSocket::MAX_MESSAGE_SIZE, 'x'),
+        [&](auto& msg) { return client.send(msg); },
+        [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfMaxLengthMessageWithTimedSendAndReceive)
+{
+    successfulSendAndReceive(
+        std::string(UnixDomainSocket::MAX_MESSAGE_SIZE, 'x'),
+        [&](auto& msg) { return client.timedSend(msg, 1_ms); },
+        [&]() { return server.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfMaxLengthMessageWithTimedSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        std::string(UnixDomainSocket::MAX_MESSAGE_SIZE, 'x'),
+        [&](auto& msg) { return client.timedSend(msg, 1_ms); },
+        [&]() { return server.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, SuccessfulCommunicationOfMaxLengthMessageWithSendAndTimedReceive)
+{
+    successfulSendAndReceive(
+        std::string(UnixDomainSocket::MAX_MESSAGE_SIZE, 'x'),
+        [&](auto& msg) { return client.send(msg); },
+        [&]() { return server.timedReceive(1_ms); });
+}
+
+void unableToSendTooLongMessage(const sendCall_t& send)
+{
+    std::string message(UnixDomainSocket::MAX_MESSAGE_SIZE + 1, 'x');
+    auto result = send(message);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_EQ(result.get_error(), IpcChannelError::MESSAGE_TOO_LONG);
+}
+
+TEST_F(UnixDomainSocket_test, UnableToSendTooLongMessageWithSend)
+{
+    unableToSendTooLongMessage([&](auto& msg) { return client.send(msg); });
+}
+
+TEST_F(UnixDomainSocket_test, UnableToSendTooLongMessageWithTimedSend)
+{
+    unableToSendTooLongMessage([&](auto& msg) { return client.timedSend(msg, 1_ms); });
+}
+
+void receivingOnClientLeadsToError(const receiveCall_t& receive)
+{
+    auto result = receive();
     EXPECT_TRUE(result.has_error());
     ASSERT_THAT(result.get_error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
+}
+
+TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToErrorWithReceive)
+{
+    receivingOnClientLeadsToError([&] { return client.receive(); });
+}
+
+TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToErrorWithTimedReceive)
+{
+    receivingOnClientLeadsToError([&] { return client.timedReceive(1_ms); });
+}
+
+TEST_F(UnixDomainSocket_test, TimedReceiveBlocks)
+{
+    auto start = std::chrono::steady_clock::now();
+    auto msg = server.timedReceive(units::Duration::fromMilliseconds(WAIT_IN_MS.count()));
+    auto end = std::chrono::steady_clock::now();
+    EXPECT_THAT(end - start, Gt(WAIT_IN_MS));
+
+    ASSERT_TRUE(msg.has_error());
+    EXPECT_EQ(msg.get_error(), IpcChannelError::TIMEOUT);
+}
+
+TEST_F(UnixDomainSocket_test, TimedReceiveBlocksUntilMessageIsReceived)
+{
+    std::string message = "asdasda";
+    std::thread waitThread([&] {
+        this->signalThreadReady();
+        auto start = std::chrono::steady_clock::now();
+        auto msg = server.timedReceive(units::Duration::fromMilliseconds(WAIT_IN_MS.count() * 2));
+        auto end = std::chrono::steady_clock::now();
+        EXPECT_THAT(end - start, Gt(WAIT_IN_MS));
+
+        ASSERT_FALSE(msg.has_error());
+        EXPECT_EQ(*msg, message);
+    });
+
+    this->waitForThread();
+    std::this_thread::sleep_for(WAIT_IN_MS);
+    ASSERT_FALSE(client.send(message).has_error());
+    waitThread.join();
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#if !defined(_WIN32)
 #include "iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 
@@ -110,4 +109,3 @@ TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToError)
     ASSERT_THAT(result.get_error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
 }
 } // namespace
-#endif

--- a/iceoryx_posh/source/capro/service_description.cpp
+++ b/iceoryx_posh/source/capro/service_description.cpp
@@ -70,8 +70,8 @@ bool ServiceDescription::ClassHash::operator!=(const ClassHash& rhs) const noexc
 
 ServiceDescription::ServiceDescription(const cxx::Serialization& f_serial) noexcept
 {
-    std::underlying_type<Scope>::type scope;
-    std::underlying_type<Interfaces>::type interfaceSource;
+    std::underlying_type<Scope>::type scope = 0;
+    std::underlying_type<Interfaces>::type interfaceSource = 0;
     f_serial.extract(m_serviceString,
                      m_instanceString,
                      m_eventString,

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -162,8 +162,7 @@ bool IpcInterfaceBase::openIpcChannel(const posix::IpcChannelSide channelSide) n
         [this](auto) { LogWarn() << "unable to destroy previous ipc channel " << m_runtimeName; });
 
     m_channelSide = channelSide;
-    IpcChannelType::create(
-        m_runtimeName, posix::IpcChannelMode::BLOCKING, m_channelSide, m_maxMessageSize, m_maxMessages)
+    IpcChannelType::create(m_runtimeName, m_channelSide, m_maxMessageSize, m_maxMessages)
         .and_then([this](auto& ipcChannel) { this->m_ipcChannel = std::move(ipcChannel); });
 
     return m_ipcChannel.isInitialized();

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -101,7 +101,7 @@ class CMqInterfaceStartupRace_test : public Test
 
         if (m_appQueue.has_error())
         {
-            m_appQueue = IpcChannelType::create(MqAppName, IpcChannelMode::BLOCKING, IpcChannelSide::CLIENT);
+            m_appQueue = IpcChannelType::create(MqAppName, IpcChannelSide::CLIENT);
         }
         ASSERT_THAT(m_appQueue.has_error(), false);
 
@@ -111,7 +111,7 @@ class CMqInterfaceStartupRace_test : public Test
     /// @note smart_lock in combination with optional is currently not really usable
     std::mutex m_roudiQueueMutex;
     IpcChannelType::result_t m_roudiQueue{
-        IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER)};
+        IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER)};
     std::mutex m_appQueueMutex;
     IpcChannelType::result_t m_appQueue;
 };
@@ -140,8 +140,7 @@ TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMq)
             exit(EXIT_FAILURE);
         });
 
-        auto m_roudiQueue2 =
-            IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER);
+        auto m_roudiQueue2 = IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER);
 
         // check if the app retries to register at RouDi
         request = m_roudiQueue2->timedReceive(15_s);
@@ -187,8 +186,7 @@ TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMqWithFullMq)
             exit(EXIT_FAILURE);
         });
 
-        auto newRoudi =
-            IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelMode::BLOCKING, IpcChannelSide::SERVER);
+        auto newRoudi = IpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER);
 
         // check if the app retries to register at RouDi
         auto request = newRoudi->timedReceive(15_s);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md

## Notes for Reviewer
This PR introduces unit tests for the unix domain sockets and abstracted the posix calls further. All socket related calls have an `iox_` prefix, this was required since in windows some calls cannot be mapped one to one.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #33 
