### PR TITLE
Iox #932 handle nullptr callbacks in waitset

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,12 +56,23 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./tools/ci/run-integration-test.sh
 
-  build-test-ubuntu-with-sanitizers:
+  build-test-ubuntu-with-sanitizers-gcc:
+    runs-on: ubuntu-20.04
+    needs: pre-flight-check
+    steps:
+      - uses: egor-tensin/setup-gcc@v1
+        with:
+          version: latest
+          platform: x64
+      - uses: actions/checkout@v2
+      - run: ./tools/ci/build-test-ubuntu-with-sanitizers.sh gcc
+
+  build-test-ubuntu-with-sanitizers-clang:
     runs-on: ubuntu-20.04
     needs: pre-flight-check
     steps:
       - uses: actions/checkout@v2
-      - run: ./tools/ci/build-test-ubuntu-with-sanitizers.sh
+      - run: ./tools/ci/build-test-ubuntu-with-sanitizers.sh clang
 
   build-test-macos-with-sanitizers:
     runs-on: macos-latest
@@ -72,12 +83,23 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./tools/ci/build-test-macos-with-sanitizers.sh
 
-  build-test-ubuntu-with-latest-clang:
+  build-ubuntu-with-latest-clang-release:
     runs-on: ubuntu-latest
     needs: pre-flight-check
     steps:
       - uses: actions/checkout@v2
-      - run: ./tools/ci/build-test-ubuntu-with-latest-clang.sh
+      - run: ./tools/ci/build-ubuntu-with-latest-clang-gcc.sh clang
+
+  build-ubuntu-with-latest-gcc-release:
+    runs-on: ubuntu-latest
+    needs: pre-flight-check
+    steps:
+      - uses: egor-tensin/setup-gcc@v1
+        with:
+          version: latest
+          platform: x64
+      - uses: actions/checkout@v2
+      - run: ./tools/ci/build-ubuntu-with-latest-clang-gcc.sh gcc
 
   # gcc 5.4 is compiler used in QNX 7.0
   build-test-ubuntu-with-gcc54:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 **Refactoring:**
 
