### PR TITLE
iox-#967 Extend ctor for in place construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Adding support for Helix QAC 2021.1[\#755](https://github.com/eclipse-iceoryx/iceoryx/issues/755) thanks to @toniglandy1
 - Axivion analysis on CI[\#409](https://github.com/eclipse-iceoryx/iceoryx/issues/409)
 - Cpptoml can be provided by an external source[\#951](https://github.com/eclipse-iceoryx/iceoryx/issues/)
+- Extend cxx::optional constructor for in place construction so that copy/move for values inside the optional even could be deleted[\#967](https://github.com/eclipse-iceoryx/iceoryx/issues/967)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
@@ -35,6 +35,12 @@ struct nullopt_t
 };
 constexpr nullopt_t nullopt = nullopt_t();
 
+/// @brief helper struct which is used to call the in-place-construction constructor
+struct Emplace_t
+{
+};
+constexpr Emplace_t Emplace{};
+
 /// @brief Optional implementation from the C++17 standard with C++11. The
 ///         interface is analog to the C++17 standard and it can be used in
 ///         factory functions which can fail.
@@ -82,6 +88,13 @@ class optional
     /// @brief Creates an optional by using the copy constructor of T.
     /// @param[in] value lvalue of type T which will be copy constructed into the optional
     optional(const T& value) noexcept;
+
+    /// @brief Creates an optional and an object inside the optional on construction by perfectly forwarding args to the
+    /// constructor of T. Could be used e.g. when T is not copyable/movable.
+    /// @tparam Targs is the template parameter pack for the perfectly forwarded arguments
+    /// @param[in] Emplace_t compile time variable to distinguish between constructors with certain behavior
+    template <typename... Targs>
+    optional(Emplace_t, Targs&&... args) noexcept;
 
     /// @brief The destructor will call the destructor of T if a value is set.
     ~optional() noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
@@ -36,10 +36,10 @@ struct nullopt_t
 constexpr nullopt_t nullopt = nullopt_t();
 
 /// @brief helper struct which is used to call the in-place-construction constructor
-struct Emplace_t
+struct in_place_t
 {
 };
-constexpr Emplace_t Emplace{};
+constexpr in_place_t in_place{};
 
 /// @brief Optional implementation from the C++17 standard with C++11. The
 ///         interface is analog to the C++17 standard and it can be used in
@@ -92,9 +92,9 @@ class optional
     /// @brief Creates an optional and an object inside the optional on construction by perfectly forwarding args to the
     /// constructor of T. Could be used e.g. when T is not copyable/movable.
     /// @tparam Targs is the template parameter pack for the perfectly forwarded arguments
-    /// @param[in] Emplace_t compile time variable to distinguish between constructors with certain behavior
+    /// @param[in] in_place_t compile time variable to distinguish between constructors with certain behavior
     template <typename... Targs>
-    optional(Emplace_t, Targs&&... args) noexcept;
+    optional(in_place_t, Targs&&... args) noexcept;
 
     /// @brief The destructor will call the destructor of T if a value is set.
     ~optional() noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/optional.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/optional.inl
@@ -64,6 +64,13 @@ inline optional<T>::optional(optional&& rhs) noexcept
 }
 
 template <typename T>
+template <typename... Targs>
+inline optional<T>::optional(Emplace_t, Targs&&... args) noexcept
+{
+    construct_value(std::forward<Targs>(args)...);
+}
+
+template <typename T>
 inline optional<T>& optional<T>::operator=(const optional& rhs) noexcept
 {
     if (this != &rhs)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/optional.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/optional.inl
@@ -65,7 +65,7 @@ inline optional<T>::optional(optional&& rhs) noexcept
 
 template <typename T>
 template <typename... Targs>
-inline optional<T>::optional(Emplace_t, Targs&&... args) noexcept
+inline optional<T>::optional(in_place_t, Targs&&... args) noexcept
 {
     construct_value(std::forward<Targs>(args)...);
 }

--- a/iceoryx_hoofs/test/moduletests/test_cxx_optional.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_optional.cpp
@@ -422,6 +422,12 @@ TEST_F(Optional_test, MakeOptional)
 {
     struct Make
     {
+        Make()
+            : a(0)
+            , b(0)
+        {
+        }
+
         Make(int a, int b)
             : a(a)
             , b(b)
@@ -431,9 +437,12 @@ TEST_F(Optional_test, MakeOptional)
         int b;
     };
 
-    auto sut = iox::cxx::make_optional<Make>(123, 456);
-    EXPECT_THAT(sut->a, Eq(123));
-    EXPECT_THAT(sut->b, Eq(456));
+    auto sut1 = iox::cxx::make_optional<Make>(123, 456);
+    EXPECT_THAT(sut1->a, Eq(123));
+    EXPECT_THAT(sut1->b, Eq(456));
+    auto sut2 = iox::cxx::make_optional<Make>();
+    EXPECT_THAT(sut2->a, Eq(0));
+    EXPECT_THAT(sut2->b, Eq(0));
 }
 
 TEST_F(Optional_test, AndThenWhenContainingValue)
@@ -522,7 +531,7 @@ struct TestStructForInPlaceConstruction
 
 TEST_F(Optional_test, InPlaceConstructionCtorCallsDefCtorWhenCalledWithoutArgs)
 {
-    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::Emplace);
+    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::in_place);
     ASSERT_TRUE(sut.has_value());
     EXPECT_THAT(sut->val, Eq(0.0));
     ASSERT_TRUE(sut->ptr);
@@ -532,7 +541,7 @@ TEST_F(Optional_test, InPlaceConstructionCtorCallsDefCtorWhenCalledWithoutArgs)
 TEST_F(Optional_test, InPlaceConstructionCtorCallsCorrectCtorWhenCalledWithLVal)
 {
     constexpr double VAL = 4.6;
-    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::Emplace, VAL);
+    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::in_place, VAL);
     ASSERT_TRUE(sut.has_value());
     EXPECT_THAT(sut->val, Eq(VAL));
     ASSERT_TRUE(sut->ptr);
