### PR TITLE
iox-#282 Fix deprecated-copy warning

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
@@ -56,7 +56,7 @@ namespace cxx
 ///             using ThisType::operator=;  // put the assignment operators in scope
 ///
 ///             // implement ctors and assignment operators when they are implemented by the base class
-///             // this is necessary pro prevent warnings from specific compilers
+///             // this is necessary to prevent warnings from some compilers
 ///             Index() noexcept = default;
 ///             Index(const Index&) noexcept = default;
 ///             Index(Index&&) noexcept = default;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
@@ -54,6 +54,14 @@ namespace cxx
 ///         //                 otherwise the code will not compile
 ///             using ThisType::ThisType;   // this makes all constructors of NewType available for Index
 ///             using ThisType::operator=;  // put the assignment operators in scope
+///
+///             // implement ctors and assignment operators when they are implemented by the base class
+///             // this is necessary pro prevent warnings from specific compilers
+///             Index() noexcept = default;
+///             Index(const Index&) noexcept = default;
+///             Index(Index&&) noexcept = default;
+///             Index& operator=(const Index&) noexcept = default;
+///             Index& operator=(Index&&) noexcept = default;
 ///     };
 ///
 ///     Index a(123), c(456);   // allowed since we are using the policy ConstructByValueCopy

--- a/iceoryx_hoofs/test/moduletests/test_cxx_newtype.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_newtype.cpp
@@ -30,6 +30,14 @@ struct Sut : public T
 {
     using T::T;
     using T::operator=; // bring all operator= into scope
+
+    // implement ctors and assignment operators when they are implemented by the base class
+    // this is necessary pro prevent warnings from specific compilers
+    Sut() noexcept = default;
+    Sut(const Sut&) noexcept = default;
+    Sut(Sut&&) noexcept = default;
+    Sut& operator=(const Sut&) noexcept = default;
+    Sut& operator=(Sut&&) noexcept = default;
 };
 
 static CompileTest compileTest(R"(
@@ -89,19 +97,8 @@ TEST(NewType, CopyAssignableDoesCompile)
     Sut<cxx::NewType<int, newtype::ConstructByValueCopy, newtype::CopyAssignable, newtype::Comparable>> a(491), b(492),
         c(423);
 
-    // Ignore false positive
-    // See: https://isocpp.org/wiki/faq/strange-inheritance#hiding-rule
-
-#if (__GNUC__ == 9 && (__GNUC_MINOR__ > 1 || (__GNUC_MINOR__ == 1 && __GNUC_PATCHLEVEL__ > 0)))
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-copy"
     b = a;
-#pragma GCC diagnostic pop
     EXPECT_TRUE(a == b);
-#else
-    // Test disabled.
-#endif
 }
 
 TEST(NewType, MoveConstructableDoesCompile)

--- a/iceoryx_hoofs/test/moduletests/test_cxx_newtype.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_newtype.cpp
@@ -32,7 +32,7 @@ struct Sut : public T
     using T::operator=; // bring all operator= into scope
 
     // implement ctors and assignment operators when they are implemented by the base class
-    // this is necessary pro prevent warnings from specific compilers
+    // this is necessary to prevent warnings from some compilers
     Sut() noexcept = default;
     Sut(const Sut&) noexcept = default;
     Sut(Sut&&) noexcept = default;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This removes the suppression of the `deprecated-copy` warning and add a proper fix

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #282