+- Handle nullptr callbacks in waitset and listener[\#932](https://github.com/eclipse-iceoryx/iceoryx/issues/932)
 - Add clang-tidy rules for iceoryx_hoofs[\#889](https://github.com/eclipse-iceoryx/iceoryx/issues/889)
 - Move all tests into an anonymous namespace[\#563](https://github.com/eclipse-iceoryx/iceoryx/issues/563)
 - Refactor smart_c to use contract by design and expected[\#418](https://github.com/eclipse-iceoryx/iceoryx/issues/418)

--- a/iceoryx_binding_c/source/c_wait_set.cpp
+++ b/iceoryx_binding_c/source/c_wait_set.cpp
@@ -114,8 +114,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_state(iox_ws_t const self,
                                                  const uint64_t eventId,
                                                  void (*callback)(iox_sub_t))
 {
-    auto result = self->attachState(
-        *subscriber, c2cpp::subscriberState(subscriberState), eventId, createNotificationCallback(*callback));
+    auto result = self->attachState(*subscriber, c2cpp::subscriberState(subscriberState), eventId, {callback, nullptr});
     return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
@@ -141,8 +140,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_event(iox_ws_t const self,
                                                  const uint64_t eventId,
                                                  void (*callback)(iox_sub_t))
 {
-    auto result = self->attachEvent(
-        *subscriber, c2cpp::subscriberEvent(subscriberEvent), eventId, createNotificationCallback(*callback));
+    auto result = self->attachEvent(*subscriber, c2cpp::subscriberEvent(subscriberEvent), eventId, {callback, nullptr});
     return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
@@ -167,7 +165,7 @@ iox_WaitSetResult iox_ws_attach_user_trigger_event(iox_ws_t const self,
                                                    const uint64_t eventId,
                                                    void (*callback)(iox_user_trigger_t))
 {
-    auto result = self->attachEvent(*userTrigger, eventId, createNotificationCallback(*callback));
+    auto result = self->attachEvent(*userTrigger, eventId, {callback, nullptr});
     return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -91,6 +91,9 @@ class iox_notification_info_test : public Test
         return m_memoryManager.getChunk(chunkSettings);
     }
 
+    static void triggerCallback(iox_sub_t sub IOX_MAYBE_UNUSED)
+    {
+    }
 
     static UserTrigger* m_lastNotificationCallbackArgument;
     ConditionVariableData m_condVar{"myApp"};
@@ -142,7 +145,7 @@ TEST_F(iox_notification_info_test, notificationOriginIsUserTriggerPointerWhenIts
 
 TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsOriginatingFromThemStateBased)
 {
-    iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, NULL);
+    iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -154,7 +157,8 @@ TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsO
 
 TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsOriginatingFromThemEventBased)
 {
-    iox_ws_attach_subscriber_event(&m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, NULL);
+    iox_ws_attach_subscriber_event(
+        &m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -178,7 +182,7 @@ TEST_F(iox_notification_info_test, getOriginReturnsPointerToUserTriggerWhenOrigi
 
 TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOriginatingFromThemStateBased)
 {
-    iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, NULL);
+    iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -190,7 +194,8 @@ TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOrigin
 
 TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOriginatingFromThemEventBased)
 {
-    iox_ws_attach_subscriber_event(&m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, NULL);
+    iox_ws_attach_subscriber_event(
+        &m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -327,7 +327,7 @@ TEST_F(iox_sub_test, sendingTooMuchLeadsToOverflow)
 
 TEST_F(iox_sub_test, attachingToWaitSetWorks)
 {
-    EXPECT_EQ(iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, NULL),
+    EXPECT_EQ(iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback),
               WaitSetResult_SUCCESS);
     EXPECT_EQ(m_waitSet->size(), 1U);
 }
@@ -335,9 +335,9 @@ TEST_F(iox_sub_test, attachingToWaitSetWorks)
 TEST_F(iox_sub_test, attachingToAnotherWaitsetCleansupAtOriginalWaitset)
 {
     WaitSetMock m_waitSet2{m_condVar};
-    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, NULL);
+    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback);
 
-    EXPECT_EQ(iox_ws_attach_subscriber_state(&m_waitSet2, m_sut, SubscriberState_HAS_DATA, 0U, NULL),
+    EXPECT_EQ(iox_ws_attach_subscriber_state(&m_waitSet2, m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback),
               WaitSetResult_SUCCESS);
     EXPECT_EQ(m_waitSet->size(), 0U);
     EXPECT_EQ(m_waitSet2.size(), 1U);
@@ -345,14 +345,14 @@ TEST_F(iox_sub_test, attachingToAnotherWaitsetCleansupAtOriginalWaitset)
 
 TEST_F(iox_sub_test, detachingFromWaitSetWorks)
 {
-    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, NULL);
+    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback);
     iox_ws_detach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA);
     EXPECT_EQ(m_waitSet->size(), 0U);
 }
 
 TEST_F(iox_sub_test, hasDataTriggersWaitSetWithCorrectNotificationId)
 {
-    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 587U, NULL);
+    iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 

--- a/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
@@ -79,14 +79,14 @@ TEST_F(iox_user_trigger_test, cannotBeTriggeredWhenNotAttached)
 
 TEST_F(iox_user_trigger_test, canBeTriggeredWhenAttached)
 {
-    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, NULL);
+    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
     iox_user_trigger_trigger(m_sut);
     EXPECT_TRUE(iox_user_trigger_has_triggered(m_sut));
 }
 
 TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectNotificationId)
 {
-    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 88191U, NULL);
+    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 88191U, triggerCallback);
     iox_user_trigger_trigger(m_sut);
 
     auto eventVector = m_waitSet.wait();
@@ -111,9 +111,9 @@ TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectCallback)
 TEST_F(iox_user_trigger_test, attachingToAnotherWaitSetCleansupFirstWaitset)
 {
     WaitSetMock m_waitSet2{m_condVar};
-    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, NULL);
+    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
 
-    iox_ws_attach_user_trigger_event(&m_waitSet2, m_sut, 0U, NULL);
+    iox_ws_attach_user_trigger_event(&m_waitSet2, m_sut, 0U, triggerCallback);
 
     EXPECT_EQ(m_waitSet.size(), 0U);
     EXPECT_EQ(m_waitSet2.size(), 1U);
@@ -122,7 +122,7 @@ TEST_F(iox_user_trigger_test, attachingToAnotherWaitSetCleansupFirstWaitset)
 TEST_F(iox_user_trigger_test, disable_trigger_eventingItFromWaitsetCleansup)
 {
     WaitSetMock m_waitSet2{m_condVar};
-    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, NULL);
+    iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
 
     iox_ws_detach_user_trigger_event(&m_waitSet, m_sut);
 

--- a/tools/ci/build-test-ubuntu.sh
+++ b/tools/ci/build-test-ubuntu.sh
@@ -48,4 +48,4 @@ cd ./build
 cd -
 
 msg "building roudi examples without toml support"
-./tools/iceoryx_build_test.sh out-of-tree examples toml-config-off clean
+./tools/iceoryx_build_test.sh relwithdebinfo out-of-tree examples toml-config-off clean


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #932 
