### PR TITLE
Iox #930 add c binding for posh settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Features:**
 
+- C binding for posh configuration [\#930](https://github.com/eclipse-iceoryx/iceoryx/issues/930)
 - Enhance MacOS performance with timed{send,receive} functionality in unix domain socket[\#903](https://github.com/eclipse-iceoryx/iceoryx/issues/903)
 - Multi-Publisher support for DDS gateway and generic gateway class [\#900](https://github.com/eclipse-iceoryx/iceoryx/issues/900)
 - Replace `iox-gw-iceoryx2dds` and `iox-gw-dds2iceoryx` gateways with `iox-dds-gateway` [\#900](https://github.com/eclipse-iceoryx/iceoryx/issues/900)

--- a/iceoryx_binding_c/CMakeLists.txt
+++ b/iceoryx_binding_c/CMakeLists.txt
@@ -55,6 +55,7 @@ set(${PROJECT_NAME}_DIR ${CMAKE_CURRENT_LIST_DIR}/cmake
 ########## build building-block library ##########
 #
 add_library(${PROJECT_NAME}
+    source/c_config.cpp
     source/c_notification_info.cpp
     source/c_listener.cpp
     source/c_node.cpp

--- a/iceoryx_binding_c/include/iceoryx_binding_c/config.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/config.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_BINDING_C_CONFIG_H
+#define IOX_BINDING_C_CONFIG_H
+
+#include <stdint.h>
+
+uint32_t iox_cfg_max_publishers();
+uint32_t iox_cfg_max_subscribers_per_publisher();
+uint32_t iox_cfg_max_chunks_allocated_per_publisher_simultaneously();
+uint64_t iox_cfg_max_publisher_history();
+
+uint32_t iox_cfg_max_subscribers();
+uint32_t iox_cfg_max_chunks_held_per_subscriber_simultaneously();
+uint32_t iox_cfg_max_subscriber_queue_capacity();
+
+uint32_t iox_cfg_max_number_of_condition_variables();
+uint32_t iox_cfg_max_number_of_notifiers_per_condition_variable();
+uint32_t iox_cfg_max_number_of_attachments_per_waitset();
+uint32_t iox_cfg_max_number_of_events_per_listener();
+
+uint32_t iox_cfg_max_number_of_mempools();
+uint32_t iox_cfg_max_shm_segments();
+uint32_t iox_cfg_max_number_of_memory_provider();
+uint32_t iox_cfg_max_number_of_memory_blocks_per_memory_provider();
+
+uint32_t iox_cfg_chunk_default_user_payload_alignment();
+uint32_t iox_cfg_no_user_header_size();
+uint32_t iox_cfg_no_user_header_alignment();
+
+uint32_t iox_cfg_max_process_number();
+uint32_t iox_cfg_max_number_of_services();
+uint32_t iox_cfg_max_runtime_name_length();
+
+
+#endif

--- a/iceoryx_binding_c/include/iceoryx_binding_c/config.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/config.h
@@ -29,7 +29,7 @@ uint32_t iox_cfg_max_subscribers_per_publisher();
 uint32_t iox_cfg_max_chunks_allocated_per_publisher_simultaneously();
 
 /// @brief returns maximum history size for a publisher (e.g. samples which are hold back so
-//         that new subscribers can acquire a history)
+//         that new subscribers can acquire past data)
 uint64_t iox_cfg_max_publisher_history();
 
 /// @brief returns maximum supported amount of subscribers
@@ -42,7 +42,7 @@ uint32_t iox_cfg_max_chunks_held_per_subscriber_simultaneously();
 /// subscriber if the queue capacity is reached new samples will discard old samples
 uint32_t iox_cfg_max_subscriber_queue_capacity();
 
-/// @brief returns the maximum supported amount of condition variables. this determines how many listeners and waitset
+/// @brief returns the maximum supported amount of condition variables. this determines how many listeners and waitsets
 /// can be used in one iceoryx system
 uint32_t iox_cfg_max_number_of_condition_variables();
 
@@ -50,12 +50,12 @@ uint32_t iox_cfg_max_number_of_condition_variables();
 /// attachments a listener or waitset can have
 uint32_t iox_cfg_max_number_of_notifiers_per_condition_variable();
 
-/// @brief returns the maximum amount of attachments per waitset, is less or equal to
-/// iox_cfg_max_number_of_notifiers_per_condition_variable
+/// @brief returns the maximum amount of attachments per waitset
+/// @note is less or equal to iox_cfg_max_number_of_notifiers_per_condition_variable
 uint32_t iox_cfg_max_number_of_attachments_per_waitset();
 
-/// @brief returns the maximum amount of evens per listener, is less or equal to
-/// iox_cfg_max_number_of_notifiers_per_condition_variable
+/// @brief returns the maximum amount of evens per listener
+/// @note is less or equal to iox_cfg_max_number_of_notifiers_per_condition_variable
 uint32_t iox_cfg_max_number_of_events_per_listener();
 
 /// @brief returns the maximum amount of mempools for roudi. restricts also the number of mempools in the roudi config
@@ -66,7 +66,7 @@ uint32_t iox_cfg_max_number_of_mempools();
 /// the roudi config file
 uint32_t iox_cfg_max_shm_segments();
 
-/// @brief returns the maximum supported amount of shared memory provider
+/// @brief returns the maximum supported amount of shared memory providers
 uint32_t iox_cfg_max_number_of_memory_provider();
 
 /// @brief returns the maximum supported amount of memory blocks per shared memory provider
@@ -91,5 +91,4 @@ uint32_t iox_cfg_max_number_of_services();
 /// @brief returns the maximum runtime name length
 uint32_t iox_cfg_max_runtime_name_length();
 
-
-#endif
+#endif // IOX_BINDING_C_CONFIG_H

--- a/iceoryx_binding_c/include/iceoryx_binding_c/config.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/config.h
@@ -19,31 +19,76 @@
 
 #include <stdint.h>
 
+/// @brief returns maximum supported amount of publishers
 uint32_t iox_cfg_max_publishers();
+
+/// @brief returns maximum amount of subscribers which can be subscribed to one publisher
 uint32_t iox_cfg_max_subscribers_per_publisher();
+
+/// @brief returns maximum amount of samples a publisher can acquire at the same time with loan
 uint32_t iox_cfg_max_chunks_allocated_per_publisher_simultaneously();
+
+/// @brief returns maximum history size for a publisher (e.g. samples which are hold back so
+//         that new subscribers can acquire a history)
 uint64_t iox_cfg_max_publisher_history();
 
+/// @brief returns maximum supported amount of subscribers
 uint32_t iox_cfg_max_subscribers();
+
+/// @brief returns the maximum amount of samples which a subscriber can hold without releasing them
 uint32_t iox_cfg_max_chunks_held_per_subscriber_simultaneously();
+
+/// @brief returns the maximum subscriber queue capacity which is used when the publisher delivers samples to the
+/// subscriber if the queue capacity is reached new samples will discard old samples
 uint32_t iox_cfg_max_subscriber_queue_capacity();
 
+/// @brief returns the maximum supported amount of condition variables. this determines how many listeners and waitset
+/// can be used in one iceoryx system
 uint32_t iox_cfg_max_number_of_condition_variables();
+
+/// @brief returns the maximum supported amount of notifiers per condition variable. this determines how many
+/// attachments a listener or waitset can have
 uint32_t iox_cfg_max_number_of_notifiers_per_condition_variable();
+
+/// @brief returns the maximum amount of attachments per waitset, is less or equal to
+/// iox_cfg_max_number_of_notifiers_per_condition_variable
 uint32_t iox_cfg_max_number_of_attachments_per_waitset();
+
+/// @brief returns the maximum amount of evens per listener, is less or equal to
+/// iox_cfg_max_number_of_notifiers_per_condition_variable
 uint32_t iox_cfg_max_number_of_events_per_listener();
 
+/// @brief returns the maximum amount of mempools for roudi. restricts also the number of mempools in the roudi config
+/// file
 uint32_t iox_cfg_max_number_of_mempools();
+
+/// @brief returns the maximum number of shared memory segments. restricts also the number of configurable segments in
+/// the roudi config file
 uint32_t iox_cfg_max_shm_segments();
+
+/// @brief returns the maximum supported amount of shared memory provider
 uint32_t iox_cfg_max_number_of_memory_provider();
+
+/// @brief returns the maximum supported amount of memory blocks per shared memory provider
 uint32_t iox_cfg_max_number_of_memory_blocks_per_memory_provider();
 
+/// @brief returns the alignment of the user payload when it is not set explicitly
 uint32_t iox_cfg_chunk_default_user_payload_alignment();
+
+/// @brief returns the size of the user header when no user header is requested by the user
 uint32_t iox_cfg_no_user_header_size();
+
+/// @brief returns the alignment of the user header when no user header is requested by the user
 uint32_t iox_cfg_no_user_header_alignment();
 
+/// @brief returns the maximum supported amount of processes which can register at roudi by initializing the posh
+/// runtime
 uint32_t iox_cfg_max_process_number();
+
+/// @brief returns the maximum supported amount of services
 uint32_t iox_cfg_max_number_of_services();
+
+/// @brief returns the maximum runtime name length
 uint32_t iox_cfg_max_runtime_name_length();
 
 

--- a/iceoryx_binding_c/source/c_config.cpp
+++ b/iceoryx_binding_c/source/c_config.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
+
+extern "C" {
+#include "iceoryx_binding_c/config.h"
+}
+
+uint32_t iox_cfg_max_publishers()
+{
+    return iox::MAX_PUBLISHERS;
+}
+
+uint32_t iox_cfg_max_subscribers_per_publisher()
+{
+    return iox::MAX_SUBSCRIBERS_PER_PUBLISHER;
+}
+
+uint32_t iox_cfg_max_chunks_allocated_per_publisher_simultaneously()
+{
+    return iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY;
+}
+
+uint64_t iox_cfg_max_publisher_history()
+{
+    return iox::MAX_PUBLISHER_HISTORY;
+}
+
+uint32_t iox_cfg_max_subscribers()
+{
+    return iox::MAX_SUBSCRIBERS;
+}
+
+uint32_t iox_cfg_max_chunks_held_per_subscriber_simultaneously()
+{
+    return iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY;
+}
+
+uint32_t iox_cfg_max_subscriber_queue_capacity()
+{
+    return iox::MAX_SUBSCRIBER_QUEUE_CAPACITY;
+}
+
+uint32_t iox_cfg_max_number_of_condition_variables()
+{
+    return iox::MAX_NUMBER_OF_CONDITION_VARIABLES;
+}
+
+uint32_t iox_cfg_max_number_of_notifiers_per_condition_variable()
+{
+    return iox::MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE;
+}
+
+uint32_t iox_cfg_max_number_of_attachments_per_waitset()
+{
+    return iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET;
+}
+
+uint32_t iox_cfg_max_number_of_events_per_listener()
+{
+    return iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER;
+}
+
+uint32_t iox_cfg_max_number_of_mempools()
+{
+    return iox::MAX_NUMBER_OF_MEMPOOLS;
+}
+
+uint32_t iox_cfg_max_shm_segments()
+{
+    return iox::MAX_SHM_SEGMENTS;
+}
+
+uint32_t iox_cfg_max_number_of_memory_provider()
+{
+    return iox::MAX_NUMBER_OF_MEMORY_PROVIDER;
+}
+
+uint32_t iox_cfg_max_number_of_memory_blocks_per_memory_provider()
+{
+    return iox::MAX_NUMBER_OF_MEMORY_BLOCKS_PER_MEMORY_PROVIDER;
+}
+
+uint32_t iox_cfg_chunk_default_user_payload_alignment()
+{
+    return iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT;
+}
+
+uint32_t iox_cfg_no_user_header_size()
+{
+    return iox::CHUNK_NO_USER_HEADER_SIZE;
+}
+
+uint32_t iox_cfg_no_user_header_alignment()
+{
+    return iox::CHUNK_NO_USER_HEADER_ALIGNMENT;
+}
+
+uint32_t iox_cfg_max_process_number()
+{
+    return iox::MAX_PROCESS_NUMBER;
+}
+
+uint32_t iox_cfg_max_number_of_services()
+{
+    return iox::MAX_NUMBER_OF_SERVICES;
+}
+
+uint32_t iox_cfg_max_runtime_name_length()
+{
+    return iox::MAX_RUNTIME_NAME_LENGTH;
+}
+

--- a/iceoryx_binding_c/source/c_config.cpp
+++ b/iceoryx_binding_c/source/c_config.cpp
@@ -124,4 +124,3 @@ uint32_t iox_cfg_max_runtime_name_length()
 {
     return iox::MAX_RUNTIME_NAME_LENGTH;
 }
-

--- a/iceoryx_binding_c/test/moduletests/test_config.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_config.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+extern "C" {
+#include "iceoryx_binding_c/config.h"
+}
+
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
+
+#include "test.hpp"
+
+namespace
+{
+using namespace iox;
+
+TEST(iox_cfg, valuesAreCorrectlyConnected)
+{
+    EXPECT_EQ(iox_cfg_max_publishers(), iox::MAX_PUBLISHERS);
+    EXPECT_EQ(iox_cfg_max_subscribers_per_publisher(), iox::MAX_SUBSCRIBERS_PER_PUBLISHER);
+    EXPECT_EQ(iox_cfg_max_chunks_allocated_per_publisher_simultaneously(),
+              iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY);
+    EXPECT_EQ(iox_cfg_max_publisher_history(), iox::MAX_PUBLISHER_HISTORY);
+    EXPECT_EQ(iox_cfg_max_subscribers(), iox::MAX_SUBSCRIBERS);
+    EXPECT_EQ(iox_cfg_max_chunks_held_per_subscriber_simultaneously(),
+              iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY);
+    EXPECT_EQ(iox_cfg_max_subscriber_queue_capacity(), iox::MAX_SUBSCRIBER_QUEUE_CAPACITY);
+    EXPECT_EQ(iox_cfg_max_number_of_condition_variables(), iox::MAX_NUMBER_OF_CONDITION_VARIABLES);
+    EXPECT_EQ(iox_cfg_max_number_of_notifiers_per_condition_variable(),
+              iox::MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE);
+    EXPECT_EQ(iox_cfg_max_number_of_attachments_per_waitset(), iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET);
+    EXPECT_EQ(iox_cfg_max_number_of_events_per_listener(), iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER);
+    EXPECT_EQ(iox_cfg_max_number_of_mempools(), iox::MAX_NUMBER_OF_MEMPOOLS);
+    EXPECT_EQ(iox_cfg_max_shm_segments(), iox::MAX_SHM_SEGMENTS);
+    EXPECT_EQ(iox_cfg_max_number_of_memory_provider(), iox::MAX_NUMBER_OF_MEMORY_PROVIDER);
+    EXPECT_EQ(iox_cfg_max_number_of_memory_blocks_per_memory_provider(),
+              iox::MAX_NUMBER_OF_MEMORY_BLOCKS_PER_MEMORY_PROVIDER);
+    EXPECT_EQ(iox_cfg_chunk_default_user_payload_alignment(), iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
+    EXPECT_EQ(iox_cfg_no_user_header_size(), iox::CHUNK_NO_USER_HEADER_SIZE);
+    EXPECT_EQ(iox_cfg_no_user_header_alignment(), iox::CHUNK_NO_USER_HEADER_ALIGNMENT);
+    EXPECT_EQ(iox_cfg_max_process_number(), iox::MAX_PROCESS_NUMBER);
+    EXPECT_EQ(iox_cfg_max_number_of_services(), iox::MAX_NUMBER_OF_SERVICES);
+    EXPECT_EQ(iox_cfg_max_runtime_name_length(), iox::MAX_RUNTIME_NAME_LENGTH);
+}
+} // namespace

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -55,9 +55,6 @@ using UniquePortId = popo::TypedUniqueId<popo::BasePortData>;
 
 using SubscriberPortType = iox::build::CommunicationPolicy;
 
-/// @todo remove MAX_RECEIVERS_PER_SENDERPORT when the new port building blocks are used
-constexpr uint32_t MAX_RECEIVERS_PER_SENDERPORT = build::IOX_MAX_SUBSCRIBERS_PER_PUBLISHER;
-
 //--------- Communication Resources Start---------------------
 // Publisher
 constexpr uint32_t MAX_PUBLISHERS = build::IOX_MAX_PUBLISHERS;
@@ -107,7 +104,6 @@ constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 128U;
 static_assert(MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The WaitSet capacity is restricted by the maximum amount of notifiers per condition variable.");
 // Listener
-constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 128U;
 constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 128U;
 static_assert(MAX_NUMBER_OF_EVENTS_PER_LISTENER <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The Listener capacity is restricted by the maximum amount of notifiers per condition variable.");


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #930 
