### PR TITLE
iox-#903 timed{send,receive} supported in mac os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Features:**
 
+- Enhance MacOS performance with timed{send,receive} functionality in unix domain socket[\#903](https://github.com/eclipse-iceoryx/iceoryx/issues/903)
 - Enhance posixCall[\#805](https://github.com/eclipse-iceoryx/iceoryx/issues/805)
 - New chunk available callback for the new C++[\#391](https://github.com/eclipse-iceoryx/iceoryx/issues/391)
 - Git Hooks on iceoryx[\#486](https://github.com/eclipse-iceoryx/iceoryx/issues/486)

--- a/iceoryx_hoofs/platform/mac/source/socket.cpp
+++ b/iceoryx_hoofs/platform/mac/source/socket.cpp
@@ -17,6 +17,24 @@
 #include "iceoryx_hoofs/platform/socket.hpp"
 #include <unistd.h>
 
+#include <thread>
+
+static struct timeval getTimeoutOfSocket(int sockfd, int option_name)
+{
+    struct timeval tv;
+    socklen_t optionLength = sizeof(struct timeval);
+    if (getsockopt(sockfd, SOL_SOCKET, option_name, &tv, &optionLength) == -1)
+    {
+        return {0, 0};
+    }
+    return tv;
+}
+
+static void sleepFor(struct timeval& tv)
+{
+    std::this_thread::sleep_for(std::chrono::seconds(tv.tv_sec) + std::chrono::microseconds(tv.tv_usec));
+}
+
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
 {
     return bind(sockfd, addr, addrlen);
@@ -35,12 +53,26 @@ int iox_setsockopt(int sockfd, int level, int optname, const void* optval, sockl
 ssize_t
 iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
 {
-    return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+    auto timeout = getTimeoutOfSocket(sockfd, SO_SNDTIMEO);
+    ssize_t sentBytes = sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+    if (sentBytes <= 0 && timeout.tv_sec != 0 && timeout.tv_usec != 0)
+    {
+        sleepFor(timeout);
+        return sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+    }
+    return sentBytes;
 }
 
 ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
 {
-    return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+    auto timeout = getTimeoutOfSocket(sockfd, SO_RCVTIMEO);
+    ssize_t receivedBytes = recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+    if (receivedBytes <= 0 && timeout.tv_sec != 0 && timeout.tv_usec != 0)
+    {
+        sleepFor(timeout);
+        return recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+    }
+    return receivedBytes;
 }
 
 int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen)

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -232,16 +232,6 @@ cxx::expected<IpcChannelError> UnixDomainSocket::timedSend(const std::string& ms
     }
 
     struct timeval tv = timeout;
-#if defined(__APPLE__)
-    if (tv.tv_sec != 0 || tv.tv_usec != 0)
-    {
-        std::cerr
-            << "socket: \"" << m_name
-            << "\", timedSend with a timeout != 0 is not supported on MacOS. timedSend will behave like send instead."
-            << std::endl;
-    }
-#endif
-
     auto setsockoptCall = posixCall(iox_setsockopt)(m_sockfd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv))
                               .failureReturnValue(ERROR_CODE)
                               .ignoreErrnos(EWOULDBLOCK)
@@ -289,17 +279,6 @@ UnixDomainSocket::timedReceive(const units::Duration& timeout) const noexcept
     }
 
     struct timeval tv = timeout;
-#if defined(__APPLE__)
-    if (tv.tv_sec != 0 || tv.tv_usec != 0)
-    {
-        std::cerr
-            << "socket: \"" << m_name
-            << "\", timedReceive with a timeout != 0 is not supported on MacOS. timedReceive will behave like receive "
-               "instead."
-            << std::endl;
-    }
-#endif
-
     auto setsockoptCall = posixCall(iox_setsockopt)(m_sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv))
                               .failureReturnValue(ERROR_CODE)
                               .ignoreErrnos(EWOULDBLOCK)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #903 