@@ -542,14 +551,14 @@ TEST_F(Optional_test, InPlaceConstructionCtorCallsCorrectCtorWhenCalledWithLVal)
 TEST_F(Optional_test, InPlaceConstructionCtorCallsCorrectCtorWhenCalledWithRVal)
 {
     double val = 2.3;
-    iox::cxx::optional<TestStructForInPlaceConstruction> sut1(iox::cxx::Emplace, std::move(val));
+    iox::cxx::optional<TestStructForInPlaceConstruction> sut1(iox::cxx::in_place, std::move(val));
     ASSERT_TRUE(sut1.has_value());
     EXPECT_THAT(sut1->val, Eq(val * 2.0));
     ASSERT_TRUE(sut1->ptr);
     EXPECT_THAT(sut1->ptr->c_str(), StrEq("Hello"));
 
     std::unique_ptr<std::string> ptr(new std::string("World"));
-    iox::cxx::optional<TestStructForInPlaceConstruction> sut2(iox::cxx::Emplace, std::move(ptr));
+    iox::cxx::optional<TestStructForInPlaceConstruction> sut2(iox::cxx::in_place, std::move(ptr));
     ASSERT_TRUE(sut2.has_value());
     EXPECT_THAT(sut2->val, Eq(0.0));
     ASSERT_TRUE(sut2->ptr);
@@ -560,7 +569,7 @@ TEST_F(Optional_test, InPlaceConstructionCtorCallsCorrectCtorWhenCalledWithMixed
 {
     constexpr double VAL = 11.11;
     std::unique_ptr<std::string> ptr(new std::string("Hello World"));
-    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::Emplace, VAL, std::move(ptr));
+    iox::cxx::optional<TestStructForInPlaceConstruction> sut(iox::cxx::in_place, VAL, std::move(ptr));
     ASSERT_TRUE(sut.has_value());
     EXPECT_THAT(sut->val, Eq(VAL));
     ASSERT_TRUE(sut->ptr);


### PR DESCRIPTION
Signed-off-by: Marika Lehmann <marika.lehmann@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
Extended cxx::optional constructor for in place construction so that copy/move for values inside the optional could even be deleted

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #967 
