### PR TITLE
iox-#946 Add docker memory issue to faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Get to know the upcoming features and the project scope in [PLANNED_FEATURES.md]
 | [iceoryx-rs](https://github.com/eclipse-iceoryx/iceoryx-rs) | Experimental Rust wrapper for iceoryx | Rust |
 | [IceRay](https://github.com/elBoberido/iceray) | An iceoryx introspection client written in Rust | Rust |
 
+## Frequently Asked Questions (FAQ)
+
+[FAQ.md](./doc/website/FAQ.md)
+
 ## Governance & maintainers
 
 Please have a look at the [GOVERNANCE.md](./GOVERNANCE.md).

--- a/doc/website/FAQ.md
+++ b/doc/website/FAQ.md
@@ -2,12 +2,56 @@
 
 In this document are tips and hints documented which can help for troubleshooting on RouDi.
 
-## Available memory is insufficient
+## Does iceoryx run in a docker environment
 
-If you got this message, RouDi was not able to reserve shared memory caused by insufficient capacity.
-To avoid that you need to check how much shared memory your system offers. For example, on Ubuntu you can do that with
+Yes. Take a look at the [icedocker example](https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_examples/icedelivery)
 
-    df -H /dev/shm
+## iox-roudi fails on startup
+
+An error message like
+
+```
+user@iceoryx-host:/# iox-roudi
+Log level set to: [Warning]
+SharedMemory still there, doing an unlink of /iceoryx_mgmt
+Reserving 59736448 bytes in the shared memory [/iceoryx_mgmt]
+[ Reserving shared memory successful ]
+SharedMemory still there, doing an unlink of /root
+Reserving 27902400 bytes in the shared memory [/root]
+While setting the acquired shared memory to zero a fatal SIGBUS signal appeared
+caused by memset. The shared memory object with the following properties
+[ name = /root, sizeInBytes = 27902400, access mode = AccessMode::READ_WRITE,
+ownership = OwnerShip::MINE, baseAddressHint = (nil), permissions = 0 ] maybe
+requires more memory than it is currently available in the system.
+```
+
+indicates that there is not enough shared memory available. Check with
+
+```sh
+df -H /dev/shm
+```
+
+if you have enough memory available. In this exemplary error message we require
+`59736448` (iceoryx management data) + `27902400` (user samples) ~ `83.57mb`
+of shared memory.
+
+### docker
+
+When you are in a docker environment check if there is enough memory available
+in your docker.
+
+```
+# docker stats
+CONTAINER ID   NAME            CPU %     MEM USAGE / LIMIT   MEM %     NET I/O       BLOCK I/O     PIDS
+367b9fae6c2f   nifty_galileo   0.00%     4.48MiB / 1GiB      0.44%     11.6kB / 0B   17.6MB / 0B   1
+```
+
+If not you can restart the docker container with `--shm-size="2g"` to increase
+the total amount of available shared memory.
+
+```
+docker run -it --shm-size="2g" ubuntu
+```
 
 ## Termination of RouDi and processes
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #946 
