### PR TITLE
Allow cpptoml to be provided externally. 

### DIFF
--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -24,10 +24,13 @@ find_package(Threads REQUIRED)
 find_package(iceoryx_hoofs REQUIRED)
 
 option(TOML_CONFIG "TOML support for RouDi with dynamic configuration" ON)
+option(EXTERNAL_TOML_CONFIG "Use an externally provided cpptoml" OFF)
 option(ONE_TO_MANY_ONLY "Restricts communication to 1:n pattern" OFF)
 
 if(TOML_CONFIG)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpptoml/ ${CMAKE_BINARY_DIR}/dependencies/posh/cpptoml/prebuild)
+    if (NOT EXTERNAL_TOML_CONFIG)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpptoml/ ${CMAKE_BINARY_DIR}/dependencies/posh/cpptoml/prebuild)
+    endif()
 
     find_package(cpptoml REQUIRED)
 endif()


### PR DESCRIPTION
While adding IceOryx to Nixpkgs, I realized that the ExternalProject
mechanisms are somewhat problematic because they are not hermetic and
can fail easily depending on how strict the build sandbox is.

In this scenario, it is much easier to use `cpptoml` when provided
externally. The approach is inspired by `spdlog` and the `fmt` library.

There should be no change to the default build behavior.

In my use-case I'm adding IceOryx to the Nixpkgs eco-system, but this
would presumably also be useful for other packaging scenarios including
Bazel builds which use `rules_foreign_cc` to build IceOryx.