### PR TITLE
iox-#999 The posixCall must use the return value of the mutex functio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix typos in goals/non-goals document [\#968](https://github.com/eclipse-iceoryx/iceoryx/issues/968)
 - Catch deserialization errors for enums in publisher and subscriber options [\#989](https://github.com/eclipse-iceoryx/iceoryx/issues/989)
 - Fix linker error on QNX [\#1013](https://github.com/eclipse-iceoryx/iceoryx/issues/1013)
+- When posix mutex fails a correct error message is reported on the console [\#999](https://github.com/eclipse-iceoryx/iceoryx/issues/999)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -30,29 +30,29 @@ mutex::mutex(bool f_isRecursive) noexcept
 {
     pthread_mutexattr_t attr;
     bool isInitialized{true};
-    isInitialized &= !posixCall(pthread_mutexattr_init)(&attr).successReturnValue(0).evaluate().has_error();
+    isInitialized &= !posixCall(pthread_mutexattr_init)(&attr).returnValueMatchesErrno().evaluate().has_error();
     isInitialized &= !posixCall(pthread_mutexattr_setpshared)(&attr, PTHREAD_PROCESS_SHARED)
-                          .successReturnValue(0)
+                          .returnValueMatchesErrno()
                           .evaluate()
                           .has_error();
     isInitialized &=
         !posixCall(pthread_mutexattr_settype)(&attr, f_isRecursive ? PTHREAD_MUTEX_RECURSIVE_NP : PTHREAD_MUTEX_FAST_NP)
-             .successReturnValue(0)
+             .returnValueMatchesErrno()
              .evaluate()
              .has_error();
     isInitialized &= !posixCall(pthread_mutexattr_setprotocol)(&attr, PTHREAD_PRIO_NONE)
-                          .successReturnValue(0)
+                          .returnValueMatchesErrno()
                           .evaluate()
                           .has_error();
-    isInitialized &= !posixCall(pthread_mutex_init)(&m_handle, &attr).successReturnValue(0).evaluate().has_error();
-    isInitialized &= !posixCall(pthread_mutexattr_destroy)(&attr).successReturnValue(0).evaluate().has_error();
+    isInitialized &= !posixCall(pthread_mutex_init)(&m_handle, &attr).returnValueMatchesErrno().evaluate().has_error();
+    isInitialized &= !posixCall(pthread_mutexattr_destroy)(&attr).returnValueMatchesErrno().evaluate().has_error();
 
     cxx::Ensures(isInitialized && "Unable to create mutex");
 }
 
 mutex::~mutex() noexcept
 {
-    auto destroyCall = posixCall(pthread_mutex_destroy)(&m_handle).successReturnValue(0).evaluate();
+    auto destroyCall = posixCall(pthread_mutex_destroy)(&m_handle).returnValueMatchesErrno().evaluate();
 
     cxx::Ensures(!destroyCall.has_error() && "Could not destroy mutex");
 }
@@ -65,12 +65,12 @@ pthread_mutex_t mutex::get_native_handle() const noexcept
 
 bool mutex::lock() noexcept
 {
-    return !posixCall(pthread_mutex_lock)(&m_handle).successReturnValue(0).evaluate().has_error();
+    return !posixCall(pthread_mutex_lock)(&m_handle).returnValueMatchesErrno().evaluate().has_error();
 }
 
 bool mutex::unlock() noexcept
 {
-    return !posixCall(pthread_mutex_unlock)(&m_handle).successReturnValue(0).evaluate().has_error();
+    return !posixCall(pthread_mutex_unlock)(&m_handle).returnValueMatchesErrno().evaluate().has_error();
 }
 
 // NOLINTNEXTLINE(readability-identifier-naming) C++ STL code guidelines


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
Every `pthread_mutex***` function returns the errno directly instead of setting it indirectly. Since the `posixCall` was used wrongly the error message is always `Success` when the mutex fails. This PR corrects that.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Discovered in issue #999 and helps to further analyze it.