### PR TITLE
Add "Check Formatting" github workflows

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,13 @@
+name: Check Formatting
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, release* ]
+
+jobs:
+  check-formatting:
+     runs-on: ubuntu-20.04
+     steps:
+       - uses: actions/checkout@v2
+       - run: ./tools/check_formatting.sh

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.hpp
@@ -56,7 +56,7 @@ class static_storage
     static_storage(static_storage&&) = delete;
     static_storage& operator=(static_storage&&) = delete;
 
-    /// @brief check whether the type T will fit in the buffer 
+    /// @brief check whether the type T will fit in the buffer
     /// @return true if the type fits in the buffer, false otherwise
     /// @note can be checked at compile time
     template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
@@ -216,8 +216,8 @@ inline typename internal::get_type_at_index<0, TypeIndex, Types...>::type* varia
 
 template <typename... Types>
 template <uint64_t TypeIndex>
-inline const typename internal::get_type_at_index<0, TypeIndex, Types...>::type* variant<Types...>::get_at_index() const
-    noexcept
+inline const typename internal::get_type_at_index<0, TypeIndex, Types...>::type*
+variant<Types...>::get_at_index() const noexcept
 {
     using T = typename internal::get_type_at_index<0, TypeIndex, Types...>::type;
     return const_cast<const T*>(const_cast<variant*>(this)->template get_at_index<TypeIndex>());

--- a/iceoryx_hoofs/test/moduletests/test_static_storage.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_static_storage.cpp
@@ -55,7 +55,6 @@ struct alignas(Align) Bytes
 
 namespace
 {
-
 TEST(static_storage_test, CapacityIsConsistent)
 {
     constexpr uint64_t CAPACITY = 16;

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -127,8 +127,8 @@ GatewayGeneric<channel_t, gateway_t>::findChannel(const iox::capro::ServiceDescr
 }
 
 template <typename channel_t, typename gateway_t>
-inline void GatewayGeneric<channel_t, gateway_t>::forEachChannel(const cxx::function_ref<void(channel_t&)> f) const
-    noexcept
+inline void
+GatewayGeneric<channel_t, gateway_t>::forEachChannel(const cxx::function_ref<void(channel_t&)> f) const noexcept
 {
     auto guardedVector = m_channels.getScopeGuard();
     for (auto channel = guardedVector->begin(); channel != guardedVector->end(); ++channel)

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
@@ -136,8 +136,8 @@ class PortManager
     void removeEntryFromServiceRegistry(const capro::IdString_t& service, const capro::IdString_t& instance) noexcept;
 
     template <typename T, std::enable_if_t<std::is_same<T, iox::build::OneToManyPolicy>::value>* = nullptr>
-    cxx::optional<RuntimeName_t> doesViolateCommunicationPolicy(const capro::ServiceDescription& service) const
-        noexcept;
+    cxx::optional<RuntimeName_t>
+    doesViolateCommunicationPolicy(const capro::ServiceDescription& service) const noexcept;
 
     template <typename T, std::enable_if_t<std::is_same<T, iox::build::ManyToManyPolicy>::value>* = nullptr>
     cxx::optional<RuntimeName_t>

--- a/iceoryx_posh/source/capro/service_description.cpp
+++ b/iceoryx_posh/source/capro/service_description.cpp
@@ -40,15 +40,14 @@ ServiceDescription::ClassHash::ClassHash(const std::initializer_list<uint32_t>& 
     }
 }
 
-uint32_t& ServiceDescription::ClassHash::operator[](
-    iox::cxx::range<uint64_t, 0U, CLASS_HASH_ELEMENT_COUNT - 1> index) noexcept
+uint32_t&
+ServiceDescription::ClassHash::operator[](iox::cxx::range<uint64_t, 0U, CLASS_HASH_ELEMENT_COUNT - 1> index) noexcept
 {
     return data[index];
 }
 
-const uint32_t&
-    ServiceDescription::ClassHash::operator[](iox::cxx::range<uint64_t, 0U, CLASS_HASH_ELEMENT_COUNT - 1> index) const
-    noexcept
+const uint32_t& ServiceDescription::ClassHash::operator[](
+    iox::cxx::range<uint64_t, 0U, CLASS_HASH_ELEMENT_COUNT - 1> index) const noexcept
 {
     return data[index];
 }

--- a/tools/check_formatting.sh
+++ b/tools/check_formatting.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+fail() {
+    printf "\033[1;31merror: %s: %s\033[0m\n" ${FUNCNAME[1]} "${1:-"Unknown error"}"
+    exit 1
+}
+
+# check clang-format
+hash clang-format || fail "clang-format not found"
+CLANG_MAJOR_VERSION=$(clang-format --version | awk '{print $(NF)}' | sed 's/\..*$//')
+[[ $CLANG_MAJOR_VERSION -ge "10" ]] || fail "clang-format of version 10 or higher is not installed."
+
+cd $(git rev-parse --show-toplevel)
+
+# format files
+git ls-files | grep -E "\.(c|cpp|inl|h|hpp)$" | xargs clang-format -i -style=file
+
+# check incorrectly formatted fails and fail
+git diff-index --name-only --exit-code HEAD --


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
