### PR TITLE
Add unique test IDs to iceoryx posh

### DIFF
--- a/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
+++ b/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
@@ -37,6 +37,7 @@ class InterfacePortRequestStackBlowup_test : public RouDi_GTest
 
 TEST_F(InterfacePortRequestStackBlowup_test, RouDiMustContinue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d912182d-2a74-4056-be1d-19b538c10c9c");
     iox::runtime::PoshRuntime::initRuntime("interface_port_request_stack_blowup");
     GatewayBase sut(iox::capro::Interfaces::INTERNAL);
     iox::capro::CaproMessage caproMessage;

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -119,6 +119,7 @@ class CMqInterfaceStartupRace_test : public Test
 #if !defined(__APPLE__)
 TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMq)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a94080de-e07d-433b-be0d-6ca748006664");
     /// @note this test checks if the application handles the situation when the roudi mqueue was not properly cleaned
     /// up and tries to use the obsolet mqueue while RouDi gets restarted and cleans its resources up and creates a new
     /// mqueue
@@ -164,6 +165,7 @@ TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMq)
 
 TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMqWithFullMq)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e7594a83-d0d1-49fb-8882-9d4dcc0372ef");
     /// @note this test checks if the application handles the situation when the roudi mqueue was not properly cleaned
     /// up and tries to use the obsolet mqueue while RouDi gets restarted and cleans its resources up and creates a new
     /// mqueue, the obsolete mqueue was filled up to the max message size, e.g. by the KEEP_ALIVE messages
@@ -218,6 +220,7 @@ TEST_F(CMqInterfaceStartupRace_test, DISABLED_ObsoleteRouDiMqWithFullMq)
 
 TEST_F(CMqInterfaceStartupRace_test, ObsoleteRegAck)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "16eb0dff-ef66-4943-b7a4-c0c0f079a0ae");
     /// @note this test checks if the application handles the situation when it sends an REG request to RouDi,
     /// terminates, gets restarted and sends a new REG request while RouDi has not yet processed the first REG request;
     /// this results in a message in the application mqueue which will be read with the next command and results in a

--- a/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
@@ -230,6 +230,7 @@ class ChunkBuildingBlocks_IntegrationTest : public Test
 
 TEST_F(ChunkBuildingBlocks_IntegrationTest, TwoHopsThreeThreadsNoSoFi)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "710aaa1d-2df4-491d-b32e-cce3744b22c3");
     std::thread subscribingThread(&ChunkBuildingBlocks_IntegrationTest::subscribe, this);
     std::thread forwardingThread(&ChunkBuildingBlocks_IntegrationTest::forward, this);
     std::thread publishingThread(&ChunkBuildingBlocks_IntegrationTest::publish, this);

--- a/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_pub_sub_listener.cpp
@@ -64,6 +64,7 @@ class PubSubListener_IntegrationTest : public RouDi_GTest
 /// UndefinedBehaviorSanitizer.
 TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDetachingWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "111bd422-3492-4fd6-8cca-d2cbda650567");
     m_listener
         ->attachEvent(*m_subscriber,
                       iox::popo::SubscriberEvent::DATA_RECEIVED,
@@ -79,6 +80,7 @@ TEST_F(PubSubListener_IntegrationTest, SubscriberGoesOutOfScopeAndDetachingWorks
 /// by the UndefinedBehaviorSanitizer.
 TEST_F(PubSubListener_IntegrationTest, UntypedSubscriberGoesOutOfScopeAndDetachingWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62bb5c0f-242f-4524-868a-252dfe123b58");
     m_listener
         ->attachEvent(*m_untypedSubscriber,
                       iox::popo::SubscriberEvent::DATA_RECEIVED,

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -372,6 +372,7 @@ constexpr uint32_t Mepoo_IntegrationTest::DEFAULT_NUMBER_OF_CHUNKS;
 
 TEST_F(Mepoo_IntegrationTest, MempoolConfigCheck)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aa78a873-ee8d-445c-a42a-6548bd7c2c6b");
     MemPoolInfoContainer memPoolTestContainer;
 
     auto testMempoolConfig = defaultMemPoolConfig();
@@ -408,6 +409,7 @@ TEST_F(Mepoo_IntegrationTest, MempoolConfigCheck)
 
 TEST_F(Mepoo_IntegrationTest, WrongSampleSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f03bfe1c-5892-4638-979c-2532097347c1");
     MemPoolInfoContainer memPoolTestContainer;
     auto testMempoolConfig = defaultMemPoolConfig();
     SetUp(memPoolTestContainer, testMempoolConfig, configType::CUSTOM);
@@ -427,6 +429,7 @@ TEST_F(Mepoo_IntegrationTest, WrongSampleSize)
 
 TEST_F(Mepoo_IntegrationTest, SampleOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62fcd41b-426a-4dbb-b69f-24288044deff");
     MemPoolInfoContainer memPoolTestContainer;
     auto testMempoolConfig = defaultMemPoolConfig();
     SetUp(memPoolTestContainer, testMempoolConfig, configType::CUSTOM);

--- a/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
+++ b/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
@@ -97,6 +97,7 @@ class PublisherSubscriberCommunication_test : public RouDi_GTest
 
 TEST_F(PublisherSubscriberCommunication_test, AllSubscriberInterfacesCanBeSubscribedToPublisherWithInternalInterface)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aba18b27-bf64-49a7-8ad6-06a84b23a455");
     auto publisher = createPublisher<int>();
     this->InterOpWait();
 
@@ -127,6 +128,7 @@ TEST_F(PublisherSubscriberCommunication_test, AllSubscriberInterfacesCanBeSubscr
 
 TEST_F(PublisherSubscriberCommunication_test, SubscriberCanOnlyBeSubscribedWhenInterfaceDiffersFromPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c01fa002-84ae-4017-a801-e790a3a04702");
     for (uint16_t publisherInterface = 0U; publisherInterface < static_cast<uint16_t>(capro::Interfaces::INTERFACE_END);
          ++publisherInterface)
     {
@@ -179,6 +181,7 @@ TEST_F(PublisherSubscriberCommunication_test, SubscriberCanOnlyBeSubscribedWhenI
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_forward_list)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "97cbebbe-d430-4437-881d-90329e73dd42");
     using Type_t = ComplexDataType<forward_list<string<5>, 5>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -208,6 +211,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_forward_lis
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_list)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4c5fa83a-935d-46ba-8adf-91e1de6acc89");
     using Type_t = ComplexDataType<list<int64_t, 5>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -240,6 +244,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_list)
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_optional)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "341ff552-a7a7-4dd9-be83-29d41bf142ec");
     using Type_t = ComplexDataType<list<optional<int32_t>, 5>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -272,6 +277,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_optional)
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_stack)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c378e0db-d863-4cad-9efa-4daec364b266");
     using Type_t = ComplexDataType<stack<int64_t, 10>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -306,6 +312,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_stack)
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_string)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0603b4ca-f41a-4280-9984-cf1465ee05c7");
     using Type_t = ComplexDataType<string<128>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -330,6 +337,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_string)
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_vector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fdfe4d05-c61a-4a99-b0b7-5e79da2700d5");
     using Type_t = ComplexDataType<vector<string<128>, 20>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -359,6 +367,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_vector)
 
 TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_variant)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0b5688ff-2367-4c76-93a2-6e447403c5ed");
     using Type_t = ComplexDataType<vector<variant<string<128>, int>, 20>>;
     auto publisher = createPublisher<Type_t>();
     this->InterOpWait();
@@ -394,6 +403,7 @@ TEST_F(PublisherSubscriberCommunication_test, SendingComplexDataType_variant)
 
 TEST_F(PublisherSubscriberCommunication_test, PublisherBlocksWhenBlockingActivatedOnBothSidesAndSubscriberQueueIsFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e97f1665-3488-4288-8fde-f485067bfeb4");
     auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
     this->InterOpWait();
 
@@ -436,6 +446,7 @@ TEST_F(PublisherSubscriberCommunication_test, PublisherBlocksWhenBlockingActivat
 
 TEST_F(PublisherSubscriberCommunication_test, PublisherDoesNotBlockAndDiscardsSamplesWhenNonBlockingActivated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1d92226d-fb3a-487c-bf52-6eb3c7946dc6");
     auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
     this->InterOpWait();
 
@@ -470,6 +481,7 @@ TEST_F(PublisherSubscriberCommunication_test, PublisherDoesNotBlockAndDiscardsSa
 
 TEST_F(PublisherSubscriberCommunication_test, NoSubscriptionWhenSubscriberWantsBlockingAndPublisherDoesNotOfferBlocking)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0144704-6dd7-4354-a41d-d4e512633484");
     auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
     this->InterOpWait();
 
@@ -485,6 +497,7 @@ TEST_F(PublisherSubscriberCommunication_test, NoSubscriptionWhenSubscriberWantsB
 
 TEST_F(PublisherSubscriberCommunication_test, SubscriptionWhenSubscriberDoesNotRequireBlockingButPublisherSupportsIt)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "228ea848-8926-4779-9e38-4d92eeb87feb");
     auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
     this->InterOpWait();
 
@@ -501,6 +514,7 @@ TEST_F(PublisherSubscriberCommunication_test, SubscriptionWhenSubscriberDoesNotR
 
 TEST_F(PublisherSubscriberCommunication_test, MixedOptionsSetupWorksWithBlocking)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c60ade45-1765-40ca-bc4b-7452c82ba127");
     auto publisherBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
     auto publisherNonBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
     this->InterOpWait();

--- a/iceoryx_posh/test/integrationtests/test_roudi_findservice.cpp
+++ b/iceoryx_posh/test/integrationtests/test_roudi_findservice.cpp
@@ -42,6 +42,7 @@ class RoudiFindService_test : public RouDi_GTest
 
 TEST_F(RoudiFindService_test, OfferSingleMethodServiceSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "30f0e255-3584-4ab2-b7a6-85c16026852d");
     auto isServiceOffered = senderRuntime->offerService({"service1", "instance1", "event1"});
     this->InterOpWait();
 
@@ -56,6 +57,7 @@ TEST_F(RoudiFindService_test, OfferSingleMethodServiceSingleInstance)
 
 TEST_F(RoudiFindService_test, OfferServiceWithDefaultServiceDescriptionFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1db1ce50-4e95-46f3-8682-9cc90576dbc0");
     auto isServiceOffered = senderRuntime->offerService(iox::capro::ServiceDescription());
     this->InterOpWait();
 
@@ -64,6 +66,7 @@ TEST_F(RoudiFindService_test, OfferServiceWithDefaultServiceDescriptionFails)
 
 TEST_F(RoudiFindService_test, OfferServiceWithValidEventIdSucessfull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1107d0e3-42e1-4b24-9a4d-cef8badb7154");
     auto isServiceOffered = senderRuntime->offerService({"service1", "instance1", "event1"});
     this->InterOpWait();
 
@@ -72,6 +75,7 @@ TEST_F(RoudiFindService_test, OfferServiceWithValidEventIdSucessfull)
 
 TEST_F(RoudiFindService_test, OfferServiceWithInvalidEventIdFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b67b4990-e2fd-4efa-ab5d-e53c4ee55972");
     auto isServiceOffered =
         senderRuntime->offerService({"service1", iox::capro::InvalidIdString, iox::capro::InvalidIdString});
     this->InterOpWait();
@@ -81,6 +85,7 @@ TEST_F(RoudiFindService_test, OfferServiceWithInvalidEventIdFails)
 
 TEST_F(RoudiFindService_test, ReofferedServiceWithValidServiceDescriptionCanBeFound)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e3af6f8-7798-4887-8526-f797068492ba");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
     EXPECT_TRUE(senderRuntime->stopOfferService({"service1", "instance1", "event1"}));
@@ -97,6 +102,7 @@ TEST_F(RoudiFindService_test, ReofferedServiceWithValidServiceDescriptionCanBeFo
 
 TEST_F(RoudiFindService_test, OfferExsistingServiceMultipleTimesIsRedundant)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ae0790ed-4e1b-4f12-94b3-c9e56433c935");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
@@ -111,6 +117,7 @@ TEST_F(RoudiFindService_test, OfferExsistingServiceMultipleTimesIsRedundant)
 
 TEST_F(RoudiFindService_test, FindSameServiceMultipleTimesReturnsSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "21948bcf-fe7e-44b4-b93b-f46303e3e050");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
 
@@ -127,6 +134,7 @@ TEST_F(RoudiFindService_test, FindSameServiceMultipleTimesReturnsSingleInstance)
 
 TEST_F(RoudiFindService_test, OfferMultiMethodServiceSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25bf794d-450e-47ce-a920-ab2ea479af39");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service2", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service3", "instance1", "event1"}));
@@ -150,6 +158,7 @@ TEST_F(RoudiFindService_test, OfferMultiMethodServiceSingleInstance)
 
 TEST_F(RoudiFindService_test, OfferMultiMethodServiceWithDistinctSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1984e907-e990-48b2-8cbd-eab3f67cd162");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service2", "instance2", "event2"}));
     this->InterOpWait();
@@ -171,6 +180,7 @@ TEST_F(RoudiFindService_test, OfferMultiMethodServiceWithDistinctSingleInstance)
 
 TEST_F(RoudiFindService_test, SubscribeAnyInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e0b1a12-6995-45f4-8fd8-59acbca9bfa8");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance2", "event2"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance3", "event3"}));
@@ -188,6 +198,7 @@ TEST_F(RoudiFindService_test, SubscribeAnyInstance)
 
 TEST_F(RoudiFindService_test, OfferSingleMethodServiceMultiInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "538bec69-ea02-400e-8643-c833d6e84972");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance2", "event2"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance3", "event3"}));
@@ -211,6 +222,7 @@ TEST_F(RoudiFindService_test, OfferSingleMethodServiceMultiInstance)
 
 TEST_F(RoudiFindService_test, OfferMultiMethodServiceMultiInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "360839a7-9309-4e7e-8e89-892097a87f7a");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance2", "event2"}));
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance3", "event3"}));
@@ -252,12 +264,14 @@ TEST_F(RoudiFindService_test, OfferMultiMethodServiceMultiInstance)
 
 TEST_F(RoudiFindService_test, StopOfferWithInvalidServiceDescriptionFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7f758831-674b-4ea2-b5ee-1be0b22d8292");
     EXPECT_FALSE(senderRuntime->stopOfferService(
         {iox::capro::InvalidIdString, iox::capro::InvalidIdString, iox::capro::InvalidIdString}));
 }
 
 TEST_F(RoudiFindService_test, StopOfferSingleMethodServiceSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84676338-d7ea-409e-88c3-22155bababed");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
     EXPECT_TRUE(senderRuntime->stopOfferService({"service1", "instance1", "event1"}));
@@ -270,6 +284,7 @@ TEST_F(RoudiFindService_test, StopOfferSingleMethodServiceSingleInstance)
 
 TEST_F(RoudiFindService_test, StopOfferMultiMethodServiceSingleInstance)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e4f99eb1-7496-4a1e-bbd1-ebdb07e1ec9b");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service2", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service3", "instance1", "event1"}));
@@ -294,6 +309,7 @@ TEST_F(RoudiFindService_test, StopOfferMultiMethodServiceSingleInstance)
 
 TEST_F(RoudiFindService_test, StopOfferServiceRedundantCall)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c41f0a85-5774-45ab-8618-5ea45675e8b2");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
     EXPECT_TRUE(senderRuntime->stopOfferService({"service1", "instance1", "event1"}));
@@ -309,6 +325,7 @@ TEST_F(RoudiFindService_test, StopOfferServiceRedundantCall)
 
 TEST_F(RoudiFindService_test, StopNonExistingService)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de76c8d3-8090-4247-b5d3-d57fb27f2d32");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
     EXPECT_TRUE(senderRuntime->stopOfferService({"service2", "instance2", "event2"}));
@@ -322,6 +339,7 @@ TEST_F(RoudiFindService_test, StopNonExistingService)
 
 TEST_F(RoudiFindService_test, FindNonExistingServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "86b87264-4df4-4d20-9357-06391ca1d57f");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service2", "instance1", "event1"}));
     EXPECT_TRUE(senderRuntime->offerService({"service3", "instance1", "event1"}));
@@ -342,6 +360,7 @@ TEST_F(RoudiFindService_test, FindNonExistingServices)
 
 TEST_F(RoudiFindService_test, InterfacePort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b455c123-3290-4a72-83ec-6b12da95181e");
     EXPECT_TRUE(senderRuntime->offerService({"service1", "instance1", "event1"}));
     this->InterOpWait();
 
@@ -367,6 +386,7 @@ TEST_F(RoudiFindService_test, InterfacePort)
 
 TEST_F(RoudiFindService_test, findServiceMaxServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "68628cc2-df6d-46e4-8586-7563f43bf10c");
     ServiceContainer serviceContainerExp;
     for (size_t i = 0; i < iox::MAX_NUMBER_OF_SERVICES; i++)
     {
@@ -387,6 +407,7 @@ TEST_F(RoudiFindService_test, findServiceMaxServices)
 
 TEST_F(RoudiFindService_test, findServiceserviceContainerOverflowError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f2f8d8c0-8712-4e7a-9e33-2b2a918f8a71");
     size_t noOfInstances = (iox::MAX_NUMBER_OF_SERVICES + 1);
     ServiceContainer serviceContainerExp;
     for (size_t i = 0; i < noOfInstances; i++)

--- a/iceoryx_posh/test/integrationtests/test_roudi_roudi_environment.cpp
+++ b/iceoryx_posh/test/integrationtests/test_roudi_roudi_environment.cpp
@@ -33,6 +33,7 @@ class RouDiEnvironment_test : public Test
 
 TEST_F(RouDiEnvironment_test, StartingRouDiTwiceLeadsToError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "38075292-7897-4db5-b20e-f06ab324ad31");
     RouDiEnvironment m_sut{iox::RouDiConfig_t().setDefaults()};
     EXPECT_DEATH({ RouDiEnvironment m_sut2{iox::RouDiConfig_t().setDefaults()}; }, ".*");
 }

--- a/iceoryx_posh/test/integrationtests/test_shm_sigbus_handler.cpp
+++ b/iceoryx_posh/test/integrationtests/test_shm_sigbus_handler.cpp
@@ -30,6 +30,7 @@ using namespace ::testing;
 
 TEST(ShmCreatorDeathTest, AllocatingTooMuchMemoryLeadsToExitWithSIGBUS)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d6c8949d-42c9-4b2c-a150-4306cb2a57f6");
     const iox::ShmName_t TEST_SHM_NAME{"/test_name"};
     // the death test makes only sense on platforms which are zeroing the whole shared memory
     // if the memory is only reserved a death will never occur

--- a/iceoryx_posh/test/moduletests/test_base_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_base_port.cpp
@@ -164,12 +164,14 @@ class BasePort_test : public Test
 
 TYPED_TEST(BasePort_test, CallingGetCaProServiceDescriptionWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cb52f436-8ca4-46fd-8ae6-1518086898bc");
     using PortData_t = typename TestFixture::PortData_t;
     EXPECT_THAT(this->sut.getCaProServiceDescription(), Eq(expectedServiceDescription<PortData_t>()));
 }
 
 TYPED_TEST(BasePort_test, CallingGetRuntimeNameWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5df7c7cb-efe0-4ae7-9da1-5a5c977b5c22");
     using PortData_t = typename TestFixture::PortData_t;
     EXPECT_THAT(this->sut.getRuntimeName(), Eq(expectedProcessName<PortData_t>()));
 }

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -37,6 +37,7 @@ class CaproMessage_test : public Test
 
 TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "76ac087b-c931-4c96-8e6e-0490c97d4994");
     IdString_t testServiceID{"1"};
     IdString_t testEventID{"2"};
     IdString_t testInstanceID{"3"};
@@ -56,6 +57,7 @@ TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
 
 TEST_F(CaproMessage_test, DefaultArgsOfCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9192864e-3713-402e-9d92-1a5e803a93ee");
     CaproMessage testObj(CaproMessageType::OFFER, ServiceDescription("1", "2", "3"));
 
     EXPECT_EQ(CaproMessageSubType::NOSUBTYPE, testObj.m_subType);

--- a/iceoryx_posh/test/moduletests/test_capro_service.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_service.cpp
@@ -46,6 +46,7 @@ class ServiceDescription_test : public Test
 
 TEST_F(ServiceDescription_test, ServiceDescriptionClassHashDefaultCtorCreatesClassHashWithDefaultValues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3b57b18f-cd68-49ee-8fbb-7b1fcc878a16");
     ServiceDescription::ClassHash testHash{};
 
     EXPECT_EQ(uint32_t(0), testHash[0]);
@@ -56,6 +57,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionClassHashDefaultCtorCreatesCla
 
 TEST_F(ServiceDescription_test, ServiceDescriptionClassHashCtorCreatesClassHashWithValuesPassedToTheCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "00d1f6f1-4011-406e-a18e-85af7fa401f4");
     ServiceDescription::ClassHash testHash{1U, 2U, 3U, 4U};
 
     EXPECT_EQ(uint32_t(1), testHash[0]);
@@ -66,6 +68,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionClassHashCtorCreatesClassHashW
 
 TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithEqualityOperatorReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dc2e03b0-d9ac-49fd-8d1d-6e2393ce3d68");
     ServiceDescription::ClassHash testHash1{15U, 25U, 35U, 45U};
     ServiceDescription::ClassHash testHash2{55U, 65U, 75U, 85U};
 
@@ -74,6 +77,7 @@ TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithEqualityOperator
 
 TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithEqualityOperatorReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3423678c-d45e-4b36-bce6-7e6d0a5bc2a6");
     ServiceDescription::ClassHash testHash1{10U, 20U, 30U, 40U};
     ServiceDescription::ClassHash testHash2{10U, 20U, 30U, 40U};
 
@@ -82,6 +86,7 @@ TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithEqualityOperator
 
 TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithNotEqualOperatorReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "59d7790f-5d1f-4f1f-9cf6-8f474ae8978f");
     ServiceDescription::ClassHash testHash1{12U, 24U, 36U, 48U};
     ServiceDescription::ClassHash testHash2{60U, 72U, 84U, 96U};
 
@@ -90,6 +95,7 @@ TEST_F(ServiceDescription_test, ComparingTwoUnequalClassHashWithNotEqualOperator
 
 TEST_F(ServiceDescription_test, ComparingTwoEqualClassHashWithNotEqualOperatorReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "498fa728-7fbb-4e99-8e95-eaf267284f22");
     ServiceDescription::ClassHash testHash1{11U, 22U, 33U, 44U};
     ServiceDescription::ClassHash testHash2{11U, 22U, 33U, 44U};
 
@@ -98,6 +104,7 @@ TEST_F(ServiceDescription_test, ComparingTwoEqualClassHashWithNotEqualOperatorRe
 
 TEST_F(ServiceDescription_test, ClassHashWithValuesAssignedUsingAssignmentOperatorStoresTheValueInTheCorrespondingIndex)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2d37a48e-ba08-4fc8-9215-77bac17bd49b");
     ServiceDescription::ClassHash testHash{};
 
     testHash[0] = 10U;
@@ -113,6 +120,7 @@ TEST_F(ServiceDescription_test, ClassHashWithValuesAssignedUsingAssignmentOperat
 
 TEST_F(ServiceDescription_test, ClassHashSubsriptOperatorOutOfBoundsFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ac4b4cb3-503c-4e39-a549-684176e7557a");
     ServiceDescription::ClassHash testHash{1U, 2U, 3U, 4U};
 
     testHash[0] = 1U;
@@ -132,6 +140,7 @@ TEST_F(ServiceDescription_test, ClassHashSubsriptOperatorOutOfBoundsFails)
 /// only intended to check the functionality by injecting the valus directly.
 TEST_F(ServiceDescription_test, ServiceDescriptionSerializationCreatesServiceDescriptionWithValuesPassedToTheCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0bda1264-f1b0-41d5-b1c4-f8e7f2a5806a");
     ServiceDescription::ClassHash testHash = {11U, 21U, 31U, 41U};
     testService = "Service";
     testInstance = "Instance";
@@ -172,6 +181,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionSerializationCreatesServiceDes
 TEST_F(ServiceDescription_test,
        ServiceDescriptionObjectInitialisationWithOutOfBoundaryScopeLeadsToInvalidDeserialization)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0a94b000-54ac-415a-a7c7-6f1348676f03");
     ServiceDescription::ClassHash testHash = {14U, 28U, 42U, 56U};
     testService = "Service";
     testInstance = "Instance";
@@ -198,6 +208,7 @@ TEST_F(ServiceDescription_test,
 TEST_F(ServiceDescription_test,
        ServiceDescriptionObjectInitialisationWithOutOfBoundaryInterfaceSourceLeadsToInvalidDeserialization)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "29fac03f-a845-4180-89b7-8367a203646e");
     ServiceDescription::ClassHash testHash = {17U, 34U, 51U, 68U};
     testService = "Service";
     testInstance = "Instance";
@@ -222,6 +233,7 @@ TEST_F(ServiceDescription_test,
 
 TEST_F(ServiceDescription_test, ServiceDescriptionObjectInitialisationWithEmptyStringLeadsToInvalidDeserialization)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4607d73d-d27d-4694-833d-2e28162589cd");
     std::string emptyString;
     iox::cxx::Serialization invalidSerialObj{emptyString};
 
@@ -233,6 +245,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionObjectInitialisationWithEmptyS
 
 TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesStringsToInvalidString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "707156f8-8145-4710-b6ac-3e94dbac7237");
     ServiceDescription serviceDescription1 = ServiceDescription();
 
     EXPECT_THAT(serviceDescription1.getServiceIDString(), StrEq(InvalidIdString));
@@ -242,6 +255,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesStringsT
 
 TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesTheScopeToWorldWide)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8e6b26b1-3363-45d8-abad-3b4c1ec122af");
     ServiceDescription serviceDescription1 = ServiceDescription();
 
     EXPECT_THAT(serviceDescription1.getScope(), Eq(Scope::WORLDWIDE));
@@ -249,6 +263,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesTheScope
 
 TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesTheInterfaceToInternal)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "87c50b2a-d771-4985-8fdd-497a5f97dc35");
     ServiceDescription serviceDescription1 = ServiceDescription();
 
     EXPECT_THAT(serviceDescription1.getSourceInterface(), Eq(Interfaces::INTERNAL));
@@ -256,6 +271,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesTheInter
 
 TEST_F(ServiceDescription_test, ServiceDescriptionStringCtorCreatesServiceDescriptionWithValuesPassedToTheCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "560685b0-780c-420e-8f9d-bbfe2460d15f");
     testService = "1";
     testInstance = "2";
     testEvent = "3";
@@ -274,6 +290,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionStringCtorCreatesServiceDescri
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithAnyServiceAnyInstanceAnyEventIDsAreEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f149fab2-b1a3-406e-aee1-30a3c2e9e169");
     IdString_t testService = iox::roudi::Wildcard;
     IdString_t testEvent = iox::roudi::Wildcard;
     IdString_t testInstance = iox::roudi::Wildcard;
@@ -285,6 +302,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithAnyServiceAnyInstanceA
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidServicesAreNotEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "42329498-78b4-4cef-8629-918ca2783529");
     IdString_t testService1 = "1";
     IdString_t testEvent1 = "2";
     IdString_t testInstance1 = "3";
@@ -297,6 +315,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidServi
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidEventsAreNotEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8a06cd60-af12-4bf8-abb7-ad42b301d879");
     IdString_t testService1 = "1";
     IdString_t testEvent1 = "2";
     IdString_t testInstance1 = "3";
@@ -309,6 +328,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidEvent
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidInstancesAreNotEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f1e13385-89b0-4aa0-9b97-8f39d5f5c0ae");
     IdString_t testService1 = "1";
     IdString_t testEvent1 = "2";
     IdString_t testInstance1 = "3";
@@ -321,6 +341,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentButValidInsta
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentAndValidServiceInstanceEventsAreNotEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b0ab9583-802b-4d9f-b114-08e44be74e44");
     IdString_t testService1 = "1";
     IdString_t testEvent1 = "2";
     IdString_t testInstance1 = "3";
@@ -335,6 +356,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithDifferentAndValidServi
 
 TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithSameStringsComparedWithInequalityOperatorReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1623a8a8-b892-45ce-a54a-ff13491069b7");
     IdString_t testService = "1";
     IdString_t testEvent = "2";
     IdString_t testInstance = "3";
@@ -346,6 +368,7 @@ TEST_F(ServiceDescription_test, TwoServiceDescriptionsWithSameStringsComparedWit
 
 TEST_F(ServiceDescription_test, ServiceMatchMethodReturnsTrueIfTheServiceStringIsSame)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "47bb698b-bb13-4885-afab-b5a975b67715");
     IdString_t sameService = "1";
     ServiceDescription description1 = ServiceDescription(sameService, iox::roudi::Wildcard, iox::roudi::Wildcard);
     ServiceDescription description2 = ServiceDescription(sameService, iox::roudi::Wildcard, iox::roudi::Wildcard);
@@ -355,6 +378,7 @@ TEST_F(ServiceDescription_test, ServiceMatchMethodReturnsTrueIfTheServiceStringI
 
 TEST_F(ServiceDescription_test, ServiceMatchMethodReturnsFalseIfTheServiceIDsAreDifferent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9ccd5f69-aca9-4e3d-9ba7-83581abde0f3");
     IdString_t serviceID1 = "1";
     IdString_t serviceID2 = "2";
     ServiceDescription description1 = ServiceDescription(serviceID1, iox::roudi::Wildcard, iox::roudi::Wildcard);
@@ -365,6 +389,7 @@ TEST_F(ServiceDescription_test, ServiceMatchMethodReturnsFalseIfTheServiceIDsAre
 
 TEST_F(ServiceDescription_test, IsInternalMethodReturnsTrueWhenTheScopeIsSetToInternal)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fc611c5d-484f-43c7-899e-12085d3e6018");
     IdString_t testService = "1";
     IdString_t testEvent = "2";
     IdString_t testInstance = "3";
@@ -377,6 +402,7 @@ TEST_F(ServiceDescription_test, IsInternalMethodReturnsTrueWhenTheScopeIsSetToIn
 
 TEST_F(ServiceDescription_test, GetScopeMethodReturnsTheCorrespondingValueOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ddc13a6b-a2aa-4271-b479-f4d4177d048e");
     IdString_t testService = "1";
     IdString_t testEvent = "2";
     IdString_t testInstance = "3";
@@ -389,6 +415,7 @@ TEST_F(ServiceDescription_test, GetScopeMethodReturnsTheCorrespondingValueOfScop
 
 TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenServiceIDIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "008bbc55-894f-4083-bc78-b0dac7bd52f0");
     IdString_t testServiceID = InvalidIdString;
     IdString_t testEventID = "1";
     IdString_t testInstanceID = "1";
@@ -399,6 +426,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenServiceIDIsInvali
 
 TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenInstanceIDIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8b5b66fd-5d04-4200-bb7a-bf8afea9c2c4");
     IdString_t testServiceID = "1";
     IdString_t testEventID = "1";
     IdString_t testInstanceID = InvalidIdString;
@@ -409,6 +437,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenInstanceIDIsInval
 
 TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenEventIDIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "afea0f45-d40a-41e3-931c-46b0cc2f8f5b");
     IdString_t testServiceID = "1";
     IdString_t testEventID = InvalidIdString;
     IdString_t testInstanceID = "1";
@@ -419,6 +448,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionIsInvalidWhenEventIDIsInvalid)
 
 TEST_F(ServiceDescription_test, ServiceDescriptionIsValidWhenServiceInstanceAndEventIDsAreValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c88a8049-abf5-44f0-9b08-99fb83ce861f");
     IdString_t testServiceID = "1";
     IdString_t testEventID = "1";
     IdString_t testInstanceID = "1";
@@ -429,6 +459,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionIsValidWhenServiceInstanceAndE
 
 TEST_F(ServiceDescription_test, LessThanOperatorReturnsFalseIfServiceStringOfFirstServiceDescriptionIsLessThanSecond)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4fe380cc-fa94-48e9-99dd-ec2e220eff16");
     ServiceDescription serviceDescription1("TestService1", "TestInstance", "TestEvent");
     ServiceDescription serviceDescription2("TestService2", "TestInstance", "TestEvent");
 
@@ -437,6 +468,7 @@ TEST_F(ServiceDescription_test, LessThanOperatorReturnsFalseIfServiceStringOfFir
 
 TEST_F(ServiceDescription_test, LessThanOperatorReturnsFalseIfInstanceStringOfFirstServiceDescriptionIsLessThanSecond)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d5b0053e-9e7d-4176-80e1-52f057978c42");
     ServiceDescription serviceDescription1("TestService", "TestInstance1", "TestEvent");
     ServiceDescription serviceDescription2("TestService", "TestInstance2", "TestEvent");
 
@@ -445,6 +477,7 @@ TEST_F(ServiceDescription_test, LessThanOperatorReturnsFalseIfInstanceStringOfFi
 
 TEST_F(ServiceDescription_test, LessThanOperatorReturnsFalseIfEventStringOfFirstServiceDescriptionIsLessThanSecond)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8ab96b9a-5464-4b60-9d15-f31b5e3b4ee9");
     ServiceDescription serviceDescription1("TestService", "TestInstance", "TestEvent1");
     ServiceDescription serviceDescription2("TestService", "TestInstance", "TestEvent2");
 

--- a/iceoryx_posh/test/moduletests/test_compatibility_check_level.cpp
+++ b/iceoryx_posh/test/moduletests/test_compatibility_check_level.cpp
@@ -43,6 +43,7 @@ class CompatibilityCheckLevel_test : public Test
 
 TEST_F(CompatibilityCheckLevel_test, OffLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a36d8dd3-1004-4000-991b-bc131d02b26e");
     auto sut = CompatibilityCheckLevel::OFF;
 
     {
@@ -57,6 +58,7 @@ TEST_F(CompatibilityCheckLevel_test, OffLeadsToCorrectString)
 
 TEST_F(CompatibilityCheckLevel_test, MajorLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "77b29d8e-0ff8-45af-8826-d391f45063df");
     auto sut = CompatibilityCheckLevel::MAJOR;
 
     {
@@ -71,6 +73,7 @@ TEST_F(CompatibilityCheckLevel_test, MajorLeadsToCorrectString)
 
 TEST_F(CompatibilityCheckLevel_test, MinorLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f9e7ba62-6474-4b41-91a0-725d6a6e7baf");
     auto sut = CompatibilityCheckLevel::MINOR;
 
     {
@@ -85,6 +88,7 @@ TEST_F(CompatibilityCheckLevel_test, MinorLeadsToCorrectString)
 
 TEST_F(CompatibilityCheckLevel_test, PatchLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5f77f683-3de0-438d-af0c-424a1b24b99d");
     auto sut = CompatibilityCheckLevel::PATCH;
 
     {
@@ -99,6 +103,7 @@ TEST_F(CompatibilityCheckLevel_test, PatchLeadsToCorrectString)
 
 TEST_F(CompatibilityCheckLevel_test, CommitIdLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "55bc3dbe-9a85-4cf7-9f9e-441c72e7c895");
     auto sut = CompatibilityCheckLevel::COMMIT_ID;
 
     {
@@ -113,6 +118,7 @@ TEST_F(CompatibilityCheckLevel_test, CommitIdLeadsToCorrectString)
 
 TEST_F(CompatibilityCheckLevel_test, BuildDateLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0259873-8840-48ac-8f3c-f99e8bcc7691");
     auto sut = CompatibilityCheckLevel::BUILD_DATE;
 
     {

--- a/iceoryx_posh/test/moduletests/test_fixed_size_container.cpp
+++ b/iceoryx_posh/test/moduletests/test_fixed_size_container.cpp
@@ -55,6 +55,7 @@ class FixedSizeContainer_test : public Test
 
 TEST_F(FixedSizeContainer_test, addSingleElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "07b8892c-947e-40a8-aaed-a24dacdc2850");
     FixedSizeContainer<int, 1> container;
     EXPECT_THAT(container.add(12), Ne(NOT_AN_ELEMENT));
     EXPECT_THAT(container.add(12), Eq(NOT_AN_ELEMENT));
@@ -62,6 +63,7 @@ TEST_F(FixedSizeContainer_test, addSingleElementContainer)
 
 TEST_F(FixedSizeContainer_test, addMultiElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "78024408-52e1-41ea-8b0a-7cfefe516cb1");
     constexpr uint32_t capacity = 123;
     FixedSizeContainer<int, capacity> container;
     for (uint32_t k = 0; k < capacity; ++k)
@@ -77,6 +79,7 @@ TEST_F(FixedSizeContainer_test, addMultiElementContainer)
 
 TEST_F(FixedSizeContainer_test, removeAndSizeSingleElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "614bd693-7427-4557-90a3-5dbcf6ea7ff6");
     FixedSizeContainer<int, 1> container;
     EXPECT_THAT(container.size(), Eq(0u));
     container.remove(0);
@@ -100,6 +103,7 @@ TEST_F(FixedSizeContainer_test, removeAndSizeSingleElementContainer)
 
 TEST_F(FixedSizeContainer_test, removeAndSizeMultiElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "20a93c9c-7c80-494a-a85d-6313efe2f99e");
     constexpr uint32_t capacity = 100;
     FixedSizeContainer<int, capacity> container;
 
@@ -138,6 +142,7 @@ TEST_F(FixedSizeContainer_test, removeAndSizeMultiElementContainer)
 
 TEST_F(FixedSizeContainer_test, addAndVerifySingleElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0dabbf3-6d68-4596-9819-1de011fbe272");
     FixedSizeContainer<int, 1> container;
 
     EXPECT_THAT(container.get(0), Eq(nullptr));
@@ -150,6 +155,7 @@ TEST_F(FixedSizeContainer_test, addAndVerifySingleElementContainer)
 
 TEST_F(FixedSizeContainer_test, addAndVerifyMultiElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de654427-1873-4583-b6a6-117869ca86f0");
     constexpr size_t capacity = 25;
     FixedSizeContainer<size_t, capacity> container;
 
@@ -172,6 +178,7 @@ TEST_F(FixedSizeContainer_test, addAndVerifyMultiElementContainer)
 
 TEST_F(FixedSizeContainer_test, removeAndVerifySingleElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "221a8117-673c-445e-b1fa-88fe2117d440");
     FixedSizeContainer<int, 1> container;
 
     EXPECT_THAT(container.get(0), Eq(nullptr));
@@ -183,6 +190,7 @@ TEST_F(FixedSizeContainer_test, removeAndVerifySingleElementContainer)
 
 TEST_F(FixedSizeContainer_test, removeAndVerifyMultiElementContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ad112c45-1166-41f9-8cd0-af604677957f");
     constexpr size_t capacity = 25;
     FixedSizeContainer<size_t, capacity> container;
     for (size_t i = 0; i < capacity; ++i)

--- a/iceoryx_posh/test/moduletests/test_gw_channel.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_channel.cpp
@@ -56,6 +56,7 @@ class ChannelTest : public Test
 // ======================================== Tests ======================================== //
 TEST_F(ChannelTest, ReturnsEmptyOptionalIfObjectPoolExhausted)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c4444a37-2044-4bba-aa22-9fabc0a7b5f4");
     auto channel = iox::gw::Channel<StubbedIceoryxTerminal, StubbedExternalTerminal>::create(
         {"", "", ""}, StubbedIceoryxTerminal::Options());
     EXPECT_FALSE(channel.has_error());

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_discovery.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_discovery.cpp
@@ -59,6 +59,7 @@ class GatewayDiscovery_test : public Test
 
 TEST_F(GatewayDiscovery_test, GetCaproMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee901042-940c-4929-b7d0-acad0b752cb3");
     InterfacePort_mock interfacePortImplMock;
     iox::gw::GatewayDiscovery<InterfacePort_mock> GatewayDiscovery =
         GatewayDiscoveryAccess<InterfacePort_mock>(interfacePortImplMock);

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
@@ -63,6 +63,7 @@ class GatewayGenericTest : public Test
 // ======================================== Tests ======================================== //
 TEST_F(GatewayGenericTest, AddedChannelsAreStored)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "da5e4a66-4f88-48bb-a684-4d10a19684b5");
     // ===== Setup
     auto testService = iox::capro::ServiceDescription("service", "instance", "event");
 
@@ -76,6 +77,7 @@ TEST_F(GatewayGenericTest, AddedChannelsAreStored)
 
 TEST_F(GatewayGenericTest, DoesNotAddDuplicateChannels)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fdd568b4-b377-48a3-8d2a-7f131bf1bba6");
     // ===== Setup
     auto testService = iox::capro::ServiceDescription("service", "instance", "event");
 
@@ -90,6 +92,7 @@ TEST_F(GatewayGenericTest, DoesNotAddDuplicateChannels)
 
 TEST_F(GatewayGenericTest, IgnoresWildcardServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "27984b07-f100-4cc3-9092-7f8afb8adca0");
     // ===== Setup
     auto completeWildcardService = iox::capro::ServiceDescription("*", "*", "*");
     auto wildcardServiceService = iox::capro::ServiceDescription("*", "instance", "event");
@@ -114,6 +117,7 @@ TEST_F(GatewayGenericTest, IgnoresWildcardServices)
 
 TEST_F(GatewayGenericTest, ProperlyManagesMultipleChannels)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d6126772-9069-47c4-b8b0-4325eecba208");
     // ===== Setup
     auto serviceOne = iox::capro::ServiceDescription("serviceOne", "instanceOne", "eventOne");
     auto serviceTwo = iox::capro::ServiceDescription("serviceTwo", "instanceTwo", "eventTwo");
@@ -138,6 +142,7 @@ TEST_F(GatewayGenericTest, ProperlyManagesMultipleChannels)
 
 TEST_F(GatewayGenericTest, HandlesMaxmimumChannelCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b4385e8-c717-4368-8121-b7d526fd22ac");
     // ===== Setup
     TestGatewayGeneric gw{};
 
@@ -158,6 +163,7 @@ TEST_F(GatewayGenericTest, HandlesMaxmimumChannelCapacity)
 
 TEST_F(GatewayGenericTest, ThrowsErrorWhenExceedingMaximumChannelCapaicity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f73c1fe0-d5d3-4527-9acb-29692c5fd19f");
     // ===== Setup
     TestGatewayGeneric gw{};
 
@@ -180,6 +186,7 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenExceedingMaximumChannelCapaicity)
 
 TEST_F(GatewayGenericTest, ThrowsErrorWhenAttemptingToRemoveNonexistantChannel)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cd9f8279-5876-418a-9606-7413a9c2df35");
     // ===== Setup
     auto testServiceA = iox::capro::ServiceDescription("serviceA", "instanceA", "eventA");
     auto testServiceB = iox::capro::ServiceDescription("serviceB", "instanceB", "eventB");
@@ -199,6 +206,7 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenAttemptingToRemoveNonexistantChannel)
 
 TEST_F(GatewayGenericTest, DiscardedChannelsAreNotStored)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b9f4cfcc-210d-4a61-83bf-d12da0ff7480");
     // ===== Setup
     auto testService = iox::capro::ServiceDescription("service", "instance", "event");
 
@@ -214,6 +222,7 @@ TEST_F(GatewayGenericTest, DiscardedChannelsAreNotStored)
 
 TEST_F(GatewayGenericTest, FindChannelReturnsCopyOfFoundChannel)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3c97dd37-cdd4-4e93-b202-36cdcf3c1029");
     // ===== Setup
     auto testService = iox::capro::ServiceDescription("service", "instance", "event");
 
@@ -231,6 +240,7 @@ TEST_F(GatewayGenericTest, FindChannelReturnsCopyOfFoundChannel)
 
 TEST_F(GatewayGenericTest, FindChannelGivesEmptyOptionalIfNoneFound)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "83cccfe0-68e6-4a35-b098-35c6c49c7743");
     // ===== Setup
     auto storedChannelService = iox::capro::ServiceDescription("service", "instance", "event");
     auto notStoredChannelService = iox::capro::ServiceDescription("otherService", "otherInstance", "otherEvent");
@@ -245,6 +255,7 @@ TEST_F(GatewayGenericTest, FindChannelGivesEmptyOptionalIfNoneFound)
 
 TEST_F(GatewayGenericTest, ForEachChannelExecutesGivenFunctionForAllStoredChannels)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "df23a642-f247-42c8-8df3-4daba32bc397");
     // ===== Setup
     auto testServiceA = iox::capro::ServiceDescription("serviceA", "instanceA", "eventA");
     auto testServiceB = iox::capro::ServiceDescription("serviceB", "instanceB", "eventB");

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
@@ -32,6 +32,7 @@ using UserPayloadOffset_t = ChunkHeader::UserPayloadOffset_t;
 
 TEST(ChunkHeader_test, ChunkHeaderHasInitializedMembers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b998bcb8-7db0-457d-a25a-86eae34f68dd");
     constexpr uint32_t CHUNK_SIZE{753U};
     constexpr uint32_t USER_PAYLOAD_SIZE{8U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
@@ -64,6 +65,7 @@ TEST(ChunkHeader_test, ChunkHeaderHasInitializedMembers)
 
 TEST(ChunkHeader_test, ChunkHeaderUserPayloadSizeTypeIsLargeEnoughForMempoolChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "540e2e95-0890-4522-ae7f-c6d867679e0b");
     using ChunkSize_t = std::result_of<decltype (&MemPool::getChunkSize)(MemPool)>::type;
 
     auto maxOfChunkSizeType = std::numeric_limits<ChunkSize_t>::max();
@@ -76,6 +78,7 @@ TEST(ChunkHeader_test, ChunkHeaderUserPayloadSizeTypeIsLargeEnoughForMempoolChun
 
 TEST(ChunkHeader_test, UserPayloadFunctionCalledFromNonConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d6b0fcce-8b49-429c-a1d2-c047b4b2e368");
     constexpr uint32_t CHUNK_SIZE{753U};
     constexpr uint32_t USER_PAYLOAD_SIZE{8U};
 
@@ -93,6 +96,7 @@ TEST(ChunkHeader_test, UserPayloadFunctionCalledFromNonConstChunkHeaderWorks)
 
 TEST(ChunkHeader_test, UserPayloadFunctionCalledFromConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "091451db-09ed-4aa4-bcfe-d45c0c6d6c14");
     constexpr uint32_t CHUNK_SIZE{753U};
     constexpr uint32_t USER_PAYLOAD_SIZE{8U};
 
@@ -110,18 +114,21 @@ TEST(ChunkHeader_test, UserPayloadFunctionCalledFromConstChunkHeaderWorks)
 
 TEST(ChunkHeader_test, UserPayloadFunctionCalledFromNonConstChunkHeaderReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8876c866-2dda-4fb4-a96b-cee7f6b5e00b");
     auto isNonConstReturn = std::is_same<decltype(std::declval<ChunkHeader>().userPayload()), void*>::value;
     EXPECT_TRUE(isNonConstReturn);
 }
 
 TEST(ChunkHeader_test, UserPayloadFunctionCalledFromConstChunkHeaderReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "34957f49-06b3-426b-a0ba-df9071611fb2");
     auto isConstReturn = std::is_same<decltype(std::declval<const ChunkHeader>().userPayload()), const void*>::value;
     EXPECT_TRUE(isConstReturn);
 }
 
 TEST(ChunkHeader_test, UserHeaderFunctionCalledFromNonConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2ddbb681-e8bb-42e0-9546-e9fd64c44be0");
     alignas(ChunkHeader) static uint8_t storage[1024 * 1024];
 
     constexpr uint32_t CHUNK_SIZE{753U};
@@ -144,6 +151,7 @@ TEST(ChunkHeader_test, UserHeaderFunctionCalledFromNonConstChunkHeaderWorks)
 
 TEST(ChunkHeader_test, UserHeaderFunctionCalledFromConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "04f902b9-0870-4ba4-b761-856e9bbfcd85");
     alignas(ChunkHeader) static uint8_t storage[1024 * 1024];
 
     constexpr uint32_t CHUNK_SIZE{753U};
@@ -167,18 +175,21 @@ TEST(ChunkHeader_test, UserHeaderFunctionCalledFromConstChunkHeaderWorks)
 
 TEST(ChunkHeader_test, UserHeaderFunctionCalledFromNonConstChunkHeaderReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "420fc560-c309-4fc2-9224-aec70c8212cc");
     auto isNonConstReturn = std::is_same<decltype(std::declval<ChunkHeader>().userHeader()), void*>::value;
     EXPECT_TRUE(isNonConstReturn);
 }
 
 TEST(ChunkHeader_test, UserHeaderFunctionCalledFromConstChunkHeaderReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ca80c797-a22a-4d47-ba79-0f858b5d7836");
     auto isConstReturn = std::is_same<decltype(std::declval<const ChunkHeader>().userHeader()), const void*>::value;
     EXPECT_TRUE(isConstReturn);
 }
 
 TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithNullptrReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9297471a-42ab-454c-9a10-ae2dd71e6bf9");
     constexpr void* USER_PAYLOAD{nullptr};
     auto chunkHeader = ChunkHeader::fromUserPayload(USER_PAYLOAD);
     EXPECT_THAT(chunkHeader, Eq(nullptr));
@@ -186,6 +197,7 @@ TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithNullptrReturnsNullptr)
 
 TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithConstNullptrReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de23b1ac-6552-4613-ac66-707d22157a0c");
     constexpr const void* USER_PAYLOAD{nullptr};
     auto chunkHeader = ChunkHeader::fromUserPayload(USER_PAYLOAD);
     EXPECT_THAT(chunkHeader, Eq(nullptr));
@@ -193,6 +205,7 @@ TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithConstNullptrReturnsNullp
 
 TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithNonConstParamReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "835d2c6e-490d-478d-a882-f51d113a73a3");
     auto isNonConstReturn =
         std::is_same<decltype(ChunkHeader::fromUserPayload(std::declval<void*>())), ChunkHeader*>::value;
     EXPECT_TRUE(isNonConstReturn);
@@ -200,6 +213,7 @@ TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithNonConstParamReturnsNonC
 
 TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithConstParamReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "57ea3b52-fad4-4250-ab4d-276d5472edf1");
     auto isConstReturn =
         std::is_same<decltype(ChunkHeader::fromUserPayload(std::declval<const void*>())), const ChunkHeader*>::value;
     EXPECT_TRUE(isConstReturn);
@@ -207,6 +221,7 @@ TEST(ChunkHeader_test, FromUserPayloadFunctionCalledWithConstParamReturnsConstTy
 
 TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithNullptrReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "56fc6dd9-791b-4803-bd1a-5a0b53b0875d");
     constexpr void* USER_HEADER{nullptr};
     auto chunkHeader = ChunkHeader::fromUserHeader(USER_HEADER);
     EXPECT_THAT(chunkHeader, Eq(nullptr));
@@ -214,6 +229,7 @@ TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithNullptrReturnsNullptr)
 
 TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithConstNullptrReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f388ae41-7102-4d35-806e-4a572890e7a0");
     constexpr const void* USER_HEADER{nullptr};
     auto chunkHeader = ChunkHeader::fromUserHeader(USER_HEADER);
     EXPECT_THAT(chunkHeader, Eq(nullptr));
@@ -221,6 +237,7 @@ TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithConstNullptrReturnsNullpt
 
 TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithNonConstParamReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "993df4e6-2cc2-4ae1-b4d4-01a4ded65ba4");
     auto isNonConstReturn =
         std::is_same<decltype(ChunkHeader::fromUserHeader(std::declval<void*>())), ChunkHeader*>::value;
     EXPECT_TRUE(isNonConstReturn);
@@ -228,6 +245,7 @@ TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithNonConstParamReturnsNonCo
 
 TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithConstParamReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9b9a09b8-0baa-4a30-95e4-d081e01038d2");
     auto isConstReturn =
         std::is_same<decltype(ChunkHeader::fromUserHeader(std::declval<const void*>())), const ChunkHeader*>::value;
     EXPECT_TRUE(isConstReturn);
@@ -235,6 +253,7 @@ TEST(ChunkHeader_test, FromUserHeaderFunctionCalledWithConstParamReturnsConstTyp
 
 TEST(ChunkHeader_test, UsedChunkSizeIsSizeOfChunkHeaderWhenUserPayloadIsZero)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67d3907e-5090-4814-b726-2a37e8780395");
     constexpr uint32_t CHUNK_SIZE{2 * sizeof(ChunkHeader)};
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
 
@@ -249,6 +268,7 @@ TEST(ChunkHeader_test, UsedChunkSizeIsSizeOfChunkHeaderWhenUserPayloadIsZero)
 
 TEST(ChunkHeader_test, UsedChunkSizeIsSizeOfChunkHeaderPlusOneWhenUserPayloadIsOne)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a0cd3a1-3edc-441a-9ba6-486a463ad9d7");
     constexpr uint32_t CHUNK_SIZE{2 * sizeof(ChunkHeader)};
     constexpr uint32_t USER_PAYLOAD_SIZE{1U};
 
@@ -263,6 +283,7 @@ TEST(ChunkHeader_test, UsedChunkSizeIsSizeOfChunkHeaderPlusOneWhenUserPayloadIsO
 
 TEST(ChunkHeader_test, ConstructorTerminatesWhenUserPayloadSizeExceedsChunkSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c8f911eb-ed0d-495a-8858-9fc45f5a06e8");
     constexpr uint32_t CHUNK_SIZE{128U};
     constexpr uint32_t USER_PAYLOAD_SIZE{2U * CHUNK_SIZE};
 
@@ -443,6 +464,7 @@ INSTANTIATE_TEST_SUITE_P(ChunkHeader_test,
 
 TEST_P(ChunkHeader_AlteringUserPayloadWithoutUserHeader, CheckIntegrityOfChunkHeaderWithoutUserHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e80e27f1-de7c-4be4-a83e-9f0eb766de12");
     const auto userPayloadParams = GetParam();
 
     SCOPED_TRACE(std::string("User-Payload: size = ") + iox::cxx::convert::toString(userPayloadParams.size)
@@ -499,6 +521,7 @@ INSTANTIATE_TEST_SUITE_P(ChunkHeader_test,
 
 TEST_P(ChunkHeader_AlteringUserPayloadWithUserHeader, CheckIntegrityOfChunkHeaderWithUserHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0d45cb6-cf0c-44e7-b759-fdc25535c9c4");
     const auto userPayloadParams = GetParam();
 
     SCOPED_TRACE(std::string("User-Payload: size = ") + iox::cxx::convert::toString(userPayloadParams.size)

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
@@ -33,6 +33,7 @@ using UserPayloadOffset_t = iox::mepoo::ChunkHeader::UserPayloadOffset_t;
 
 TEST(ChunkSettings_test, CallingUserPayloadSizeReturnsCorrectValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "09b4d176-7fab-4957-8eb7-9c274dfa0ab1");
     constexpr uint32_t USER_PAYLOAD_SIZE{42U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     constexpr uint32_t USER_HEADER_SIZE{64U};
@@ -48,6 +49,7 @@ TEST(ChunkSettings_test, CallingUserPayloadSizeReturnsCorrectValue)
 
 TEST(ChunkSettings_test, CallingUserPayloadAlignmentReturnsCorrectValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "310e7342-9654-4c27-8be8-419b63f5c783");
     constexpr uint32_t USER_PAYLOAD_SIZE{42U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     constexpr uint32_t USER_HEADER_SIZE{64U};
@@ -63,6 +65,7 @@ TEST(ChunkSettings_test, CallingUserPayloadAlignmentReturnsCorrectValue)
 
 TEST(ChunkSettings_test, CallingUserHeaderSizeReturnsCorrectValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c39d8d59-1f37-428c-b902-16e8eb8f80e7");
     constexpr uint32_t USER_PAYLOAD_SIZE{42U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     constexpr uint32_t USER_HEADER_SIZE{64U};
@@ -78,6 +81,7 @@ TEST(ChunkSettings_test, CallingUserHeaderSizeReturnsCorrectValue)
 
 TEST(ChunkSettings_test, CallingUserHeaderAlignmentReturnsCorrectValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf75ffae-7ace-4eb7-b6ab-c6dfc7e3251e");
     constexpr uint32_t USER_PAYLOAD_SIZE{42U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     constexpr uint32_t USER_HEADER_SIZE{64U};
@@ -93,6 +97,7 @@ TEST(ChunkSettings_test, CallingUserHeaderAlignmentReturnsCorrectValue)
 
 TEST(ChunkSettings_test, CallingRequiredChunkSizeReturnsCorrectValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8e8ba2a5-467b-4bf3-9231-2228187c9ca7");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
     constexpr uint32_t USER_HEADER_SIZE{iox::CHUNK_NO_USER_HEADER_SIZE};
@@ -114,6 +119,7 @@ TEST(ChunkSettings_test, CallingRequiredChunkSizeReturnsCorrectValue)
 
 TEST(ChunkSettings_test, NoCustomUserPayloadAlignmentAndTooLargeUserPayload_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1ac315d5-fb8d-4529-b141-110fe7c7988d");
     constexpr uint32_t USER_PAYLOAD_SIZE{std::numeric_limits<uint32_t>::max()};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
     constexpr uint32_t USER_HEADER_SIZE{iox::CHUNK_NO_USER_HEADER_SIZE};
@@ -128,6 +134,7 @@ TEST(ChunkSettings_test, NoCustomUserPayloadAlignmentAndTooLargeUserPayload_Fail
 
 TEST(ChunkSettings_test, CustomUserPayloadAlignmentAndTooLargeUserPayload_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fade135d-636f-4b06-8f5d-b33eece1175c");
     constexpr uint32_t USER_PAYLOAD_SIZE{std::numeric_limits<uint32_t>::max()};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{alignof(ChunkHeader) * 2};
     constexpr uint32_t USER_HEADER_SIZE{iox::CHUNK_NO_USER_HEADER_SIZE};
@@ -142,6 +149,7 @@ TEST(ChunkSettings_test, CustomUserPayloadAlignmentAndTooLargeUserPayload_Fails)
 
 TEST(ChunkSettings_test, UserHeaderAndTooLargeUserPayload_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b61df037-6dae-4350-896e-9ffad96db028");
     constexpr uint32_t USER_PAYLOAD_SIZE{std::numeric_limits<uint32_t>::max()};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{alignof(ChunkHeader) * 2};
     constexpr uint32_t USER_HEADER_SIZE{8U};
@@ -160,6 +168,7 @@ TEST(ChunkSettings_test, UserHeaderAndTooLargeUserPayload_Fails)
 
 TEST(ChunkSettings_test, UserPayloadAlignmentNotPowerOfTwo_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "76ad6bad-5175-4475-8834-7a569cb0e489");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{13U};
     constexpr uint32_t USER_HEADER_SIZE{0U};
@@ -174,6 +183,7 @@ TEST(ChunkSettings_test, UserPayloadAlignmentNotPowerOfTwo_Fails)
 
 TEST(ChunkSettings_test, UserHeaderAlignmentNotPowerOfTwo_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2287e0f5-5206-4033-8b23-01fc9ee7d14f");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{1U};
     constexpr uint32_t USER_HEADER_SIZE{0U};
@@ -188,6 +198,7 @@ TEST(ChunkSettings_test, UserHeaderAlignmentNotPowerOfTwo_Fails)
 
 TEST(ChunkSettings_test, UserHeaderAlignmentLargerThanChunkHeaderAlignment_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6425744a-0ef7-47c3-8819-5c51bb41add7");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
     constexpr uint32_t USER_HEADER_SIZE{8U};
@@ -202,6 +213,7 @@ TEST(ChunkSettings_test, UserHeaderAlignmentLargerThanChunkHeaderAlignment_Fails
 
 TEST(ChunkSettings_test, UserHeaderSizeNotMultipleOfAlignment_Fails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5f5d9a0-ee02-45f3-8d72-ef493ddbac8e");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
     constexpr uint32_t USER_HEADER_SIZE{12U};
@@ -268,6 +280,7 @@ INSTANTIATE_TEST_SUITE_P(ChunkSettings_test,
 
 TEST_P(ChunkSettings_AlteringUserPayloadWithoutUserHeader, RequiredChunkSizeIsCorrect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ec520e0a-043d-43eb-80b5-91e93c89dc62");
     const auto userPayload = GetParam();
 
     SCOPED_TRACE(std::string("User-Payload: size = ") + iox::cxx::convert::toString(userPayload.size)
@@ -359,6 +372,7 @@ uint32_t expectedChunkSizeWithUserHeader(const PayloadParams& userPayload, uint3
 TEST_P(ChunkSettings_AlteringUserPayloadWithUserHeader,
        MultipleUserHeaderSizesAndAlignments_ResultsIn_RequiredChunkSizeIsCorrect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67b54ff2-0ab6-4fe4-b697-8fca2e22c009");
     const auto userPayload = GetParam();
 
     SCOPED_TRACE(std::string("User-Payload: size = ") + iox::cxx::convert::toString(userPayload.size)

--- a/iceoryx_posh/test/moduletests/test_mepoo_config.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_config.cpp
@@ -35,6 +35,7 @@ class MePooConfig_Test : public Test
 
 TEST_F(MePooConfig_Test, AddMemPoolMethodAddsTheCorrespondingMempoolInTheMemPoolConfigContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e2e10dcf-039a-4865-a8fa-5a716994f213");
     MePooConfig sut;
     constexpr uint32_t SIZE{128U};
     constexpr uint32_t CHUNK_COUNT{100U};
@@ -48,6 +49,7 @@ TEST_F(MePooConfig_Test, AddMemPoolMethodAddsTheCorrespondingMempoolInTheMemPool
 
 TEST_F(MePooConfig_Test, AddingMempoolWhenTheMemPoolConfigContainerIsFullReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67227cee-44e2-445f-ba6b-5066e7348757");
     MePooConfig sut;
     constexpr uint32_t SIZE{128U};
     constexpr uint32_t CHUNK_COUNT{100U};
@@ -61,6 +63,7 @@ TEST_F(MePooConfig_Test, AddingMempoolWhenTheMemPoolConfigContainerIsFullReturns
 
 TEST_F(MePooConfig_Test, SetDefaultMethodAddsTheDefaultMemPoolConfigurationToTheMemPoolConfigContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "744b4d55-9782-421d-aafb-4464ec00d2a1");
     MePooConfig sut;
     MePooConfig::Entry defaultEntry[7] = {{128U, 10000U},
                                           {1024U, 5000U},
@@ -82,6 +85,7 @@ TEST_F(MePooConfig_Test, SetDefaultMethodAddsTheDefaultMemPoolConfigurationToThe
 
 TEST_F(MePooConfig_Test, GetMemoryConfigMethodReturnsTheMemPoolConfigContainerWithAddedMempools)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "45abbd55-9d30-4fdc-abf8-4dd85c2d48b4");
     MePooConfig sut;
     constexpr uint32_t CHUNK_COUNT{100U};
     constexpr uint32_t SIZE{128U};
@@ -96,6 +100,7 @@ TEST_F(MePooConfig_Test, GetMemoryConfigMethodReturnsTheMemPoolConfigContainerWi
 
 TEST_F(MePooConfig_Test, OptimizeMethodCombinesTwoMempoolWithSameSizeAndDoublesTheChunkCountInTheMemPoolConfigContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b39e5bc5-4352-4427-be72-deeed45d937d");
     MePooConfig sut;
     constexpr uint32_t CHUNK_COUNT{100U};
     constexpr uint32_t SIZE{100U};
@@ -110,6 +115,7 @@ TEST_F(MePooConfig_Test, OptimizeMethodCombinesTwoMempoolWithSameSizeAndDoublesT
 
 TEST_F(MePooConfig_Test, OptimizeMethodRemovesTheMempoolWithSizeZeroInTheMemPoolConfigContainer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "56209c3e-8b69-45cd-8ea5-ef347152ff7c");
     MePooConfig sut;
     constexpr uint32_t CHUNK_COUNT{100U};
     constexpr uint32_t SIZE_1{64U};
@@ -128,6 +134,7 @@ TEST_F(MePooConfig_Test, OptimizeMethodRemovesTheMempoolWithSizeZeroInTheMemPool
 
 TEST_F(MePooConfig_Test, OptimizeMethodSortsTheAddedMempoolsInTheMemPoolConfigContainerInIncreasingOrderOfSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9034d02-9fa9-404f-955c-12f647b3a946");
     MePooConfig sut;
     constexpr uint32_t CHUNK_COUNT{100U};
     constexpr uint32_t SIZE_1{512U};
@@ -147,6 +154,7 @@ TEST_F(MePooConfig_Test, OptimizeMethodSortsTheAddedMempoolsInTheMemPoolConfigCo
 
 TEST_F(MePooConfig_Test, VerifyOptimizeMethodOnMePooConfigWithNoAddedMemPools)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8ee01d92-acb6-4841-b844-2ae151c53200");
     MePooConfig sut;
 
     sut.optimize();

--- a/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
@@ -85,6 +85,7 @@ class MemoryManager_test : public Test
 
 TEST_F(MemoryManager_test, AddingMempoolNotInTheIncreasingOrderReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "df439901-8d42-4532-8494-21d5447ef7d7");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
     mempoolconf.addMemPool({CHUNK_SIZE_128, CHUNK_COUNT});
@@ -105,6 +106,7 @@ TEST_F(MemoryManager_test, AddingMempoolNotInTheIncreasingOrderReturnsError)
 
 TEST_F(MemoryManager_test, WrongCallOfConfigureMemoryManagerReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "04cbf769-8721-454b-b038-96dd467ac3c2");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
     mempoolconf.addMemPool({CHUNK_SIZE_64, CHUNK_COUNT});
@@ -124,6 +126,7 @@ TEST_F(MemoryManager_test, WrongCallOfConfigureMemoryManagerReturnsError)
 
 TEST_F(MemoryManager_test, GetMempoolInfoMethodForOutOfBoundaryMempoolIndexReturnsZeroForAllMempoolAttributes)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "897e635e-d6df-46be-a3f0-7373b4116102");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
     mempoolconf.addMemPool({CHUNK_SIZE_64, CHUNK_COUNT});
@@ -140,6 +143,7 @@ TEST_F(MemoryManager_test, GetMempoolInfoMethodForOutOfBoundaryMempoolIndexRetur
 
 TEST_F(MemoryManager_test, GetNumberOfMemPoolsMethodReturnsTheNumberOfMemPools)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e3c05153-add7-4098-8045-88960970d2a7");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
     mempoolconf.addMemPool({CHUNK_SIZE_64, CHUNK_COUNT});
@@ -152,6 +156,7 @@ TEST_F(MemoryManager_test, GetNumberOfMemPoolsMethodReturnsTheNumberOfMemPools)
 
 TEST_F(MemoryManager_test, GetChunkMethodWithNoMemPoolInMemConfigReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dff31ea2-8ae0-4786-8c97-633af59c287d");
     iox::cxx::optional<iox::Error> detectedError;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&detectedError](const iox::Error error, const std::function<void()>, const iox::ErrorLevel errorLevel) {
@@ -176,6 +181,7 @@ TEST_F(MemoryManager_test, GetChunkMethodWithNoMemPoolInMemConfigReturnsError)
 
 TEST_F(MemoryManager_test, GetChunkMethodWithChunkSizeGreaterThanAvailableChunkSizeInMemPoolConfigReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d2104b74-5092-484d-bb9d-554996dffbc5");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
     mempoolconf.addMemPool({CHUNK_SIZE_64, CHUNK_COUNT});
@@ -205,6 +211,7 @@ TEST_F(MemoryManager_test, GetChunkMethodWithChunkSizeGreaterThanAvailableChunkS
 
 TEST_F(MemoryManager_test, GetChunkMethodWhenNoFreeChunksInMemPoolConfigReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0f201458-040e-43b1-a51b-698c2957ca7c");
     constexpr uint32_t CHUNK_COUNT{1U};
     constexpr uint32_t PAYLOAD_SIZE{100U};
     mempoolconf.addMemPool({CHUNK_SIZE_128, CHUNK_COUNT});
@@ -232,6 +239,7 @@ TEST_F(MemoryManager_test, GetChunkMethodWhenNoFreeChunksInMemPoolConfigReturnsE
 
 TEST_F(MemoryManager_test, VerifyGetChunkMethodWhenTheRequestedChunkIsAvailableInMemPoolConfig)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5069a9d-ae2f-4466-ae13-53b0794dd292");
     constexpr uint32_t CHUNK_COUNT{10U};
     mempoolconf.addMemPool({CHUNK_SIZE_128, CHUNK_COUNT});
     sut->configureMemoryManager(mempoolconf, *allocator, *allocator);
@@ -248,6 +256,7 @@ TEST_F(MemoryManager_test, VerifyGetChunkMethodWhenTheRequestedChunkIsAvailableI
 
 TEST_F(MemoryManager_test, getChunkSingleMemPoolAllChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6623841b-baf0-4636-a5d4-b21e4678b7e8");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     mempoolconf.addMemPool({128, CHUNK_COUNT});
@@ -265,6 +274,7 @@ TEST_F(MemoryManager_test, getChunkSingleMemPoolAllChunks)
 
 TEST_F(MemoryManager_test, getChunkSingleMemPoolToMuchChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8af072c7-425b-4820-bc28-0c1e6bad0441");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     mempoolconf.addMemPool({CHUNK_SIZE_128, CHUNK_COUNT});
@@ -280,6 +290,7 @@ TEST_F(MemoryManager_test, getChunkSingleMemPoolToMuchChunks)
 
 TEST_F(MemoryManager_test, freeChunkSingleMemPoolFullToEmptyToFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0cbb56ae-c5a3-46b6-bfab-abbf91b0ed64");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     // chunks are freed when they go out of scope
@@ -301,6 +312,7 @@ TEST_F(MemoryManager_test, freeChunkSingleMemPoolFullToEmptyToFull)
 
 TEST_F(MemoryManager_test, getChunkMultiMemPoolSingleChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b22f804d-2e12-40c3-8bec-f9a0ab375e98");
     constexpr uint32_t CHUNK_COUNT{10U};
 
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
@@ -320,6 +332,7 @@ TEST_F(MemoryManager_test, getChunkMultiMemPoolSingleChunk)
 
 TEST_F(MemoryManager_test, getChunkMultiMemPoolAllChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cdb65377-7579-4c76-9931-9552071fff5c");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
@@ -341,6 +354,7 @@ TEST_F(MemoryManager_test, getChunkMultiMemPoolAllChunks)
 
 TEST_F(MemoryManager_test, getChunkMultiMemPoolTooMuchChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "975e1347-9b39-4fda-a95a-0725b04f7d7d");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
@@ -369,6 +383,7 @@ TEST_F(MemoryManager_test, getChunkMultiMemPoolTooMuchChunks)
 
 TEST_F(MemoryManager_test, emptyMemPoolDoesNotResultInAcquiringChunksFromOtherMemPools)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c2ff3937-6cdf-43ad-bec6-5203521a8f57");
     constexpr uint32_t CHUNK_COUNT{100};
 
     mempoolconf.addMemPool({CHUNK_SIZE_32, CHUNK_COUNT});
@@ -392,6 +407,7 @@ TEST_F(MemoryManager_test, emptyMemPoolDoesNotResultInAcquiringChunksFromOtherMe
 
 TEST_F(MemoryManager_test, freeChunkMultiMemPoolFullToEmptyToFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0eddc5b5-e28f-43df-9da7-2c12014284a5");
     constexpr uint32_t CHUNK_COUNT{100U};
 
     // chunks are freed when they go out of scope
@@ -433,6 +449,7 @@ TEST_F(MemoryManager_test, freeChunkMultiMemPoolFullToEmptyToFull)
 
 TEST_F(MemoryManager_test, getChunkWithUserPayloadSizeZeroShouldNotFail)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9fbfe1ff-9d59-449b-b164-433bbb031125");
     constexpr uint32_t USER_PAYLOAD_SIZE{0U};
     auto chunkSettingsResult = ChunkSettings::create(USER_PAYLOAD_SIZE, iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
     ASSERT_FALSE(chunkSettingsResult.has_error());
@@ -448,12 +465,14 @@ TEST_F(MemoryManager_test, getChunkWithUserPayloadSizeZeroShouldNotFail)
 
 TEST_F(MemoryManager_test, addMemPoolWithChunkCountZeroShouldFail)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "be653b65-a2d1-42eb-98b5-d161c6ba7c08");
     mempoolconf.addMemPool({32, 0});
     EXPECT_DEATH({ sut->configureMemoryManager(mempoolconf, *allocator, *allocator); }, ".*");
 }
 
 TEST(MemoryManagerEnumString_test, asStringLiteralConvertsEnumValuesToStrings)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5f6c3942-0af5-4c48-b44c-7268191dbac5");
     using Error = iox::mepoo::MemoryManager::Error;
 
     // each bit corresponds to an enum value and must be set to true on test
@@ -487,6 +506,7 @@ TEST(MemoryManagerEnumString_test, asStringLiteralConvertsEnumValuesToStrings)
 
 TEST(MemoryManagerEnumString_test, LogStreamConvertsEnumValueToString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4a3539e5-5465-4352-b2b7-a850e104c173");
     Logger_Mock loggerMock;
 
     auto sut = iox::mepoo::MemoryManager::Error::MEMPOOL_OUT_OF_CHUNKS;

--- a/iceoryx_posh/test/moduletests/test_mepoo_mempool.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_mempool.cpp
@@ -52,6 +52,7 @@ class MemPool_test : public Test
 
 TEST_F(MemPool_test, MempoolCtorInitialisesTheObjectWithValuesPassedToTheCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b15b0da5-74e0-481b-87b6-53888b8a9890");
     char memory[8192];
     iox::posix::Allocator allocator{memory, 8192U};
 
@@ -65,6 +66,7 @@ TEST_F(MemPool_test, MempoolCtorInitialisesTheObjectWithValuesPassedToTheCtor)
 
 TEST_F(MemPool_test, MempoolCtorWhenChunkSizeIsNotAMultipleOfAlignmentReturnError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee06090a-8e3c-4df2-b74e-ed50e29b84e6");
     char memory[8192U];
     iox::posix::Allocator allocator{memory, 100U};
     constexpr uint32_t NOT_ALLIGNED_CHUNKED_SIZE{33U};
@@ -85,6 +87,7 @@ TEST_F(MemPool_test, MempoolCtorWhenChunkSizeIsNotAMultipleOfAlignmentReturnErro
 
 TEST_F(MemPool_test, MempoolCtorWhenChunkSizeIsSmallerThanChunkMemoryAlignmentGetsTerminated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "52df897a-0847-476c-9d2f-99cb16432199");
     constexpr uint32_t CHUNK_SIZE_SMALLER_THAN_MEMORY_ALIGNMENT = iox::mepoo::MemPool::CHUNK_MEMORY_ALIGNMENT - 1U;
 
     EXPECT_DEATH(
@@ -94,11 +97,13 @@ TEST_F(MemPool_test, MempoolCtorWhenChunkSizeIsSmallerThanChunkMemoryAlignmentGe
 
 TEST_F(MemPool_test, MempoolCtorWhenNumberOfChunksIsZeroGetsTerminated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5c43e1b-e5b5-4a69-8c4c-8b95752ade8e");
     constexpr uint32_t INVALID_NUMBER_OF_CHUNKS = 0U;
     EXPECT_DEATH({ iox::mepoo::MemPool sut(CHUNK_SIZE, INVALID_NUMBER_OF_CHUNKS, allocator, allocator); }, ".*");
 }
 TEST_F(MemPool_test, GetChunkMethodWhenAllTheChunksAreUsedReturnsNullPointer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "43caa0b0-419b-4749-988d-c3af5ada35ad");
     for (uint8_t i = 0U; i < NUMBER_OF_CHUNKS; i++)
     {
         sut.getChunk();
@@ -109,6 +114,7 @@ TEST_F(MemPool_test, GetChunkMethodWhenAllTheChunksAreUsedReturnsNullPointer)
 
 TEST_F(MemPool_test, WritingDataToAChunkStoresTheCorrespondingDataInTheChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4550d044-d1c8-493d-b839-40509b03407f");
     std::vector<uint8_t*> chunks;
     for (uint8_t i = 0U; i < NUMBER_OF_CHUNKS; i++)
     {
@@ -126,16 +132,19 @@ TEST_F(MemPool_test, WritingDataToAChunkStoresTheCorrespondingDataInTheChunk)
 
 TEST_F(MemPool_test, GetChunkSizeMethodReturnsTheSizeOfTheChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f32e1446-1a60-4d1d-b713-4193b49466bd");
     EXPECT_THAT(sut.getChunkSize(), Eq(CHUNK_SIZE));
 }
 
 TEST_F(MemPool_test, GetChunkCountMethodReturnsTheNumberOfChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f8012260-ec47-4e0e-9d15-964740887938");
     EXPECT_THAT(sut.getChunkCount(), Eq(NUMBER_OF_CHUNKS));
 }
 
 TEST_F(MemPool_test, GetUsedChunksMethodReturnsTheNumberOfUsedChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1e2d1a62-5bbf-4139-a7cf-c0ca9650441f");
     for (uint32_t i = 0U; i < NUMBER_OF_CHUNKS; ++i)
     {
         sut.getChunk();
@@ -145,6 +154,7 @@ TEST_F(MemPool_test, GetUsedChunksMethodReturnsTheNumberOfUsedChunks)
 
 TEST_F(MemPool_test, VerifyFreeChunkMethodWhichFreesTheUsedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e590fa58-732f-4027-85a9-9e0c8593ea70");
     std::vector<uint8_t*> chunks;
     for (uint32_t i = 0U; i < NUMBER_OF_CHUNKS; ++i)
     {
@@ -160,6 +170,7 @@ TEST_F(MemPool_test, VerifyFreeChunkMethodWhichFreesTheUsedChunk)
 
 TEST_F(MemPool_test, FreeChunkMethodWhenSameChunkIsTriedToFreeTwiceReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0fc95552-4714-4a8a-9144-98aafbd37dc7");
     std::vector<uint8_t*> chunks;
     constexpr uint32_t INDEX{0U};
     chunks.push_back(reinterpret_cast<uint8_t*>(sut.getChunk()));
@@ -179,6 +190,7 @@ TEST_F(MemPool_test, FreeChunkMethodWhenSameChunkIsTriedToFreeTwiceReturnsError)
 
 TEST_F(MemPool_test, FreeChunkMethodWhenTheChunkIndexIsInvalidReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fb68953e-d47a-4658-8109-6b1974a8baab");
     std::vector<uint8_t*> chunks;
     constexpr uint32_t INVALID_INDEX{1U};
     chunks.push_back(reinterpret_cast<uint8_t*>(sut.getChunk()));
@@ -188,6 +200,7 @@ TEST_F(MemPool_test, FreeChunkMethodWhenTheChunkIndexIsInvalidReturnsError)
 
 TEST_F(MemPool_test, GetMinFreeMethodReturnsTheNumberOfFreeChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b6cf614e-836a-4a15-850e-700031bfa016");
     std::vector<uint8_t*> chunks;
     for (uint32_t i = 0U; i < NUMBER_OF_CHUNKS; ++i)
     {
@@ -198,11 +211,13 @@ TEST_F(MemPool_test, GetMinFreeMethodReturnsTheNumberOfFreeChunks)
 
 TEST_F(MemPool_test, dieWhenMempoolChunkSizeIsSmallerThan32Bytes)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7704246e-42b5-46fd-8827-ebac200390e1");
     EXPECT_DEATH({ iox::mepoo::MemPool sut(12, 10, allocator, allocator); }, ".*");
 }
 
 TEST_F(MemPool_test, dieWhenMempoolChunkSizeIsNotPowerOf32)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a354976-235a-4a94-8af2-2bc872f705f4");
     EXPECT_DEATH({ iox::mepoo::MemPool sut(333, 10, allocator, allocator); }, ".*");
 }
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -130,11 +130,13 @@ MePooSegment_test::SharedMemoryObject_MOCK::createFct MePooSegment_test::SharedM
 
 TEST_F(MePooSegment_test, DISABLED_sharedMemoryFileHandleRightsAfterConstructor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4719f767-3413-46cd-8d1e-92a3ca92760e");
     /// @todo
 }
 
 TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(SharedMemoryCreationParameter))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0fcfefd4-3a84-43a5-9805-057a60239184");
     MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [](const SharedMemory::Name_t f_name,
                                                                        const uint64_t,
                                                                        const iox::posix::AccessMode f_accessMode,
@@ -153,6 +155,7 @@ TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(SharedMemoryCreationPara
 
 TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetSharedMemoryObject))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e1c12dd0-fd7d-4be3-918b-08d16a68c8e0");
     uint64_t memorySizeInBytes{0};
     MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [&](const SharedMemory::Name_t,
                                                                         const uint64_t f_memorySizeInBytes,
@@ -172,16 +175,19 @@ TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetSharedMemoryObject))
 
 TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetReaderGroup))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ad3fd360-3765-45ae-8285-fe4ae60c91ae");
     EXPECT_THAT(sut.getReaderGroup(), Eq(iox::posix::PosixGroup("iox_roudi_test1")));
 }
 
 TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetWriterGroup))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3aa34489-bd46-4e77-89d6-20e82211e1a4");
     EXPECT_THAT(sut.getWriterGroup(), Eq(iox::posix::PosixGroup("iox_roudi_test2")));
 }
 
 TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetMemoryManager))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4bc4af78-4beb-42eb-aee4-0f7cffb66411");
     ASSERT_THAT(sut.getMemoryManager().getNumberOfMemPools(), Eq(1U));
     auto config = sut.getMemoryManager().getMemPoolInfo(0);
     ASSERT_THAT(config.m_numChunks, Eq(100U));

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
@@ -129,6 +129,7 @@ class SegmentManager_test : public Test
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForReadUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a3af818a-c119-4182-948a-1e709c29d97f");
     auto mapping = sut.getSegmentMappings(PosixUser{"iox_roudi_test1"});
     ASSERT_THAT(mapping.size(), Eq(1u));
     EXPECT_THAT(mapping[0].m_isWritable, Eq(false));
@@ -136,6 +137,7 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForR
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForWriteUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5e5d3128-5e4b-41e9-b541-ba9dc0bd57e3");
     auto mapping = sut.getSegmentMappings(PosixUser{"iox_roudi_test2"});
     ASSERT_THAT(mapping.size(), Eq(2u));
     EXPECT_THAT(mapping[0].m_isWritable == mapping[1].m_isWritable, Eq(false));
@@ -143,18 +145,21 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForW
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsEmptyForNonRegisteredUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7cf9a658-bb2d-444f-af67-0355e8f45ea2");
     auto mapping = sut.getSegmentMappings(PosixUser{"roudi_test4"});
     ASSERT_THAT(mapping.size(), Eq(0u));
 }
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsEmptyForNonExistingUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ca869fa8-49cd-43bc-8d72-4024b45f1f5f");
     auto mapping = sut.getSegmentMappings(PosixUser{"no_user"});
     ASSERT_THAT(mapping.size(), Eq(0u));
 }
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserWithWriteUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2fd4262a-20d2-4631-9b63-610944f28120");
     auto memoryManager = sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"iox_roudi_test2"}).m_memoryManager;
     ASSERT_TRUE(memoryManager.has_value());
     ASSERT_THAT(memoryManager.value().get().getNumberOfMemPools(), Eq(2u));
@@ -167,17 +172,20 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUse
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserFailWithReadOnlyUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9d7c18fd-b8db-425a-830d-22c781091244");
     EXPECT_FALSE(
         sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"iox_roudi_test1"}).m_memoryManager.has_value());
 }
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserFailWithNonExistingUser))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bff18ab5-89ff-45e0-97ea-5409169ddf9a");
     EXPECT_FALSE(sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"no_user"}).m_memoryManager.has_value());
 }
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMoreThanOneWriterGroupFails))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3fa29560-7341-43bf-a22e-2d3550b49e4e");
     auto errorHandlerCalled{false};
     iox::Error receivedError{iox::Error::kNO_ERROR};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -197,6 +205,7 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMoreThanOneWrite
 
 TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMaximumNumberOfSegmentsWorks))
 {
+    ::testing::Test::RecordProperty("TEST_ID", "79db009a-da1a-4140-b375-f174af615d54");
     SegmentConfig segmentConfig = getSegmentConfigWithMaximumNumberOfSegements();
     SegmentManager<MePooSegmentMock> sut{segmentConfig, &allocator};
 }

--- a/iceoryx_posh/test/moduletests/test_mepoo_shared_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shared_chunk.cpp
@@ -68,6 +68,7 @@ class SharedChunk_Test : public Test
 
 TEST_F(SharedChunk_Test, SharedChunkObjectUpOnInitilizationSetsTheChunkHeaderToNullPointer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "37eabb48-502c-4c06-a0f8-237796702107");
     SharedChunk sut;
 
     EXPECT_THAT(sut.getChunkHeader(), Eq(nullptr));
@@ -75,6 +76,7 @@ TEST_F(SharedChunk_Test, SharedChunkObjectUpOnInitilizationSetsTheChunkHeaderToN
 
 TEST_F(SharedChunk_Test, VerifyCopyConstructorOfSharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bee0c277-8542-4a72-be1e-7940ba5390e7");
     SharedChunk sut1(sut);
 
     EXPECT_EQ(sut.release(), sut1.release());
@@ -82,6 +84,7 @@ TEST_F(SharedChunk_Test, VerifyCopyConstructorOfSharedChunk)
 
 TEST_F(SharedChunk_Test, VerifyMoveConstructorOfSharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c13e0a4c-556b-4ab1-a750-17b3b0f7a01d");
     SharedChunk sut1(chunkManagement);
 
     SharedChunk sut2(std::move(sut1));
@@ -92,6 +95,7 @@ TEST_F(SharedChunk_Test, VerifyMoveConstructorOfSharedChunk)
 
 TEST_F(SharedChunk_Test, VerifiyCopyAssigmentWithSharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b18be03-beeb-449d-8b04-01a40c648d95");
     SharedChunk sut1;
 
     sut1 = sut;
@@ -101,6 +105,7 @@ TEST_F(SharedChunk_Test, VerifiyCopyAssigmentWithSharedChunk)
 
 TEST_F(SharedChunk_Test, VerifiyMoveAssigmentForSharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "99e37ef4-493d-43d3-a14d-ed12299ce9ae");
     SharedChunk sut1(chunkManagement);
     SharedChunk sut2;
 
@@ -112,11 +117,13 @@ TEST_F(SharedChunk_Test, VerifiyMoveAssigmentForSharedChunk)
 
 TEST_F(SharedChunk_Test, CompareWithSameMemoryChunkComparesToUserPayload)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "010e9453-2140-4342-afa9-bbab8a835aff");
     EXPECT_THAT(sut == sut.getUserPayload(), Eq(true));
 }
 
 TEST_F(SharedChunk_Test, GetChunkHeaderMethodReturnsNullPointerWhenSharedChunkObjectIsInitialisedWithNullPointer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "211d82c7-4b8c-49c6-a9dd-b8e79c481d90");
     SharedChunk sut;
 
     EXPECT_THAT(sut.getChunkHeader(), Eq(nullptr));
@@ -124,6 +131,7 @@ TEST_F(SharedChunk_Test, GetChunkHeaderMethodReturnsNullPointerWhenSharedChunkOb
 
 TEST_F(SharedChunk_Test, GetChunkHeaderMethodReturnsValidPointerWhenSharedChunkObjectIsInitialisedWithAValidPointer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3c3a3769-5825-4bb0-9daa-0bce0152a26b");
     void* newChunk = mempool.getChunk();
     SharedChunk sut(GetChunkManagement(newChunk));
 
@@ -132,6 +140,7 @@ TEST_F(SharedChunk_Test, GetChunkHeaderMethodReturnsValidPointerWhenSharedChunkO
 
 TEST_F(SharedChunk_Test, EqualityOperatorOnTwoSharedChunkWithTheSameContentReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "65a7ce87-5f64-48af-830d-71ab03db39e9");
     SharedChunk sut1{chunkManagement};
 
     EXPECT_TRUE(sut == sut1);
@@ -139,6 +148,7 @@ TEST_F(SharedChunk_Test, EqualityOperatorOnTwoSharedChunkWithTheSameContentRetur
 
 TEST_F(SharedChunk_Test, EqualityOperatorOnTwoSharedChunkWithDifferentContentReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84ebd9aa-83f1-4978-bd96-e4d8c03452bf");
     SharedChunk sut1;
 
     EXPECT_FALSE(sut == sut1);
@@ -146,6 +156,7 @@ TEST_F(SharedChunk_Test, EqualityOperatorOnTwoSharedChunkWithDifferentContentRet
 
 TEST_F(SharedChunk_Test, EqualityOperatorOnSharedChunkAndSharedChunkPayloadWithDifferentChunkManagementsReturnFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9e473823-5e95-4454-9740-e731c7aa46a7");
     SharedChunk sut1;
 
     EXPECT_FALSE(sut1 == sut.getUserPayload());
@@ -153,6 +164,7 @@ TEST_F(SharedChunk_Test, EqualityOperatorOnSharedChunkAndSharedChunkPayloadWithD
 
 TEST_F(SharedChunk_Test, EqualityOperatorOnSharedChunkAndSharedChunkPayloadWithSameChunkManagementsReturnTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e2d4ced9-ec74-47c5-abc2-ec9952168622");
     SharedChunk sut1{chunkManagement};
 
     EXPECT_TRUE(sut == sut1.getUserPayload());
@@ -160,11 +172,13 @@ TEST_F(SharedChunk_Test, EqualityOperatorOnSharedChunkAndSharedChunkPayloadWithS
 
 TEST_F(SharedChunk_Test, BoolOperatorOnValidSharedChunkReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3627515b-3f96-407f-a89e-a8f73aa8c70c");
     EXPECT_TRUE(sut);
 }
 
 TEST_F(SharedChunk_Test, BoolOperatorOnSharedChunkWithChunkManagementAsNullPointerReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53b2fd08-0188-439b-adc1-0602c97b8946");
     SharedChunk sut;
 
     EXPECT_FALSE(sut);
@@ -173,6 +187,7 @@ TEST_F(SharedChunk_Test, BoolOperatorOnSharedChunkWithChunkManagementAsNullPoint
 
 TEST_F(SharedChunk_Test, GetUserPayloadMethodReturnsNullPointerWhen_m_chunkmanagmentIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9eca2ed-d4e5-4739-8537-bd5ce273a939");
     SharedChunk sut1;
 
     EXPECT_THAT(sut1.getUserPayload(), Eq(nullptr));
@@ -180,6 +195,7 @@ TEST_F(SharedChunk_Test, GetUserPayloadMethodReturnsNullPointerWhen_m_chunkmanag
 
 TEST_F(SharedChunk_Test, GetUserPayloadMethodReturnsValidPointerWhen_m_chunkmanagmentIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "89ec859c-75cc-439c-84f5-0021696fee5e");
     using DATA_TYPE = uint32_t;
     constexpr DATA_TYPE USER_DATA{7337U};
     ChunkHeader* newChunk = static_cast<ChunkHeader*>(mempool.getChunk());
@@ -197,6 +213,7 @@ TEST_F(SharedChunk_Test, GetUserPayloadMethodReturnsValidPointerWhen_m_chunkmana
 
 TEST_F(SharedChunk_Test, MultipleSharedChunksCleanup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a8675bfb-cfa6-4cab-9ffe-2e8cfb4a2519");
     {
         SharedChunk sut3, sut4, sut5;
         {
@@ -231,6 +248,7 @@ TEST_F(SharedChunk_Test, MultipleSharedChunksCleanup)
 
 TEST_F(SharedChunk_Test, MultipleChunksCleanup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8d6f4575-7d86-4314-851f-537c7b3e75e5");
     {
         iox::mepoo::SharedChunk sut2(GetChunkManagement(mempool.getChunk()));
         {
@@ -265,6 +283,7 @@ TEST_F(SharedChunk_Test, MultipleChunksCleanup)
 
 TEST_F(SharedChunk_Test, NonEqualityOperatorOnTwoSharedChunkWithDifferentContentReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "50b24296-10ca-44e4-8150-bdf6202c589d");
     SharedChunk sut1;
 
     EXPECT_TRUE(sut1 != sut);
@@ -272,6 +291,7 @@ TEST_F(SharedChunk_Test, NonEqualityOperatorOnTwoSharedChunkWithDifferentContent
 
 TEST_F(SharedChunk_Test, NonEqualityOperatorOnTwoSharedChunkWithSameContentReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "152831f0-19c9-473e-8599-9fd0828dd173");
     SharedChunk sut1{chunkManagement};
 
     EXPECT_FALSE(sut1 != sut);
@@ -279,6 +299,7 @@ TEST_F(SharedChunk_Test, NonEqualityOperatorOnTwoSharedChunkWithSameContentRetur
 
 TEST_F(SharedChunk_Test, NonEqualityOperatorOnSharedChunkAndSharedChunkPayloadWithDifferentChunkManagementsReturnTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7e9666a7-13e8-46c4-ad06-59e2b3d62cca");
     SharedChunk sut1;
 
     EXPECT_TRUE(sut != sut1.getUserPayload());
@@ -286,6 +307,7 @@ TEST_F(SharedChunk_Test, NonEqualityOperatorOnSharedChunkAndSharedChunkPayloadWi
 
 TEST_F(SharedChunk_Test, NonEqualityOperatorOnSharedChunkAndSharedChunkPayloadWithSameChunkManagementsReturnFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b07f53b5-51c8-471f-9c63-05f432ec79e6");
     SharedChunk sut1{chunkManagement};
 
     EXPECT_FALSE(sut != sut1.getUserPayload());
@@ -293,6 +315,7 @@ TEST_F(SharedChunk_Test, NonEqualityOperatorOnSharedChunkAndSharedChunkPayloadWi
 
 TEST_F(SharedChunk_Test, ReleaseMethodReturnsChunkManagementPointerOfSharedChunkObjectAndSetsTheChunkHeaderToNull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "16d50171-28d2-4caa-b1b3-cdb56e366e26");
     ChunkManagement* returnValue = sut.release();
 
     EXPECT_EQ(returnValue, chunkManagement);

--- a/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
@@ -168,44 +168,52 @@ SharedPointer_Test::counter_t SharedPointer_Test::TestClass::counter;
 
 TEST_F(SharedPointer_Test, DefaultCTor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "035f3c9f-4b42-4a67-baae-a4347cd482cc");
     EXPECT_THAT(SharedPointer_Test::TestClass::counter.ctor, Eq(1));
 }
 
 TEST_F(SharedPointer_Test, ConstGetMethod)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c97a8b0c-bbf0-4ad1-8bb8-4c85c806478a");
     EXPECT_THAT(*const_cast<const SharedPointer<int>&>(sut).get(), Eq(42));
 }
 
 TEST_F(SharedPointer_Test, GetMethod)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b3069e1-3ded-46b4-b1cd-bfc44098adcb");
     *sut.get() = 7781;
     EXPECT_THAT(*sut.get(), Eq(7781));
 }
 
 TEST_F(SharedPointer_Test, ConstArrowOperator)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d44bb68e-d87f-4996-a20f-7ee5602c184a");
     EXPECT_THAT(const_cast<const SharedPointer<TestClass>&>(sutComplex)->a, Eq(1337));
 }
 
 TEST_F(SharedPointer_Test, ArrowOperator)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "17ca6efe-ba9e-4fed-af2d-676939873250");
     sutComplex->Increase();
     EXPECT_THAT(sutComplex->a, Eq(1349));
 }
 
 TEST_F(SharedPointer_Test, ConstStarOperator)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "587cc118-094c-4390-8fce-66ae3a95e93d");
     EXPECT_THAT((*const_cast<const SharedPointer<TestClass>&>(sutComplex)).b, Eq(851));
 }
 
 TEST_F(SharedPointer_Test, StarOperator)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ec938d1e-dcef-40fb-b1e8-f56e7265c014");
     (*sut)++;
     EXPECT_THAT(*sut, Eq(43));
 }
 
 TEST_F(SharedPointer_Test, CopyConstructor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0e2ed79c-d4a5-4702-9aa1-240f205274e6");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 313, 1313).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -228,6 +236,7 @@ TEST_F(SharedPointer_Test, CopyConstructor)
 
 TEST_F(SharedPointer_Test, MoveConstructor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "183d0ce3-a078-4bab-95f5-87b0da1e9842");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 15, 25).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -250,6 +259,7 @@ TEST_F(SharedPointer_Test, MoveConstructor)
 
 TEST_F(SharedPointer_Test, CopyAssignment)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fafcefb2-b599-4862-bf56-6ad6d593d1a5");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -268,6 +278,7 @@ TEST_F(SharedPointer_Test, CopyAssignment)
 
 TEST_F(SharedPointer_Test, MoveAssignment)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3be4dd7a-66cf-458c-9b9c-55459b02e75c");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -287,6 +298,7 @@ TEST_F(SharedPointer_Test, MoveAssignment)
 
 TEST_F(SharedPointer_Test, CopyToEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "94ab4d3f-1faf-4be8-bd04-b78c7f4850a8");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -305,6 +317,7 @@ TEST_F(SharedPointer_Test, CopyToEmpty)
 
 TEST_F(SharedPointer_Test, CopyFromEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee9dddea-0c80-44df-9dd0-5c9d4d4116ae");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -321,6 +334,7 @@ TEST_F(SharedPointer_Test, CopyFromEmpty)
 
 TEST_F(SharedPointer_Test, MoveToEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fae2118e-4a8d-4b59-bfcb-6819c5728e0c");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -339,6 +353,7 @@ TEST_F(SharedPointer_Test, MoveToEmpty)
 
 TEST_F(SharedPointer_Test, MoveFromEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d9b1a79c-a949-4532-a86b-ed49e7b5a0bb");
     {
         auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
         EXPECT_THAT(TestClass::counter.ctor, Eq(2)); // sutComplex is 1
@@ -355,11 +370,13 @@ TEST_F(SharedPointer_Test, MoveFromEmpty)
 
 TEST_F(SharedPointer_Test, DefaultCTorProvidesInvalidSharedPointer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b1183195-6829-48d9-96fd-caddaa7e9155");
     EXPECT_THAT(static_cast<bool>(SharedPointer<int>()), Eq(false));
 }
 
 TEST_F(SharedPointer_Test, SharedPointerWithContentIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "df031cdb-2cbe-4ef9-84ae-e177594e1941");
     auto sut3 = SharedPointer<TestClass>::create(chunk3, 1, 2).value();
     EXPECT_THAT(static_cast<bool>(sut3), Eq(true));
 }

--- a/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
@@ -65,6 +65,7 @@ class ShmSafeUnmanagedChunk_test : public Test
 
 TEST_F(ShmSafeUnmanagedChunk_test, DefaultConstructedResultsInLogicalNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7311a772-6787-47f6-a8c6-b674e3feb84e");
     ShmSafeUnmanagedChunk sut;
 
     EXPECT_TRUE(sut.isLogicalNullptr());
@@ -72,6 +73,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, DefaultConstructedResultsInLogicalNullptr)
 
 TEST_F(ShmSafeUnmanagedChunk_test, ConstructedWithEmptySharedChunkResultsInLogicalNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e2aced3-7dea-4349-a87e-eacb16059182");
     SharedChunk sharedChunk;
     ShmSafeUnmanagedChunk sut(sharedChunk);
 
@@ -80,6 +82,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, ConstructedWithEmptySharedChunkResultsInLogic
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallIsLogicalNullptrOnSutConstructedWithSharedChunkResultsNotInLogicalNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b11245ae-d15b-460f-8688-144f2ef50f72");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -91,6 +94,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallIsLogicalNullptrOnSutConstructedWithShare
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallIsLogicalNullptrOnSutPreviouslyCalledReleaseToSharedChunkResultsInLogicalNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ae81e3d9-a84d-47d0-beec-97845b0c3dba");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -102,6 +106,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallIsLogicalNullptrOnSutPreviouslyCalledRele
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallIsLogicalNullptrOnSutPreviouslyCalledDuplicateToSharedChunkResultsNotInLogicalNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "178c3a1a-2f74-47d1-99e8-f3b60a32ada0");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -114,6 +119,7 @@ TEST_F(ShmSafeUnmanagedChunk_test,
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallReleaseToSharedChunkOnDefaultConstructedSutResultsInEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe82457b-c9e2-48d2-86f8-0f4067ed0ff8");
     ShmSafeUnmanagedChunk sut;
 
     EXPECT_FALSE(sut.releaseToSharedChunk());
@@ -121,6 +127,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallReleaseToSharedChunkOnDefaultConstructedS
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallReleaseToSharedChunkOnSutConstructedWithSharedChunkResultsInNotEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62b9cff4-1e4f-4504-8b63-261b98f19758");
     ShmSafeUnmanagedChunk sut(getChunkFromMemoryManager());
 
     EXPECT_EQ(memoryManager.getMemPoolInfo(0).m_usedChunks, 1U);
@@ -131,6 +138,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallReleaseToSharedChunkOnSutConstructedWithS
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallReleaseToSharedChunkTwiceOnSutConstructedWithSharedChunkResultsInEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "76cddbd2-7578-431b-9aed-c3ba52856027");
     ShmSafeUnmanagedChunk sut(getChunkFromMemoryManager());
     sut.releaseToSharedChunk();
 
@@ -139,6 +147,7 @@ TEST_F(ShmSafeUnmanagedChunk_test,
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallDuplicateToSharedChunkOnDefaultConstructedSutResultsEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ced30491-3ec2-4818-904a-4bff6eb31b0f");
     ShmSafeUnmanagedChunk sut;
 
     EXPECT_FALSE(sut.cloneToSharedChunk());
@@ -149,6 +158,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallDuplicateToSharedChunkOnDefaultConstructe
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallDuplicateToSharedChunkOnSutConstructedWithSharedChunkResultsInNotEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "259b124c-1ac0-40cc-b832-0d2bf298e2eb");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -163,6 +173,7 @@ TEST_F(ShmSafeUnmanagedChunk_test,
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallDuplicateToSharedChunkOnSutPreviouslyCalledReleaseToSharedChunkResultsInEmptySharedChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9469e24-5bb9-4077-856a-a04d3693439d");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -173,6 +184,7 @@ TEST_F(ShmSafeUnmanagedChunk_test,
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnNonConstDefaultConstructedSutResultsInNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ca9d879c-73e5-466f-a84c-356719b660f5");
     ShmSafeUnmanagedChunk sut;
 
     EXPECT_EQ(sut.getChunkHeader(), nullptr);
@@ -180,6 +192,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnNonConstDefaultConstructe
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnNonConstSutConstructedWithSharedChunkResultsInValidHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2975af2c-7e1e-486e-bfee-e28018884655");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -193,6 +206,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnNonConstSutConstructedWit
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnConstDefaultConstructedSutResultsInNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "944a4dd4-8961-4962-82d5-7a042e1f7288");
     const ShmSafeUnmanagedChunk sut;
 
     EXPECT_EQ(sut.getChunkHeader(), nullptr);
@@ -200,6 +214,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnConstDefaultConstructedSu
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnConstSutConstructedWithSharedChunkResultsInValidHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d54a2f30-0b98-430e-9080-b3dc4818cc5e");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -215,6 +230,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallGetChunkHeaderOnConstSutConstructedWithSh
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallNonConstGetChunkHeaderResultsInNonConstChunkHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "68288e57-b923-43bd-baa4-2a820b84dafa");
     auto isNonConstReturn =
         std::is_same<decltype(std::declval<ShmSafeUnmanagedChunk>().getChunkHeader()), ChunkHeader*>::value;
     EXPECT_TRUE(isNonConstReturn);
@@ -222,6 +238,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallNonConstGetChunkHeaderResultsInNonConstCh
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallConstGetChunkHeaderResultsInConstChunkHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6cca0b6b-c124-4040-939d-645831dc0aa1");
     auto isConstReturn =
         std::is_same<decltype(std::declval<const ShmSafeUnmanagedChunk>().getChunkHeader()), const ChunkHeader*>::value;
     EXPECT_TRUE(isConstReturn);
@@ -229,6 +246,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallConstGetChunkHeaderResultsInConstChunkHea
 
 TEST_F(ShmSafeUnmanagedChunk_test, CallIsNotLogicalNullptrAndHasNoOtherOwnersOnDefaultConstructedResultsInFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "21bae265-f6b8-438c-b838-e749de87faa8");
     ShmSafeUnmanagedChunk sut;
 
     EXPECT_FALSE(sut.isNotLogicalNullptrAndHasNoOtherOwners());
@@ -237,6 +255,7 @@ TEST_F(ShmSafeUnmanagedChunk_test, CallIsNotLogicalNullptrAndHasNoOtherOwnersOnD
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallIsNotLogicalNullptrAndHasNoOtherOwnersOnOnSutConstructedWithSharedChunkResultsInTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cae3e82c-82b3-490d-820b-901bc838b9e6");
     ShmSafeUnmanagedChunk sut(getChunkFromMemoryManager());
 
     EXPECT_TRUE(sut.isNotLogicalNullptrAndHasNoOtherOwners());
@@ -247,6 +266,7 @@ TEST_F(ShmSafeUnmanagedChunk_test,
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallIsNotLogicalNullptrAndHasNoOtherOwnersOnOnSutConstructedWithSharedChunkAndOtherOwnerResultsInFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "59b23c6a-e566-41a1-993c-7ff013e71e8d");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -260,6 +280,7 @@ TEST_F(
     ShmSafeUnmanagedChunk_test,
     CallIsNotLogicalNullptrAndHasNoOtherOwnersOnOnSutConstructedWithSharedChunkAndOtherOwnerReleasedOwnershipResultsInTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8ced90e5-0c6f-4831-883b-d35f9d8c7af5");
     auto sharedChunk = getChunkFromMemoryManager();
 
     ShmSafeUnmanagedChunk sut(sharedChunk);
@@ -275,6 +296,7 @@ TEST_F(
 TEST_F(ShmSafeUnmanagedChunk_test,
        CallIsNotLogicalNullptrAndHasNoOtherOwnersOnOnSutPreviouslyCalledReleaseToSharedChunkResultsInFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1564e9ca-77a1-4e68-83c0-ec6032c61e6b");
     ShmSafeUnmanagedChunk sut(getChunkFromMemoryManager());
     sut.releaseToSharedChunk();
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
@@ -65,6 +65,7 @@ class TypedMemPool_test : public Test
 
 TEST_F(TypedMemPool_test, GetOneObject)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0cf13b53-8407-41ab-945d-b3c5964466d7");
     auto object = sut.createObject(1, 223);
     ASSERT_THAT(object.has_error(), Eq(false));
     EXPECT_THAT(object.value()->a, Eq(1));
@@ -73,6 +74,7 @@ TEST_F(TypedMemPool_test, GetOneObject)
 
 TEST_F(TypedMemPool_test, ReleaseChunkWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1a91a119-da28-4cec-8a61-8c2a0bbef673");
     {
         auto object = sut.createObject(1, 234);
         EXPECT_FALSE(object.has_error());
@@ -83,6 +85,7 @@ TEST_F(TypedMemPool_test, ReleaseChunkWhenGoingOutOfScope)
 
 TEST_F(TypedMemPool_test, OutOfChunksErrorWhenFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "850d7257-aa45-42c0-b535-b52beebe729a");
     auto object1 = sut.createObject(0xaffe, 0xdead);
     auto object2 = sut.createObject(0xaffe, 0xdead);
     auto object3 = sut.createObject(0xaffe, 0xdead);
@@ -123,6 +126,7 @@ class TypedMemPool_Semaphore_test : public Test
 
 TEST_F(TypedMemPool_Semaphore_test, CreateValidSemaphore)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "753fbb32-beec-4277-936f-2d6359a557ce");
     auto semaphorePtr = sut.createObjectWithCreationPattern<iox::posix::Semaphore::errorType_t>(
         iox::posix::CreateNamedSemaphore, "/fuuSem", S_IRUSR | S_IWUSR, 10);
     EXPECT_THAT(semaphorePtr.has_error(), Eq(false));
@@ -130,6 +134,7 @@ TEST_F(TypedMemPool_Semaphore_test, CreateValidSemaphore)
 
 TEST_F(TypedMemPool_Semaphore_test, CreateInvalidSemaphore)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "410ff52d-f14d-41f3-a1e5-f164c5accbd7");
     auto semaphorePtr = sut.createObjectWithCreationPattern<iox::posix::Semaphore::errorType_t>(
         iox::posix::CreateNamedSemaphore, "", S_IRUSR | S_IWUSR, 10);
     EXPECT_THAT(semaphorePtr.has_error(), Eq(true));

--- a/iceoryx_posh/test/moduletests/test_monitoringmode_logstream.cpp
+++ b/iceoryx_posh/test/moduletests/test_monitoringmode_logstream.cpp
@@ -39,6 +39,7 @@ class MonitoringModeLogStreamTest : public Test
 
 TEST_F(MonitoringModeLogStreamTest, MonitoringModeOffLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "09670bca-f358-475e-b202-cb56c09d825a");
     auto sut = MonitoringMode::OFF;
 
     {
@@ -53,6 +54,7 @@ TEST_F(MonitoringModeLogStreamTest, MonitoringModeOffLeadsToCorrectString)
 
 TEST_F(MonitoringModeLogStreamTest, MonitoringModeOnLeadsToCorrectString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0747ce58-58de-449a-ac07-9bffe2b33435");
     auto sut = MonitoringMode::ON;
 
     {

--- a/iceoryx_posh/test/moduletests/test_mq_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_mq_message.cpp
@@ -50,6 +50,7 @@ class IpcMessage_test : public Test
 
 TEST_F(IpcMessage_test, DefaultCTor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3f45cce1-5d93-49eb-8344-fa318a46e035");
     IpcMessage message;
     EXPECT_THAT(message.getNumberOfElements(), Eq(0u));
     EXPECT_THAT(message.getMessage(), Eq(""));
@@ -59,6 +60,7 @@ TEST_F(IpcMessage_test, DefaultCTor)
 
 TEST_F(IpcMessage_test, CTorWithInitializerList_validEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a21483b7-be79-400d-beeb-571c017db42c");
     IpcMessage message1({"abc", "def", "123123", ")(!*@&#^$)", "ABASDASD"});
     EXPECT_THAT(message1.getNumberOfElements(), Eq(5u));
     EXPECT_THAT(message1.getMessage(), Eq("abc,def,123123,)(!*@&#^$),ABASDASD,"));
@@ -91,6 +93,7 @@ TEST_F(IpcMessage_test, CTorWithInitializerList_validEntries)
 
 TEST_F(IpcMessage_test, CTorWithInitializerList_invalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d0f96a86-d579-4959-8633-bb30ab8d654f");
     IpcMessage message1({"abc", "def", "123i,123", ")(!*@&#^$)", "ABASDASD"});
     EXPECT_THAT(message1.isValid(), Eq(false));
 
@@ -103,6 +106,7 @@ TEST_F(IpcMessage_test, CTorWithInitializerList_invalidEntries)
 
 TEST_F(IpcMessage_test, CTorWithString_validMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9eb3418b-1d96-4d15-b5e3-36ef1097c1a7");
     IpcMessage message1("asd,asd,asd,asd,");
     EXPECT_THAT(message1.getNumberOfElements(), Eq(4u));
     EXPECT_THAT(message1.isValid(), Eq(true));
@@ -118,6 +122,7 @@ TEST_F(IpcMessage_test, CTorWithString_validMessage)
 
 TEST_F(IpcMessage_test, CTorWithString_invalidMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9af0d7a6-f4b4-4be6-8a46-654992cb021a");
     IpcMessage message1("asd,asd,asd,asd");
     EXPECT_THAT(message1.isValid(), Eq(false));
 
@@ -130,6 +135,7 @@ TEST_F(IpcMessage_test, CTorWithString_invalidMessage)
 
 TEST_F(IpcMessage_test, CopyCTorValidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4a44de96-0441-42e5-b3a8-90dfcc3acce6");
     IpcMessage* source = new IpcMessage({"fuu", "bar", "bla"});
     IpcMessage destination(*source);
     delete source;
@@ -144,6 +150,7 @@ TEST_F(IpcMessage_test, CopyCTorValidEntries)
 
 TEST_F(IpcMessage_test, CopyCTorInvalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1a5011bd-be96-4619-9384-563c0a5f4d11");
     IpcMessage* source = new IpcMessage({"f,uu", "bar", "bla"});
     IpcMessage destination(*source);
     delete source;
@@ -153,6 +160,7 @@ TEST_F(IpcMessage_test, CopyCTorInvalidEntries)
 
 TEST_F(IpcMessage_test, MoveCTorValidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9980d693-eb2e-441f-a707-18a5901da020");
     IpcMessage* source = new IpcMessage({"fuu", "bar", "bla"});
     IpcMessage destination(std::move(*source));
     delete source;
@@ -167,6 +175,7 @@ TEST_F(IpcMessage_test, MoveCTorValidEntries)
 
 TEST_F(IpcMessage_test, MoveCTorInvalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "65e0ac6d-ec3c-4eae-8f69-45784fc52016");
     IpcMessage* source = new IpcMessage({"f,uu", "bar", "bla"});
     IpcMessage destination(std::move(*source));
     delete source;
@@ -176,6 +185,7 @@ TEST_F(IpcMessage_test, MoveCTorInvalidEntries)
 
 TEST_F(IpcMessage_test, CopyOperatorValidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "702fcd55-447b-4d20-8137-18931d002d6b");
     IpcMessage* source = new IpcMessage({"fuu", "bar", "bla"});
     IpcMessage destination;
     destination = *source;
@@ -191,6 +201,7 @@ TEST_F(IpcMessage_test, CopyOperatorValidEntries)
 
 TEST_F(IpcMessage_test, CopyOperatorInvalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "133c5c9e-0880-4be4-b660-acb14fc445fe");
     IpcMessage* source = new IpcMessage({"f,uu", "bar", "bla"});
     IpcMessage destination;
     destination = *source;
@@ -201,6 +212,7 @@ TEST_F(IpcMessage_test, CopyOperatorInvalidEntries)
 
 TEST_F(IpcMessage_test, MoveOperatorValidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "05b92b6a-2ac8-491b-a7b8-09b1c132eea6");
     IpcMessage* source = new IpcMessage({"fuu", "bar", "bla"});
     IpcMessage destination;
     destination = std::move(*source);
@@ -216,6 +228,7 @@ TEST_F(IpcMessage_test, MoveOperatorValidEntries)
 
 TEST_F(IpcMessage_test, MoveOperatorInvalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84a2f506-66b2-46d5-a154-45d375dc37c0");
     IpcMessage* source = new IpcMessage({"f,uu", "bar", "bla"});
     IpcMessage destination;
     destination = std::move(*source);
@@ -226,6 +239,7 @@ TEST_F(IpcMessage_test, MoveOperatorInvalidEntries)
 
 TEST_F(IpcMessage_test, getElementAtIndex)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "554163c3-2119-462e-90f7-f3bd01421fad");
     IpcMessage message1({"fuu", "bar", "bla"});
 
     EXPECT_THAT(message1.getElementAtIndex(1), Eq("bar"));
@@ -249,6 +263,7 @@ TEST_F(IpcMessage_test, getElementAtIndex)
 
 TEST_F(IpcMessage_test, isValidEntry)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8b09e0ca-66b4-40ca-9449-2ae9e79eb48e");
     IpcMessage message;
 
     EXPECT_THAT(message.isValidEntry(""), Eq(true));
@@ -264,6 +279,7 @@ TEST_F(IpcMessage_test, isValidEntry)
 
 TEST_F(IpcMessage_test, IsValidWithCTorConstruction)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "57aed4a1-2817-4b33-a8b4-ba75891f29a2");
     IpcMessage message1;
     EXPECT_THAT(message1.isValid(), Eq(true));
 
@@ -291,6 +307,7 @@ TEST_F(IpcMessage_test, IsValidWithCTorConstruction)
 
 TEST_F(IpcMessage_test, IsValidWithAddEntry)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c29c21a5-0ec9-4016-9fca-d4804b3562bd");
     IpcMessage message1;
     EXPECT_THAT(message1.isValid(), Eq(true));
 
@@ -325,6 +342,7 @@ TEST_F(IpcMessage_test, IsValidWithAddEntry)
 
 TEST_F(IpcMessage_test, getMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "947eef64-112b-480c-b216-57e0c9b5688f");
     IpcMessage message1;
     EXPECT_THAT(message1.getMessage(), Eq(""));
     message1.addEntry(123);
@@ -340,6 +358,7 @@ TEST_F(IpcMessage_test, getMessage)
 
 TEST_F(IpcMessage_test, AddEntryWithValidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "370ab026-7f4c-4bdb-8a36-0a60284aaea4");
     IpcMessage message1;
 
     message1.addEntry("aaaa");
@@ -370,6 +389,7 @@ TEST_F(IpcMessage_test, AddEntryWithValidEntries)
 
 TEST_F(IpcMessage_test, AddEntryWithInvalidEntries)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e44a35a-f046-4c13-93d5-3ab5ae71931f");
     IpcMessage message1;
 
     EXPECT_THAT(message1.isValid(), Eq(true));
@@ -389,6 +409,7 @@ TEST_F(IpcMessage_test, AddEntryWithInvalidEntries)
 
 TEST_F(IpcMessage_test, clearMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "96b6d5a7-797d-4d9b-9334-290d2254dec4");
     IpcMessage message1;
 
     message1.clearMessage();
@@ -415,6 +436,7 @@ TEST_F(IpcMessage_test, clearMessage)
 
 TEST_F(IpcMessage_test, setMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5affc711-1af9-4906-ac7d-ddf408ee61c7");
     IpcMessage message1;
 
     message1.setMessage("asd1,asd2,asd3,asd4,");

--- a/iceoryx_posh/test/moduletests/test_popo_base_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_publisher.cpp
@@ -59,6 +59,7 @@ class BasePublisherTest : public Test
 
 TEST_F(BasePublisherTest, OfferDoesOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9fac841c-d067-47ec-8626-73ef7d4aa8db");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), offer).Times(1);
     // ===== Test ===== //
@@ -69,6 +70,7 @@ TEST_F(BasePublisherTest, OfferDoesOfferServiceOnUnderlyingPort)
 
 TEST_F(BasePublisherTest, StopOfferDoesStopOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e5c7b795-b996-4e87-9f2b-96fa0e01c4c3");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), stopOffer).Times(1);
     // ===== Test ===== //
@@ -79,6 +81,7 @@ TEST_F(BasePublisherTest, StopOfferDoesStopOfferServiceOnUnderlyingPort)
 
 TEST_F(BasePublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "323b75cb-539e-4888-9b2f-f3f0bcdc1d3d");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), isOffered).Times(1);
     // ===== Test ===== //
@@ -89,6 +92,7 @@ TEST_F(BasePublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 
 TEST_F(BasePublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b361e985-5187-4e51-a833-697d08cb0588");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), hasSubscribers).Times(1);
     // ===== Test ===== //
@@ -99,6 +103,7 @@ TEST_F(BasePublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 
 TEST_F(BasePublisherTest, GetServiceDescriptionCallForwardedToUnderlyingPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c3b989a9-61d5-4d8f-81b0-eacb0e368a14");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), getServiceDescription).Times(1);
     // ===== Test ===== //
@@ -109,6 +114,7 @@ TEST_F(BasePublisherTest, GetServiceDescriptionCallForwardedToUnderlyingPublishe
 
 TEST_F(BasePublisherTest, DestroysUnderlyingPortOnDestruction)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7ecca6de-7331-493b-8985-cc37af368dba");
     EXPECT_CALL(sut.port(), destroy).Times(1);
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -90,6 +90,7 @@ class BaseSubscriberTest : public Test
 
 TEST_F(BaseSubscriberTest, SubscribeCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bee5b6ab-c08c-4cb5-b39b-dd75b2fb1b40");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), subscribe()).Times(1);
     // ===== Test ===== //
@@ -100,6 +101,7 @@ TEST_F(BaseSubscriberTest, SubscribeCallForwardedToUnderlyingSubscriberPort)
 
 TEST_F(BaseSubscriberTest, GetSubscriptionStateCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8fc3be1a-cd85-44f6-8596-c7a2273eabab");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), getSubscriptionState).Times(1);
     // ===== Test ===== //
@@ -110,6 +112,7 @@ TEST_F(BaseSubscriberTest, GetSubscriptionStateCallForwardedToUnderlyingSubscrib
 
 TEST_F(BaseSubscriberTest, UnsubscribeCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d5793a32-2785-4dd3-b9ff-411070f67a5a");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), unsubscribe).Times(1);
     // ===== Test ===== //
@@ -120,6 +123,7 @@ TEST_F(BaseSubscriberTest, UnsubscribeCallForwardedToUnderlyingSubscriberPort)
 
 TEST_F(BaseSubscriberTest, HasDataCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a1c39c3a-3347-4072-a3d3-02e3cc264ae5");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), hasNewChunks).Times(1);
     // ===== Test ===== //
@@ -130,6 +134,7 @@ TEST_F(BaseSubscriberTest, HasDataCallForwardedToUnderlyingSubscriberPort)
 
 TEST_F(BaseSubscriberTest, ReceiveReturnsAllocatedMemoryChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5e3c00e1-bd7c-49bf-adaf-f0d83cd4ab99");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), tryGetChunk)
         .WillOnce(Return(ByMove(iox::cxx::success<const iox::mepoo::ChunkHeader*>(
@@ -144,6 +149,7 @@ TEST_F(BaseSubscriberTest, ReceiveReturnsAllocatedMemoryChunk)
 
 TEST_F(BaseSubscriberTest, ReceiveForwardsErrorsFromUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ff175cb2-ad97-4ba9-ab32-cd73618b0b8b");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), tryGetChunk)
         .WillOnce(Return(ByMove(iox::cxx::error<iox::popo::ChunkReceiveResult>(
@@ -158,6 +164,7 @@ TEST_F(BaseSubscriberTest, ReceiveForwardsErrorsFromUnderlyingPort)
 
 TEST_F(BaseSubscriberTest, ClearReceiveBufferCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "975653e3-4644-4a2e-8bc6-7af9830e3863");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), releaseQueuedChunks).Times(1);
     // ===== Test ===== //
@@ -168,6 +175,7 @@ TEST_F(BaseSubscriberTest, ClearReceiveBufferCallForwardedToUnderlyingSubscriber
 
 TEST_F(BaseSubscriberTest, AttachStateToWaitsetForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2b4c16fd-bb9d-4a4e-bc55-521be5c1ae18");
     iox::popo::ConditionVariableData condVar("Horscht");
     WaitSetTest waitSet(condVar);
     // ===== Setup ===== //
@@ -180,6 +188,7 @@ TEST_F(BaseSubscriberTest, AttachStateToWaitsetForwardedToUnderlyingSubscriberPo
 
 TEST_F(BaseSubscriberTest, AttachEventToWaitsetForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2588c558-9982-418d-ac4b-0d512103d0e5");
     iox::popo::ConditionVariableData condVar("Horscht");
     WaitSetTest waitSet(condVar);
     // ===== Setup ===== //
@@ -192,6 +201,7 @@ TEST_F(BaseSubscriberTest, AttachEventToWaitsetForwardedToUnderlyingSubscriberPo
 
 TEST_F(BaseSubscriberTest, WaitSetUnsetStateBasedConditionVariableWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9af5c23d-7584-4142-bd1b-1eaca706d887");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -205,6 +215,7 @@ TEST_F(BaseSubscriberTest, WaitSetUnsetStateBasedConditionVariableWhenGoingOutOf
 
 TEST_F(BaseSubscriberTest, WaitSetUnsetEventBasedConditionVariableWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d0a1d958-9681-4c88-88d8-4a6e4485d101");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -218,6 +229,7 @@ TEST_F(BaseSubscriberTest, WaitSetUnsetEventBasedConditionVariableWhenGoingOutOf
 
 TEST_F(BaseSubscriberTest, AttachingAttachedStateSubscriberToNewWaitsetDetachesItFromOriginalWaitset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "301c7202-cb9c-436c-ba6d-5c370eab9e5d");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -235,6 +247,7 @@ TEST_F(BaseSubscriberTest, AttachingAttachedStateSubscriberToNewWaitsetDetachesI
 
 TEST_F(BaseSubscriberTest, AttachingEventToAttachedStateSubscriberDetachesState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c4b37424-10ec-4217-9e64-7006e6aebad9");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -250,6 +263,7 @@ TEST_F(BaseSubscriberTest, AttachingEventToAttachedStateSubscriberDetachesState)
 
 TEST_F(BaseSubscriberTest, DetachingAttachedStateCleansup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3bff4985-752e-47c9-9232-e2382086db29");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -265,6 +279,7 @@ TEST_F(BaseSubscriberTest, DetachingAttachedStateCleansup)
 
 TEST_F(BaseSubscriberTest, DetachingAttachedEventCleansup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9b7a7e4-4374-4634-ba3d-6ffb833c5974");
     // ===== Setup ===== //
     iox::popo::ConditionVariableData condVar("Horscht");
     std::unique_ptr<WaitSetTest> waitSet{new WaitSetTest(condVar)};
@@ -280,6 +295,7 @@ TEST_F(BaseSubscriberTest, DetachingAttachedEventCleansup)
 
 TEST_F(BaseSubscriberTest, GetServiceDescriptionCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "93c5087c-2ba4-46fe-95d7-b619b49d3fe8");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), getServiceDescription).Times(1);
     // ===== Test ===== //
@@ -290,6 +306,7 @@ TEST_F(BaseSubscriberTest, GetServiceDescriptionCallForwardedToUnderlyingSubscri
 
 TEST_F(BaseSubscriberTest, HasMissedSamplesCallForwardedToUnderlyingSubscriberPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "90427619-7b26-4dc2-950b-9192be99f20a");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), hasLostChunksSinceLastCall).Times(1);
     // ===== Test ===== //
@@ -300,6 +317,7 @@ TEST_F(BaseSubscriberTest, HasMissedSamplesCallForwardedToUnderlyingSubscriberPo
 
 TEST_F(BaseSubscriberTest, DestroysUnderlyingPortOnDestruction)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2a3004af-4ccd-4df0-bdd8-6e22e97d2428");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), destroy).Times(1);
     // ===== Test ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
@@ -116,6 +116,7 @@ constexpr int64_t ChunkDistributor_test<PolicyType>::TIMEOUT_IN_MS;
 
 TYPED_TEST(ChunkDistributor_test, AddingNullptrQueueDoesNotWork)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aa7eaa9e-c337-45dc-945a-d097b8916eaa");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -124,6 +125,7 @@ TYPED_TEST(ChunkDistributor_test, AddingNullptrQueueDoesNotWork)
 
 TYPED_TEST(ChunkDistributor_test, NewChunkDistributorHasNoQueues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0a7cec8-ac5f-43c9-b627-0485bc26bbe7");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -132,6 +134,7 @@ TYPED_TEST(ChunkDistributor_test, NewChunkDistributorHasNoQueues)
 
 TYPED_TEST(ChunkDistributor_test, AfterAddingQueueChunkDistributorHasQueues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c7c4683a-b58f-4932-ad82-edc1404da67c");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -143,6 +146,7 @@ TYPED_TEST(ChunkDistributor_test, AfterAddingQueueChunkDistributorHasQueues)
 
 TYPED_TEST(ChunkDistributor_test, QueueOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "581c8cec-b2c5-426c-bf32-eff1f84d59ff");
     std::vector<std::shared_ptr<typename TestFixture::ChunkQueueData_t>> queueVector;
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
@@ -171,6 +175,7 @@ TYPED_TEST(ChunkDistributor_test, QueueOverflow)
 
 TYPED_TEST(ChunkDistributor_test, RemovingExistingQueueWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fc3876ae-24f9-4a3b-b98b-1f6e862bbb6e");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -183,6 +188,7 @@ TYPED_TEST(ChunkDistributor_test, RemovingExistingQueueWorks)
 
 TYPED_TEST(ChunkDistributor_test, RemovingNonExistingQueueChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6245045a-68b5-43c2-a026-e023a23d94c7");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -198,6 +204,7 @@ TYPED_TEST(ChunkDistributor_test, RemovingNonExistingQueueChangesNothing)
 
 TYPED_TEST(ChunkDistributor_test, RemoveAllQueuesWhenContainingOne)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9dac0648-7a7f-4689-bfbd-977d91bb65a4");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -210,6 +217,7 @@ TYPED_TEST(ChunkDistributor_test, RemoveAllQueuesWhenContainingOne)
 
 TYPED_TEST(ChunkDistributor_test, RemoveAllQueuesWhenContainingMultipleQueues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1dc5f2ee-f8d9-48d7-a5f0-e70fe48178fb");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -224,6 +232,7 @@ TYPED_TEST(ChunkDistributor_test, RemoveAllQueuesWhenContainingMultipleQueues)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5bc10e0a-d67b-4123-887c-a50dc16cf680");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -242,6 +251,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueue)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueDeliversOneChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "93a1f4af-b2e4-48a3-b4a4-56a98d1bb66e");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -258,6 +268,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueDeliversOn
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithDuplicatedQueueDeliversOneChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1f361075-9296-45ac-b355-541e8cc248b2");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -277,6 +288,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithDuplicatedQueueDel
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueMultipleChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a140a2e4-6450-42fe-a8e7-368d0ae795ae");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -299,6 +311,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueMultipleCh
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueDeliverMultipleChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b7472f6e-209d-4243-9f0a-04628a76b385");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -316,6 +329,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithOneQueueDeliverMul
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithMultipleQueues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67669bb8-9413-4419-8bb4-8f362d457744");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -342,6 +356,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithMultipleQueues)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithMultipleQueuesMultipleChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6930af8f-ab92-44ea-928b-239d45eed807");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -371,6 +386,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToAllStoredQueuesWithMultipleQueuesMult
 
 TYPED_TEST(ChunkDistributor_test, AddToHistoryWithoutQueues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1ed709b1-9129-454b-8440-50463ba1c02e");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
     auto limit = 8u;
@@ -382,6 +398,7 @@ TYPED_TEST(ChunkDistributor_test, AddToHistoryWithoutQueues)
 
 TYPED_TEST(ChunkDistributor_test, HistoryEmptyWhenCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d2df42d8-84a6-481b-811f-f8349693682c");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
     EXPECT_THAT(sut.getHistorySize(), Eq(0u));
@@ -389,6 +406,7 @@ TYPED_TEST(ChunkDistributor_test, HistoryEmptyWhenCreated)
 
 TYPED_TEST(ChunkDistributor_test, HistoryEmptyAfterClear)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "87a59dd5-8f85-4166-a296-74eed443290b");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
     auto limit = 8;
@@ -401,6 +419,7 @@ TYPED_TEST(ChunkDistributor_test, HistoryEmptyAfterClear)
 
 TYPED_TEST(ChunkDistributor_test, addToHistoryWithoutDelivery)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a01ca23c-c9c8-4695-84b3-0bfc936c96b4");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
     auto limit = 7u;
@@ -412,6 +431,7 @@ TYPED_TEST(ChunkDistributor_test, addToHistoryWithoutDelivery)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenNotAdded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "168e0415-68fa-4a5c-902b-f0ff29b55dbf");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -429,6 +449,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenNotAdded)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenAdded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4edaf3f4-5285-4a9d-b31d-8822f1e46b70");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -447,6 +468,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenAdded)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenNotAddedDoesNotChangeHistory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "539e71d3-3ec5-4aeb-bcac-aa406e0e5828");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -460,6 +482,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenNotAddedDoesNotChang
 
 TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenAddedDoesNotChangeHistory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9f594607-215e-4db5-bdae-433c185dbbcd");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -474,6 +497,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToQueueDirectlyWhenAddedDoesNotChangeHi
 
 TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithLessThanAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "faff7ece-c84b-4455-bb12-c83792056e98");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -497,6 +521,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithLessThanAvailable)
 
 TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithExactAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "884f4041-f63d-47b7-a6d3-0a84360a3862");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -525,6 +550,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithExactAvailable)
 
 TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithMoreThanAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "64f48f9a-f100-4944-a855-24317a36a97e");
     auto sutData = this->getChunkDistributorData();
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -553,6 +579,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverHistoryOnAddWithMoreThanAvailable)
 
 TYPED_TEST(ChunkDistributor_test, DeliverToSingleQueueBlocksWhenOptionsAreSetToBlocking)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0500dec-bbd8-4958-9545-a14ef68108a1");
     auto sutData = this->getChunkDistributorData(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 
@@ -590,6 +617,7 @@ TYPED_TEST(ChunkDistributor_test, DeliverToSingleQueueBlocksWhenOptionsAreSetToB
 
 TYPED_TEST(ChunkDistributor_test, MultipleBlockingQueuesWillBeFilledWhenThereBecomesSpaceAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8168749d-8472-4999-83b0-5b36a77b04ed");
     auto sutData = this->getChunkDistributorData(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
     typename TestFixture::ChunkDistributor_t sut(sutData.get());
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
@@ -102,16 +102,19 @@ class ChunkQueue_test : public Test, public ChunkQueue_testBase
 
 TYPED_TEST(ChunkQueue_test, InitialEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "589beb23-5ec7-4ca1-863a-ea0a06920502");
     EXPECT_THAT(this->m_popper.empty(), Eq(true));
 }
 
 TYPED_TEST(ChunkQueue_test, InitialConditionVariableAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7e6116fa-9bbd-4d63-bfd1-ad49edb7a24e");
     EXPECT_THAT(this->m_popper.isConditionVariableSet(), Eq(false));
 }
 
 TYPED_TEST(ChunkQueue_test, PushOneChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b73a7167-33f6-4ad3-af1d-71d4ee7feb75");
     auto chunk = this->allocateChunk();
     this->m_pusher.push(chunk);
     EXPECT_THAT(this->m_popper.empty(), Eq(false));
@@ -124,6 +127,7 @@ TYPED_TEST(ChunkQueue_test, PushOneChunk)
 
 TYPED_TEST(ChunkQueue_test, PopOneChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8fac3e28-5d2a-4321-a176-c7b7a58a93c7");
     auto chunk = this->allocateChunk();
     this->m_pusher.push(chunk);
 
@@ -138,6 +142,7 @@ TYPED_TEST(ChunkQueue_test, PopOneChunk)
 
 TYPED_TEST(ChunkQueue_test, PushedChunksMustBePoppedInTheSameOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6cbc1535-aea1-4d85-ae0a-a20e4fce3032");
     constexpr int32_t NUMBER_CHUNKS{5};
     for (int i = 0; i < NUMBER_CHUNKS; ++i)
     {
@@ -157,6 +162,7 @@ TYPED_TEST(ChunkQueue_test, PushedChunksMustBePoppedInTheSameOrder)
 
 TYPED_TEST(ChunkQueue_test, PopChunkWithIncompatibleChunkHeaderCallsErrorHandler)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "597f1da3-6f64-4254-9e41-0c4776746a14");
     auto chunk = this->allocateChunk();
     // this is currently the only possibility to test an invalid CHUNK_HEADER_VERSION
     auto chunkHeaderAddress = reinterpret_cast<uint64_t>(chunk.getChunkHeader());
@@ -179,12 +185,14 @@ TYPED_TEST(ChunkQueue_test, PopChunkWithIncompatibleChunkHeaderCallsErrorHandler
 
 TYPED_TEST(ChunkQueue_test, ClearOnEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9923de92-5c69-4b79-9f3b-793e790d07f3");
     this->m_popper.clear();
     EXPECT_THAT(this->m_popper.empty(), Eq(true));
 }
 
 TYPED_TEST(ChunkQueue_test, ClearWithData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "797f2fba-1734-4d16-be3b-46c0bf2ead8c");
     auto chunk = this->allocateChunk();
     this->m_pusher.push(chunk);
     this->m_popper.clear();
@@ -193,6 +201,7 @@ TYPED_TEST(ChunkQueue_test, ClearWithData)
 
 TYPED_TEST(ChunkQueue_test, AttachConditionVariable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5893ac55-bc8d-47b6-baa7-1282dbf4c849");
     ConditionVariableData condVar("Horscht");
 
     this->m_popper.setConditionVariable(condVar, 0U);
@@ -202,6 +211,7 @@ TYPED_TEST(ChunkQueue_test, AttachConditionVariable)
 
 TYPED_TEST(ChunkQueue_test, PushAndNotifyConditionVariable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf87457d-fb2d-4d65-a8f2-9b4457e50b51");
     ConditionVariableData condVar("Horscht");
     ConditionListener condVarWaiter{condVar};
 
@@ -216,6 +226,7 @@ TYPED_TEST(ChunkQueue_test, PushAndNotifyConditionVariable)
 
 TYPED_TEST(ChunkQueue_test, AttachSecondConditionVariable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3e55346f-62e1-44bb-bfe8-cef929935edf");
     ConditionVariableData condVar1("Horscht");
     ConditionVariableData condVar2("Schnuppi");
     ConditionListener condVarWaiter1{condVar1};
@@ -257,23 +268,27 @@ class ChunkQueueFiFo_test : public Test, public ChunkQueue_testBase
 
 TYPED_TEST(ChunkQueueFiFo_test, InitialSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f5bf5cc0-0822-47a0-bbe2-76bbc9b12592");
     EXPECT_THAT(this->m_popper.size(), Eq(0U));
 }
 
 TYPED_TEST(ChunkQueueFiFo_test, Capacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "080fb9a1-7266-45a5-9c5c-e12a189b4b64");
     EXPECT_THAT(this->m_popper.getCurrentCapacity(), Eq(iox::MAX_SUBSCRIBER_QUEUE_CAPACITY));
 }
 
 /// @note API currently not supported
 TYPED_TEST(ChunkQueueFiFo_test, DISABLED_SetCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f2e1c144-bb55-4423-b62b-bfd8d5a64927");
     this->m_popper.setCapacity(this->RESIZED_CAPACITY);
     EXPECT_THAT(this->m_popper.getCurrentCapacity(), Eq(this->RESIZED_CAPACITY));
 }
 
 TYPED_TEST(ChunkQueueFiFo_test, PushFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "04378227-277b-486b-9acd-f9ada80f4b4e");
     for (auto i = 0U; i < iox::MAX_SUBSCRIBER_QUEUE_CAPACITY; ++i)
     {
         auto chunk = this->allocateChunk();
@@ -317,23 +332,27 @@ class ChunkQueueSoFi_test : public Test, public ChunkQueue_testBase
 
 TYPED_TEST(ChunkQueueSoFi_test, InitialSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2521ae60-85bb-45df-9dd0-5159f9dc90ce");
     EXPECT_THAT(this->m_popper.size(), Eq(0U));
 }
 
 TYPED_TEST(ChunkQueueSoFi_test, Capacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "093a05f5-fa09-4e6a-9b32-e3a716c16464");
     EXPECT_THAT(this->m_popper.getCurrentCapacity(), Eq(iox::MAX_SUBSCRIBER_QUEUE_CAPACITY));
 }
 
 
 TYPED_TEST(ChunkQueueSoFi_test, SetCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e15eaaf0-2858-4f17-999a-4a2e03a86e99");
     this->m_popper.setCapacity(this->RESIZED_CAPACITY);
     EXPECT_THAT(this->m_popper.getCurrentCapacity(), Eq(this->RESIZED_CAPACITY));
 }
 
 TYPED_TEST(ChunkQueueSoFi_test, PushFull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "74fca742-d53a-4503-ab9a-95733f94844a");
     for (auto i = 0u; i < iox::MAX_SUBSCRIBER_QUEUE_CAPACITY; ++i)
     {
         auto chunk = this->allocateChunk();
@@ -358,11 +377,13 @@ TYPED_TEST(ChunkQueueSoFi_test, PushFull)
 
 TYPED_TEST(ChunkQueueSoFi_test, InitialNoLostChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf7298e9-fd5b-4b7e-8688-37580713050f");
     EXPECT_FALSE(this->m_popper.hasLostChunks());
 }
 
 TYPED_TEST(ChunkQueueSoFi_test, IndicateALostChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "adec2b96-2589-4974-8877-4dd1b46603c6");
     this->m_pusher.lostAChunk();
 
     EXPECT_TRUE(this->m_popper.hasLostChunks());
@@ -370,6 +391,7 @@ TYPED_TEST(ChunkQueueSoFi_test, IndicateALostChunk)
 
 TYPED_TEST(ChunkQueueSoFi_test, LostChunkInfoIsResetAfterRead)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a739477d-1b27-46da-8682-cc52d2c05bfd");
     this->m_pusher.lostAChunk();
     this->m_popper.hasLostChunks();
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -96,6 +96,7 @@ class ChunkReceiver_test : public Test
 
 TEST_F(ChunkReceiver_test, getNoChunkFromEmptyQueue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "27846f97-8882-408f-9de3-f74c0aa7e0d8");
     auto maybeChunkHeader = m_chunkReceiver.tryGet();
     ASSERT_TRUE(maybeChunkHeader.has_error());
     EXPECT_EQ(maybeChunkHeader.get_error(), iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE);
@@ -103,6 +104,7 @@ TEST_F(ChunkReceiver_test, getNoChunkFromEmptyQueue)
 
 TEST_F(ChunkReceiver_test, getAndReleaseOneChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eb7a28f5-24e7-4eb3-a48e-641a46e1bcf4");
     {
         // have a scope her to release the shared chunk we allocate
         auto sharedChunk = getChunkFromMemoryManager();
@@ -122,6 +124,7 @@ TEST_F(ChunkReceiver_test, getAndReleaseOneChunk)
 
 TEST_F(ChunkReceiver_test, getAndReleaseMultipleChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "32bfe8a5-8d17-4912-9591-c4f29bdd390e");
     std::vector<const iox::mepoo::ChunkHeader*> chunks;
 
     for (size_t i = 0; i < iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY; i++)
@@ -155,6 +158,7 @@ TEST_F(ChunkReceiver_test, getAndReleaseMultipleChunks)
 
 TEST_F(ChunkReceiver_test, getTooMuchWithoutRelease)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "58ff9db1-7ab9-471d-9492-4bd8fab47fcf");
     // one more is OK, but we assume that one is released then (aligned with ara::com behavior)
     // therefore MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY+1
     for (size_t i = 0; i < iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY + 1; i++)
@@ -181,6 +185,7 @@ TEST_F(ChunkReceiver_test, getTooMuchWithoutRelease)
 
 TEST_F(ChunkReceiver_test, releaseInvalidChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2a47fd0e-a217-4565-98af-05779c938340");
     {
         // have a scope her to release the shared chunk we allocate
         auto sharedChunk = getChunkFromMemoryManager();
@@ -208,6 +213,7 @@ TEST_F(ChunkReceiver_test, releaseInvalidChunk)
 
 TEST_F(ChunkReceiver_test, Cleanup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "36ed48ca-21e6-4075-b439-6353a1773733");
     for (size_t i = 0; i < iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY + iox::MAX_SUBSCRIBER_QUEUE_CAPACITY; i++)
     {
         // MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY on user side and MAX_SUBSCRIBER_QUEUE_CAPACITY in the queue

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -116,6 +116,7 @@ class ChunkSender_test : public Test
 
 TEST_F(ChunkSender_test, allocate_OneChunkWithoutUserHeaderAndSmallUserPayloadAlignmentResultsInSmallChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3c60fd47-6637-4a9f-bf1b-1b5f707a0cdf");
     constexpr uint32_t USER_PAYLOAD_SIZE{SMALL_CHUNK / 2};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT};
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
@@ -126,6 +127,7 @@ TEST_F(ChunkSender_test, allocate_OneChunkWithoutUserHeaderAndSmallUserPayloadAl
 
 TEST_F(ChunkSender_test, allocate_OneChunkWithoutUserHeaderAndLargeUserPayloadAlignmentResultsInLargeChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a1743fc6-65a2-4218-be6b-b0b8c2e7d1f7");
     constexpr uint32_t USER_PAYLOAD_SIZE{SMALL_CHUNK / 2};
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{SMALL_CHUNK};
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
@@ -136,6 +138,7 @@ TEST_F(ChunkSender_test, allocate_OneChunkWithoutUserHeaderAndLargeUserPayloadAl
 
 TEST_F(ChunkSender_test, allocate_OneChunkWithLargeUserHeaderResultsInLargeChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e13e06e5-3c9a-4ec2-812c-4ea73cd1d4eb");
     constexpr uint32_t LARGE_HEADER_SIZE{SMALL_CHUNK};
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), LARGE_HEADER_SIZE, USER_HEADER_ALIGNMENT);
@@ -145,6 +148,7 @@ TEST_F(ChunkSender_test, allocate_OneChunkWithLargeUserHeaderResultsInLargeChunk
 
 TEST_F(ChunkSender_test, allocate_ChunkHasOriginIdSet)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7e33b20b-93f9-4b53-926b-20295ac73b61");
     iox::UniquePortId uniqueId;
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         uniqueId, sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
@@ -155,6 +159,7 @@ TEST_F(ChunkSender_test, allocate_ChunkHasOriginIdSet)
 
 TEST_F(ChunkSender_test, allocate_MultipleChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0be0972d-f7d4-4400-bbc9-31767aef2e2b");
     auto chunk1 = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunk2 = m_chunkSender.tryAllocate(
@@ -169,6 +174,7 @@ TEST_F(ChunkSender_test, allocate_MultipleChunks)
 
 TEST_F(ChunkSender_test, allocate_Overflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "93e3689a-a1f2-46d2-887d-8c04560161af");
     std::vector<iox::mepoo::ChunkHeader*> chunks;
 
     // tryAllocate chunks until MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY level
@@ -200,6 +206,7 @@ TEST_F(ChunkSender_test, allocate_Overflow)
 
 TEST_F(ChunkSender_test, freeChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b4a6eb09-a431-4f38-bd0c-38baf896a639");
     std::vector<iox::mepoo::ChunkHeader*> chunks;
 
     // tryAllocate chunks until MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY level
@@ -227,6 +234,7 @@ TEST_F(ChunkSender_test, freeChunk)
 
 TEST_F(ChunkSender_test, freeInvalidChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0d9f448d-f622-44f3-a78b-31b0a7b0d1a8");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_FALSE(maybeChunkHeader.has_error());
@@ -247,6 +255,7 @@ TEST_F(ChunkSender_test, freeInvalidChunk)
 
 TEST_F(ChunkSender_test, sendWithoutReceiver)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b9c56b90-2b9d-4097-a908-8f2282b83e10");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_FALSE(maybeChunkHeader.has_error());
@@ -263,6 +272,7 @@ TEST_F(ChunkSender_test, sendWithoutReceiver)
 
 TEST_F(ChunkSender_test, sendMultipleWithoutReceiverAndAlwaysLast)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5b798e6-5163-460b-a2d6-cce5592d3c04");
     for (size_t i = 0; i < 100; i++)
     {
         auto maybeChunkHeader = m_chunkSender.tryAllocate(
@@ -291,6 +301,7 @@ TEST_F(ChunkSender_test, sendMultipleWithoutReceiverAndAlwaysLast)
 
 TEST_F(ChunkSender_test, sendMultipleWithoutReceiverWithHistoryNoLastReuse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fb782ba8-f457-4f4c-9b3e-c616fa329261");
     for (size_t i = 0; i < 10 * HISTORY_CAPACITY; i++)
     {
         auto maybeChunkHeader = m_chunkSenderWithHistory.tryAllocate(
@@ -319,6 +330,7 @@ TEST_F(ChunkSender_test, sendMultipleWithoutReceiverWithHistoryNoLastReuse)
 
 TEST_F(ChunkSender_test, sendOneWithReceiver)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9279f04c-e37c-4d0f-8217-720afe59f52b");
     ASSERT_FALSE(m_chunkSender.tryAddQueue(&m_chunkQueueData).has_error());
 
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
@@ -346,6 +358,7 @@ TEST_F(ChunkSender_test, sendOneWithReceiver)
 
 TEST_F(ChunkSender_test, sendMultipleWithReceiver)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "07e6a360-f5ae-4cd9-9bee-54b3c31c3390");
     ASSERT_FALSE(m_chunkSender.tryAddQueue(&m_chunkQueueData).has_error());
     iox::popo::ChunkQueuePopper<ChunkQueueData_t> checkQueue(&m_chunkQueueData);
     EXPECT_TRUE(NUM_CHUNKS_IN_POOL <= checkQueue.getCurrentCapacity());
@@ -379,6 +392,7 @@ TEST_F(ChunkSender_test, sendMultipleWithReceiver)
 
 TEST_F(ChunkSender_test, sendTillRunningOutOfChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b951495a-e216-43ff-96a0-a530b7a6455b");
     ASSERT_FALSE(m_chunkSender.tryAddQueue(&m_chunkQueueData).has_error());
     iox::popo::ChunkQueuePopper<ChunkQueueData_t> checkQueue(&m_chunkQueueData);
     EXPECT_TRUE(NUM_CHUNKS_IN_POOL <= checkQueue.getCurrentCapacity());
@@ -412,6 +426,7 @@ TEST_F(ChunkSender_test, sendTillRunningOutOfChunks)
 
 TEST_F(ChunkSender_test, sendInvalidChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "72680d04-71aa-4229-84c3-11ce8442e9b3");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_FALSE(maybeChunkHeader.has_error());
@@ -432,6 +447,7 @@ TEST_F(ChunkSender_test, sendInvalidChunk)
 
 TEST_F(ChunkSender_test, pushToHistory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5ef98161-c7f9-455b-a9db-8eaa1a6b3342");
     for (size_t i = 0; i < 10 * HISTORY_CAPACITY; i++)
     {
         auto maybeChunkHeader = m_chunkSenderWithHistory.tryAllocate(
@@ -446,6 +462,7 @@ TEST_F(ChunkSender_test, pushToHistory)
 
 TEST_F(ChunkSender_test, pushInvalidChunkToHistory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4b28c59a-ab22-4e2e-8e1a-4246a7dfc38f");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_FALSE(maybeChunkHeader.has_error());
@@ -466,6 +483,7 @@ TEST_F(ChunkSender_test, pushInvalidChunkToHistory)
 
 TEST_F(ChunkSender_test, sendMultipleWithReceiverNoLastReuse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "955b4e9d-6c17-45d4-85ca-3a4411e71957");
     ASSERT_FALSE(m_chunkSender.tryAddQueue(&m_chunkQueueData).has_error());
 
     for (size_t i = 0; i < NUM_CHUNKS_IN_POOL; i++)
@@ -496,6 +514,7 @@ TEST_F(ChunkSender_test, sendMultipleWithReceiverNoLastReuse)
 
 TEST_F(ChunkSender_test, sendMultipleWithReceiverLastReuseBecauseAlreadyConsumed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "18ffac1d-1ac9-4318-94f0-1178f3d68a2a");
     ASSERT_FALSE(m_chunkSender.tryAddQueue(&m_chunkQueueData).has_error());
 
     for (size_t i = 0; i < NUM_CHUNKS_IN_POOL; i++)
@@ -531,6 +550,7 @@ TEST_F(ChunkSender_test, sendMultipleWithReceiverLastReuseBecauseAlreadyConsumed
 
 TEST_F(ChunkSender_test, ReuseLastIfSmaller)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cff81129-75aa-45bb-a427-870286fb3ee5");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), BIG_CHUNK, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     ASSERT_FALSE(maybeChunkHeader.has_error());
@@ -556,6 +576,7 @@ TEST_F(ChunkSender_test, ReuseLastIfSmaller)
 
 TEST_F(ChunkSender_test, NoReuseOfLastIfBigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "44eb7a6c-d50e-4915-a458-e401e96c4c6d");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), SMALL_CHUNK, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     ASSERT_FALSE(maybeChunkHeader.has_error());
@@ -581,6 +602,7 @@ TEST_F(ChunkSender_test, NoReuseOfLastIfBigger)
 
 TEST_F(ChunkSender_test, ReuseOfLastIfBiggerButFitsInChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1deadbe1-7877-486a-941e-9d41d03b5aba");
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         iox::UniquePortId(), SMALL_CHUNK - 10, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     ASSERT_FALSE(maybeChunkHeader.has_error());
@@ -606,6 +628,7 @@ TEST_F(ChunkSender_test, ReuseOfLastIfBiggerButFitsInChunk)
 
 TEST_F(ChunkSender_test, Cleanup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5e5ab921-24bf-45a9-9572-68e444120baa");
     EXPECT_TRUE((HISTORY_CAPACITY + iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY) <= NUM_CHUNKS_IN_POOL);
 
     for (size_t i = 0; i < HISTORY_CAPACITY; i++)

--- a/iceoryx_posh/test/moduletests/test_popo_client_options.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client_options.cpp
@@ -24,6 +24,7 @@ using namespace ::testing;
 
 TEST(ClientOptions_test, SerializationRoundTripIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1d803ab0-a657-4a84-b261-ec289a7353e6");
     iox::popo::ClientOptions defaultOptions;
     iox::popo::ClientOptions testOptions;
 
@@ -58,6 +59,7 @@ TEST(ClientOptions_test, SerializationRoundTripIsSuccessful)
 
 TEST(ClientOptions_test, DeserializingBogusDataFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eb7341fd-f216-4422-8065-cbbadefd567b");
     const auto bogusSerialization = iox::cxx::Serialization::create("hypnotoad", "brain slug", "rock star");
     iox::popo::ClientOptions::deserialize(bogusSerialization)
         .and_then([&](auto&) {
@@ -85,6 +87,7 @@ iox::cxx::Serialization enumSerialization(QueueFullPolicyUT responseQueueFullPol
 
 TEST(ClientOptions_test, DeserializingValidResponseQueueFullAndServerTooSlowPolicyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "877ad373-eb51-4613-9b68-b93baa4c6eae");
     constexpr QueueFullPolicyUT RESPONSE_QUEUE_FULL_POLICY{
         static_cast<QueueFullPolicyUT>(iox::popo::QueueFullPolicy::BLOCK_PUBLISHER)};
     constexpr ConsumerTooSlowPolicyUT SERVER_TOO_SLOW_POLICY{
@@ -104,6 +107,7 @@ TEST(ClientOptions_test, DeserializingValidResponseQueueFullAndServerTooSlowPoli
 
 TEST(ClientOptions_test, DeserializingInvalidResponseQueueFullPolicyFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5495324-67d0-4f0c-b979-f93d4b68adc5");
     constexpr QueueFullPolicyUT RESPONSE_QUEUE_FULL_POLICY{111};
     constexpr ConsumerTooSlowPolicyUT SERVER_TOO_SLOW_POLICY{
         static_cast<ConsumerTooSlowPolicyUT>(iox::popo::ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA)};
@@ -122,6 +126,7 @@ TEST(ClientOptions_test, DeserializingInvalidResponseQueueFullPolicyFails)
 
 TEST(ClientOptions_test, DeserializingInvalidServerTooSlowPolicyFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6485377c-9a75-4aba-8045-8b129aa1c529");
     constexpr QueueFullPolicyUT RESPONSE_QUEUE_FULL_POLICY{
         static_cast<QueueFullPolicyUT>(iox::popo::QueueFullPolicy::BLOCK_PUBLISHER)};
     constexpr ConsumerTooSlowPolicyUT SERVER_TOO_SLOW_POLICY{111};

--- a/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
@@ -226,18 +226,21 @@ constexpr iox::units::Duration ClientPort_test::DEADLOCK_TIMEOUT;
 
 TEST_F(ClientPort_test, InitialConnectionStateOnPortWithConnectOnCreateIs_CONNECTED)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5d6dd457-b111-45d8-8bac-ae354288ff93");
     auto& sut = clientPortWithConnectOnCreate;
     EXPECT_THAT(sut.portUser.getConnectionState(), Eq(iox::ConnectionState::CONNECTED));
 }
 
 TEST_F(ClientPort_test, InitialConnectionStateOnPortWithoutConnectOnCreateIs_NOT_CONNECTED)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "068d6415-1554-4f67-85da-0dd1dab77e68");
     auto& sut = clientPortWithoutConnectOnCreate;
     EXPECT_THAT(sut.portUser.getConnectionState(), Eq(iox::ConnectionState::NOT_CONNECTED));
 }
 
 TEST_F(ClientPort_test, AllocateRequestDoesNotFailAndUsesTheMempool)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d82b0152-8ed4-4022-ada8-f8926f27a9b1");
     auto& sut = clientPortWithConnectOnCreate;
     EXPECT_THAT(getNumberOfUsedChunks(), Eq(0U));
 
@@ -249,6 +252,7 @@ TEST_F(ClientPort_test, AllocateRequestDoesNotFailAndUsesTheMempool)
 
 TEST_F(ClientPort_test, FreeRequestWithNullptrCallsErrorHandler)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f21bc4ab-4080-4994-b862-5cb8c8738b46");
     auto& sut = clientPortWithConnectOnCreate;
 
     iox::cxx::optional<iox::Error> detectedError;
@@ -266,6 +270,7 @@ TEST_F(ClientPort_test, FreeRequestWithNullptrCallsErrorHandler)
 
 TEST_F(ClientPort_test, FreeRequestWithValidRequestWorksAndReleasesTheChunkToTheMempool)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d2eb1ec3-78de-453b-bf97-860f3c57362b");
     auto& sut = clientPortWithConnectOnCreate;
     sut.portUser.allocateRequest(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT)
         .and_then([&](auto& requestHeader) {
@@ -281,6 +286,7 @@ TEST_F(ClientPort_test, FreeRequestWithValidRequestWorksAndReleasesTheChunkToThe
 
 TEST_F(ClientPort_test, SendRequestWithNullptrOnConnectedClientPortTerminates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e50da541-7621-46e8-accb-46a6b5d7e69b");
     auto& sut = clientPortWithConnectOnCreate;
 
     iox::cxx::optional<iox::Error> detectedError;
@@ -303,6 +309,7 @@ TEST_F(ClientPort_test, SendRequestWithNullptrOnConnectedClientPortTerminates)
 
 TEST_F(ClientPort_test, SendRequestOnConnectedClientPortEnqueuesRequestToServerQueue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "861efd1d-31ae-436d-9a0c-84da5bf99a57");
     constexpr int64_t SEQUENCE_ID{42U};
     auto& sut = clientPortWithConnectOnCreate;
     sut.portUser.allocateRequest(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT)
@@ -328,6 +335,7 @@ TEST_F(ClientPort_test, SendRequestOnConnectedClientPortEnqueuesRequestToServerQ
 
 TEST_F(ClientPort_test, SendRequestOnNotConnectedClientPortDoesNotEnqueuesRequestToServerQueue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46c418a8-4f4f-4393-a190-8f5d41deb05e");
     auto& sut = clientPortWithoutConnectOnCreate;
     sut.portUser.allocateRequest(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT)
         .and_then([&](auto& requestHeader) { sut.portUser.sendRequest(requestHeader); })
@@ -341,6 +349,7 @@ TEST_F(ClientPort_test, SendRequestOnNotConnectedClientPortDoesNotEnqueuesReques
 
 TEST_F(ClientPort_test, ConnectAfterPreviousSendRequestCallDoesNotEnqueuesRequestToServerQueue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3348d22d-d08e-4855-8316-8b2ce77274ee");
     auto& sut = clientPortWithoutConnectOnCreate;
     sut.portUser.allocateRequest(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT)
         .and_then([&](auto& requestHeader) { sut.portUser.sendRequest(requestHeader); })
@@ -357,6 +366,7 @@ TEST_F(ClientPort_test, ConnectAfterPreviousSendRequestCallDoesNotEnqueuesReques
 
 TEST_F(ClientPort_test, GetResponseOnNotConnectedClientPortHasNoResponse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ecb320c9-1c95-410e-84d6-9aa9763b9768");
     auto& sut = clientPortWithoutConnectOnCreate;
     sut.portUser.getResponse()
         .and_then([&](auto&) {
@@ -368,6 +378,7 @@ TEST_F(ClientPort_test, GetResponseOnNotConnectedClientPortHasNoResponse)
 
 TEST_F(ClientPort_test, GetResponseOnConnectedClientPortWithEmptyResponseQueueHasNoResponse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e6efd53-c056-4d95-9d73-2fcfe7a6b69a");
     auto& sut = clientPortWithConnectOnCreate;
     sut.portUser.getResponse()
         .and_then([&](auto&) {
@@ -379,6 +390,7 @@ TEST_F(ClientPort_test, GetResponseOnConnectedClientPortWithEmptyResponseQueueHa
 
 TEST_F(ClientPort_test, GetResponseOnConnectedClientPortWithNonEmptyResponseQueueHasResponse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f9625942-d69f-404a-a419-cf2f5f20dd85");
     constexpr int64_t SEQUENCE_ID{13U};
     auto& sut = clientPortWithConnectOnCreate;
 
@@ -398,6 +410,7 @@ TEST_F(ClientPort_test, GetResponseOnConnectedClientPortWithNonEmptyResponseQueu
 
 TEST_F(ClientPort_test, ReleaseResponseWithNullptrIsTerminating)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b6ad4c2a-7c52-45ee-afd3-29c286489311");
     auto& sut = clientPortWithConnectOnCreate;
 
     iox::cxx::optional<iox::Error> detectedError;
@@ -415,6 +428,7 @@ TEST_F(ClientPort_test, ReleaseResponseWithNullptrIsTerminating)
 
 TEST_F(ClientPort_test, ReleaseResponseWithValidResponseReleasesChunkToTheMempool)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3f625d3e-9ef3-4329-9c80-95af0327cbc0");
     auto& sut = clientPortWithConnectOnCreate;
 
     constexpr uint32_t USER_PAYLOAD_SIZE{10};
@@ -438,12 +452,14 @@ TEST_F(ClientPort_test, ReleaseResponseWithValidResponseReleasesChunkToTheMempoo
 
 TEST_F(ClientPort_test, HasNewResponseOnEmptyResponseQueueReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "42f50429-e1e1-41b9-bbcd-5d14a0eda189");
     auto& sut = clientPortWithConnectOnCreate;
     EXPECT_FALSE(sut.portUser.hasNewResponses());
 }
 
 TEST_F(ClientPort_test, HasNewResponseOnNonEmptyResponseQueueReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2b0dbb32-2d5b-4eac-96d3-6cf7a8cbac15");
     auto& sut = clientPortWithConnectOnCreate;
 
     constexpr uint32_t USER_PAYLOAD_SIZE{10};
@@ -455,6 +471,7 @@ TEST_F(ClientPort_test, HasNewResponseOnNonEmptyResponseQueueReturnsTrue)
 
 TEST_F(ClientPort_test, HasNewResponseOnEmptyResponseQueueAfterPreviouslyNotEmptyReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9cd91de8-9687-436a-9d7d-95d2754eee30");
     auto& sut = clientPortWithConnectOnCreate;
 
     constexpr uint32_t USER_PAYLOAD_SIZE{10};
@@ -468,12 +485,14 @@ TEST_F(ClientPort_test, HasNewResponseOnEmptyResponseQueueAfterPreviouslyNotEmpt
 
 TEST_F(ClientPort_test, HasLostResponsesSinceLastCallWithoutLosingResponsesReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8eba3173-6b4a-4073-90ad-133e279a6215");
     auto& sut = clientPortWithConnectOnCreate;
     EXPECT_FALSE(sut.portUser.hasLostResponsesSinceLastCall());
 }
 
 TEST_F(ClientPort_test, HasLostResponsesSinceLastCallWithoutLosingResponsesAndQueueFullReturnsFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8a5765a9-dc20-40fc-95ea-84391e7a927e");
     auto& sut = clientPortWithConnectOnCreate;
 
     EXPECT_TRUE(pushResponses(sut.responseQueuePusher, QUEUE_CAPACITY));
@@ -482,6 +501,7 @@ TEST_F(ClientPort_test, HasLostResponsesSinceLastCallWithoutLosingResponsesAndQu
 
 TEST_F(ClientPort_test, HasLostResponsesSinceLastCallWithLosingResponsesReturnsTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "28bb1d1f-4b6f-4f03-ba31-24fa4d75a44d");
     auto& sut = clientPortWithConnectOnCreate;
 
     EXPECT_FALSE(pushResponses(sut.responseQueuePusher, QUEUE_CAPACITY + 1U));
@@ -490,6 +510,7 @@ TEST_F(ClientPort_test, HasLostResponsesSinceLastCallWithLosingResponsesReturnsT
 
 TEST_F(ClientPort_test, HasLostResponsesSinceLastCallReturnsFalseAfterPreviouslyReturningTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "233cf99e-52fc-4e9c-b2bf-77928a4370ab");
     auto& sut = clientPortWithConnectOnCreate;
 
     EXPECT_FALSE(pushResponses(sut.responseQueuePusher, QUEUE_CAPACITY + 1U));
@@ -499,12 +520,14 @@ TEST_F(ClientPort_test, HasLostResponsesSinceLastCallReturnsFalseAfterPreviously
 
 TEST_F(ClientPort_test, ConditionVariableInitiallyNotSet)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a9b75cb2-9968-4b90-b444-92d8cff2ca97");
     auto& sut = clientPortWithConnectOnCreate;
     EXPECT_FALSE(sut.portUser.isConditionVariableSet());
 }
 
 TEST_F(ClientPort_test, SettingConditionVariableWithoutConditionVariablePresentWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "86c03248-f9a6-4f4b-830f-fac5ec8c5cc3");
     iox::popo::ConditionVariableData condVar{"hypnotoad"};
     constexpr uint32_t NOTIFICATION_INDEX{1};
 
@@ -516,6 +539,7 @@ TEST_F(ClientPort_test, SettingConditionVariableWithoutConditionVariablePresentW
 
 TEST_F(ClientPort_test, UnsettingConditionVariableWithConditionVariablePresentWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2f10db20-e236-4b9d-9162-4d8ea5c9f4c9");
     iox::popo::ConditionVariableData condVar{"brain slug"};
     constexpr uint32_t NOTIFICATION_INDEX{2};
 
@@ -529,6 +553,7 @@ TEST_F(ClientPort_test, UnsettingConditionVariableWithConditionVariablePresentWo
 
 TEST_F(ClientPort_test, UnsettingConditionVariableWithoutConditionVariablePresentIsHandledGracefully)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8e89da27-ba82-46f7-ad41-844373e103e7");
     auto& sut = clientPortWithConnectOnCreate;
     sut.portUser.unsetConditionVariable();
 
@@ -537,6 +562,7 @@ TEST_F(ClientPort_test, UnsettingConditionVariableWithoutConditionVariablePresen
 
 TEST_F(ClientPort_test, ConnectOnNotConnectedClientPortResultsInStateChange)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "52c6cc2f-58c9-4215-9c91-71f0e7b8e40d");
     auto& sut = clientPortWithoutConnectOnCreate;
 
     sut.portUser.connect();
@@ -546,6 +572,7 @@ TEST_F(ClientPort_test, ConnectOnNotConnectedClientPortResultsInStateChange)
 
 TEST_F(ClientPort_test, ConnectOnConnectedClientPortResultsInNoStateChange)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "08e3e53b-9303-4d5f-8f1d-c5878adf5783");
     auto& sut = clientPortWithConnectOnCreate;
 
     sut.portUser.connect();
@@ -555,6 +582,7 @@ TEST_F(ClientPort_test, ConnectOnConnectedClientPortResultsInNoStateChange)
 
 TEST_F(ClientPort_test, DisconnectOnConnectedClientPortResultsInStateChange)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d1d4ce8-737f-4438-bd61-173625032c76");
     auto& sut = clientPortWithConnectOnCreate;
 
     sut.portUser.disconnect();
@@ -564,6 +592,7 @@ TEST_F(ClientPort_test, DisconnectOnConnectedClientPortResultsInStateChange)
 
 TEST_F(ClientPort_test, DisconnectOnNotConnectedClientPortResultsInNoStateChange)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "82ff5a16-2b4f-4480-88b1-8983242ed677");
     auto& sut = clientPortWithoutConnectOnCreate;
 
     sut.portUser.disconnect();
@@ -578,6 +607,7 @@ TEST_F(ClientPort_test, DisconnectOnNotConnectedClientPortResultsInNoStateChange
 
 TEST_F(ClientPort_test, GetResponseQueueFullPolicyOnPortWithDefaultOptionIsDiscardOldesData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf169034-c413-4362-a6cd-72ec0d6cf958");
     auto& sut = clientPortWithConnectOnCreate;
 
     EXPECT_THAT(sut.portRouDi.getResponseQueueFullPolicy(), Eq(QueueFullPolicy2::DISCARD_OLDEST_DATA));
@@ -585,6 +615,7 @@ TEST_F(ClientPort_test, GetResponseQueueFullPolicyOnPortWithDefaultOptionIsDisca
 
 TEST_F(ClientPort_test, GetResponseQueueFullPolicyOnPortWithBlockProducerOptionIsBlockProducer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "40c3b25e-8a95-415b-9acb-6a67fd7d868a");
     auto& sut = clientPortWithBlockProducerResponseQueuePolicy;
 
     EXPECT_THAT(sut.portRouDi.getResponseQueueFullPolicy(), Eq(QueueFullPolicy2::BLOCK_PRODUCER));
@@ -592,6 +623,7 @@ TEST_F(ClientPort_test, GetResponseQueueFullPolicyOnPortWithBlockProducerOptionI
 
 TEST_F(ClientPort_test, TryGetCaProMessageOnConnectHasCaProMessageTypeConnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eac43f13-b486-4e8b-a5b9-4fc274113d08");
     auto& sut = clientPortWithoutConnectOnCreate;
 
     sut.portUser.connect();
@@ -604,6 +636,7 @@ TEST_F(ClientPort_test, TryGetCaProMessageOnConnectHasCaProMessageTypeConnect)
 
 TEST_F(ClientPort_test, TryGetCaProMessageOnDisconnectHasCaProMessageTypeDisconnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53bb7a12-affb-4ad0-8846-4fb20bbe4a72");
     auto& sut = clientPortWithConnectOnCreate;
 
     sut.portUser.disconnect();
@@ -616,6 +649,7 @@ TEST_F(ClientPort_test, TryGetCaProMessageOnDisconnectHasCaProMessageTypeDisconn
 
 TEST_F(ClientPort_test, ReleaseAllChunksWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0d88645-3c8f-47e1-8989-7557675c1207");
     auto& sut = clientPortWithConnectOnCreate;
 
     // produce chunks for the chunk sender
@@ -643,6 +677,7 @@ TEST_F(ClientPort_test, ReleaseAllChunksWorks)
 
 TEST_F(ClientPort_test, StateNotConnectedWithCaProMessageTypeOfferRemainsInStateNotConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "849f1825-61da-4bad-8390-b14173905611");
     auto& sut = initAndGetClientPortForStateTransitionTests();
 
     auto caproMessage = CaproMessage{CaproMessageType::OFFER, sut.portData.m_serviceDescription};
@@ -654,6 +689,7 @@ TEST_F(ClientPort_test, StateNotConnectedWithCaProMessageTypeOfferRemainsInState
 
 TEST_F(ClientPort_test, StateNotConnectedWithCaProMessageTypeConnectTransitionsToStateConnectRequested)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "72c72160-f53e-4062-90cb-b7a51017b5be");
     auto& sut = initAndGetClientPortForStateTransitionTests();
 
     auto caproMessage = CaproMessage{CaproMessageType::CONNECT, sut.portData.m_serviceDescription};
@@ -668,6 +704,7 @@ TEST_F(ClientPort_test, StateNotConnectedWithCaProMessageTypeConnectTransitionsT
 
 TEST_F(ClientPort_test, StateConnectRequestedWithCaProMessageTypeNackTransitionsToStateWaitForOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d8921cb0-6a8d-43a4-a6ef-384bd3475aae");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::CONNECT_REQUESTED);
@@ -681,6 +718,7 @@ TEST_F(ClientPort_test, StateConnectRequestedWithCaProMessageTypeNackTransitions
 
 TEST_F(ClientPort_test, StateConnectRequestedWithCaProMessageTypeAckTransitionsToStateConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3651e440-9d20-48b8-bbf6-ca063f41b767");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::CONNECT_REQUESTED);
@@ -696,6 +734,7 @@ TEST_F(ClientPort_test, StateConnectRequestedWithCaProMessageTypeAckTransitionsT
 
 TEST_F(ClientPort_test, StateWaitForOfferWithCaProMessageTypeDisconnetTransitionsToStateNotConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fa9925d1-e867-4155-aa8c-3bfa411b09db");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::WAIT_FOR_OFFER);
@@ -709,6 +748,7 @@ TEST_F(ClientPort_test, StateWaitForOfferWithCaProMessageTypeDisconnetTransition
 
 TEST_F(ClientPort_test, StateWaitForOfferWithCaProMessageTypeOfferTransitionsToStateConnectRequested)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "527a9ca0-f3c7-4bce-8e88-e4ab753358f1");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::WAIT_FOR_OFFER);
@@ -725,6 +765,7 @@ TEST_F(ClientPort_test, StateWaitForOfferWithCaProMessageTypeOfferTransitionsToS
 
 TEST_F(ClientPort_test, StateConnectedWithCaProMessageTypeStopOfferTransitionsToStateWaitForOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4c07d376-f316-4805-9a91-575289beae94");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::CONNECTED);
@@ -740,6 +781,7 @@ TEST_F(ClientPort_test, StateConnectedWithCaProMessageTypeStopOfferTransitionsTo
 
 TEST_F(ClientPort_test, StateConnectedWithCaProMessageTypeDisconnectTransitionsToStateDisconnectRequested)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bb3c606e-2ab0-4b76-a7dc-83bec1068171");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::CONNECTED);
@@ -758,6 +800,7 @@ TEST_F(ClientPort_test, StateConnectedWithCaProMessageTypeDisconnectTransitionsT
 
 TEST_F(ClientPort_test, StateDisconnectRequestedWithCaProMessageTypeAckTransitionsToStateNotConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1c5f2052-7397-4e23-b53a-8127cce62063");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::DISCONNECT_REQUESTED);
@@ -773,6 +816,7 @@ TEST_F(ClientPort_test, StateDisconnectRequestedWithCaProMessageTypeAckTransitio
 
 TEST_F(ClientPort_test, StateDisconnectRequestedWithCaProMessageTypeNackTransitionsToStateNotConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0d24f15e-5ff3-4c96-8e74-a404cd7f3605");
     auto& sut = initAndGetClientPortForStateTransitionTests();
     sut.portUser.connect();
     tryAdvanceToState(sut, iox::ConnectionState::DISCONNECT_REQUESTED);
@@ -793,6 +837,7 @@ TEST_F(ClientPort_test, StateDisconnectRequestedWithCaProMessageTypeNackTransiti
 
 TEST_F(ClientPort_test, InvalidStateTransitionsCallErrorHandler)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "465258d2-b58d-41fe-bc18-e7fd43dd233d");
     constexpr iox::ConnectionState ALL_STATES[]{iox::ConnectionState::NOT_CONNECTED,
                                                 iox::ConnectionState::CONNECT_REQUESTED,
                                                 iox::ConnectionState::WAIT_FOR_OFFER,

--- a/iceoryx_posh/test/moduletests/test_popo_condition_variable.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_condition_variable.cpp
@@ -64,6 +64,7 @@ class ConditionVariable_test : public Test
 
 TEST_F(ConditionVariable_test, ConditionListenerIsNeitherCopyNorMovable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2105fbcf-ed66-4042-aae3-46c2bb82a63c");
     EXPECT_FALSE(std::is_copy_constructible<ConditionListener>::value);
     EXPECT_FALSE(std::is_move_constructible<ConditionListener>::value);
     EXPECT_FALSE(std::is_copy_assignable<ConditionListener>::value);
@@ -72,6 +73,7 @@ TEST_F(ConditionVariable_test, ConditionListenerIsNeitherCopyNorMovable)
 
 TEST_F(ConditionVariable_test, ConditionNotifierIsNeitherCopyNorMovable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "51b971ea-2fb1-4280-8663-6f86c70ee06a");
     EXPECT_FALSE(std::is_copy_constructible<ConditionNotifier>::value);
     EXPECT_FALSE(std::is_move_constructible<ConditionNotifier>::value);
     EXPECT_FALSE(std::is_copy_assignable<ConditionNotifier>::value);
@@ -80,17 +82,20 @@ TEST_F(ConditionVariable_test, ConditionNotifierIsNeitherCopyNorMovable)
 
 TEST_F(ConditionVariable_test, NotifyOnceResultsInBeingTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "372125d2-82b4-4729-bc93-661578af4739");
     m_signaler.notify();
     EXPECT_TRUE(m_waiter.wasNotified());
 }
 
 TEST_F(ConditionVariable_test, NoNotifyResultsInNotBeingTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "abe8a485-63d3-486a-b62a-94648b7f7954");
     EXPECT_FALSE(m_waiter.wasNotified());
 }
 
 TEST_F(ConditionVariable_test, WaitResetsAllNotificationsInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ebc9c42a-14e7-471c-a9df-9c5641b5767d");
     m_signaler.notify();
     m_signaler.notify();
     m_signaler.notify();
@@ -111,6 +116,7 @@ TEST_F(ConditionVariable_test, WaitResetsAllNotificationsInWait)
 
 TEST_F(ConditionVariable_test, WaitAndNotifyResultsInImmediateTriggerMultiThreaded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "39b40c73-3dcc-4af6-9682-b62816c69854");
     std::atomic<int> counter{0};
     std::thread waiter([&] {
         EXPECT_THAT(counter, Eq(0));
@@ -126,6 +132,7 @@ TEST_F(ConditionVariable_test, WaitAndNotifyResultsInImmediateTriggerMultiThread
 
 TEST_F(ConditionVariable_test, AllNotificationsAreFalseAfterConstruction)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4e5f6dbc-84cc-468a-9d64-f5ed88012ebc");
     ConditionVariableData sut;
     for (auto& notification : sut.m_activeNotifications)
     {
@@ -135,11 +142,13 @@ TEST_F(ConditionVariable_test, AllNotificationsAreFalseAfterConstruction)
 
 TEST_F(ConditionVariable_test, CorrectRuntimeNameAfterConstructionWithRuntimeName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "acc65071-09ec-40ce-82b4-74964525fabf");
     EXPECT_THAT(m_condVarData.m_runtimeName.c_str(), StrEq(m_runtimeName));
 }
 
 TEST_F(ConditionVariable_test, AllNotificationsAreFalseAfterConstructionWithRuntimeName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4825e152-08e3-414e-a34f-d93d048f84b8");
     for (auto& notification : m_condVarData.m_activeNotifications)
     {
         EXPECT_THAT(notification, Eq(false));
@@ -148,6 +157,7 @@ TEST_F(ConditionVariable_test, AllNotificationsAreFalseAfterConstructionWithRunt
 
 TEST_F(ConditionVariable_test, NotifyActivatesCorrectIndex)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2c372bcc-7e91-47c1-8ab9-ccd5be048562");
     constexpr Type_t EVENT_INDEX = iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER - 1U;
     ConditionNotifier sut(m_condVarData, EVENT_INDEX);
     sut.notify();
@@ -166,18 +176,21 @@ TEST_F(ConditionVariable_test, NotifyActivatesCorrectIndex)
 
 TEST_F(ConditionVariable_test, TimedWaitWithZeroTimeoutWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "582f0b1c-c717-410e-8143-61459db672ad");
     ConditionListener sut(m_condVarData);
     EXPECT_TRUE(sut.timedWait(iox::units::Duration::fromSeconds(0)).empty());
 }
 
 TEST_F(ConditionVariable_test, TimedWaitWithoutNotificationReturnsEmptyVector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "15aaf499-9731-4c53-88f3-88af4983eae0");
     ConditionListener sut(m_condVarData);
     EXPECT_TRUE(sut.timedWait(iox::units::Duration::fromMilliseconds(100)).empty());
 }
 
 TEST_F(ConditionVariable_test, TimedWaitReturnsOneNotifiedIndex)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bf9ed236-bba9-43cd-84b2-6769d7f47d50");
     ConditionListener sut(m_condVarData);
     ConditionNotifier(m_condVarData, 6U).notify();
 
@@ -189,6 +202,7 @@ TEST_F(ConditionVariable_test, TimedWaitReturnsOneNotifiedIndex)
 
 TEST_F(ConditionVariable_test, TimedWaitReturnsMultipleNotifiedIndices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "771c2c11-effb-435a-9c67-a7d9471fdb6e");
     ConditionListener sut(m_condVarData);
     ConditionNotifier(m_condVarData, 5U).notify();
     ConditionNotifier(m_condVarData, 15U).notify();
@@ -202,6 +216,7 @@ TEST_F(ConditionVariable_test, TimedWaitReturnsMultipleNotifiedIndices)
 
 TEST_F(ConditionVariable_test, TimedWaitReturnsAllNotifiedIndices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "38ee654b-228a-4462-9614-2901cb5272aa");
     ConditionListener sut(m_condVarData);
     for (uint64_t i = 0U; i < iox::MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE; ++i)
     {
@@ -261,6 +276,7 @@ TIMING_TEST_F(ConditionVariable_test, TimedWaitBlocksUntilNotification, Repeat(5
 
 TEST_F(ConditionVariable_test, WaitIsNonBlockingAfterDestroyAndReturnsEmptyVector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "39bd43c0-c310-4f42-8baa-6873fbbbe705");
     ConditionListener sut(m_condVarData);
 
     sut.destroy();
@@ -271,6 +287,7 @@ TEST_F(ConditionVariable_test, WaitIsNonBlockingAfterDestroyAndReturnsEmptyVecto
 
 TEST_F(ConditionVariable_test, WaitIsNonBlockingAfterDestroyAndNotifyAndReturnsEmptyVector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b803fc3e-f3a6-405c-86a0-ecedc06d0c05");
     ConditionListener sut(m_condVarData);
     sut.destroy();
 
@@ -283,6 +300,7 @@ TEST_F(ConditionVariable_test, WaitIsNonBlockingAfterDestroyAndNotifyAndReturnsE
 
 TEST_F(ConditionVariable_test, DestroyWakesUpWaitWhichReturnsEmptyVector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ed0e434c-6efd-4218-88a8-9332e33f92fd");
     ConditionListener sut(m_condVarData);
 
     NotificationVector_t activeNotifications;
@@ -298,6 +316,7 @@ TEST_F(ConditionVariable_test, DestroyWakesUpWaitWhichReturnsEmptyVector)
 
 TEST_F(ConditionVariable_test, GetCorrectNotificationVectorAfterNotifyAndWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "41a25c52-a358-4e94-b4a5-f315fb5124cd");
     constexpr Type_t EVENT_INDEX = iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER - 1U;
     ConditionNotifier notifier(m_condVarData, EVENT_INDEX);
     ConditionListener listener(m_condVarData);
@@ -311,6 +330,7 @@ TEST_F(ConditionVariable_test, GetCorrectNotificationVectorAfterNotifyAndWait)
 
 TEST_F(ConditionVariable_test, GetCorrectNotificationVectorAfterMultipleNotifyAndWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b09bb18-e6c7-42cb-bb34-2da0dd26ca06");
     constexpr Type_t FIRST_EVENT_INDEX = iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER - 1U;
     constexpr Type_t SECOND_EVENT_INDEX = 0U;
     ConditionNotifier notifier1(m_condVarData, FIRST_EVENT_INDEX);
@@ -328,6 +348,7 @@ TEST_F(ConditionVariable_test, GetCorrectNotificationVectorAfterMultipleNotifyAn
 
 TEST_F(ConditionVariable_test, WaitAndNotifyResultsInCorrectNotificationVector)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4cac0ad0-083b-43dd-867e-dd6abb0291e8");
     constexpr Type_t EVENT_INDEX = iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER - 5U;
     ConditionNotifier notifier(m_condVarData, EVENT_INDEX);
     ConditionListener listener(m_condVarData);
@@ -432,11 +453,13 @@ void waitReturnsSortedListWhenTriggeredInOrder(ConditionVariable_test& test,
 
 TEST_F(ConditionVariable_test, WaitReturnsSortedListWhenTriggeredInOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d9cfc71a-3300-41f8-b66f-486bdf5d27bc");
     waitReturnsSortedListWhenTriggeredInOrder(*this, [this] { return m_waiter.wait(); });
 }
 
 TEST_F(ConditionVariable_test, TimedWaitReturnsSortedListWhenTriggeredInOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e9f875f6-c8ff-4c9c-aafa-78f7c0942bba");
     waitReturnsSortedListWhenTriggeredInOrder(
         *this, [this] { return m_waiter.timedWait(iox::units::Duration::fromSeconds(1)); });
 }
@@ -459,11 +482,13 @@ void waitReturnsSortedListWhenTriggeredInReverseOrder(
 
 TEST_F(ConditionVariable_test, WaitReturnsSortedListWhenTriggeredInReverseOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a28eb73d-c279-46ed-b6f8-369b10045ea5");
     waitReturnsSortedListWhenTriggeredInReverseOrder(*this, [this] { return m_waiter.wait(); });
 }
 
 TEST_F(ConditionVariable_test, TimedWaitReturnsSortedListWhenTriggeredInReverseOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53050a1c-fb1c-42aa-a376-bfb095bf5f94");
     waitReturnsSortedListWhenTriggeredInReverseOrder(
         *this, [this] { return m_waiter.timedWait(iox::units::Duration::fromSeconds(1)); });
 }

--- a/iceoryx_posh/test/moduletests/test_popo_interface_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_interface_port.cpp
@@ -45,6 +45,7 @@ class InterfacePort_test : public Test
 
 TEST_F(InterfacePort_test, EveryMessageCanBeDispatchedWhenInterfacePortIsInternal)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a9700e7f-20cb-4cbe-baeb-c38701ce9ec4");
     InterfacePortData interfacePortData("", capro::Interfaces::INTERNAL);
 
     for (uint16_t interface = 0; interface < static_cast<uint16_t>(capro::Interfaces::INTERFACE_END); ++interface)
@@ -60,6 +61,7 @@ TEST_F(InterfacePort_test, EveryMessageCanBeDispatchedWhenInterfacePortIsInterna
 
 TEST_F(InterfacePort_test, MessageDispatchedIfInterfacesDifferWhenInterfacePortIsNotInternal)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e0ee7518-2be0-4526-9562-f54070fe884e");
     for (uint16_t myInterface = 0; myInterface < static_cast<uint16_t>(capro::Interfaces::INTERFACE_END); ++myInterface)
     {
         if (static_cast<capro::Interfaces>(myInterface) == capro::Interfaces::INTERNAL)
@@ -86,6 +88,7 @@ TEST_F(InterfacePort_test, MessageDispatchedIfInterfacesDifferWhenInterfacePortI
 
 TEST_F(InterfacePort_test, MessageDiscaredIfInterfacesAreEqualWhenInterfacePortIsNotInternal)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ca6d13f9-db06-4e45-8c59-449a69f9e8b5");
     for (uint16_t myInterface = 0; myInterface < static_cast<uint16_t>(capro::Interfaces::INTERFACE_END); ++myInterface)
     {
         if (static_cast<capro::Interfaces>(myInterface) == capro::Interfaces::INTERNAL)

--- a/iceoryx_posh/test/moduletests/test_popo_listener.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_listener.cpp
@@ -320,16 +320,19 @@ struct AttachEvent<0U>
 //////////////////////////////////
 TEST_F(Listener_test, CapacityIsEqualToMAX_NUMBER_OF_EVENTS_PER_LISTENER)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1139a55e-d48c-4076-8616-be71e6b69c0a");
     EXPECT_THAT(m_sut->capacity(), Eq(iox::MAX_NUMBER_OF_EVENTS_PER_LISTENER));
 }
 
 TEST_F(Listener_test, IsEmptyWhenConstructed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9d0e1023-a8bf-42b5-a03e-c3ea764fd934");
     EXPECT_THAT(m_sut->size(), Eq(0U));
 }
 
 TEST_F(Listener_test, AttachingWithoutEnumIfEnoughSpaceAvailableWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "42f0fdf5-9218-4f50-927a-8bcad4e7065f");
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0U], createNotificationCallback(Listener_test::triggerCallback<0U>))
                      .has_error());
     EXPECT_THAT(m_sut->size(), Eq(1U));
@@ -337,12 +340,14 @@ TEST_F(Listener_test, AttachingWithoutEnumIfEnoughSpaceAvailableWorks)
 
 TEST_F(Listener_test, AttachWithoutEnumTillCapacityIsFullWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "da15361c-cb03-45c7-a8ea-feff753d2d0f");
     fillUpWithSimpleEvents();
     EXPECT_THAT(m_sut->size(), Eq(m_sut->capacity()));
 }
 
 TEST_F(Listener_test, DetachDecreasesSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f35060a7-88f6-4df2-8a77-a27bb1214252");
     fillUpWithSimpleEvents();
     m_sut->detachEvent(m_simpleEvents[0U]);
     EXPECT_THAT(m_sut->size(), Eq(m_sut->capacity() - 1U));
@@ -350,6 +355,7 @@ TEST_F(Listener_test, DetachDecreasesSize)
 
 TEST_F(Listener_test, AttachWithoutEnumOneMoreThanCapacityFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e51317c2-4007-4531-9666-2edbe02c9da3");
     fillUpWithSimpleEvents();
     auto result = m_sut->attachEvent(m_simpleEvents[m_sut->capacity()],
                                      createNotificationCallback(Listener_test::triggerCallback<0U>));
@@ -360,6 +366,7 @@ TEST_F(Listener_test, AttachWithoutEnumOneMoreThanCapacityFails)
 
 TEST_F(Listener_test, AttachingWithEnumIfEnoughSpaceAvailableWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b41bdfd6-ef04-47cd-9bf3-dfbf6424aea8");
     EXPECT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::Hypnotoad,
@@ -370,11 +377,13 @@ TEST_F(Listener_test, AttachingWithEnumIfEnoughSpaceAvailableWorks)
 
 TEST_F(Listener_test, AttachWithEnumTillCapacityIsFullWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "05eea314-75f0-40c8-ac97-81094556c974");
     EXPECT_TRUE(fillUpWithSimpleEventsWithEnum(SimpleEvent::Hypnotoad));
 }
 
 TEST_F(Listener_test, AttachWithEnumOneMoreThanCapacityFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "56c0e83d-fa47-4952-b8d7-24b044381668");
     fillUpWithSimpleEventsWithEnum(SimpleEvent::Hypnotoad);
     auto result = m_sut->attachEvent(m_simpleEvents[m_sut->capacity()],
                                      SimpleEvent::Hypnotoad,
@@ -386,6 +395,7 @@ TEST_F(Listener_test, AttachWithEnumOneMoreThanCapacityFails)
 
 TEST_F(Listener_test, DetachMakesSpaceForAnotherAttachWithEventEnum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "66b44835-f9af-404d-86be-cda891785180");
     fillUpWithSimpleEventsWithEnum(SimpleEvent::Hypnotoad);
 
     m_sut->detachEvent(m_simpleEvents[0U], SimpleEvent::Hypnotoad);
@@ -398,6 +408,7 @@ TEST_F(Listener_test, DetachMakesSpaceForAnotherAttachWithEventEnum)
 
 TEST_F(Listener_test, DetachMakesSpaceForAnotherAttachWithoutEventEnum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f2632526-7d9c-48cc-8fb8-5579ef1f9bad");
     fillUpWithSimpleEvents();
 
     m_sut->detachEvent(m_simpleEvents[0U]);
@@ -409,6 +420,7 @@ TEST_F(Listener_test, DetachMakesSpaceForAnotherAttachWithoutEventEnum)
 
 TEST_F(Listener_test, AttachingEventWithoutEventTypeLeadsToAttachedNoEventEnumTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "02963e32-50d5-48b1-a938-8064598cc589");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0U], createNotificationCallback(Listener_test::triggerCallback<0U>))
                      .has_error());
     EXPECT_TRUE(m_simpleEvents[0U].m_handleNoEventEnum.isValid());
@@ -416,6 +428,7 @@ TEST_F(Listener_test, AttachingEventWithoutEventTypeLeadsToAttachedNoEventEnumTr
 
 TEST_F(Listener_test, AttachingEventWithEventTypeLeadsToAttachedTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "841ca69d-c092-49f9-8c5a-27f83e7c451e");
     ASSERT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::StoepselBachelorParty,
@@ -426,6 +439,7 @@ TEST_F(Listener_test, AttachingEventWithEventTypeLeadsToAttachedTriggerHandle)
 
 TEST_F(Listener_test, OverridingAlreadyAttachedEventWithEnumFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "333cd1de-76d5-4b96-9dca-f8a25c928a5b");
     ASSERT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::StoepselBachelorParty,
@@ -441,6 +455,7 @@ TEST_F(Listener_test, OverridingAlreadyAttachedEventWithEnumFails)
 
 TEST_F(Listener_test, OverridingAlreadyAttachedEventWithoutEnumFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "33129abd-fb5c-48d7-a6ad-75b68161aa24");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0U], createNotificationCallback(Listener_test::triggerCallback<0U>))
                      .has_error());
 
@@ -452,6 +467,7 @@ TEST_F(Listener_test, OverridingAlreadyAttachedEventWithoutEnumFails)
 
 TEST_F(Listener_test, AttachingSameClassWithTwoDifferentEventsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "83ee5edb-e426-4c76-a181-1613c3039151");
     ASSERT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::Hypnotoad,
@@ -467,6 +483,7 @@ TEST_F(Listener_test, AttachingSameClassWithTwoDifferentEventsWorks)
 
 TEST_F(Listener_test, AttachingNullptrCallbackFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d15379e9-9628-4a2e-b80a-e4836c8ec8db");
     auto empty_callback = createNotificationCallback(attachCallback);
     empty_callback.m_callback = nullptr;
     empty_callback.m_contextData = nullptr;
@@ -478,6 +495,7 @@ TEST_F(Listener_test, AttachingNullptrCallbackFails)
 
 TEST_F(Listener_test, AttachingNullptrCallbackWithEventFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eba903e2-c7c1-46b2-97c3-0e05c58caca5");
     auto empty_callback = createNotificationCallback(attachCallback);
     empty_callback.m_callback = nullptr;
     empty_callback.m_contextData = nullptr;
@@ -489,6 +507,7 @@ TEST_F(Listener_test, AttachingNullptrCallbackWithEventFails)
 
 TEST_F(Listener_test, DetachingSameClassWithDifferentEventEnumChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9f97ac76-f7d4-4353-94df-8b3ec9fefcc7");
     ASSERT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::Hypnotoad,
@@ -501,6 +520,7 @@ TEST_F(Listener_test, DetachingSameClassWithDifferentEventEnumChangesNothing)
 
 TEST_F(Listener_test, DetachingDifferentClassWithSameEventEnumChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "64760cc1-7d65-4c2c-a6f1-83db62c2b18a");
     ASSERT_FALSE(m_sut
                      ->attachEvent(m_simpleEvents[0U],
                                    SimpleEvent::Hypnotoad,
@@ -513,6 +533,7 @@ TEST_F(Listener_test, DetachingDifferentClassWithSameEventEnumChangesNothing)
 
 TEST_F(Listener_test, AttachingWithoutEnumTillCapacityFilledSetsUpNoEventEnumTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9dd3c485-c129-4d57-8318-50c6bec17888");
     fillUpWithSimpleEvents();
 
     for (uint64_t i = 0U; i < m_sut->capacity(); ++i)
@@ -523,6 +544,7 @@ TEST_F(Listener_test, AttachingWithoutEnumTillCapacityFilledSetsUpNoEventEnumTri
 
 TEST_F(Listener_test, DTorDetachesAllAttachedEventsWithoutEnum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4204bd01-86d1-4213-a020-5d58e4173d70");
     fillUpWithSimpleEvents();
 
     auto capacity = m_sut->capacity();
@@ -536,6 +558,7 @@ TEST_F(Listener_test, DTorDetachesAllAttachedEventsWithoutEnum)
 
 TEST_F(Listener_test, DTorDetachesAllAttachedEventsWithEnum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1bd485f3-a634-473a-8f6b-fd344de10a85");
     fillUpWithSimpleEventsWithEnum(SimpleEvent::Hypnotoad);
 
     auto capacity = m_sut->capacity();
@@ -549,6 +572,7 @@ TEST_F(Listener_test, DTorDetachesAllAttachedEventsWithEnum)
 
 TEST_F(Listener_test, AttachedEventDTorDetachesItself)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "198f5c98-5d65-4c16-8201-86d47f1d23e6");
     {
         SimpleEventClass fuu;
         ASSERT_FALSE(
@@ -560,6 +584,7 @@ TEST_F(Listener_test, AttachedEventDTorDetachesItself)
 
 TEST_F(Listener_test, AttachingSimpleEventWithoutEnumSetsNoEventEnumTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a2e5c6f-7b60-47e4-8b29-321584857c57");
     SimpleEventClass fuu;
     ASSERT_FALSE(m_sut->attachEvent(fuu, createNotificationCallback(Listener_test::triggerCallback<0U>)).has_error());
 
@@ -568,6 +593,7 @@ TEST_F(Listener_test, AttachingSimpleEventWithoutEnumSetsNoEventEnumTriggerHandl
 
 TEST_F(Listener_test, DetachingSimpleEventResetsTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b0d30f2b-0ad2-46b8-acc1-04416019c50e");
     SimpleEventClass fuu;
     ASSERT_FALSE(m_sut->attachEvent(fuu, createNotificationCallback(Listener_test::triggerCallback<0U>)).has_error());
     m_sut->detachEvent(fuu);
@@ -577,6 +603,7 @@ TEST_F(Listener_test, DetachingSimpleEventResetsTriggerHandle)
 
 TEST_F(Listener_test, AttachingEventWithEnumSetsTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "350d25da-eb06-48a9-9b47-e23f7dafba53");
     SimpleEventClass fuu;
     ASSERT_FALSE(m_sut
                      ->attachEvent(fuu,
@@ -589,6 +616,7 @@ TEST_F(Listener_test, AttachingEventWithEnumSetsTriggerHandle)
 
 TEST_F(Listener_test, DetachingEventWithEnumResetsTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bc51566f-8b10-490b-bba1-a14865d7d07b");
     SimpleEventClass fuu;
     ASSERT_FALSE(m_sut
                      ->attachEvent(fuu,
@@ -602,6 +630,7 @@ TEST_F(Listener_test, DetachingEventWithEnumResetsTriggerHandle)
 
 TEST_F(Listener_test, DetachingNonAttachedEventResetsNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "32deeace-1857-4a52-b3e7-c915037d9950");
     SimpleEventClass fuu;
     ASSERT_FALSE(m_sut
                      ->attachEvent(fuu,

--- a/iceoryx_posh/test/moduletests/test_popo_notification_info.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_notification_info.cpp
@@ -55,6 +55,7 @@ class NotificationInfo_test : public Test
 
 TEST_F(NotificationInfo_test, defaultCTorConstructsEmptyNotificationInfo)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5677ccf1-4072-4600-a67c-b34c7a258444");
     int bla;
     NotificationInfo sut;
 
@@ -65,27 +66,32 @@ TEST_F(NotificationInfo_test, defaultCTorConstructsEmptyNotificationInfo)
 
 TEST_F(NotificationInfo_test, getNotificationIdReturnsValidNotificationId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "68a5240f-e9ab-4bf7-93a3-2d36f4ddc176");
     EXPECT_EQ(m_sut.getNotificationId(), 1478U);
 }
 
 TEST_F(NotificationInfo_test, doesOriginateFromStatesOriginCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9d362dc-cd25-42e6-907d-82da6d079061");
     EXPECT_EQ(m_sut.doesOriginateFrom(&m_origin), true);
     EXPECT_EQ(m_sut.doesOriginateFrom(&m_falseOrigin), false);
 }
 
 TEST_F(NotificationInfo_test, getOriginReturnsCorrectOriginWhenHavingCorrectType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a1ad935f-9658-460a-863b-57dedac07ff8");
     EXPECT_EQ(m_sut.getOrigin<NotificationOriginTest>(), &m_origin);
 }
 
 TEST_F(NotificationInfo_test, constGetOriginReturnsCorrectOriginWhenHavingCorrectType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "97a222ab-0ddf-4ab6-be27-056739844e20");
     EXPECT_EQ(const_cast<const NotificationInfo&>(m_sut).getOrigin<NotificationOriginTest>(), &m_origin);
 }
 
 TEST_F(NotificationInfo_test, getOriginReturnsNullptrWithWrongType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "badb467b-bf64-4e43-af30-77c163e90c99");
     auto errorHandlerCalled{false};
     iox::Error errorHandlerType;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -102,6 +108,7 @@ TEST_F(NotificationInfo_test, getOriginReturnsNullptrWithWrongType)
 
 TEST_F(NotificationInfo_test, constGetOriginReturnsNullptrWithWrongType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4fdb2bed-9928-4181-b195-e411d1b16572");
     auto errorHandlerCalled{false};
     iox::Error errorHandlerType;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -118,12 +125,14 @@ TEST_F(NotificationInfo_test, constGetOriginReturnsNullptrWithWrongType)
 
 TEST_F(NotificationInfo_test, triggerCallbackReturnsTrueAndCallsCallbackWithSettedCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b2ed19d1-cf45-4cc0-ad92-fa652d215a17");
     EXPECT_TRUE(m_sut());
     EXPECT_EQ(m_origin.m_callbackOrigin, &m_origin);
 }
 
 TEST_F(NotificationInfo_test, triggerCallbackReturnsFalseWithUnsetCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d015f42f-cc01-467a-b568-e957a45a97e6");
     m_sut = NotificationInfo{&m_origin, 9U, NotificationCallback<NotificationOriginTest, int>{}};
     EXPECT_FALSE(m_sut());
 }

--- a/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
@@ -67,6 +67,7 @@ class PublisherTest : public Test
 
 TEST_F(PublisherTest, LoansChunkLargeEnoughForTheType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "38d0779a-1fd5-407d-95aa-2cf24fcf3a09");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     // ===== Test ===== //
@@ -79,6 +80,7 @@ TEST_F(PublisherTest, LoansChunkLargeEnoughForTheType)
 
 TEST_F(PublisherTest, LoanedSampleIsDefaultInitialized)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "52b5de5e-be1b-4815-8ac6-45b8dd3e9814");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     // ===== Test ===== //
@@ -92,6 +94,7 @@ TEST_F(PublisherTest, LoanedSampleIsDefaultInitialized)
 
 TEST_F(PublisherTest, LoanWithArgumentsCallsCustomCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1fd165ed-73a2-4465-a740-6d7b502b0d95");
     constexpr uint64_t CUSTOM_VALUE{73};
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
@@ -106,6 +109,7 @@ TEST_F(PublisherTest, LoanWithArgumentsCallsCustomCtor)
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e341963-5917-440b-b01a-2fc8fff64def");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -123,6 +127,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithAdditionalAr
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithNoAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "98bf5461-58c6-401d-a599-8e8f4dc5f806");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -138,6 +143,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithNoAdditional
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfACallableStructWithNoAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d5decb3d-3080-4d32-8b5a-2a6e673e17c2");
     struct CallableStruct
     {
         void operator()(DummyData* allocation)
@@ -158,6 +164,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfACallableStructWithNoAd
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfACallableStructWithAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a14a270-118d-4067-9906-3a608fe046cd");
     struct CallableStruct
     {
         void operator()(DummyData* allocation, int, float)
@@ -189,6 +196,7 @@ void freeFunctionWithAdditionalArgs(DummyData* allocation, int, float)
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithNoAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eae5694a-25c3-48ec-b1ac-518321730773");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -201,6 +209,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithNoAd
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithAdditionalArguments)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5696d415-1278-4bfe-891f-9c994cd0025e");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -213,6 +222,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithAddi
 
 TEST_F(PublisherTest, CanLoanSamplesAndPublishCopiesOfProvidedValues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84d2599b-f6b2-497d-b2e9-029b58738552");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -226,6 +236,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishCopiesOfProvidedValues)
 
 TEST_F(PublisherTest, LoanFailsAndForwardsAllocationErrorsToCaller)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "257750cd-3a1b-4363-a6d2-4318590528bb");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(
             ByMove(iox::cxx::error<iox::popo::AllocationError>(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS))));
@@ -240,6 +251,7 @@ TEST_F(PublisherTest, LoanFailsAndForwardsAllocationErrorsToCaller)
 
 TEST_F(PublisherTest, LoanedSamplesContainPointerToChunkHeader)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "935108d7-bf2f-4557-8722-f7f474f413a3");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     // ===== Test ===== //
@@ -253,6 +265,7 @@ TEST_F(PublisherTest, LoanedSamplesContainPointerToChunkHeader)
 
 TEST_F(PublisherTest, PublishingSendsUnderlyingMemoryChunkOnPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "743183e2-76cb-4d51-9643-a962d933fdac");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
@@ -266,18 +279,21 @@ TEST_F(PublisherTest, PublishingSendsUnderlyingMemoryChunkOnPublisherPort)
 
 TEST_F(PublisherTest, OfferDoesOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "047b39f4-f35d-4b1f-9b27-d58229a89820");
     EXPECT_CALL(sut, offer).Times(1);
     // ===== Test ===== //
     sut.offer();
 }
 TEST_F(PublisherTest, StopOfferDoesStopOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d4bfdd25-3f41-4768-8a6e-2d99dff41257");
     EXPECT_CALL(sut, stopOffer).Times(1);
     sut.stopOffer();
 }
 
 TEST_F(PublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "df690425-77ea-43ea-8b4a-2fe0ad6288e7");
     EXPECT_CALL(sut, isOffered).Times(1);
     // ===== Test ===== //
     sut.isOffered();
@@ -285,6 +301,7 @@ TEST_F(PublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 
 TEST_F(PublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aeaa8b55-f814-4073-a173-835df8c84be5");
     EXPECT_CALL(sut, hasSubscribers).Times(1);
     // ===== Test ===== //
     sut.hasSubscribers();
@@ -292,6 +309,7 @@ TEST_F(PublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 
 TEST_F(PublisherTest, GetServiceDescriptionCallForwardedToUnderlyingPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "55c87b44-715c-41d6-8004-677e284089c8");
     EXPECT_CALL(sut, getServiceDescription).Times(1);
     // ===== Test ===== //
     sut.getServiceDescription();

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_options.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_options.cpp
@@ -24,6 +24,7 @@ using namespace ::testing;
 
 TEST(PublisherOptions_test, SerializationRoundTripIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "56b3d95b-b5a9-4692-b2bc-6d8762965f2a");
     iox::popo::PublisherOptions defaultOptions;
     iox::popo::PublisherOptions testOptions;
 
@@ -51,6 +52,7 @@ TEST(PublisherOptions_test, SerializationRoundTripIsSuccessful)
 
 TEST(PublisherOptions_test, DeserializingBogusDataFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "01c4b42b-5636-4bd2-b2de-c5320b170d71");
     const auto bogusSerialization = iox::cxx::Serialization::create("hypnotoad", "brain slug", "rock star");
     iox::popo::PublisherOptions::deserialize(bogusSerialization)
         .and_then([&](auto&) { FAIL() << "Deserialization is expected to fail!"; })
@@ -59,6 +61,7 @@ TEST(PublisherOptions_test, DeserializingBogusDataFails)
 
 TEST(PublisherOptions_test, DeserializingInvalidSubscriberTooSlowPolicyFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8903ee4a-8a05-4df4-8f8f-f6cb87f41da8");
     constexpr uint64_t HISTORY_CAPACITY{42U};
     const iox::NodeName_t NODE_NAME{"harr-harr"};
     constexpr bool OFFER_ON_CREATE{true};

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -116,27 +116,32 @@ class PublisherPort_test : public Test
 
 TEST_F(PublisherPort_test, initialStateIsOfferedWithDefaultOptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "70bd6717-6ccf-4191-b4e5-f9e3470eae07");
     EXPECT_TRUE(m_sutWithDefaultOptionsUserSide.isOffered());
 }
 
 TEST_F(PublisherPort_test, initialStateIsNotOfferedWhenNoOfferOnCreate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46e14a35-8264-45a3-b157-f335c4564276");
     EXPECT_FALSE(m_sutNoOfferOnCreateUserSide.isOffered());
 }
 
 TEST_F(PublisherPort_test, initialStateIsNoSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5be59ad-3921-45e9-a5f8-74c8015ddced");
     EXPECT_FALSE(m_sutNoOfferOnCreateUserSide.hasSubscribers());
 }
 
 TEST_F(PublisherPort_test, noWaitingForSubscriberWithDefaultOptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d1f74874-257a-4e8f-aabf-8eadad5b4367");
     EXPECT_THAT(m_sutWithDefaultOptionsRouDiSide.getSubscriberTooSlowPolicy(),
                 Eq(iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA));
 }
 
 TEST_F(PublisherPort_test, initialStateReturnsOfferCaProMessageWithDefaultOptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "033a2229-609b-47a7-adc1-ab696ab36d46");
     auto maybeCaproMessage = m_sutWithDefaultOptionsRouDiSide.tryGetCaProMessage();
 
     ASSERT_TRUE(maybeCaproMessage.has_value());
@@ -146,6 +151,7 @@ TEST_F(PublisherPort_test, initialStateReturnsOfferCaProMessageWithDefaultOption
 
 TEST_F(PublisherPort_test, initialStateReturnsNoCaProMessageWhenNoOfferOnCreate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "93112fd3-f67e-424f-aac5-7758a7a6ea27");
     auto maybeCaproMessage = m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
 
     EXPECT_FALSE(maybeCaproMessage.has_value());
@@ -153,12 +159,14 @@ TEST_F(PublisherPort_test, initialStateReturnsNoCaProMessageWhenNoOfferOnCreate)
 
 TEST_F(PublisherPort_test, waitingForSubscriberWhenDesired)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49526d1a-e81a-4e4a-8fb4-1a96dee83ae7");
     EXPECT_THAT(m_sutWaitForSubscriberRouDiSide.getSubscriberTooSlowPolicy(),
                 Eq(iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER));
 }
 
 TEST_F(PublisherPort_test, offerCallResultsInOfferedState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d15f9164-7c9a-46cf-aecb-253e5a7e1b79");
     m_sutNoOfferOnCreateUserSide.offer();
 
     EXPECT_TRUE(m_sutNoOfferOnCreateUserSide.isOffered());
@@ -166,6 +174,7 @@ TEST_F(PublisherPort_test, offerCallResultsInOfferedState)
 
 TEST_F(PublisherPort_test, offerCallResultsInOfferCaProMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "328fa84e-ca6b-4e58-b47c-559709855751");
     m_sutNoOfferOnCreateUserSide.offer();
 
     auto maybeCaproMessage = m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
@@ -180,6 +189,7 @@ TEST_F(PublisherPort_test, offerCallResultsInOfferCaProMessage)
 
 TEST_F(PublisherPort_test, stopOfferCallResultsInNotOfferedState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49985d1e-e7ed-4fc2-9d0a-d78d61b74e3c");
     m_sutNoOfferOnCreateUserSide.offer();
 
     m_sutNoOfferOnCreateUserSide.stopOffer();
@@ -189,6 +199,7 @@ TEST_F(PublisherPort_test, stopOfferCallResultsInNotOfferedState)
 
 TEST_F(PublisherPort_test, stopOfferCallResultsInStopOfferCaProMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0980c54a-2420-4f25-8546-8ca4b36e504b");
     // arrange, we need a transition from offer to stop offer, also form a RouDi point of view
     // therefore we must also get the offer CapPro message (but ignore it here)
     m_sutNoOfferOnCreateUserSide.offer();
@@ -205,6 +216,7 @@ TEST_F(PublisherPort_test, stopOfferCallResultsInStopOfferCaProMessage)
 
 TEST_F(PublisherPort_test, offerStateChangesThatEndUpInTheSameStateDoNotReturnACaProMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "885962f8-b5f1-4ed8-9001-ba95aa2b8db2");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateUserSide.stopOffer();
 
@@ -216,6 +228,7 @@ TEST_F(PublisherPort_test, offerStateChangesThatEndUpInTheSameStateDoNotReturnAC
 TEST_F(PublisherPort_test,
        offerCallWhenHavingHistoryResultsInOfferCaProMessageWithSubTypeFieldAndCorrectHistoryCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fc607126-8bee-4e02-b1c6-4f8eb27076a8");
     m_sutWithHistoryUserSide.offer();
 
     auto maybeCaproMessage = m_sutWithHistoryRouDiSide.tryGetCaProMessage();
@@ -229,6 +242,7 @@ TEST_F(PublisherPort_test,
 
 TEST_F(PublisherPort_test, allocatingAChunkWithoutUserHeaderAndSmallUserPayloadAlignmentResultsInSmallChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "467e0f06-3450-4cc9-ab84-5ccd5efab69d");
     constexpr uint32_t USER_PAYLOAD_SIZE{SMALL_CHUNK / 2};
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
@@ -239,6 +253,7 @@ TEST_F(PublisherPort_test, allocatingAChunkWithoutUserHeaderAndSmallUserPayloadA
 
 TEST_F(PublisherPort_test, allocatingAChunkWithoutUserHeaderAndLargeUserPayloadAlignmentResultsInLargeChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3bdf0578-93b3-470d-84af-9139919665db");
     constexpr uint32_t USER_PAYLOAD_SIZE{SMALL_CHUNK / 2};
     constexpr uint32_t LARGE_USER_PAYLOAD_ALIGNMENT{SMALL_CHUNK};
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
@@ -250,6 +265,7 @@ TEST_F(PublisherPort_test, allocatingAChunkWithoutUserHeaderAndLargeUserPayloadA
 
 TEST_F(PublisherPort_test, allocatingAChunkWithLargeUserHeaderResultsInLargeChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "598e04d8-8a37-43ef-b686-64e7b2723ffe");
     constexpr uint32_t USER_PAYLOAD_SIZE{SMALL_CHUNK / 2};
     constexpr uint32_t LARGE_USER_HEADER_SIZE{SMALL_CHUNK};
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
@@ -261,6 +277,7 @@ TEST_F(PublisherPort_test, allocatingAChunkWithLargeUserHeaderResultsInLargeChun
 
 TEST_F(PublisherPort_test, releasingAnAllocatedChunkReleasesTheMemory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0a88a36b-73c5-4699-8d88-bfe4c19bfd81");
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         10U, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunkHeader = maybeChunkHeader.value();
@@ -273,6 +290,7 @@ TEST_F(PublisherPort_test, releasingAnAllocatedChunkReleasesTheMemory)
 
 TEST_F(PublisherPort_test, allocatedChunkContainsPublisherIdAsOriginId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6b873fcb-d67d-48ca-a67d-b807311161d4");
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         10U, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunkHeader = maybeChunkHeader.value();
@@ -283,6 +301,7 @@ TEST_F(PublisherPort_test, allocatedChunkContainsPublisherIdAsOriginId)
 
 TEST_F(PublisherPort_test, allocateAndSendAChunkWithoutSubscriberHoldsTheLast)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7b2e2930-4271-4e56-ac84-810d6d5745e4");
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         10U, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunkHeader = maybeChunkHeader.value();
@@ -295,6 +314,7 @@ TEST_F(PublisherPort_test, allocateAndSendAChunkWithoutSubscriberHoldsTheLast)
 
 TEST_F(PublisherPort_test, allocateAndSendMultipleChunksWithoutSubscriberHoldsOnlyTheLast)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "761cdd5c-2692-4e0b-b978-609524c48708");
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         10U, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunkHeader = maybeChunkHeader.value();
@@ -314,6 +334,7 @@ TEST_F(PublisherPort_test, allocateAndSendMultipleChunksWithoutSubscriberHoldsOn
 
 TEST_F(PublisherPort_test, subscribeWhenNotOfferedReturnsNACK)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "71148938-58f1-4189-8461-8bab912e32c6");
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
                                       iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
@@ -330,6 +351,7 @@ TEST_F(PublisherPort_test, subscribeWhenNotOfferedReturnsNACK)
 
 TEST_F(PublisherPort_test, unsubscribeWhenNotSubscribedReturnsNACK)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c68043b2-e7e1-4b73-a860-3b2980505545");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
@@ -348,6 +370,7 @@ TEST_F(PublisherPort_test, unsubscribeWhenNotSubscribedReturnsNACK)
 
 TEST_F(PublisherPort_test, subscribeWhenOfferedReturnsACKAndWeHaveSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4e5fa8bb-7b07-49f7-9228-47b66afb00c7");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
@@ -367,6 +390,7 @@ TEST_F(PublisherPort_test, subscribeWhenOfferedReturnsACKAndWeHaveSubscribers)
 
 TEST_F(PublisherPort_test, unsubscribeWhenSubscribedReturnsACKAndWeHaveNoMoreSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d11815bc-0d63-481e-83c7-4eed60322062");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
@@ -389,6 +413,7 @@ TEST_F(PublisherPort_test, unsubscribeWhenSubscribedReturnsACKAndWeHaveNoMoreSub
 
 TEST_F(PublisherPort_test, subscribeManyIsFine)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7ee3c448-7091-4a99-b03b-6ae321cf96ba");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     // using dummy pointers for the provided chunk queue data
@@ -414,6 +439,7 @@ TEST_F(PublisherPort_test, subscribeManyIsFine)
 
 TEST_F(PublisherPort_test, subscribeTillOverflowReturnsNACK)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4726b002-93df-48cd-b190-757fe772d694");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     // using dummy pointers for the provided chunk queue data
@@ -441,6 +467,7 @@ TEST_F(PublisherPort_test, subscribeTillOverflowReturnsNACK)
 
 TEST_F(PublisherPort_test, sendWhenSubscribedDeliversAChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "659db6ee-7843-4aa7-b633-916614b6a711");
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
@@ -469,6 +496,7 @@ TEST_F(PublisherPort_test, sendWhenSubscribedDeliversAChunk)
 
 TEST_F(PublisherPort_test, subscribeWithHistoryLikeTheARAField)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "12ea9650-c928-4185-8519-be949e2afcf7");
     iox::popo::PublisherOptions options;
     options.historyCapacity = 1U;
     iox::popo::PublisherPortData publisherPortDataHistory{
@@ -508,6 +536,7 @@ TEST_F(PublisherPort_test, subscribeWithHistoryLikeTheARAField)
 
 TEST_F(PublisherPort_test, noLastChunkWhenNothingSent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a9a076d8-ed09-4344-9053-d3d513a17d0a");
     auto maybeLastChunkHeader = m_sutNoOfferOnCreateUserSide.tryGetPreviousChunk();
 
     EXPECT_FALSE(maybeLastChunkHeader.has_value());
@@ -515,6 +544,7 @@ TEST_F(PublisherPort_test, noLastChunkWhenNothingSent)
 
 TEST_F(PublisherPort_test, lastChunkAvailableAfterSend)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b44de075-2a53-4576-92db-5fcb41d68700");
     auto maybeChunkHeader = m_sutNoOfferOnCreateUserSide.tryAllocateChunk(
         10U, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     auto chunkHeader = maybeChunkHeader.value();
@@ -529,6 +559,7 @@ TEST_F(PublisherPort_test, lastChunkAvailableAfterSend)
 
 TEST_F(PublisherPort_test, cleanupReleasesAllChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a78f11a6-8d4e-4ab5-888a-a2706ff97ec1");
     // push some chunks to history
     for (size_t i = 0; i < iox::MAX_PUBLISHER_HISTORY; i++)
     {

--- a/iceoryx_posh/test/moduletests/test_popo_rpc_header.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_rpc_header.cpp
@@ -63,6 +63,7 @@ void checkRpcBaseHeader(const RpcBaseHeaderAccess* sut,
 
 TEST_F(RpcBaseHeader_test, ConstructorWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "54b62ac7-30a7-424b-b149-8255afbf0a0d");
     const iox::UniquePortId clientQueueUniquePortId;
     constexpr uint32_t LAST_KNOWN_CLIENT_QUEUE_INDEX{13};
     constexpr int64_t SEQUENCE_ID{42};
@@ -81,16 +82,19 @@ TEST_F(RpcBaseHeader_test, ConstructorWorks)
 
 TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionFromNonConstContextWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c58aa0ac-8897-4ac5-a2aa-53999902f504");
     EXPECT_THAT(static_cast<RpcBaseHeader*>(sut)->getChunkHeader(), Eq(chunk.chunkHeader()));
 }
 
 TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionFromConstContextWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6fa9caf1-7ebb-4995-a684-4416d6644b7e");
     EXPECT_THAT(static_cast<const RpcBaseHeader*>(sut)->getChunkHeader(), Eq(chunk.chunkHeader()));
 }
 
 TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionCalledFromNonConstContextReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3105ac6e-62cd-4655-a6d8-b70593a77c60");
     auto isNonConstReturn =
         std::is_same<decltype(std::declval<RpcBaseHeader>().getChunkHeader()), iox::mepoo::ChunkHeader*>::value;
     EXPECT_TRUE(isNonConstReturn);
@@ -98,6 +102,7 @@ TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionCalledFromNonConstContextReturn
 
 TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionCalledFromConstContextReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "36e1e4fc-ac81-4fd7-95ff-38afa391a3da");
     auto isConstReturn = std::is_same<decltype(std::declval<const RpcBaseHeader>().getChunkHeader()),
                                       const iox::mepoo::ChunkHeader*>::value;
     EXPECT_TRUE(isConstReturn);
@@ -105,22 +110,26 @@ TEST_F(RpcBaseHeader_test, GetChunkHeaderFunctionCalledFromConstContextReturnsCo
 
 TEST_F(RpcBaseHeader_test, GetUserPayloadFunctionFromNonConstContextWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7ee7b88e-8fc1-4b6b-a84b-f89c9480855e");
     EXPECT_THAT(static_cast<RpcBaseHeader*>(sut)->getUserPayload(), Eq(chunk.chunkHeader()->userPayload()));
 }
 
 TEST_F(RpcBaseHeader_test, GetUserPayloadFunctionFromConstContextWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0ac0611a-f4c8-414e-bab2-fc6a41a68f9c");
     EXPECT_THAT(static_cast<const RpcBaseHeader*>(sut)->getUserPayload(), Eq(chunk.chunkHeader()->userPayload()));
 }
 
 TEST_F(RpcBaseHeader_test, GetUserPayloadFunctionCalledFromNonConstContextReturnsNonConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7b815d45-1dc2-44f1-9baf-013d8e76e5ca");
     auto isNonConstReturn = std::is_same<decltype(std::declval<RpcBaseHeader>().getUserPayload()), void*>::value;
     EXPECT_TRUE(isNonConstReturn);
 }
 
 TEST_F(RpcBaseHeader_test, GetUserPayloadFunctionCalledFromConstContextReturnsConstType)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "06c91e8c-7495-40da-88ed-c201f3cf8da1");
     auto isConstReturn =
         std::is_same<decltype(std::declval<const RpcBaseHeader>().getUserPayload()), const void*>::value;
     EXPECT_TRUE(isConstReturn);
@@ -144,6 +153,7 @@ class RequestHeader_test : public Test
 
 TEST_F(RequestHeader_test, ConstructorWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4af7c64c-5f9f-4598-b405-567658e128db");
     const iox::UniquePortId clientQueueUniquePortId;
     constexpr uint32_t LAST_KNOWN_CLIENT_QUEUE_INDEX{13};
     constexpr int64_t EXPECTED_SEQUENCE_ID{0};
@@ -163,6 +173,7 @@ TEST_F(RequestHeader_test, ConstructorWorks)
 
 TEST_F(RequestHeader_test, SetSequenceIdWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fde17d21-33b9-4c23-a482-9bce99b8c346");
     constexpr int64_t SEQUENCE_ID{666};
 
     sut->setSequenceId(SEQUENCE_ID);
@@ -172,6 +183,7 @@ TEST_F(RequestHeader_test, SetSequenceIdWorks)
 
 TEST_F(RequestHeader_test, SetFireAndForgetWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1947a27b-251c-403f-a063-74d47309486d");
     sut->setFireAndForget();
 
     EXPECT_THAT(sut->isFireAndForget(), Eq(true));
@@ -197,6 +209,7 @@ class ResponseHeader_test : public Test
 
 TEST_F(ResponseHeader_test, ConstructorWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ec3d90c3-2126-420c-a31c-f1c6a0731791");
     const iox::UniquePortId clientQueueUniquePortId;
     constexpr uint32_t LAST_KNOWN_CLIENT_QUEUE_INDEX{17};
     constexpr int64_t SEQUENCE_ID{555};
@@ -217,6 +230,7 @@ TEST_F(ResponseHeader_test, ConstructorWorks)
 
 TEST_F(ResponseHeader_test, SetServerErrorWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b455d8dc-2349-4618-b73f-4567c70b616a");
     sut->setServerError();
 
     EXPECT_THAT(sut->hasServerError(), Eq(true));

--- a/iceoryx_posh/test/moduletests/test_popo_sample.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_sample.cpp
@@ -71,6 +71,7 @@ class SampleTest : public Test
 
 TEST_F(SampleTest, PublishesSampleViaPublisherInterfaceWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0b13578c-d654-4802-80a4-f45e5fd73268");
     // ===== Setup ===== //
     ChunkMock<DummyData> chunk;
     iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), [](DummyData*) {}};
@@ -89,6 +90,7 @@ TEST_F(SampleTest, PublishesSampleViaPublisherInterfaceWorks)
 
 TEST_F(SampleTest, PublishingEmptySampleCallsErrorHandler)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b49bdcb3-6f8a-42c1-bb6c-a745f1a49b0e");
     // ===== Setup ===== //
     ChunkMock<DummyData> chunk;
     iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), [](DummyData*) {}};
@@ -118,6 +120,7 @@ TEST_F(SampleTest, PublishingEmptySampleCallsErrorHandler)
 
 TEST_F(SampleTest, CallingGetUserHeaderFromNonConstTypeReturnsCorrectAddress)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d26dd24c-0c84-4c3d-96ab-bf51e52c9e9f");
     // ===== Setup ===== //
     ChunkMock<DummyData, DummyHeader> chunk;
     iox::cxx::unique_ptr<DummyData> testSamplePtr{chunk.sample(), [](DummyData*) {}};
@@ -136,6 +139,7 @@ TEST_F(SampleTest, CallingGetUserHeaderFromNonConstTypeReturnsCorrectAddress)
 
 TEST_F(SampleTest, CallingGetUserHeaderFromConstTypeReturnsCorrectAddress)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fb6b6706-7a15-4ae2-a77a-d4b21431ca57");
     // ===== Setup ===== //
     ChunkMock<DummyData, DummyHeader> chunk;
     iox::cxx::unique_ptr<const DummyData> testSamplePtr{chunk.sample(), [](const DummyData*) {}};

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber.cpp
@@ -70,6 +70,7 @@ class SubscriberTest : public Test
 
 TEST_F(SubscriberTest, GetsUIDViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3b30966b-b50d-41f5-8be3-6f85ab14776d");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getUid).Times(1);
     // ===== Test ===== //
@@ -80,6 +81,7 @@ TEST_F(SubscriberTest, GetsUIDViaBaseSubscriber)
 
 TEST_F(SubscriberTest, GetsServiceDescriptionViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5c08916d-69a4-436b-8ade-bcf43fdc7b6a");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getServiceDescription).Times(1);
     // ===== Test ===== //
@@ -90,6 +92,7 @@ TEST_F(SubscriberTest, GetsServiceDescriptionViaBaseSubscriber)
 
 TEST_F(SubscriberTest, GetsSubscriptionStateViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4050a941-5b42-4a30-b00e-6a9f2c6aba0d");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getSubscriptionState).Times(1);
     // ===== Test ===== //
@@ -100,6 +103,7 @@ TEST_F(SubscriberTest, GetsSubscriptionStateViaBaseSubscriber)
 
 TEST_F(SubscriberTest, SubscribesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "067056dc-86a2-49a8-99fa-a4cac40d691f");
     // ===== Setup ===== //
     EXPECT_CALL(sut, subscribe).Times(1);
     // ===== Test ===== //
@@ -110,6 +114,7 @@ TEST_F(SubscriberTest, SubscribesViaBaseSubscriber)
 
 TEST_F(SubscriberTest, UnsubscribesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9da25521-3cb1-4c09-ad6d-166408fa37f2");
     // ===== Setup ===== //
     EXPECT_CALL(sut, unsubscribe).Times(1);
     // ===== Test ===== //
@@ -120,6 +125,7 @@ TEST_F(SubscriberTest, UnsubscribesViaBaseSubscriber)
 
 TEST_F(SubscriberTest, ChecksForNewSamplesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "27b37735-30db-422a-9b05-64c0a8daa18a");
     // ===== Setup ===== //
     EXPECT_CALL(sut, hasData).Times(1);
     // ===== Test ===== //
@@ -130,6 +136,7 @@ TEST_F(SubscriberTest, ChecksForNewSamplesViaBaseSubscriber)
 
 TEST_F(SubscriberTest, ChecksForMissedSamplesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a1c5f6f0-196a-457e-9990-cbeb89400619");
     // ===== Setup ===== //
     EXPECT_CALL(sut, hasMissedData).Times(1);
     // ===== Test ===== //
@@ -140,6 +147,7 @@ TEST_F(SubscriberTest, ChecksForMissedSamplesViaBaseSubscriber)
 
 TEST_F(SubscriberTest, TakeReturnsAllocatedMemoryChunksWrappedInSample)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "57507fcd-c7db-4b78-9e75-17c28c6ae5d7");
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
@@ -155,6 +163,7 @@ TEST_F(SubscriberTest, TakeReturnsAllocatedMemoryChunksWrappedInSample)
 
 TEST_F(SubscriberTest, ReceivedSamplesAreAutomaticallyDeletedWhenOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f32c401d-0620-4a4b-800f-eda94a493efd");
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
@@ -171,6 +180,7 @@ TEST_F(SubscriberTest, ReceivedSamplesAreAutomaticallyDeletedWhenOutOfScope)
 
 TEST_F(SubscriberTest, ReleasesQueuedDataViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f30fe1ae-046c-48b3-b5cd-b9adbf9b864f");
     // ===== Setup ===== //
     EXPECT_CALL(sut, releaseQueuedData).Times(1);
     // ===== Test ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_options.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_options.cpp
@@ -24,6 +24,7 @@ using namespace ::testing;
 
 TEST(SubscriberOptions_test, SerializationRoundTripIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c8e9480d-15be-43d7-9218-fb6a2ce9b91e");
     iox::popo::SubscriberOptions defaultOptions;
     iox::popo::SubscriberOptions testOptions;
 
@@ -55,6 +56,7 @@ TEST(SubscriberOptions_test, SerializationRoundTripIsSuccessful)
 
 TEST(SubscriberOptions_test, DeserializingBogusDataFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6b4b77cc-09ce-4f71-b2b5-371be27f863a");
     const auto bogusSerialization = iox::cxx::Serialization::create("hypnotoad", "brain slug", "rock star");
     iox::popo::SubscriberOptions::deserialize(bogusSerialization)
         .and_then([&](auto&) { FAIL() << "Deserialization is expected to fail!"; })
@@ -63,6 +65,7 @@ TEST(SubscriberOptions_test, DeserializingBogusDataFails)
 
 TEST(SubscriberOptions_test, DeserializingInvalidQueueFullPolicyFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c41116d5-315d-4921-a322-03a6a26df4e0");
     constexpr uint64_t QUEUE_CAPACITY{73U};
     constexpr uint64_t HISTORY_REQUEST{42U};
     const iox::NodeName_t NODE_NAME{"harr-harr"};

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
@@ -85,11 +85,13 @@ const iox::capro::ServiceDescription SubscriberPortSingleProducer_test::TEST_SER
 
 TEST_F(SubscriberPortSingleProducer_test, InitialStateNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3f4429fa-aa94-42de-9f53-bcd15a1e5b60");
     EXPECT_THAT(m_sutUserSideSingleProducer.getSubscriptionState(), Eq(iox::SubscribeState::NOT_SUBSCRIBED));
 }
 
 TEST_F(SubscriberPortSingleProducer_test, InitialStateNoChunksAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "11a25a0b-eea6-42f9-8937-955ab014916c");
     auto maybeChunkHeader = m_sutUserSideSingleProducer.tryGetChunk();
 
     ASSERT_TRUE(maybeChunkHeader.has_error());
@@ -99,11 +101,13 @@ TEST_F(SubscriberPortSingleProducer_test, InitialStateNoChunksAvailable)
 
 TEST_F(SubscriberPortSingleProducer_test, InitialStateNoChunksLost)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d59df0c5-8635-41ab-b0fe-51c57fb9d66a");
     EXPECT_FALSE(m_sutUserSideSingleProducer.hasLostChunksSinceLastCall());
 }
 
 TEST_F(SubscriberPortSingleProducer_test, InitialStateReturnsNoCaProMessageWhenNoSubOnCreate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2957282d-2c80-4d1c-bace-59d3f8e23a3f");
     auto maybeCaproMessage = m_sutRouDiSideSingleProducer.tryGetCaProMessage();
 
     EXPECT_FALSE(maybeCaproMessage.has_value());
@@ -111,6 +115,7 @@ TEST_F(SubscriberPortSingleProducer_test, InitialStateReturnsNoCaProMessageWhenN
 
 TEST_F(SubscriberPortSingleProducer_test, InitialStateReturnsSubCaProMessageWithDefaultOptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e4e92212-eff9-40cb-87a2-10c650185217");
     auto maybeCaproMessage = m_sutRouDiSideDefaultOptions.tryGetCaProMessage();
 
     ASSERT_TRUE(maybeCaproMessage.has_value());
@@ -120,6 +125,7 @@ TEST_F(SubscriberPortSingleProducer_test, InitialStateReturnsSubCaProMessageWith
 
 TEST_F(SubscriberPortSingleProducer_test, SubscribeCallResultsInSubCaProMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3efdb6ed-4b04-4a28-8e5a-aeb7329ad188");
     m_sutUserSideSingleProducer.subscribe();
 
     auto maybeCaproMessage = m_sutRouDiSideSingleProducer.tryGetCaProMessage();
@@ -133,6 +139,7 @@ TEST_F(SubscriberPortSingleProducer_test, SubscribeCallResultsInSubCaProMessage)
 
 TEST_F(SubscriberPortSingleProducer_test, SubscribeRequestedWhenCallingSubscribe)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cccc4f43-61c9-4785-af2d-29cbad7420da");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
 
@@ -143,6 +150,7 @@ TEST_F(SubscriberPortSingleProducer_test, SubscribeRequestedWhenCallingSubscribe
 
 TEST_F(SubscriberPortSingleProducer_test, NackResponseOnSubResultsInWaitForOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "83a4dedd-bb97-4991-a247-28334939263f");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK,
@@ -156,6 +164,7 @@ TEST_F(SubscriberPortSingleProducer_test, NackResponseOnSubResultsInWaitForOffer
 
 TEST_F(SubscriberPortSingleProducer_test, AckResponseOnSubResultsInSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f12ab584-0e74-438c-b39a-a447e2540d5c");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -169,6 +178,7 @@ TEST_F(SubscriberPortSingleProducer_test, AckResponseOnSubResultsInSubscribed)
 
 TEST_F(SubscriberPortSingleProducer_test, OfferInWaitForOfferTriggersSubMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ffa573b9-db23-401c-95ee-85ba80833464");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK,
@@ -188,6 +198,7 @@ TEST_F(SubscriberPortSingleProducer_test, OfferInWaitForOfferTriggersSubMessage)
 
 TEST_F(SubscriberPortSingleProducer_test, OfferInWaitForOfferResultsInSubscribeRequested)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4045be99-d1ef-4f3e-98c1-e956a19da1a1");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK,
@@ -203,6 +214,7 @@ TEST_F(SubscriberPortSingleProducer_test, OfferInWaitForOfferResultsInSubscribeR
 
 TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInWaitForOfferResultsInNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8bc335a2-441f-47e0-8681-d753d824fb52");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK,
@@ -218,6 +230,7 @@ TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInWaitForOfferResultsInNotS
 
 TEST_F(SubscriberPortSingleProducer_test, StopOfferInSubscribedResultsInWaitForOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "227d649e-0a53-41f5-8d22-4ead7a39379d");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -233,6 +246,7 @@ TEST_F(SubscriberPortSingleProducer_test, StopOfferInSubscribedResultsInWaitForO
 
 TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInSubscribedTriggersUnsubMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e865a067-d68d-4d29-a6d4-55819632c8dc");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -251,6 +265,7 @@ TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInSubscribedTriggersUnsubMe
 
 TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInSubscribedResultsInUnsubscribeRequested)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "040b1cbb-5f63-4da4-b63d-a8bd02773888");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -266,6 +281,7 @@ TEST_F(SubscriberPortSingleProducer_test, UnsubscribeInSubscribedResultsInUnsubs
 
 TEST_F(SubscriberPortSingleProducer_test, AckInUnsubscribeRequestedResultsInNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62a1d42c-6d5f-46ed-a758-411ae074e2cf");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -282,6 +298,7 @@ TEST_F(SubscriberPortSingleProducer_test, AckInUnsubscribeRequestedResultsInNotS
 
 TEST_F(SubscriberPortSingleProducer_test, NackInUnsubscribeRequestedResultsInNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "32592636-20c6-4b0f-8d27-c48c0fc8aa0f");
     m_sutUserSideSingleProducer.subscribe();
     m_sutRouDiSideSingleProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -299,6 +316,7 @@ TEST_F(SubscriberPortSingleProducer_test, NackInUnsubscribeRequestedResultsInNot
 
 TEST_F(SubscriberPortSingleProducer_test, InvalidMessageResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "23aaa4fd-5567-4831-b539-802c5de238ab");
     auto errorHandlerCalled{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&errorHandlerCalled](const iox::Error, const std::function<void()>, const iox::ErrorLevel) {
@@ -315,6 +333,7 @@ TEST_F(SubscriberPortSingleProducer_test, InvalidMessageResultsInError)
 
 TEST_F(SubscriberPortSingleProducer_test, AckWhenNotWaitingForResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "541719e5-fdfa-4ef8-86f6-a9baf4919fe8");
     auto errorHandlerCalled{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&errorHandlerCalled](const iox::Error, const std::function<void()>, const iox::ErrorLevel) {
@@ -331,6 +350,7 @@ TEST_F(SubscriberPortSingleProducer_test, AckWhenNotWaitingForResultsInError)
 
 TEST_F(SubscriberPortSingleProducer_test, NackWhenNotWaitingForResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "063e3a61-209b-4755-abfa-69aed6258ab3");
     auto errorHandlerCalled{false};
     iox::Error receivedError;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -381,11 +401,13 @@ class SubscriberPortMultiProducer_test : public Test
 
 TEST_F(SubscriberPortMultiProducer_test, InitialStateNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "03cdb90f-d34d-47c7-866a-097db0d2852f");
     EXPECT_THAT(m_sutUserSideMultiProducer.getSubscriptionState(), Eq(iox::SubscribeState::NOT_SUBSCRIBED));
 }
 
 TEST_F(SubscriberPortMultiProducer_test, InitialStateReturnsSubCaProMessageWithDefaultOptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "967afa81-ca32-4895-91d6-b1217d0408fa");
     auto maybeCaproMessage = m_sutRouDiSideMultiProducer.tryGetCaProMessage();
 
     ASSERT_TRUE(maybeCaproMessage.has_value());
@@ -395,6 +417,7 @@ TEST_F(SubscriberPortMultiProducer_test, InitialStateReturnsSubCaProMessageWithD
 
 TEST_F(SubscriberPortMultiProducer_test, SubscribeCallResultsInSubCaProMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3676eadc-a1f1-4ea8-838c-b9940977bba7");
     m_sutUserSideMultiProducer.subscribe();
 
     auto maybeCaproMessage = m_sutRouDiSideMultiProducer.tryGetCaProMessage();
@@ -408,6 +431,7 @@ TEST_F(SubscriberPortMultiProducer_test, SubscribeCallResultsInSubCaProMessage)
 
 TEST_F(SubscriberPortMultiProducer_test, SubscribedWhenCallingSubscribe)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a9ee3134-6135-477f-82b4-5f11fdb534c5");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
 
@@ -418,6 +442,7 @@ TEST_F(SubscriberPortMultiProducer_test, SubscribedWhenCallingSubscribe)
 
 TEST_F(SubscriberPortMultiProducer_test, NackResponseOnSubStillSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c741d9d0-e644-4417-8842-2c9a6923fab2");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK,
@@ -431,6 +456,7 @@ TEST_F(SubscriberPortMultiProducer_test, NackResponseOnSubStillSubscribed)
 
 TEST_F(SubscriberPortMultiProducer_test, AckResponseOnSubStillSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9592b3f7-6fe7-46a9-92e4-dd263bd3d748");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -444,6 +470,7 @@ TEST_F(SubscriberPortMultiProducer_test, AckResponseOnSubStillSubscribed)
 
 TEST_F(SubscriberPortMultiProducer_test, OfferInSubscribedTriggersSubMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "386e1cf5-26fd-4883-9f22-214922ff50d5");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::OFFER,
@@ -461,6 +488,7 @@ TEST_F(SubscriberPortMultiProducer_test, OfferInSubscribedTriggersSubMessage)
 
 TEST_F(SubscriberPortMultiProducer_test, UnsubscribeInSubscribedResultsInNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "61291a6b-d199-4be4-baba-aeac1cdc97e1");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     m_sutUserSideMultiProducer.unsubscribe();
@@ -473,6 +501,7 @@ TEST_F(SubscriberPortMultiProducer_test, UnsubscribeInSubscribedResultsInNotSubs
 
 TEST_F(SubscriberPortMultiProducer_test, StopOfferInSubscribedRemainsInSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe2996eb-435d-4196-a772-6834f4937c5a");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -488,6 +517,7 @@ TEST_F(SubscriberPortMultiProducer_test, StopOfferInSubscribedRemainsInSubscribe
 
 TEST_F(SubscriberPortMultiProducer_test, UnsubscribeInSubscribedTriggersUnsubMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1a466097-60a6-4566-b7a3-5aedc7f71dd7");
     m_sutUserSideMultiProducer.subscribe();
     m_sutRouDiSideMultiProducer.tryGetCaProMessage(); // only RouDi changes state
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK,
@@ -506,6 +536,7 @@ TEST_F(SubscriberPortMultiProducer_test, UnsubscribeInSubscribedTriggersUnsubMes
 
 TEST_F(SubscriberPortMultiProducer_test, InvalidMessageResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "419aa91f-991b-4814-b1ee-11637ee14d30");
     auto errorHandlerCalled{false};
     iox::Error receivedError;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -90,6 +90,7 @@ INSTANTIATE_TEST_SUITE_P(ValidTest,
 
 TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedInServiceDescription)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "48c13126-f1f9-457f-8e3b-78a27f451101");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -113,6 +114,7 @@ TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedInServiceDescription
 
 TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedForServiceDescriptionToParseInTomlConfigFile)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9fc62870-448d-4ccb-b8a0-be76884841fb");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -143,6 +145,7 @@ TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedForServiceDescriptio
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoServiceNameInServiceDescriptionReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fbdf3cdd-133c-4689-a73c-1ee2976b6726");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -159,6 +162,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoServiceNameInServiceDescriptionReturn
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoInstanceNameInServiceDescriptionReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b7382a1-7f78-4725-82b1-2508299719cc");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -175,6 +179,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoInstanceNameInServiceDescriptionRetur
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoEventNameInServiceDescriptionReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "44c56d0a-daa4-4ea5-b889-7b3758ec5c59");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -191,6 +196,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoEventNameInServiceDescriptionReturnIn
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoServicesInConfigReturnIncompleteConfigurationError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "14a75eaf-7eac-4ccd-a797-79dca9f382fc");
     auto toml = cpptoml::make_table();
 
     auto result = iox::config::StubbedTomlGatewayConfigParser::validate(*toml);
@@ -203,6 +209,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoServicesInConfigReturnIncompleteConfi
 // test fails on every machine which is using such a config.
 TEST_F(TomlGatewayConfigParserSuiteTest, DISABLED_ParseWithoutParameterTakeDefaultPathReturnNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f18a7245-c4d5-4ad2-a74e-a622103f45f3");
     auto result = TomlGatewayConfigParser::parse();
     ASSERT_FALSE(result.has_error());
 
@@ -212,6 +219,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, DISABLED_ParseWithoutParameterTakeDefau
 
 TEST_F(TomlGatewayConfigParserSuiteTest, ParseWithEmptyPathReturnEmptyConfig)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1dc2aec6-31ab-4748-8e5f-f44be9777dcd");
     iox::roudi::ConfigFilePathString_t path = "";
 
     auto result = TomlGatewayConfigParser::parse(path);
@@ -224,6 +232,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, ParseWithEmptyPathReturnEmptyConfig)
 TEST_F(TomlGatewayConfigParserSuiteTest,
        ParseWithoutServiceNameInServiceDescriptionInTomlConfigFileReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c789eb60-935a-454d-95de-5083c0288a0a");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -243,6 +252,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
 TEST_F(TomlGatewayConfigParserSuiteTest,
        ParseWithoutInstanceNameInServiceDescriptionInTomlConfigFileReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d40950c8-4be0-4b48-9188-e18d46e21225");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -262,6 +272,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
 TEST_F(TomlGatewayConfigParserSuiteTest,
        ParseWithoutEventNameInServiceDescriptionInTomlConfigFileReturnIncompleteServiceDescriptionError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b81898dc-8f84-475d-af5b-5095abd31a15");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -281,6 +292,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
 TEST_F(TomlGatewayConfigParserSuiteTest,
        ParseWithoutServicesConfigurationInTomlConfigFileReturnIncompleteConfigurationError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e2a712d9-7f8b-45e2-a6a0-e16e8990c844");
     auto toml = cpptoml::make_table();
     CreateTmpTomlFile(toml);
 
@@ -292,6 +304,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
 
 TEST_F(TomlGatewayConfigParserSuiteTest, DuplicatedServicesDescriptionInTomlFileReturnOnlyOneEntry)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "093f09d6-67ab-4da2-933f-e20fb5c42444");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -318,6 +331,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, DuplicatedServicesDescriptionInTomlFile
 
 TEST_F(TomlGatewayConfigParserSuiteTest, ParseValidConfigFileWithMaximumAllowedNumberOfConfiguredServicesReturnNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "979101e3-764e-484f-aa6e-94b5c1cc0b5d");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
 
@@ -355,6 +369,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, ParseValidConfigFileWithMaximumAllowedN
 TEST_F(TomlGatewayConfigParserSuiteTest,
        ParseValidConfigFileWithMoreThanMaximumAllowedNumberOfConfiguredServicesReturnError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5fd22d76-1d13-4364-8fd7-2f5d434714f4");
     auto toml = cpptoml::make_table();
     auto serviceArray = cpptoml::make_table_array();
     auto serviceEntry = cpptoml::make_table();
@@ -389,6 +404,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(TomlGatewayConfigParserTest, ParseMalformedInputFileCausesError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46f32eaf-b4d5-4ae1-b57e-aa23fcfcd2d5");
     const auto parseErrorInputFile = GetParam();
 
     m_configFilePath.append(iox::cxx::TruncateToCapacity, parseErrorInputFile.second);

--- a/iceoryx_posh/test/moduletests/test_popo_trigger.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_trigger.cpp
@@ -113,6 +113,7 @@ Trigger_test::TriggerClass* Trigger_test::TriggerClass::m_lastCallbackArgument =
 
 TEST_F(Trigger_test, TriggerWithValidOriginIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "54b79e70-4b18-4d37-b652-821218a176e0");
     Trigger sut = createValidStateBasedTrigger();
 
     EXPECT_TRUE(sut.isValid());
@@ -121,6 +122,7 @@ TEST_F(Trigger_test, TriggerWithValidOriginIsValid)
 
 TEST_F(Trigger_test, MovedConstructedValidTriggerIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "08a65b29-c171-47b3-9de5-29ae6cb3b0b7");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 90001U;
     constexpr uint64_t originTypeHash = 40001U;
@@ -141,6 +143,7 @@ TEST_F(Trigger_test, MovedConstructedValidTriggerIsValid)
 
 TEST_F(Trigger_test, MovedAssignedValidTriggerIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49205508-79d9-4a54-8d23-96eb70bb8446");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 190001U;
     constexpr uint64_t originTypeHash = 140001U;
@@ -167,6 +170,7 @@ TEST_F(Trigger_test, MovedAssignedValidTriggerIsValid)
 
 TEST_F(Trigger_test, TriggerWithNullptrOriginIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ade4ce54-1659-4d1d-8784-f8f0edc65fb0");
     constexpr uint64_t eventId = 0U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -188,6 +192,7 @@ TEST_F(Trigger_test, TriggerWithNullptrOriginIsValid)
 
 TEST_F(Trigger_test, TriggerWithInvalidHasTriggeredCallbackCallsErrorHandlerAndIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "33a753fe-2f45-48ed-8350-1fe7163105df");
     constexpr uint64_t eventId = 0U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -219,6 +224,7 @@ TEST_F(Trigger_test, TriggerWithInvalidHasTriggeredCallbackCallsErrorHandlerAndI
 
 TEST_F(Trigger_test, TriggerWithEmptyResetCallCallsErrorHandlerAndIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c9990f56-711f-4fbd-a0cc-42ecd26152d4");
     constexpr uint64_t eventId = 0U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -250,6 +256,7 @@ TEST_F(Trigger_test, TriggerWithEmptyResetCallCallsErrorHandlerAndIsInvalid)
 
 TEST_F(Trigger_test, ResetInvalidatesTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3d8c297c-04d1-4ce1-b51e-684666470bc5");
     Trigger sut = createValidStateBasedTrigger();
     sut.reset();
 
@@ -260,6 +267,7 @@ TEST_F(Trigger_test, ResetInvalidatesTrigger)
 
 TEST_F(Trigger_test, InvalidateInvalidatesTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e4b87606-acf4-4962-9b68-48650457f2e0");
     Trigger sut = createValidStateBasedTrigger();
     sut.invalidate();
 
@@ -270,6 +278,7 @@ TEST_F(Trigger_test, InvalidateInvalidatesTrigger)
 
 TEST_F(Trigger_test, ResetCallsResetcallbackWithCorrectTriggerOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9ce18ec9-b6c9-47d9-afec-57be1724737c");
     Trigger sut = createValidStateBasedTrigger();
     auto uniqueId = sut.getUniqueId();
     sut.reset();
@@ -279,6 +288,7 @@ TEST_F(Trigger_test, ResetCallsResetcallbackWithCorrectTriggerOrigin)
 
 TEST_F(Trigger_test, ResetSetsTriggerIdToInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ed2f8f50-4a6e-4fb9-bd49-d605c87b1cfb");
     Trigger sut = createValidStateBasedTrigger();
     sut.reset();
 
@@ -287,6 +297,7 @@ TEST_F(Trigger_test, ResetSetsTriggerIdToInvalid)
 
 TEST_F(Trigger_test, TriggerWithEmptyResetInvalidatesTriggerWhenBeingResetted)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "64b55c52-06cf-4d96-bb17-2121aa6e68e6");
     constexpr uint64_t eventId = 0U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -313,6 +324,7 @@ TEST_F(Trigger_test, TriggerWithEmptyResetInvalidatesTriggerWhenBeingResetted)
 
 TEST_F(Trigger_test, TriggerCallsHasTriggeredCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7fa3c68f-6b84-41e4-9ab1-b32f98bd8353");
     Trigger sut = createValidStateBasedTrigger();
 
     m_triggerClass.m_hasTriggered = true;
@@ -323,6 +335,7 @@ TEST_F(Trigger_test, TriggerCallsHasTriggeredCallback)
 
 TEST_F(Trigger_test, HasTriggeredCallbackReturnsAlwaysFalseWhenInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3895a8fb-6ffe-4a0f-9490-3058aac28eac");
     Trigger sut = createValidStateBasedTrigger();
     m_triggerClass.m_hasTriggered = true;
     sut.reset();
@@ -332,6 +345,7 @@ TEST_F(Trigger_test, HasTriggeredCallbackReturnsAlwaysFalseWhenInvalid)
 
 TEST_F(Trigger_test, UpdateOriginLeadsToDifferentHasTriggeredCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49bb8996-baea-4f9b-84eb-3a1b7b12b10b");
     TriggerClass secondTriggerClass;
     Trigger sut = createValidStateBasedTrigger();
 
@@ -345,6 +359,7 @@ TEST_F(Trigger_test, UpdateOriginLeadsToDifferentHasTriggeredCallback)
 
 TEST_F(Trigger_test, TriggerUpdateOriginToSameOriginChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f0790144-6307-4d17-85a2-b1ff22f0de11");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 123U;
     constexpr uint64_t originTypeHash = 123123U;
@@ -356,6 +371,7 @@ TEST_F(Trigger_test, TriggerUpdateOriginToSameOriginChangesNothing)
 
 TEST_F(Trigger_test, UpdateOriginDoesNotUpdateHasTriggeredIfItsNotOriginatingFromOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "69d05155-84e8-4ae9-9a36-cf09dcc5426a");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 891U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -381,6 +397,7 @@ TEST_F(Trigger_test, UpdateOriginDoesNotUpdateHasTriggeredIfItsNotOriginatingFro
 
 TEST_F(Trigger_test, UpdateOriginLeadsToDifferentResetCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "075fc5f8-ecef-482b-a5a9-e0c1257156e6");
     Trigger sut = createValidStateBasedTrigger();
     TriggerClass secondTriggerClass;
 
@@ -393,6 +410,7 @@ TEST_F(Trigger_test, UpdateOriginLeadsToDifferentResetCallback)
 
 TEST_F(Trigger_test, UpdateOriginDoesNotUpdateResetIfItsNotOriginatingFromOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8c41d2cf-d556-49de-ab07-87ee2a194694");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 892U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -417,6 +435,7 @@ TEST_F(Trigger_test, UpdateOriginDoesNotUpdateResetIfItsNotOriginatingFromOrigin
 
 TEST_F(Trigger_test, UpdateOriginUpdatesOriginOfNotificationInfo)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d1c99278-38c2-4195-8058-94fd8c4061fa");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 893U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t type = 0U;
@@ -438,6 +457,7 @@ TEST_F(Trigger_test, UpdateOriginUpdatesOriginOfNotificationInfo)
 
 TEST_F(Trigger_test, TriggerIsLogicalEqualToItself)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "90e2a167-ac32-4eab-818d-57e0ffadfe42");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 894U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t originType = 4123U;
@@ -457,6 +477,7 @@ TEST_F(Trigger_test, TriggerIsLogicalEqualToItself)
 
 TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginTypeDiffers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de5132b2-d750-4ef7-aa76-9826c91e22da");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 4896U;
     constexpr uint64_t uniqueTriggerId1 = 0U;
     constexpr uint64_t originType = 84123U;
@@ -477,6 +498,7 @@ TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginTypeDiffers)
 
 TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginAndOriginTypeHashDiffers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7a14f657-1053-47bf-9ffb-bbceef1c6403");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 4896U;
     constexpr uint64_t uniqueTriggerId1 = 0U;
     constexpr uint64_t originType = 84U;
@@ -498,6 +520,7 @@ TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginAndOriginTypeHashDiffers)
 
 TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginTypeAndOriginTypeHashDiffers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ddfc4457-a2da-494e-b27b-4f590614fda4");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 4896U;
     constexpr uint64_t uniqueTriggerId1 = 0U;
     constexpr uint64_t originType = 584U;
@@ -521,6 +544,7 @@ TEST_F(Trigger_test, TriggerIsNotLogicalEqualIfOriginTypeAndOriginTypeHashDiffer
 
 TEST_F(Trigger_test, TriggerIsNotLogicalEqualWhenInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f398a2de-4191-48cd-a991-32e65705653d");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 4896U;
     constexpr uint64_t uniqueTriggerId1 = 0U;
     constexpr uint64_t originType = 584U;
@@ -544,6 +568,7 @@ TEST_F(Trigger_test, TriggerIsNotLogicalEqualWhenInvalid)
 
 TEST_F(Trigger_test, ValidEventBasedTriggerIsValidAndAlwaysTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "89c5a02d-d63e-4c3f-b5e2-dc1cd82c9b4e");
     Trigger sut = createValidEventBasedTrigger();
     EXPECT_TRUE(sut.isValid());
     EXPECT_TRUE(sut.isStateConditionSatisfied());
@@ -553,6 +578,7 @@ TEST_F(Trigger_test, ValidEventBasedTriggerIsValidAndAlwaysTriggered)
 
 TEST_F(Trigger_test, InvalidatedEventBasedTriggerIsNotValidAndNotTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0326188b-a56d-4ac4-bb48-bdbfa3c89ef4");
     Trigger sut = createValidEventBasedTrigger();
     sut.invalidate();
 
@@ -564,6 +590,7 @@ TEST_F(Trigger_test, InvalidatedEventBasedTriggerIsNotValidAndNotTriggered)
 
 TEST_F(Trigger_test, ResetEventBasedTriggerIsNotValidAndNotTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "379b7b0d-fc6e-4b54-b9c0-e90f17c4f3b9");
     Trigger sut = createValidEventBasedTrigger();
     sut.reset();
 
@@ -575,6 +602,7 @@ TEST_F(Trigger_test, ResetEventBasedTriggerIsNotValidAndNotTriggered)
 
 TEST_F(Trigger_test, ValidEventBasedTriggerIsLogicalEqualToSameEventOriginAndEmptyHasTriggeredCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "74159b9c-066f-4c5d-a8e3-7a29aae1fa7f");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 4584U;
     constexpr uint64_t originTypeHash = 4513U;
@@ -585,6 +613,7 @@ TEST_F(Trigger_test, ValidEventBasedTriggerIsLogicalEqualToSameEventOriginAndEmp
 
 TEST_F(Trigger_test, ValidEventBasedTriggerIsNotLogicalEqualToDifferentEventOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "69142086-6c77-47e8-9d56-09be5a3eefc8");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 458U;
     constexpr uint64_t originTypeHash = 413U;
@@ -596,6 +625,7 @@ TEST_F(Trigger_test, ValidEventBasedTriggerIsNotLogicalEqualToDifferentEventOrig
 
 TEST_F(Trigger_test, InvalidEventBasedTriggerIsLogicalEqualToSameEventOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "45225f4a-ae2a-4f67-a101-4a7f006b0904");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 4598U;
     constexpr uint64_t originTypeHash = 4883U;
@@ -607,6 +637,7 @@ TEST_F(Trigger_test, InvalidEventBasedTriggerIsLogicalEqualToSameEventOrigin)
 
 TEST_F(Trigger_test, InvalidEventBasedTriggerIsNotLogicalEqualToDifferentEventOrigin)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d619868-0c74-483a-b68e-e9f91940c229");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 48U;
     constexpr uint64_t originTypeHash = 83U;
@@ -619,6 +650,7 @@ TEST_F(Trigger_test, InvalidEventBasedTriggerIsNotLogicalEqualToDifferentEventOr
 
 TEST_F(Trigger_test, ValidEventBasedTriggerUpdateOriginWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "78e691d5-9572-4eda-83f3-45a5d8b04265");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 24598U;
     constexpr uint64_t originTypeHash = 24883U;
@@ -632,6 +664,7 @@ TEST_F(Trigger_test, ValidEventBasedTriggerUpdateOriginWorks)
 
 TEST_F(Trigger_test, ValidEventBasedTriggerUpdateOriginWorksToSameOriginChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e64bd163-fae3-4e72-b351-e947d1eaf64f");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 324598U;
     constexpr uint64_t originTypeHash = 324883U;
@@ -643,6 +676,7 @@ TEST_F(Trigger_test, ValidEventBasedTriggerUpdateOriginWorksToSameOriginChangesN
 
 TEST_F(Trigger_test, InvalidEventBasedTriggerUpdateOriginDoesNotWork)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1c53ac2c-6fc4-4beb-9c2d-0bafcbbd3ff8");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 424598U;
     constexpr uint64_t originTypeHash = 424883U;
@@ -657,6 +691,7 @@ TEST_F(Trigger_test, InvalidEventBasedTriggerUpdateOriginDoesNotWork)
 
 TEST_F(Trigger_test, EventBasedTriggerWithEmptyResetCallInvokesErrorHandlerAndIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f57c80dc-13d9-49c6-9fca-1f7b51b836b9");
     constexpr uint64_t eventId = 0U;
     constexpr uint64_t uniqueTriggerId = 0U;
     constexpr uint64_t originType = 0U;
@@ -687,6 +722,7 @@ TEST_F(Trigger_test, EventBasedTriggerWithEmptyResetCallInvokesErrorHandlerAndIs
 
 TEST_F(Trigger_test, EventBasedMovedConstructedWithValidTriggerWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2de4db14-a80d-4b9a-8483-718d9940b508");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 7424598U;
     constexpr uint64_t originTypeHash = 6424883U;
@@ -706,6 +742,7 @@ TEST_F(Trigger_test, EventBasedMovedConstructedWithValidTriggerWorks)
 
 TEST_F(Trigger_test, EventBasedMovedAssignedWithValidTriggerWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "92484233-74eb-4228-8ea0-e996cb3978b4");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 74598U;
     constexpr uint64_t originTypeHash = 243U;
@@ -729,6 +766,7 @@ TEST_F(Trigger_test, EventBasedMovedAssignedWithValidTriggerWorks)
 
 TEST_F(Trigger_test, EventBasedMovedConstructedWithInvalidTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d8259fd0-1dde-482a-a485-097a7819e4e5");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 997458U;
     constexpr uint64_t originTypeHash = 99243U;
@@ -749,6 +787,7 @@ TEST_F(Trigger_test, EventBasedMovedConstructedWithInvalidTrigger)
 
 TEST_F(Trigger_test, EventBasedMovedAssignedWithInvalidTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "526ae232-4078-42c8-9488-6dfacd0af79c");
     constexpr uint64_t id = 0U;
     constexpr uint64_t originType = 740598U;
     constexpr uint64_t originTypeHash = 20043U;

--- a/iceoryx_posh/test/moduletests/test_popo_trigger_handle.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_trigger_handle.cpp
@@ -52,12 +52,14 @@ class TriggerHandle_test : public Test
 
 TEST_F(TriggerHandle_test, IsValidWhenConditionVariableIsNotNull)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3b2ece7a-bd79-45c9-85e6-7868f82bd0f4");
     EXPECT_TRUE(m_sut.isValid());
     EXPECT_TRUE(m_sut);
 }
 
 TEST_F(TriggerHandle_test, DefaultCTorConstructsInvalidHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9910af97-c47a-4048-8c06-13402e02b1ee");
     TriggerHandle sut2;
 
     EXPECT_FALSE(sut2.isValid());
@@ -67,6 +69,7 @@ TEST_F(TriggerHandle_test, DefaultCTorConstructsInvalidHandle)
 
 TEST_F(TriggerHandle_test, InvalidateCreatesInvalidTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3fdd92d9-d598-443c-b71e-708cf12b874c");
     m_sut.invalidate();
 
     EXPECT_FALSE(m_sut.isValid());
@@ -76,6 +79,7 @@ TEST_F(TriggerHandle_test, InvalidateCreatesInvalidTriggerHandle)
 
 TEST_F(TriggerHandle_test, ResetCreatesInvalidTriggerHandle)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1d977b12-75ce-4374-88bc-d7e814db4fad");
     m_sut.reset();
 
     EXPECT_FALSE(m_sut.isValid());
@@ -85,6 +89,7 @@ TEST_F(TriggerHandle_test, ResetCreatesInvalidTriggerHandle)
 
 TEST_F(TriggerHandle_test, ResetCallsResetCallbackWhenHandleIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2f4b5803-de4a-42f5-afc2-7953a211158d");
     m_sut.reset();
     EXPECT_EQ(m_resetCallbackId, 12U);
     EXPECT_THAT(m_sut.getUniqueId(), Eq(Trigger::INVALID_TRIGGER_ID));
@@ -92,6 +97,7 @@ TEST_F(TriggerHandle_test, ResetCallsResetCallbackWhenHandleIsValid)
 
 TEST_F(TriggerHandle_test, ResetDoesNotCallResetCallbackWhenHandleIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "900c0fb5-81a7-46dd-bf5f-1df6072bcb53");
     m_sut.invalidate();
     m_sut.reset();
     EXPECT_EQ(m_resetCallbackId, 0U);
@@ -100,17 +106,20 @@ TEST_F(TriggerHandle_test, ResetDoesNotCallResetCallbackWhenHandleIsInvalid)
 
 TEST_F(TriggerHandle_test, getConditionVariableDataReturnsCorrectVar)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d5722115-2624-4f19-992e-52afb98b9dd5");
     EXPECT_EQ(m_sut.getConditionVariableData(), &m_condVar);
 }
 
 TEST_F(TriggerHandle_test, getUniqueIdReturnsCorrectId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "856e38a0-c5eb-461c-9445-efb5b21cc5db");
     TriggerHandle sut2{m_condVar, {*m_self, &TriggerHandle_test::resetCallback}, 8912U};
     EXPECT_EQ(sut2.getUniqueId(), 8912U);
 }
 
 TEST_F(TriggerHandle_test, triggerNotifiesConditionVariable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "11e752c8-d473-4bfd-b973-869c3b2d9fbc");
     std::atomic_int stage{0};
 
     std::thread t([&] {
@@ -129,23 +138,27 @@ TEST_F(TriggerHandle_test, triggerNotifiesConditionVariable)
 
 TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseAfterCreation)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4a40fead-103f-4f3a-a4db-4b8aacae1b57");
     EXPECT_FALSE(m_sut.wasTriggered());
 }
 
 TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseWhenHandleIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46f36789-894a-4aba-b17e-d844e4cb90ee");
     m_sut.reset();
     EXPECT_FALSE(m_sut.wasTriggered());
 }
 
 TEST_F(TriggerHandle_test, wasTriggeredReturnsTrueAfterItWasTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "afc27579-011b-4879-82e4-0377a3bfb68d");
     m_sut.trigger();
     EXPECT_TRUE(m_sut.wasTriggered());
 }
 
 TEST_F(TriggerHandle_test, wasTriggeredReturnsFalseAfterItWasTriggeredAndTheListenerResetIt)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7d44c016-4abd-4897-bd7a-0a9ce41ffa1f");
     m_sut.trigger();
     ConditionListener(m_condVar).timedWait(units::Duration::fromSeconds(0U));
     EXPECT_FALSE(m_sut.wasTriggered());

--- a/iceoryx_posh/test/moduletests/test_popo_typed_unique_id.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_typed_unique_id.cpp
@@ -28,6 +28,7 @@ using namespace iox::cxx;
 
 TEST(TypedUniqueId_RouDiId, SettingTheRouDiIdWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "473467bf-1a6f-4cd2-acd8-447a623a5301");
     uint16_t someId = 1243u;
     iox::popo::internal::setUniqueRouDiId(someId);
     EXPECT_EQ(iox::popo::internal::getUniqueRouDiId(), someId);
@@ -36,6 +37,7 @@ TEST(TypedUniqueId_RouDiId, SettingTheRouDiIdWorks)
 
 TEST(TypedUniqueId_RouDiId, SettingTheRouDiIdTwiceFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe468314-cd38-4363-bbf9-f106bf9ec1f4");
     uint16_t someId = 1243u;
     bool errorHandlerCalled = false;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -52,6 +54,7 @@ TEST(TypedUniqueId_RouDiId, SettingTheRouDiIdTwiceFails)
 
 TEST(TypedUniqueId_RouDiId, GettingTheRouDiIdWithoutSettingFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "68de213f-7009-4573-8791-9f09f8ba413c");
     bool errorHandlerCalled = false;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&errorHandlerCalled](const iox::Error error IOX_MAYBE_UNUSED,
@@ -79,18 +82,21 @@ TYPED_TEST_SUITE(TypedUniqueId_test, Implementations);
 
 TYPED_TEST(TypedUniqueId_test, DefaultConstructorIncrementsID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2912c5bb-fd6d-46b4-ab32-97cfb7018860");
     typename TestFixture::UniqueIDType a, b;
     EXPECT_THAT(static_cast<uint64_t>(a) + 1, Eq(static_cast<uint64_t>(b)));
 }
 
 TYPED_TEST(TypedUniqueId_test, CopyConstructorSetsSameID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dbe1a4fd-f4fe-47e5-83ef-38a9e59afd94");
     typename TestFixture::UniqueIDType a, b(a);
     EXPECT_THAT(static_cast<uint64_t>(a), Eq(static_cast<uint64_t>(b)));
 }
 
 TYPED_TEST(TypedUniqueId_test, CopyConstructorAssignmentSetsSameID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "31dfad29-0da0-41b8-b78f-dbeda0d7e684");
     typename TestFixture::UniqueIDType a, b;
     a = b;
     EXPECT_THAT(a, Eq(b));
@@ -98,6 +104,7 @@ TYPED_TEST(TypedUniqueId_test, CopyConstructorAssignmentSetsSameID)
 
 TYPED_TEST(TypedUniqueId_test, MoveConstructorSetsSameID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2abb1afa-094a-4d28-a3cc-328212ad2f7b");
     typename TestFixture::UniqueIDType a;
     auto id = static_cast<uint64_t>(a);
     decltype(a) b(std::move(a));
@@ -106,6 +113,7 @@ TYPED_TEST(TypedUniqueId_test, MoveConstructorSetsSameID)
 
 TYPED_TEST(TypedUniqueId_test, MoveAssignmentSetsSameID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5d8a8771-be7a-45d2-b2bb-be89938241b6");
     typename TestFixture::UniqueIDType a, b;
     auto id = static_cast<uint64_t>(a);
     b = std::move(a);
@@ -114,6 +122,7 @@ TYPED_TEST(TypedUniqueId_test, MoveAssignmentSetsSameID)
 
 TYPED_TEST(TypedUniqueId_test, SameIDsAreEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4040fe82-3220-402d-8618-b152f6c1042e");
     typename TestFixture::UniqueIDType a, b(a);
     EXPECT_TRUE(a == b);
     EXPECT_TRUE(a <= b);
@@ -123,6 +132,7 @@ TYPED_TEST(TypedUniqueId_test, SameIDsAreEqual)
 
 TYPED_TEST(TypedUniqueId_test, DifferentIDsAreNotEqual)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ca8c7eae-d2af-4560-9bb7-c2e876103a62");
     typename TestFixture::UniqueIDType a, b;
     EXPECT_FALSE(a == b);
     EXPECT_TRUE(a <= b);
@@ -132,6 +142,7 @@ TYPED_TEST(TypedUniqueId_test, DifferentIDsAreNotEqual)
 
 TYPED_TEST(TypedUniqueId_test, LatestIDIsGreatestID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1327e92a-bc07-4ec9-8bc5-ee5a935ccd66");
     typename TestFixture::UniqueIDType a, b;
     EXPECT_TRUE(a < b);
     EXPECT_TRUE(a <= b);
@@ -141,6 +152,7 @@ TYPED_TEST(TypedUniqueId_test, LatestIDIsGreatestID)
 
 TYPED_TEST(TypedUniqueId_test, FirstIDIsSmallestID)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6951e91f-0112-4c97-b972-34ddeada4191");
     typename TestFixture::UniqueIDType a, b;
     EXPECT_FALSE(b < a);
     EXPECT_FALSE(b <= a);
@@ -150,6 +162,7 @@ TYPED_TEST(TypedUniqueId_test, FirstIDIsSmallestID)
 
 TYPED_TEST(TypedUniqueId_test, ConversionToUint64)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c1c58736-9755-4736-b163-3c8cc26db80d");
     typename TestFixture::UniqueIDType a, b;
     uint64_t id = static_cast<uint64_t>(a);
     b = a;
@@ -158,12 +171,14 @@ TYPED_TEST(TypedUniqueId_test, ConversionToUint64)
 
 TYPED_TEST(TypedUniqueId_test, CreatingAnUniqueIdWithDefaultCTorIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0d810ee1-8ddd-48b3-8b53-d4430dd4bbe6");
     typename TestFixture::UniqueIDType a;
     EXPECT_TRUE(a.isValid());
 }
 
 TYPED_TEST(TypedUniqueId_test, InvalidIdIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d0576b8d-65d2-4b53-88c0-05078f434a41");
     typename TestFixture::UniqueIDType a(InvalidId);
     EXPECT_FALSE(a.isValid());
 }

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
@@ -57,6 +57,7 @@ class UntypedPublisherTest : public Test
 
 TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ddf997c8-ef8e-4f89-802e-66f1c4bf4980");
     constexpr uint32_t USER_PAYLOAD_SIZE = 7U;
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT = 128U;
     EXPECT_CALL(portMock,
@@ -74,6 +75,7 @@ TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeWorks)
 
 TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeAndUserHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3f191e7e-4a1c-421d-bc17-917eaf497682");
     TestUntypedPublisher sutWithUserHeader{{"", "", ""}};
     MockPublisherPortUser& portMockWithUserHeader{sutWithUserHeader.mockPort()};
 
@@ -94,6 +96,7 @@ TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeAndUserHeaderWorks)
 
 TEST_F(UntypedPublisherTest, LoanFailsIfPortCannotSatisfyAllocationRequest)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b609f96e-ea08-46b2-9b72-d162a8273cb5");
     constexpr uint32_t ALLOCATION_SIZE = 17U;
     EXPECT_CALL(portMock, tryAllocateChunk(ALLOCATION_SIZE, _, _, _))
         .WillOnce(Return(
@@ -108,6 +111,7 @@ TEST_F(UntypedPublisherTest, LoanFailsIfPortCannotSatisfyAllocationRequest)
 
 TEST_F(UntypedPublisherTest, ReleaseDelegatesCallToPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e114b083-10c7-403e-a841-a04487a5f1e0");
     constexpr uint32_t ALLOCATION_SIZE = 7U;
     EXPECT_CALL(portMock, tryAllocateChunk(ALLOCATION_SIZE, _, _, _))
         .WillOnce(Return(ByMove(iox::cxx::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
@@ -125,6 +129,7 @@ TEST_F(UntypedPublisherTest, ReleaseDelegatesCallToPort)
 
 TEST_F(UntypedPublisherTest, PublishesUserPayloadViaUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "33479ad8-a7bf-47f9-a9ea-0025fbf1026c");
     // ===== Setup ===== //
     EXPECT_CALL(portMock, sendChunk).Times(1);
     // ===== Test ===== //
@@ -137,18 +142,21 @@ TEST_F(UntypedPublisherTest, PublishesUserPayloadViaUnderlyingPort)
 
 TEST_F(UntypedPublisherTest, OfferDoesOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cd396859-0677-4289-8f6b-7c955b9a7a03");
     EXPECT_CALL(sut, offer).Times(1);
     // ===== Test ===== //
     sut.offer();
 }
 TEST_F(UntypedPublisherTest, StopOfferDoesStopOfferServiceOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "80d4bca6-87d0-4b6e-b7cb-d5e24e340921");
     EXPECT_CALL(sut, stopOffer).Times(1);
     sut.stopOffer();
 }
 
 TEST_F(UntypedPublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "90f92d0d-100e-4b03-8d20-65aa2f6ddcac");
     EXPECT_CALL(sut, isOffered).Times(1);
     // ===== Test ===== //
     sut.isOffered();
@@ -156,6 +164,7 @@ TEST_F(UntypedPublisherTest, isOfferedDoesCheckIfPortIsOfferedOnUnderlyingPort)
 
 TEST_F(UntypedPublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "83eed655-8369-4a35-bfea-df22a535a33e");
     EXPECT_CALL(sut, hasSubscribers).Times(1);
     // ===== Test ===== //
     sut.hasSubscribers();
@@ -163,6 +172,7 @@ TEST_F(UntypedPublisherTest, isOfferedDoesCheckIfUnderylingPortHasSubscribers)
 
 TEST_F(UntypedPublisherTest, GetServiceDescriptionCallForwardedToUnderlyingPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9799e5ea-1455-4cb0-9fd6-6248a902dfb0");
     EXPECT_CALL(sut, getServiceDescription).Times(1);
     // ===== Test ===== //
     sut.getServiceDescription();

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_subscriber.cpp
@@ -55,6 +55,7 @@ class UntypedSubscriberTest : public Test
 
 TEST_F(UntypedSubscriberTest, GetsUIDViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dfe1c24c-d012-4dba-8a24-1b3edbb436f4");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getUid).Times(1);
     // ===== Test ===== //
@@ -65,6 +66,7 @@ TEST_F(UntypedSubscriberTest, GetsUIDViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, GetsServiceDescriptionViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bfbdea6a-7194-463f-9b38-ed11a5e2abc1");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getServiceDescription).Times(1);
     // ===== Test ===== //
@@ -75,6 +77,7 @@ TEST_F(UntypedSubscriberTest, GetsServiceDescriptionViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, GetsSubscriptionStateViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "da01f90a-da83-41f3-9621-b5b28a87504b");
     // ===== Setup ===== //
     EXPECT_CALL(sut, getSubscriptionState).Times(1);
     // ===== Test ===== //
@@ -85,6 +88,7 @@ TEST_F(UntypedSubscriberTest, GetsSubscriptionStateViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, SubscribesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c805d0d0-225b-46cc-a873-2fd399e75dc5");
     // ===== Setup ===== //
     EXPECT_CALL(sut, subscribe).Times(1);
     // ===== Test ===== //
@@ -95,6 +99,7 @@ TEST_F(UntypedSubscriberTest, SubscribesViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, UnsubscribesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f0470300-b2d5-4589-b93b-79efac76c56e");
     // ===== Setup ===== //
     EXPECT_CALL(sut, unsubscribe).Times(1);
     // ===== Test ===== //
@@ -105,6 +110,7 @@ TEST_F(UntypedSubscriberTest, UnsubscribesViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, ChecksForNewSamplesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aff0709c-7486-4139-81de-5cfee29337f8");
     // ===== Setup ===== //
     EXPECT_CALL(sut, hasData).Times(1);
     // ===== Test ===== //
@@ -115,6 +121,7 @@ TEST_F(UntypedSubscriberTest, ChecksForNewSamplesViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, ChecksForMissedSamplesViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "afa8f28c-35c7-4eff-921f-0a75685ef28e");
     // ===== Setup ===== //
     EXPECT_CALL(sut, hasMissedData).Times(1);
     // ===== Test ===== //
@@ -125,6 +132,7 @@ TEST_F(UntypedSubscriberTest, ChecksForMissedSamplesViaBaseSubscriber)
 
 TEST_F(UntypedSubscriberTest, TakeReturnsAllocatedMemoryChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e80e82f8-d573-407d-9640-b148d8679ed4");
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
@@ -141,6 +149,7 @@ TEST_F(UntypedSubscriberTest, TakeReturnsAllocatedMemoryChunk)
 
 TEST_F(UntypedSubscriberTest, ReleasesQueuedDataViaBaseSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "66c0fb02-aa6d-48dd-8439-754e05cd29af");
     // ===== Setup ===== //
     EXPECT_CALL(sut, releaseQueuedData).Times(1);
     // ===== Test ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
@@ -88,11 +88,13 @@ class UsedChunkList_test : public Test
 
 TEST_F(UsedChunkList_test, OneChunkCanBeAdded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe1ee816-b0a6-4468-9652-b0b32e310960");
     EXPECT_TRUE(sut.insert(getChunkFromMemoryManager()));
 }
 
 TEST_F(UsedChunkList_test, AddSameChunkTwiceWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cad24b29-fc1b-4c71-b1be-c04d8653ec9f");
     auto chunk = getChunkFromMemoryManager();
     sut.insert(chunk);
 
@@ -101,6 +103,7 @@ TEST_F(UsedChunkList_test, AddSameChunkTwiceWorks)
 
 TEST_F(UsedChunkList_test, MultipleChunksCanBeAdded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "14eafeb1-ff36-415d-a7f5-a31250332efc");
     EXPECT_TRUE(sut.insert(getChunkFromMemoryManager()));
     EXPECT_TRUE(sut.insert(getChunkFromMemoryManager()));
     EXPECT_TRUE(sut.insert(getChunkFromMemoryManager()));
@@ -108,11 +111,13 @@ TEST_F(UsedChunkList_test, MultipleChunksCanBeAdded)
 
 TEST_F(UsedChunkList_test, AddChunksUpToCapacityWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1b1b9b29-e00f-4791-9a62-f8fd398fb955");
     createMultipleChunks(USED_CHUNK_LIST_CAPACITY, [this](SharedChunk&& chunk) { EXPECT_TRUE(sut.insert(chunk)); });
 }
 
 TEST_F(UsedChunkList_test, AddChunksUntilOverflowIsHandledGracefully)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6922015f-bf26-4bf3-8b7d-8adf6e846030");
     createMultipleChunks(USED_CHUNK_LIST_CAPACITY, [this](SharedChunk&& chunk) { EXPECT_TRUE(sut.insert(chunk)); });
 
     EXPECT_FALSE(sut.insert(getChunkFromMemoryManager()));
@@ -120,6 +125,7 @@ TEST_F(UsedChunkList_test, AddChunksUntilOverflowIsHandledGracefully)
 
 TEST_F(UsedChunkList_test, OneChunkCanBeRemoved)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "50ffb5df-59ef-4dd4-a2a6-c7ad342c24ae");
     auto chunk = getChunkFromMemoryManager();
     auto chunkHeader = chunk.getChunkHeader();
     sut.insert(chunk);
@@ -133,6 +139,7 @@ TEST_F(UsedChunkList_test, OneChunkCanBeRemoved)
 
 TEST_F(UsedChunkList_test, RemoveSameChunkAddedTwiceWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5d87cd89-d413-44e9-b728-472eef78a8f9");
     auto chunk = getChunkFromMemoryManager();
     auto chunkHeader = chunk.getChunkHeader();
     sut.insert(chunk);
@@ -150,6 +157,7 @@ TEST_F(UsedChunkList_test, RemoveSameChunkAddedTwiceWorks)
 
 TEST_F(UsedChunkList_test, MultipleChunksCanBeRemoved)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "13dd689b-d0b4-4d30-a154-0b8a9e7de5e1");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(3U, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());
@@ -168,6 +176,7 @@ TEST_F(UsedChunkList_test, MultipleChunksCanBeRemoved)
 
 TEST_F(UsedChunkList_test, MultipleChunksCanBeRemovedInReverseOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bab1402e-1217-4d3f-8386-c78777c709bf");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(3U, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());
@@ -187,6 +196,7 @@ TEST_F(UsedChunkList_test, MultipleChunksCanBeRemovedInReverseOrder)
 
 TEST_F(UsedChunkList_test, MultipleChunksCanBeRemovedInArbitraryOrder)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1f8030d5-be3e-4804-a1f3-c3f7ebcbf88b");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(3U, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());
@@ -206,6 +216,7 @@ TEST_F(UsedChunkList_test, MultipleChunksCanBeRemovedInArbitraryOrder)
 
 TEST_F(UsedChunkList_test, UsedChunkListCanBeFilledToCapacityAndFullyEmptied)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5932b727-dfbe-4041-985d-7a819c8ea06c");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(USED_CHUNK_LIST_CAPACITY, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());
@@ -224,6 +235,7 @@ TEST_F(UsedChunkList_test, UsedChunkListCanBeFilledToCapacityAndFullyEmptied)
 
 TEST_F(UsedChunkList_test, RemoveChunkFromEmptyListIsHandledGracefully)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2c4a64d1-07cc-4334-89bf-dd58ad291af5");
     auto chunk = getChunkFromMemoryManager();
     auto chunkHeader = chunk.getChunkHeader();
 
@@ -234,6 +246,7 @@ TEST_F(UsedChunkList_test, RemoveChunkFromEmptyListIsHandledGracefully)
 
 TEST_F(UsedChunkList_test, RemoveChunkNotInListIsHandledGracefully)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ecca24b5-c526-4c41-b78f-ff34d6e9ee3e");
     createMultipleChunks(3U, [&](SharedChunk&& chunk) { sut.insert(chunk); });
 
     auto chunk = getChunkFromMemoryManager();
@@ -246,6 +259,7 @@ TEST_F(UsedChunkList_test, RemoveChunkNotInListIsHandledGracefully)
 
 TEST_F(UsedChunkList_test, RemoveChunkNotInListDoesNotRemoveOtherChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a01903b-3fd2-4632-a941-60621d6f3450");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(3U, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());
@@ -267,6 +281,7 @@ TEST_F(UsedChunkList_test, RemoveChunkNotInListDoesNotRemoveOtherChunk)
 
 TEST_F(UsedChunkList_test, ChunksAddedToTheUsedChunkKeepsTheChunkAlive)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ea43942e-1000-4dbf-ad05-00af18373fc1");
     EXPECT_THAT(memoryManager.getMemPoolInfo(0U).m_usedChunks, Eq(0U));
 
     sut.insert(getChunkFromMemoryManager());
@@ -276,6 +291,7 @@ TEST_F(UsedChunkList_test, ChunksAddedToTheUsedChunkKeepsTheChunkAlive)
 
 TEST_F(UsedChunkList_test, RemovingChunkFromListLetsTheSharedChunkReturnOwnershipToTheMempool)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "058ded9f-fa74-4a37-a2c1-3a9511f3153d");
     {
         auto chunk = getChunkFromMemoryManager();
         auto chunkHeader = chunk.getChunkHeader();
@@ -290,6 +306,7 @@ TEST_F(UsedChunkList_test, RemovingChunkFromListLetsTheSharedChunkReturnOwnershi
 
 TEST_F(UsedChunkList_test, CallingCleanupReleasesAllChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "765e2726-b022-41fc-a839-77db9ac07d2b");
     std::vector<ChunkHeader*> chunkHeaderInUse;
     createMultipleChunks(USED_CHUNK_LIST_CAPACITY, [&](SharedChunk&& chunk) {
         chunkHeaderInUse.push_back(chunk.getChunkHeader());

--- a/iceoryx_posh/test/moduletests/test_popo_user_trigger.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_user_trigger.cpp
@@ -61,17 +61,20 @@ UserTrigger* UserTrigger_test::m_callbackOrigin = nullptr;
 
 TEST_F(UserTrigger_test, IsNotTriggeredWhenCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "efe755c5-e84d-43a9-bbd9-7836133a119c");
     EXPECT_FALSE(m_sut.hasTriggered());
 }
 
 TEST_F(UserTrigger_test, CannotBeTriggeredWhenNotAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ad9d7d67-ef86-4d52-9752-1fdf9a8e12c6");
     m_sut.trigger();
     EXPECT_FALSE(m_sut.hasTriggered());
 }
 
 TEST_F(UserTrigger_test, CannotBeTriggeredMultipleTimesWhenNotAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d921a26-0f29-499b-a6b5-d5175585e9e5");
     m_sut.trigger();
     m_sut.trigger();
     m_sut.trigger();
@@ -81,6 +84,7 @@ TEST_F(UserTrigger_test, CannotBeTriggeredMultipleTimesWhenNotAttached)
 
 TEST_F(UserTrigger_test, CanBeTriggeredWhenAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "91c21a9f-4059-4b70-878a-d0ea17d56d1e");
     ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
     m_sut.trigger();
     EXPECT_TRUE(m_sut.hasTriggered());
@@ -88,6 +92,7 @@ TEST_F(UserTrigger_test, CanBeTriggeredWhenAttached)
 
 TEST_F(UserTrigger_test, CanBeTriggeredMultipleTimesWhenAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "18440767-e3f9-4e8c-acf2-9875124289db");
     ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
     m_sut.trigger();
     m_sut.trigger();
@@ -98,6 +103,7 @@ TEST_F(UserTrigger_test, CanBeTriggeredMultipleTimesWhenAttached)
 
 TEST_F(UserTrigger_test, UserTriggerGoesOutOfScopeCleansupAtWaitSet)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "99229230-90ee-45fc-b063-0ae6344d0308");
     {
         UserTrigger sut;
         ASSERT_FALSE(m_waitSet.attachEvent(sut).has_error());
@@ -108,6 +114,7 @@ TEST_F(UserTrigger_test, UserTriggerGoesOutOfScopeCleansupAtWaitSet)
 
 TEST_F(UserTrigger_test, ReattachedUserTriggerCleansUpWhenOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7f3068c9-46a5-41ca-a967-953ca0e7116b");
     {
         UserTrigger sut;
 
@@ -121,6 +128,7 @@ TEST_F(UserTrigger_test, ReattachedUserTriggerCleansUpWhenOutOfScope)
 
 TEST_F(UserTrigger_test, AttachingToAnotherWaitSetCleansupFirstWaitset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b0f76d38-81a7-4ce3-8511-89391519ea8e");
     UserTrigger sut;
 
     ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
@@ -132,6 +140,7 @@ TEST_F(UserTrigger_test, AttachingToAnotherWaitSetCleansupFirstWaitset)
 
 TEST_F(UserTrigger_test, AttachingToSameWaitsetTwiceLeadsToOneAttachment)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "abf7d7cc-1409-4706-8669-0ea23e78ba26");
     UserTrigger sut;
 
     ASSERT_FALSE(m_waitSet.attachEvent(m_sut).has_error());
@@ -142,6 +151,7 @@ TEST_F(UserTrigger_test, AttachingToSameWaitsetTwiceLeadsToOneAttachment)
 
 TEST_F(UserTrigger_test, TriggersWaitSet)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "346dd5a8-a109-42ba-aab0-268dce37215f");
     using namespace iox::units::duration_literals;
     UserTrigger sut;
 
@@ -155,6 +165,7 @@ TEST_F(UserTrigger_test, TriggersWaitSet)
 
 TEST_F(UserTrigger_test, DetachingFromAttachedWaitsetCleansUp)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d3debaa9-f72d-49e1-82d9-bd1ff13530f7");
     UserTrigger sut;
     ASSERT_FALSE(m_waitSet.attachEvent(sut).has_error());
 
@@ -165,6 +176,7 @@ TEST_F(UserTrigger_test, DetachingFromAttachedWaitsetCleansUp)
 
 TEST_F(UserTrigger_test, UserTriggerCallbackCanBeCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c95a5d7a-6de1-4419-9a19-0a1c6dd927d4");
     UserTrigger sut;
     ASSERT_FALSE(m_waitSet.attachEvent(sut, 123U, createNotificationCallback(UserTrigger_test::callback)).has_error());
     sut.trigger();
@@ -178,6 +190,7 @@ TEST_F(UserTrigger_test, UserTriggerCallbackCanBeCalled)
 
 TEST_F(UserTrigger_test, UserTriggerCallbackCanBeCalledOverloadWithoutId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c3af7155-5d27-468b-854b-0530f704cdf1");
     UserTrigger sut;
     ASSERT_FALSE(m_waitSet.attachEvent(sut, 0U, createNotificationCallback(UserTrigger_test::callback)).has_error());
     sut.trigger();

--- a/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
@@ -403,6 +403,7 @@ SimpleState2 WaitSet_test::SimpleEventClass::m_simpleState2TriggerCallback = Sim
 
 TEST_F(WaitSet_test, AttachEventOnceIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67eb525b-e991-42e0-8dc6-b19640ed095b");
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0]).has_error());
     EXPECT_TRUE(m_simpleEvents[0].hasEventSet());
     EXPECT_FALSE(m_simpleEvents[0].hasStateSet());
@@ -412,11 +413,13 @@ TEST_F(WaitSet_test, AttachEventOnceIsSuccessful)
 
 TEST_F(WaitSet_test, AttachMaxEventsIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "13f533a2-fe92-4180-8729-50ff3ab7c53a");
     EXPECT_TRUE(attachAllEvents());
 }
 
 TEST_F(WaitSet_test, AttachMoreThanMaxEventsFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6047fc25-6e1c-42d7-89a4-21510f579855");
     EXPECT_TRUE(attachAllEvents());
 
     EXPECT_TRUE(m_sut->attachEvent(m_simpleEvents[iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET]).has_error());
@@ -428,6 +431,7 @@ TEST_F(WaitSet_test, AttachMoreThanMaxEventsFails)
 
 TEST_F(WaitSet_test, AttachStateOnceIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62b8b76c-a5c0-41ea-ab6b-156b2540917a");
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0]).has_error());
     EXPECT_TRUE(m_simpleEvents[0].hasStateSet());
     EXPECT_FALSE(m_simpleEvents[0].hasEventSet());
@@ -437,11 +441,13 @@ TEST_F(WaitSet_test, AttachStateOnceIsSuccessful)
 
 TEST_F(WaitSet_test, AttachMaxStatesIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cb0bc6ec-adc3-46a3-b511-cd98cc66c656");
     EXPECT_TRUE(attachAllStates());
 }
 
 TEST_F(WaitSet_test, AttachMoreThanMaxStatesFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f877bbdc-6219-4a3b-9395-7decd2c30715");
     EXPECT_TRUE(attachAllStates());
 
     EXPECT_TRUE(m_sut->attachState(m_simpleEvents[iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET]).has_error());
@@ -453,6 +459,7 @@ TEST_F(WaitSet_test, AttachMoreThanMaxStatesFails)
 
 TEST_F(WaitSet_test, AttachMoreThanMaxFailsWithMixedEventsStates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7616ed90-080c-422a-8a52-798e92f3d097");
     EXPECT_TRUE(attachAllWithEventStateMix());
 
     EXPECT_TRUE(m_sut->attachEvent(m_simpleEvents[iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET]).has_error());
@@ -464,6 +471,7 @@ TEST_F(WaitSet_test, AttachMoreThanMaxFailsWithMixedEventsStates)
 
 TEST_F(WaitSet_test, AttachingSameEventTwiceResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cbbedc2a-68dc-4a77-be61-34ff70d7a3dc");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 0U;
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
     auto result2 = m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
@@ -476,6 +484,7 @@ TEST_F(WaitSet_test, AttachingSameEventTwiceResultsInError)
 
 TEST_F(WaitSet_test, AttachingSameStateTwiceResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "abe4f5f5-9360-4743-b88a-e741f2706aef");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 0U;
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
     auto result2 = m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
@@ -488,6 +497,7 @@ TEST_F(WaitSet_test, AttachingSameStateTwiceResultsInError)
 
 TEST_F(WaitSet_test, AttachingSameEventWithNonNullIdTwiceResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "14074c98-6cd1-4152-842f-d769402ea7b4");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 121U;
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
     auto result2 = m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
@@ -500,6 +510,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithNonNullIdTwiceResultsInError)
 
 TEST_F(WaitSet_test, AttachingSameStateWithNonNullIdTwiceResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "12f82b42-2357-4f9e-93f5-7433418629e8");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 121U;
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
     auto result2 = m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
@@ -512,6 +523,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithNonNullIdTwiceResultsInError)
 
 TEST_F(WaitSet_test, AttachingSameEventWithDifferentIdResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7dc5a359-025a-48d1-9040-e0ba408e3ed7");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 2101U;
     constexpr uint64_t ANOTHER_USER_DEFINED_EVENT_ID = 9121U;
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
@@ -523,6 +535,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithDifferentIdResultsInError)
 
 TEST_F(WaitSet_test, AttachingSameStateWithDifferentIdResultsInError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2a5670bd-5160-47be-a9f5-a9029d7566af");
     constexpr uint64_t USER_DEFINED_EVENT_ID = 2101U;
     constexpr uint64_t ANOTHER_USER_DEFINED_EVENT_ID = 9121U;
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID).has_error());
@@ -534,6 +547,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithDifferentIdResultsInError)
 
 TEST_F(WaitSet_test, DetachingAttachedEventIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b4358d62-2670-4817-bfee-65c45da6405b");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0]).has_error());
     m_sut->detachEvent(m_simpleEvents[0]);
     EXPECT_THAT(m_sut->size(), Eq(0U));
@@ -543,6 +557,7 @@ TEST_F(WaitSet_test, DetachingAttachedEventIsSuccessful)
 
 TEST_F(WaitSet_test, DetachingAttachedStateIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fed30b7f-d6b7-46a3-bec6-ccb414318f2e");
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0]).has_error());
     m_sut->detachState(m_simpleEvents[0]);
     EXPECT_THAT(m_sut->size(), Eq(0U));
@@ -552,6 +567,7 @@ TEST_F(WaitSet_test, DetachingAttachedStateIsSuccessful)
 
 TEST_F(WaitSet_test, DetachingAttachedEventTwiceWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dd76f97e-d221-421a-9884-5f546a39421f");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0]).has_error());
     m_sut->detachEvent(m_simpleEvents[0]);
     m_sut->detachEvent(m_simpleEvents[0]);
@@ -562,6 +578,7 @@ TEST_F(WaitSet_test, DetachingAttachedEventTwiceWorks)
 
 TEST_F(WaitSet_test, DetachingAttachedStateTwiceWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8a7ba7bb-6b45-41e5-8032-56608be23d69");
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0]).has_error());
     m_sut->detachState(m_simpleEvents[0]);
     m_sut->detachState(m_simpleEvents[0]);
@@ -572,6 +589,7 @@ TEST_F(WaitSet_test, DetachingAttachedStateTwiceWorks)
 
 TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherEvent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "98b70d41-2845-46a8-8fc3-b7d05b76765c");
     ASSERT_TRUE(attachAllEvents());
 
     m_sut->detachEvent(m_simpleEvents[0]);
@@ -585,6 +603,7 @@ TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherEvent)
 
 TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eb1abaf9-3be3-4050-9b73-e7b08ed25e10");
     ASSERT_TRUE(attachAllStates());
 
     m_sut->detachState(m_simpleEvents[0]);
@@ -598,6 +617,7 @@ TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherState)
 
 TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherAttachmentWithMixedEventsStates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "87db3ed1-b949-412a-80f0-4455f17602b8");
     ASSERT_TRUE(attachAllWithEventStateMix());
 
     m_sut->detachState(m_simpleEvents[0]);
@@ -611,24 +631,28 @@ TEST_F(WaitSet_test, DetachingMakesSpaceForAnotherAttachmentWithMixedEventsState
 
 TEST_F(WaitSet_test, DetachingAllEventAttachmentsOfFullWaitSetIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ab3a1cd7-fd54-48f1-ae0b-a2e596c43d77");
     EXPECT_TRUE(attachAllEvents());
     EXPECT_TRUE(detachAllEvents());
 }
 
 TEST_F(WaitSet_test, DetachingAllStateAttachmentsOfFullWaitSetIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "36a006dd-9f7f-442d-88ea-37a79f4193fd");
     EXPECT_TRUE(attachAllStates());
     EXPECT_TRUE(detachAllStates());
 }
 
 TEST_F(WaitSet_test, DetachingAllMixedAttachmentsOfFullWaitSetIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cbaa0de2-908f-478d-936d-d6e16f3bcc87");
     EXPECT_TRUE(attachAllWithEventStateMix());
     EXPECT_TRUE(detachAllWithEventStateMix());
 }
 
 TEST_F(WaitSet_test, DetachingAttachedEventWithDetachStateChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4ddf3a17-64d7-44ce-a228-2b8d147ca8ab");
     EXPECT_TRUE(m_sut->attachEvent(m_simpleEvents[0]));
 
     m_sut->detachState(m_simpleEvents[0]);
@@ -639,6 +663,7 @@ TEST_F(WaitSet_test, DetachingAttachedEventWithDetachStateChangesNothing)
 
 TEST_F(WaitSet_test, DetachingAttachedStateWithDetachEventChangesNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25c185f1-180a-4caa-86d5-fc02eb5d65d2");
     EXPECT_TRUE(m_sut->attachState(m_simpleEvents[0]));
 
     m_sut->detachEvent(m_simpleEvents[0]);
@@ -649,6 +674,7 @@ TEST_F(WaitSet_test, DetachingAttachedStateWithDetachEventChangesNothing)
 
 TEST_F(WaitSet_test, AttachingEventWithEnumIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ad4a906f-4f1e-4d85-b2ab-d5e8ad4ce872");
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1).has_error());
     EXPECT_THAT(m_sut->size(), Eq(1U));
     EXPECT_THAT(SimpleEventClass::m_simpleEvent1, Eq(SimpleEvent1::EVENT1));
@@ -658,6 +684,7 @@ TEST_F(WaitSet_test, AttachingEventWithEnumIsSuccessful)
 
 TEST_F(WaitSet_test, AttachingSameEventWithEnumFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eede8515-f406-4b96-a132-06cec1afe3ba");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1).has_error());
 
     auto result = m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1);
@@ -671,6 +698,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithEnumFails)
 
 TEST_F(WaitSet_test, AttachingSameEventWithDifferentEnumValueSucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "809101ea-f2cd-4023-bf56-d1480ccdde4c");
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1).has_error());
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT2).has_error());
 
@@ -684,6 +712,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithDifferentEnumValueSucceeds)
 
 TEST_F(WaitSet_test, AttachingSameEventWithDifferentEnumTypeSucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0132cb70-afc9-4b80-87d0-692e20715350");
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1).has_error());
     EXPECT_FALSE(m_sut->attachEvent(m_simpleEvents[0], SimpleEvent2::EVENT1).has_error());
 
@@ -697,6 +726,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithDifferentEnumTypeSucceeds)
 
 TEST_F(WaitSet_test, AttachingStateWithEnumIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e45cc4ea-26d0-4395-8d04-090ec48dcb30");
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1).has_error());
     EXPECT_THAT(m_sut->size(), Eq(1U));
     EXPECT_THAT(SimpleEventClass::m_simpleState1, Eq(SimpleState1::STATE1));
@@ -706,6 +736,7 @@ TEST_F(WaitSet_test, AttachingStateWithEnumIsSuccessful)
 
 TEST_F(WaitSet_test, AttachingSameStateWithEnumFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de485c47-195e-490b-8028-97647bed21aa");
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1).has_error());
 
     auto result = m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1);
@@ -719,6 +750,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithEnumFails)
 
 TEST_F(WaitSet_test, AttachingSameStateWithDifferentEnumValueSucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5fac3148-affb-4cbc-867f-08dd6bf4bbca");
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1).has_error());
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE2).has_error());
 
@@ -732,6 +764,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithDifferentEnumValueSucceeds)
 
 TEST_F(WaitSet_test, AttachingSameStateWithDifferentEnumTypeSucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7ea90219-6fb6-4907-9992-e94304f5fb6c");
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1).has_error());
     EXPECT_FALSE(m_sut->attachState(m_simpleEvents[0], SimpleState2::STATE1).has_error());
 
@@ -753,6 +786,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithDifferentEnumTypeSucceeds)
 
 TEST_F(WaitSet_test, ResetCallbackIsCalledWhenWaitsetGoesOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e6505b19-2d92-4bae-a7fe-55b2d7933787");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0]).has_error());
     ASSERT_FALSE(m_sut->attachState(m_simpleEvents[1]).has_error());
     std::vector<uint64_t> uniqueTriggerIds;
@@ -768,6 +802,7 @@ TEST_F(WaitSet_test, ResetCallbackIsCalledWhenWaitsetGoesOutOfScope)
 
 TEST_F(WaitSet_test, ResetCallbackIsCalledWhenFullWaitsetGoesOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ba745725-e0f9-4085-a513-49d5e5f7bb16");
     attachAllWithEventStateMix();
     std::vector<uint64_t> uniqueTriggerIds;
     for (uint64_t i = 0U; i < iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
@@ -791,6 +826,7 @@ TEST_F(WaitSet_test, ResetCallbackIsCalledWhenFullWaitsetGoesOutOfScope)
 
 TEST_F(WaitSet_test, EventAttachmentRemovesItselfFromWaitsetWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "81efdd57-7986-4533-84f5-676aca90ec04");
     for (uint64_t i = 0U; i + 1U < iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[i], 100U + i).has_error());
@@ -812,6 +848,7 @@ TEST_F(WaitSet_test, EventAttachmentRemovesItselfFromWaitsetWhenGoingOutOfScope)
 
 TEST_F(WaitSet_test, StateAttachmentRemovesItselfFromWaitsetWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "06062f01-c814-427d-91ed-f1ed4d2e4b07");
     for (uint64_t i = 0U; i + 1U < iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         ASSERT_FALSE(m_sut->attachState(m_simpleEvents[i], 100U + i).has_error());
@@ -833,6 +870,7 @@ TEST_F(WaitSet_test, StateAttachmentRemovesItselfFromWaitsetWhenGoingOutOfScope)
 
 TEST_F(WaitSet_test, MultipleAttachmentsRemovingThemselfFromWaitsetWhenGoingOutOfScope)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a3e7bd84-8af9-49e8-9e22-e28e0ce00bab");
     attachAllWithEventStateMix();
 
     // here the attachments go out of scope
@@ -843,6 +881,7 @@ TEST_F(WaitSet_test, MultipleAttachmentsRemovingThemselfFromWaitsetWhenGoingOutO
 
 TEST_F(WaitSet_test, AttachmentsGoingOutOfScopeReducesSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f798143f-4bd3-4776-b086-7239cedf2031");
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0]).has_error());
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[1]).has_error());
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[2]).has_error());
@@ -865,6 +904,7 @@ TEST_F(WaitSet_test, AttachmentsGoingOutOfScopeReducesSize)
 ////////////////////////
 TEST_F(WaitSet_test, WaitBlocksWhenNothingTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "66c4d11f-f330-4629-b74a-faa87440a9a0");
     std::atomic_bool doStartWaiting{false};
     std::atomic_bool isThreadFinished{false};
     for (uint64_t i = 0U; i < iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
@@ -894,6 +934,7 @@ TEST_F(WaitSet_test, WaitBlocksWhenNothingTriggered)
 
 TEST_F(WaitSet_test, TimedWaitReturnsNothingWhenNothingTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bf1a8c00-e9c9-43e1-813e-64fd12d4e055");
     iox::cxx::vector<expected<TriggerHandle, WaitSetError>*, iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET> trigger;
     for (uint64_t i = 0U; i < iox::MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
@@ -923,11 +964,13 @@ void WaitReturnsTheOneTriggeredCondition(WaitSet_test* test,
 
 TEST_F(WaitSet_test, WaitReturnsTheOneTriggeredCondition)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1e631eb4-c4d6-4b62-a8dc-44500a3f497f");
     WaitReturnsTheOneTriggeredCondition(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsTheOneTriggeredCondition)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9312f87a-13ca-494e-81e8-f2100cc56646");
     WaitReturnsTheOneTriggeredCondition(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -955,11 +998,13 @@ void WaitReturnsAllTriggeredConditionWhenMultipleAreTriggered(
 
 TEST_F(WaitSet_test, WaitReturnsAllTriggeredConditionWhenMultipleAreTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1292fbcb-df42-47c4-9888-e71f1243f8ef");
     WaitReturnsAllTriggeredConditionWhenMultipleAreTriggered(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsAllTriggeredConditionWhenMultipleAreTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c651b1ff-3622-4da9-98d9-23376d6863a7");
     WaitReturnsAllTriggeredConditionWhenMultipleAreTriggered(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -989,11 +1034,13 @@ void WaitReturnsAllTriggeredConditionWhenAllAreTriggered(
 
 TEST_F(WaitSet_test, WaitReturnsAllTriggeredConditionWhenAllAreTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5ef3060-e636-4bf7-acc3-47d7de8796c8");
     WaitReturnsAllTriggeredConditionWhenAllAreTriggered(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsAllTriggeredConditionWhenAllAreTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a1e6d732-1f25-461c-b061-4418e1d25dd9");
     WaitReturnsAllTriggeredConditionWhenAllAreTriggered(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -1017,11 +1064,13 @@ void WaitReturnsEventTriggersWithOneCorrectCallback(WaitSet_test* test,
 
 TEST_F(WaitSet_test, WaitReturnsEventTriggersWithOneCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e6c1f551-4d1b-4e85-80fc-aa7d135478b0");
     WaitReturnsEventTriggersWithOneCorrectCallback(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsEventTriggersWithTwoCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5e1dbc44-db59-479a-ab59-a30486c33b82");
     WaitReturnsEventTriggersWithOneCorrectCallback(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -1059,11 +1108,13 @@ void WaitReturnsEventTriggersWithTwoCorrectCallbacksWithContextData(
 
 TEST_F(WaitSet_test, WaitReturnsEventTriggersWithTwoCorrectCallbacksWithContextData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6215eb19-9304-40b8-a700-96ac3331338e");
     WaitReturnsEventTriggersWithTwoCorrectCallbacksWithContextData(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsEventTriggersWithTwoCorrectCallbacksWithContextData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee21de8a-ba45-42aa-9428-5cfd83d66fa2");
     WaitReturnsEventTriggersWithTwoCorrectCallbacksWithContextData(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -1087,11 +1138,13 @@ void WaitReturnsStateTriggersWithOneCorrectCallback(WaitSet_test* test,
 
 TEST_F(WaitSet_test, WaitReturnsStateTriggersWithOneCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d5a1d84a-0882-494f-a3e8-3781e3adba96");
     WaitReturnsStateTriggersWithOneCorrectCallback(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsStateTriggersWithTwoCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3a087010-496d-4e0e-9352-a8a8dc7a16be");
     WaitReturnsStateTriggersWithOneCorrectCallback(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -1129,11 +1182,13 @@ void WaitReturnsStateTriggersWithTwoCorrectCallbacksWithContextData(
 
 TEST_F(WaitSet_test, WaitReturnsStateTriggersWithTwoCorrectCallbacksWithContextData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "27fa9ad0-b1a4-45e7-be4a-e620ec083ac3");
     WaitReturnsStateTriggersWithTwoCorrectCallbacksWithContextData(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, TimedWaitReturnsStateTriggersWithTwoCorrectCallbacksWithContextData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "03746599-c01f-4d9c-b4bc-68890f3b4cc5");
     WaitReturnsStateTriggersWithTwoCorrectCallbacksWithContextData(this, [&] { return m_sut->timedWait(10_ms); });
 }
 
@@ -1160,11 +1215,13 @@ void NonResetStatesAreReturnedAgain(WaitSet_test* test,
 
 TEST_F(WaitSet_test, NonResetStatesAreReturnedAgainInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ac2001d2-29fa-4c87-a874-6052e7158000");
     NonResetStatesAreReturnedAgain(this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, NonResetStatesAreReturnedAgainInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0968c3d-82d1-4f4a-89d3-9495c417de32");
     NonResetStatesAreReturnedAgain(this, [&] { return m_sut->wait(); });
 }
 
@@ -1188,12 +1245,14 @@ void TriggeredEventsAreNotReturnedTwice(WaitSet_test* test,
 
 TEST_F(WaitSet_test, TriggeredEventsAreNotReturnedTwiceInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1f2ea5d1-ebd0-4d1c-818a-3ee160f09266");
     TriggeredEventsAreNotReturnedTwice(this,
                                        [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, TriggeredEventsAreNotReturnedTwiceInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "627f5612-724b-45d7-86dd-78cb28c7c6e6");
     TriggeredEventsAreNotReturnedTwice(this, [&] { return m_sut->wait(); });
 }
 
@@ -1222,12 +1281,14 @@ void InMixSetupOnlyStateTriggerAreReturnedTwice(WaitSet_test* test,
 
 TEST_F(WaitSet_test, InMixSetupOnlyStateTriggerAreReturnedTwiceInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4ddc13f8-0a50-4446-977b-701606b6e972");
     InMixSetupOnlyStateTriggerAreReturnedTwice(
         this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, InMixSetupOnlyStateTriggerAreReturnedTwiceInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf4a8278-3999-46df-8ef0-d26752eecc03");
     InMixSetupOnlyStateTriggerAreReturnedTwice(this, [&] { return m_sut->wait(); });
 }
 
@@ -1253,12 +1314,14 @@ void WhenStateIsNotResetAndEventIsTriggeredBeforeItIsReturnedAgain(
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventIsTriggeredBeforeItIsReturnedAgainInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "afce92a2-e6a8-489b-bef6-6c225ce69e41");
     WhenStateIsNotResetAndEventIsTriggeredBeforeItIsReturnedAgain(
         this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventIsTriggeredBeforeItIsReturnedAgainInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "903f03d9-14a4-4b93-864d-b4cc9dc2af36");
     WhenStateIsNotResetAndEventIsTriggeredBeforeItIsReturnedAgain(this, [&] { return m_sut->wait(); });
 }
 
@@ -1284,12 +1347,14 @@ void WhenStateIsNotResetAndEventIsTriggeredAfterItIsReturnedAgain(
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventIsTriggeredAfterItIsReturnedAgainInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "40ab8422-1b9b-4d0a-837d-2f7317b93c03");
     WhenStateIsNotResetAndEventIsTriggeredAfterItIsReturnedAgain(
         this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventIsTriggeredAfterItIsReturnedAgainInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "39050968-20d7-4e10-9d03-ad4c30368497");
     WhenStateIsNotResetAndEventIsTriggeredAfterItIsReturnedAgain(this, [&] { return m_sut->wait(); });
 }
 
@@ -1327,12 +1392,14 @@ void WhenStateIsNotResetAndEventsAreTriggeredItIsReturnedAgain(
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventsAreTriggeredItIsReturnedAgainInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c49a11fc-66fc-46dc-b957-582a315f963a");
     WhenStateIsNotResetAndEventsAreTriggeredItIsReturnedAgain(
         this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, WhenStateIsNotResetAndEventsAreTriggeredItIsReturnedAgainInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "39235ee8-1687-4d36-b5b6-3a22931297b8");
     WhenStateIsNotResetAndEventsAreTriggeredItIsReturnedAgain(this, [&] { return m_sut->wait(); });
 }
 
@@ -1358,17 +1425,20 @@ void NotifyingWaitSetTwiceWithSameTriggersWorks(WaitSet_test* test,
 
 TEST_F(WaitSet_test, NotifyingWaitSetTwiceWithSameTriggersWorksInTimedWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49365392-7052-44b8-a731-d33853494be9");
     NotifyingWaitSetTwiceWithSameTriggersWorks(
         this, [&] { return m_sut->timedWait(iox::units::Duration::fromMilliseconds(100)); });
 }
 
 TEST_F(WaitSet_test, NotifyingWaitSetTwiceWithSameTriggersWorksInWait)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1700eb0f-0517-45c2-8e30-7c3ccbd97a12");
     NotifyingWaitSetTwiceWithSameTriggersWorks(this, [&] { return m_sut->wait(); });
 }
 
 TEST_F(WaitSet_test, EventBasedTriggerIsReturnedOnlyOnceWhenItsTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84da1aef-eaef-4a4b-a089-3ccd2f543b5a");
     m_simpleEvents[0].m_isEventBased = true;
     m_simpleEvents[0].m_autoResetTrigger = false;
 
@@ -1386,6 +1456,7 @@ TEST_F(WaitSet_test, EventBasedTriggerIsReturnedOnlyOnceWhenItsTriggered)
 
 TEST_F(WaitSet_test, MixingEventAndStateBasedTriggerHandlesEventTriggeresWithWaitCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1df0d6ca-1190-4f5a-bb76-dbb7f155c3fb");
     m_simpleEvents[0].m_autoResetTrigger = false;
     m_simpleEvents[1].m_autoResetTrigger = false;
 
@@ -1407,6 +1478,7 @@ TEST_F(WaitSet_test, MixingEventAndStateBasedTriggerHandlesEventTriggeresWithWai
 
 TEST_F(WaitSet_test, WaitUnblocksAfterMarkForDestructionCall)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a7c0b153-65da-4603-bd82-5f5db5841a2b");
     std::atomic_bool doStartWaiting{false};
     std::atomic_bool isThreadFinished{false};
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0U], 0U).has_error());
@@ -1434,6 +1506,7 @@ TEST_F(WaitSet_test, WaitUnblocksAfterMarkForDestructionCall)
 
 TEST_F(WaitSet_test, TimedWaitUnblocksAfterMarkForDestructionCall)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "63573915-bb36-4ece-93be-2adc853582e6");
     std::atomic_bool doStartWaiting{false};
     std::atomic_bool isThreadFinished{false};
     ASSERT_FALSE(m_sut->attachEvent(m_simpleEvents[0U], 0U).has_error());

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -76,6 +76,7 @@ class PoshRuntime_test : public Test
 
 TEST_F(PoshRuntime_test, ValidAppName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2f4f5dc1-dde0-4520-a341-79a5edd19900");
     iox::RuntimeName_t appName("valid_name");
 
     EXPECT_NO_FATAL_FAILURE({ PoshRuntime::initRuntime(appName); });
@@ -83,6 +84,7 @@ TEST_F(PoshRuntime_test, ValidAppName)
 
 TEST_F(PoshRuntime_test, MaxAppNameLength)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dfdf3ce1-c7d4-4c57-94ea-6ed9479371e3");
     std::string maxValidName(iox::MAX_RUNTIME_NAME_LENGTH, 's');
 
     auto& runtime = PoshRuntime::initRuntime(iox::RuntimeName_t(iox::cxx::TruncateToCapacity, maxValidName));
@@ -92,6 +94,7 @@ TEST_F(PoshRuntime_test, MaxAppNameLength)
 
 TEST_F(PoshRuntime_test, NoAppName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e053d114-c79c-4391-91e1-8fcfe90ee8e4");
     const iox::RuntimeName_t invalidAppName("");
 
     EXPECT_DEATH({ PoshRuntime::initRuntime(invalidAppName); },
@@ -101,6 +104,7 @@ TEST_F(PoshRuntime_test, NoAppName)
 // To be able to test the singleton and avoid return the exisiting instance, we don't use the test fixture
 TEST(PoshRuntime, LeadingSlashAppName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "77542d11-6230-4c1e-94b2-6cf3b8fa9c6e");
     RouDiEnvironment m_roudiEnv{iox::RouDiConfig_t().setDefaults()};
 
     const iox::RuntimeName_t invalidAppName = "/miau";
@@ -125,6 +129,7 @@ TEST(PoshRuntime, LeadingSlashAppName)
 // To be able to test this, we don't use the test fixture
 TEST(PoshRuntime, AppNameEmpty)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "63900656-4fbb-466d-b6cc-f2139121092c");
     EXPECT_DEATH({ iox::runtime::PoshRuntime::getInstance(); },
                  "Cannot initialize runtime. Application name has not been specified!");
 }
@@ -132,6 +137,7 @@ TEST(PoshRuntime, AppNameEmpty)
 
 TEST_F(PoshRuntime_test, GetInstanceNameIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b82d419c-2c72-43b0-9eb1-b24bb41366ce");
     const iox::RuntimeName_t appname = "app";
 
     auto& sut = PoshRuntime::initRuntime(appname);
@@ -142,6 +148,7 @@ TEST_F(PoshRuntime_test, GetInstanceNameIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewareApplicationIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cb1e927c-cad4-4c85-a693-815a0070198f");
     const auto applicationPortData = m_runtime->getMiddlewareApplication();
 
     ASSERT_NE(nullptr, applicationPortData);
@@ -152,6 +159,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareApplicationIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewareInterfaceWithInvalidNodeNameIsNotSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d207e121-d7c2-4a23-a202-1af311f6982b");
     iox::cxx::optional<iox::Error> detectedError;
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&detectedError](const iox::Error error, const std::function<void()>, const iox::ErrorLevel errorLevel) {
@@ -168,6 +176,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareInterfaceWithInvalidNodeNameIsNotSuccessfu
 
 TEST_F(PoshRuntime_test, GetMiddlewareApplicationApplicationlistOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4dab3186-d840-4a6f-bb01-eebb7a05afca");
     auto applicationlistOverflowDetected{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&applicationlistOverflowDetected](const iox::Error error, const std::function<void()>, const iox::ErrorLevel) {
@@ -192,6 +201,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareApplicationApplicationlistOverflow)
 
 TEST_F(PoshRuntime_test, GetMiddlewareInterfaceIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "50b1d15d-0cee-41b3-a9cd-146eca553cc2");
     const auto interfacePortData = m_runtime->getMiddlewareInterface(iox::capro::Interfaces::INTERNAL, m_nodeName);
 
     ASSERT_NE(nullptr, interfacePortData);
@@ -203,6 +213,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareInterfaceIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewareInterfaceInterfacelistOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0e164d07-dede-46c3-b2a3-ad78a11c0691");
     auto interfacelistOverflowDetected{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&interfacelistOverflowDetected](const iox::Error error, const std::function<void()>, const iox::ErrorLevel) {
@@ -227,6 +238,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareInterfaceInterfacelistOverflow)
 
 TEST_F(PoshRuntime_test, SendRequestToRouDiValidMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "334e49d8-e826-4e21-9f9f-bb9c341d4706");
     m_sendBuffer << IpcMessageTypeToString(IpcMessageType::CREATE_INTERFACE) << m_runtimeName
                  << static_cast<uint32_t>(iox::capro::Interfaces::INTERNAL) << m_nodeName;
 
@@ -239,6 +251,7 @@ TEST_F(PoshRuntime_test, SendRequestToRouDiValidMessage)
 
 TEST_F(PoshRuntime_test, SendRequestToRouDiInvalidMessage)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b3f4563a-7237-4f57-8952-c39ac3dbfef2");
     m_sendBuffer << IpcMessageTypeToString(IpcMessageType::CREATE_INTERFACE) << m_runtimeName
                  << static_cast<uint32_t>(iox::capro::Interfaces::INTERNAL) << m_invalidNodeName;
 
@@ -249,6 +262,7 @@ TEST_F(PoshRuntime_test, SendRequestToRouDiInvalidMessage)
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithInvalidServiceDescriptionFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9eb179ea-346b-4381-b0e6-f864f1618cc3");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.historyCapacity = 13U;
     publisherOptions.nodeName = m_nodeName;
@@ -266,6 +280,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithInvalidServiceDescriptionFail
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2cb2e64b-8f21-4049-a35a-dbd7a1d6cbf4");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.historyCapacity = 13U;
     publisherOptions.nodeName = m_nodeName;
@@ -279,6 +294,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithHistoryGreaterMaxCapacityClampsHistoryToMaximum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "407f27bb-e507-4c1c-aab1-e5b1b8d06f46");
     // arrange
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.historyCapacity = iox::MAX_PUBLISHER_HISTORY + 1U;
@@ -294,6 +310,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithHistoryGreaterMaxCapacityClam
 
 TEST_F(PoshRuntime_test, getMiddlewarePublisherDefaultArgs)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1eae6dfa-c3f2-478b-9354-768c43bd8d96");
     const auto publisherPort = m_runtime->getMiddlewarePublisher(iox::capro::ServiceDescription("99", "1", "20"));
 
     ASSERT_NE(nullptr, publisherPort);
@@ -302,6 +319,7 @@ TEST_F(PoshRuntime_test, getMiddlewarePublisherDefaultArgs)
 
 TEST_F(PoshRuntime_test, getMiddlewarePublisherPublisherlistOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f1f1a662-9580-40a1-a116-6ea1cb791516");
     auto publisherlistOverflowDetected{false};
 
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
@@ -333,6 +351,7 @@ TEST_F(PoshRuntime_test, getMiddlewarePublisherPublisherlistOverflow)
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithSameServiceDescriptionsAndOneToManyPolicyFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "77fb6dfd-a00d-459e-9dd3-90010d7b8af7");
     auto publisherDuplicateDetected{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&publisherDuplicateDetected](const iox::Error error, const std::function<void()>, const iox::ErrorLevel) {
@@ -365,6 +384,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithSameServiceDescriptionsAndOne
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithoutOfferOnCreateLeadsToNotOfferedPublisherBeingCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5002dc8c-1f6e-4593-a2b3-4de04685c919");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.offerOnCreate = false;
 
@@ -377,6 +397,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithoutOfferOnCreateLeadsToNotOff
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithOfferOnCreateLeadsToOfferedPublisherBeingCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "639b1a0e-218d-4cde-a447-e2eec0cf2c75");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.offerOnCreate = true;
 
@@ -388,6 +409,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithOfferOnCreateLeadsToOfferedPu
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithoutExplicitlySetQueueFullPolicyLeadsToDiscardOldestData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "208418e2-64fd-47f4-b2e2-58aa4371a6a6");
     iox::popo::PublisherOptions publisherOptions;
 
     const auto publisherPortData = m_runtime->getMiddlewarePublisher(iox::capro::ServiceDescription("9", "13", "1550"),
@@ -400,6 +422,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithoutExplicitlySetQueueFullPoli
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithQueueFullPolicySetToDiscardOldestDataLeadsToDiscardOldestData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67362686-3165-4a49-a15c-ac9fcaf704d8");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.subscriberTooSlowPolicy = iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA;
 
@@ -414,6 +437,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithQueueFullPolicySetToDiscardOl
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithQueueFullPolicySetToWaitForSubscriberLeadsToWaitForSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f6439a76-69c7-422d-bcc9-7c1d82cd2990");
     iox::popo::PublisherOptions publisherOptions;
     publisherOptions.subscriberTooSlowPolicy = iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER;
 
@@ -427,6 +451,7 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithQueueFullPolicySetToWaitForSu
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithInvalidServiceDescriptionFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "08c6601e-2662-4c50-a230-e71c97730f13");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.historyRequest = 13U;
     subscriberOptions.queueCapacity = 42U;
@@ -445,6 +470,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithInvalidServiceDescriptionFai
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0cc05fe7-752e-4e2a-a8f2-be7cb8b384d2");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.historyRequest = 13U;
     subscriberOptions.queueCapacity = 42U;
@@ -462,6 +488,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueGreaterMaxCapacityClampsQueueToMaximum)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "85e2d246-bcba-4ead-a997-4c4137f05607");
     iox::popo::SubscriberOptions subscriberOptions;
     constexpr uint64_t MAX_QUEUE_CAPACITY = iox::popo::SubscriberPortUser::MemberType_t::ChunkQueueData_t::MAX_CAPACITY;
     subscriberOptions.queueCapacity = MAX_QUEUE_CAPACITY + 1U;
@@ -475,6 +502,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueGreaterMaxCapacityClamp
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueCapacityZeroClampsQueueCapacityTo1)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9da3f4da-abe8-454c-9bc6-7f866d6d0545");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.queueCapacity = 0U;
 
@@ -486,6 +514,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueCapacityZeroClampsQueue
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberDefaultArgs)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e06b999c-e237-4e32-b826-a5ffdb6bb737");
     auto subscriberPort = m_runtime->getMiddlewareSubscriber(iox::capro::ServiceDescription("99", "1", "20"));
 
     ASSERT_NE(nullptr, subscriberPort);
@@ -493,6 +522,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberDefaultArgs)
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberSubscriberlistOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d1281cbd-6520-424e-aace-fbd3aa5d73e9");
     auto subscriberlistOverflowDetected{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&subscriberlistOverflowDetected](const iox::Error error, const std::function<void()>, const iox::ErrorLevel) {
@@ -524,6 +554,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberSubscriberlistOverflow)
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithoutSubscribeOnCreateLeadsToSubscriberThatDoesNotWantToBeSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a59e3629-9aae-43e1-b88b-5dab441b1f17");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.subscribeOnCreate = false;
 
@@ -536,6 +567,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithoutSubscribeOnCreateLeadsToS
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithSubscribeOnCreateLeadsToSubscriberThatWantsToBeSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "975a6edc-cc39-46d0-9bb7-79ab69f18fc3");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.subscribeOnCreate = true;
 
@@ -547,6 +579,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithSubscribeOnCreateLeadsToSubs
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithoutExplicitlySetQueueFullPolicyLeadsToDiscardOldestData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7fdd60c2-8b18-481c-8bad-5f6f70431196");
     iox::popo::SubscriberOptions subscriberOptions;
 
     const auto subscriberPortData =
@@ -560,6 +593,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithoutExplicitlySetQueueFullPol
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueFullPolicySetToDiscardOldestDataLeadsToDiscardOldestData)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9e5df6bf-a752-4db8-9e27-ba5ae1f02a52");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.queueFullPolicy = iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA;
 
@@ -574,6 +608,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueFullPolicySetToDiscardO
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueFullPolicySetToBlockPublisherLeadsToBlockPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ab60b748-6425-4ebf-8041-285a29a92756");
     iox::popo::SubscriberOptions subscriberOptions;
     subscriberOptions.queueFullPolicy = iox::popo::QueueFullPolicy::BLOCK_PUBLISHER;
 
@@ -588,6 +623,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueFullPolicySetToBlockPub
 
 TEST_F(PoshRuntime_test, GetMiddlewareConditionVariableIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f2ccdca8-53ec-46d8-a34e-f56f996f57e0");
     auto conditionVariable = m_runtime->getMiddlewareConditionVariable();
 
     ASSERT_NE(nullptr, conditionVariable);
@@ -595,6 +631,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareConditionVariableIsSuccessful)
 
 TEST_F(PoshRuntime_test, GetMiddlewareConditionVariableListOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6776a648-03c7-4bd0-ab24-72ed7e118e4f");
     auto conditionVariableListOverflowDetected{false};
     auto errorHandlerGuard = iox::ErrorHandler::setTemporaryErrorHandler(
         [&conditionVariableListOverflowDetected](
@@ -635,6 +672,7 @@ TIMING_TEST_F(PoshRuntime_test, GetServiceRegistryChangeCounterOfferStopOfferSer
 
 TEST_F(PoshRuntime_test, CreateNodeReturnValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9f56126d-6920-491f-ba6b-d8e543a15c6a");
     const uint32_t nodeDeviceIdentifier = 1U;
     iox::runtime::NodeProperty nodeProperty(m_nodeName, nodeDeviceIdentifier);
 
@@ -649,6 +687,7 @@ TEST_F(PoshRuntime_test, CreateNodeReturnValue)
 
 TEST_F(PoshRuntime_test, CreatingNodeWithInvalidNameLeadsToTermination)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "de0254ab-c413-4dbe-83c5-2b16fb8fb88f");
     const uint32_t nodeDeviceIdentifier = 1U;
     iox::runtime::NodeProperty nodeProperty(m_invalidNodeName, nodeDeviceIdentifier);
 
@@ -667,6 +706,7 @@ TEST_F(PoshRuntime_test, CreatingNodeWithInvalidNameLeadsToTermination)
 
 TEST_F(PoshRuntime_test, OfferEmptyServiceIsInvalid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "087b965f-79ac-4629-837e-accfc43bce6d");
     auto isServiceOffered = m_runtime->offerService(iox::capro::ServiceDescription());
 
     EXPECT_FALSE(isServiceOffered);
@@ -674,6 +714,7 @@ TEST_F(PoshRuntime_test, OfferEmptyServiceIsInvalid)
 
 TEST_F(PoshRuntime_test, FindServiceWithWildcardsReturnsOnlyIntrospectionServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d944f32c-edef-44f5-a6eb-c19ee73c98eb");
     PoshRuntime* m_receiverRuntime{&iox::runtime::PoshRuntime::initRuntime("subscriber")};
 
     EXPECT_FALSE(m_runtime->offerService(iox::capro::ServiceDescription()));
@@ -692,6 +733,7 @@ TEST_F(PoshRuntime_test, FindServiceWithWildcardsReturnsOnlyIntrospectionService
 
 TEST_F(PoshRuntime_test, ShutdownUnblocksBlockingPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c3a97770-ee9a-46a4-baf7-80ebbac74f4b");
     // get publisher and subscriber
     iox::capro::ServiceDescription serviceDescription{"don't", "stop", "me"};
 
@@ -737,6 +779,7 @@ TEST_F(PoshRuntime_test, ShutdownUnblocksBlockingPublisher)
 
 TEST(PoshRuntimeFactory_test, SetValidRuntimeFactorySucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "59c4e1e6-36f6-4f6d-b4c2-e84fa891f014");
     constexpr const char HYPNOTOAD[]{"hypnotoad"};
     constexpr const char BRAIN_SLUG[]{"brain-slug"};
 
@@ -751,6 +794,7 @@ TEST(PoshRuntimeFactory_test, SetValidRuntimeFactorySucceeds)
 
 TEST(PoshRuntimeFactory_test, SetEmptyRuntimeFactoryFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "530ec778-b480-4a1e-8562-94f93cee2f5c");
     // this ensures resetting of the runtime factory in case the death test doesn't succeed
     auto mockRuntime = PoshRuntimeMock::create("hypnotoad");
 

--- a/iceoryx_posh/test/moduletests/test_posh_runtime_node.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime_node.cpp
@@ -52,6 +52,7 @@ class PoshRuntimeNode_test : public Test
 
 TEST_F(PoshRuntimeNode_test, ConstructorNodeIsSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3bba69cc-43ea-47d3-9207-08afdd7eed9b");
     const NodeName_t nodeName{"Node"};
 
     Node node("Node");
@@ -61,6 +62,7 @@ TEST_F(PoshRuntimeNode_test, ConstructorNodeIsSuccess)
 
 TEST_F(PoshRuntimeNode_test, ConstructorNodeEmptyNodeNameIsSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c1620584-9676-415d-af7a-a3f7263bafee");
     const NodeName_t nodeName{""};
 
     Node node("");
@@ -70,6 +72,7 @@ TEST_F(PoshRuntimeNode_test, ConstructorNodeEmptyNodeNameIsSuccess)
 
 TEST_F(PoshRuntimeNode_test, ConstructorNodeWithMaximalSizeNodeNameIsSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "286fa814-6681-411f-9ef9-924da4f4af28");
     const NodeName_t nodeName{
         "aaaaabbbbbcccccdddddaaaaabbbbbcccccdddddaaaaabbbbbcccccdddddaaaaabbbbbcccccdddddaaaaabbbbbcccccddddd"};
 
@@ -80,6 +83,7 @@ TEST_F(PoshRuntimeNode_test, ConstructorNodeWithMaximalSizeNodeNameIsSuccess)
 
 TEST_F(PoshRuntimeNode_test, VerifyMoveAssignmentOperatorAssignsCorrectName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "22b51fc1-90d3-4d5b-8004-a2da3d8eb5f7");
     const NodeName_t nodeName{"@!~*"};
     Node testNode(nodeName);
     Node node("Node");
@@ -91,6 +95,7 @@ TEST_F(PoshRuntimeNode_test, VerifyMoveAssignmentOperatorAssignsCorrectName)
 
 TEST_F(PoshRuntimeNode_test, SelfMoveAssignmentIsExcluded)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "10be17a2-6253-4f16-befb-08d72379d892");
     const NodeName_t nodeName{"Node"};
     Node node1(nodeName);
     Node& node2 = node1;
@@ -102,6 +107,7 @@ TEST_F(PoshRuntimeNode_test, SelfMoveAssignmentIsExcluded)
 
 TEST_F(PoshRuntimeNode_test, VerifyMoveConstructorAssignsCorrectNodeName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9322a724-7da1-4728-bff3-fa0adc2a0855");
     const NodeName_t nodeNewName{"Node"};
 
     Node node(nodeNewName);

--- a/iceoryx_posh/test/moduletests/test_posh_runtime_node_property.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime_node_property.cpp
@@ -43,6 +43,7 @@ class PoshRuntimeNodeProperty_test : public Test
 
 TEST_F(PoshRuntimeNodeProperty_test, ConstructorNodePropertyWithNodeNameIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "07f17e12-212f-42c5-ba12-b9de909042aa");
     const NodeName_t nodeName{"Node"};
     uint64_t nodeDeviceIdentifier = 1U;
 
@@ -54,6 +55,7 @@ TEST_F(PoshRuntimeNodeProperty_test, ConstructorNodePropertyWithNodeNameIsSucces
 
 TEST_F(PoshRuntimeNodeProperty_test, ConstructorNodePropertyWithSerializationIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a4c99e39-bc32-4826-a4e8-7200afe0c64b");
     const NodeName_t nodeName{"Node"};
     uint64_t nodeDeviceIdentifier = 1U;
 
@@ -70,6 +72,7 @@ TEST_F(PoshRuntimeNodeProperty_test, ConstructorNodePropertyWithSerializationIsS
 
 TEST_F(PoshRuntimeNodeProperty_test, ConstructorNodePropertyWithWrongSerializationIsNotSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9674c2bd-27a0-486c-9309-8081f514020a");
     const NodeName_t nodeName{""};
     NodeProperty sut(cxx::Serialization("Node"));
 

--- a/iceoryx_posh/test/moduletests/test_posh_runtime_single_process.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime_single_process.cpp
@@ -47,6 +47,7 @@ class PoshRuntimeSingleProcess_test : public Test
 
 TEST_F(PoshRuntimeSingleProcess_test, ConstructorPoshRuntimeSingleProcessIsSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9faf7053-86af-4d26-b3a7-fb3c6319ab86");
     iox::RouDiConfig_t defaultRouDiConfig = iox::RouDiConfig_t().setDefaults();
     IceOryxRouDiComponents roudiComponents(defaultRouDiConfig);
 
@@ -61,6 +62,7 @@ TEST_F(PoshRuntimeSingleProcess_test, ConstructorPoshRuntimeSingleProcessIsSucce
 
 TEST_F(PoshRuntimeSingleProcess_test, ConstructorPoshRuntimeSingleProcessMultipleProcessIsFound)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1cc7ad5d-5878-454a-94ba-5cf412c22682");
     RouDiEnvironment m_roudiEnv{iox::RouDiConfig_t().setDefaults()};
 
     const RuntimeName_t m_runtimeName{"App"};

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
@@ -96,6 +96,7 @@ class CmdLineParser_test : public Test
 
 TEST_F(CmdLineParser_test, NoOptionLeadsToDefaultValues)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2da1d849-a652-4c23-ab74-af0dd618a552");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -111,6 +112,7 @@ TEST_F(CmdLineParser_test, NoOptionLeadsToDefaultValues)
 
 TEST_F(CmdLineParser_test, WrongOptionLeadsUnkownOptionResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "11c1ff6b-1676-41e8-aed8-97fc2eb88b06");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -127,6 +129,7 @@ TEST_F(CmdLineParser_test, WrongOptionLeadsUnkownOptionResult)
 
 TEST_F(CmdLineParser_test, HelpLongOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b91d25db-31b7-4d3c-85cb-971236cff6a3");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -143,6 +146,7 @@ TEST_F(CmdLineParser_test, HelpLongOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, HelpShortOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e5f9bf26-99e2-4cae-b9b4-5ff1da4afc86");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -159,6 +163,7 @@ TEST_F(CmdLineParser_test, HelpShortOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, VersionShortOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "66465334-ca98-4260-9a32-0269bc415a22");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -175,6 +180,7 @@ TEST_F(CmdLineParser_test, VersionShortOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, VersionLongOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fa82d46e-6474-4158-b0f9-c970e5895827");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -191,6 +197,7 @@ TEST_F(CmdLineParser_test, VersionLongOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, MonitoringModeOptionsLeadToCorrectMode)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "362435bb-c35b-4617-b08b-17c359543c69");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     MonitoringMode modeArray[] = {MonitoringMode::ON, MonitoringMode::OFF};
     char* args[NUMBER_OF_ARGS];
@@ -214,6 +221,7 @@ TEST_F(CmdLineParser_test, MonitoringModeOptionsLeadToCorrectMode)
 
 TEST_F(CmdLineParser_test, WrongMonitoringModeOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2c2b81f2-1ba6-486f-8ec3-4cafbd0cdb3c");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -232,6 +240,7 @@ TEST_F(CmdLineParser_test, WrongMonitoringModeOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, LogLevelOptionsLeadToCorrectLogLevel)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25799d7a-9f34-4bcd-bb01-f6dbe270fac3");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     LogLevel loglevelArray[] = {LogLevel::kOff,
                                 LogLevel::kFatal,
@@ -261,6 +270,7 @@ TEST_F(CmdLineParser_test, LogLevelOptionsLeadToCorrectLogLevel)
 
 TEST_F(CmdLineParser_test, WrongLogLevelOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "00a08b20-bdf9-436a-9ead-a65e19c89f91");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -279,6 +289,7 @@ TEST_F(CmdLineParser_test, WrongLogLevelOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, KillDelayLongOptionLeadsToCorrectDelay)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a5f328a0-96e8-4ca2-8b35-efa0d9c55538");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -298,6 +309,7 @@ TEST_F(CmdLineParser_test, KillDelayLongOptionLeadsToCorrectDelay)
 
 TEST_F(CmdLineParser_test, KillDelayShortOptionLeadsToCorrectDelay)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "73d31293-a428-48e6-9c04-a22a276117ab");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -317,6 +329,7 @@ TEST_F(CmdLineParser_test, KillDelayShortOptionLeadsToCorrectDelay)
 
 TEST_F(CmdLineParser_test, KillDelayOptionOutOfBoundsLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eb6a67cd-4e5a-41df-bf79-ef5dcdb13fbf");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -335,6 +348,7 @@ TEST_F(CmdLineParser_test, KillDelayOptionOutOfBoundsLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, CompatibilityLevelOptionsLeadToCorrectCompatibilityLevel)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "62b7d5c9-0638-4314-b4f7-c622ef101045");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     CompatibilityCheckLevel loglevelArray[] = {CompatibilityCheckLevel::OFF,
                                                CompatibilityCheckLevel::MAJOR,
@@ -363,6 +377,7 @@ TEST_F(CmdLineParser_test, CompatibilityLevelOptionsLeadToCorrectCompatibilityLe
 
 TEST_F(CmdLineParser_test, WrongCompatibilityLevelOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f270804c-428c-410f-865d-2dc039fcb401");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -381,6 +396,7 @@ TEST_F(CmdLineParser_test, WrongCompatibilityLevelOptionLeadsToProgrammNotRunnin
 
 TEST_F(CmdLineParser_test, UniqueIdLongOptionLeadsToCorrectUniqueId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84d0b41d-44ae-498d-81a9-c94b92255f2b");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -401,6 +417,7 @@ TEST_F(CmdLineParser_test, UniqueIdLongOptionLeadsToCorrectUniqueId)
 
 TEST_F(CmdLineParser_test, UniqueIdShortOptionLeadsToCorrectUniqueId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a12e391c-c382-4eba-b620-59dcb1a150d9");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -421,6 +438,7 @@ TEST_F(CmdLineParser_test, UniqueIdShortOptionLeadsToCorrectUniqueId)
 
 TEST_F(CmdLineParser_test, OutOfBoundsUniqueIdOptionLeadsToProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "13f6b1fb-3c6d-4dda-87ab-d883533bb1ed");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -439,6 +457,7 @@ TEST_F(CmdLineParser_test, OutOfBoundsUniqueIdOptionLeadsToProgrammNotRunning)
 
 TEST_F(CmdLineParser_test, CmdLineParsingModeEqualToOneHandlesOnlyTheFirstOption)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1e674db9-d71a-4b82-83cc-eea2e04f4601");
     constexpr uint8_t NUMBER_OF_ARGS{5U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
@@ -43,6 +43,7 @@ class CmdLineParserConfigFileOption_test : public Test
 
 TEST_F(CmdLineParserConfigFileOption_test, NoConfigPathOptionLeadsToEmptyPath)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5848b80b-7dd6-4d64-8487-cbbec90de2b0");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -57,6 +58,7 @@ TEST_F(CmdLineParserConfigFileOption_test, NoConfigPathOptionLeadsToEmptyPath)
 
 TEST_F(CmdLineParserConfigFileOption_test, ConfigPathShortOptionIsCorrectlyRead)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d3c791ec-0927-458e-9214-1b30ee32aac1");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -75,6 +77,7 @@ TEST_F(CmdLineParserConfigFileOption_test, ConfigPathShortOptionIsCorrectlyRead)
 
 TEST_F(CmdLineParserConfigFileOption_test, ConfigPathLongOptionIsCorrectlyRead)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f8231f57-ea8a-4909-8744-a05d066ddb90");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -93,6 +96,7 @@ TEST_F(CmdLineParserConfigFileOption_test, ConfigPathLongOptionIsCorrectlyRead)
 
 TEST_F(CmdLineParserConfigFileOption_test, HelpLongOptionLeadsProgrammNotRunning)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "81d991ce-5591-404a-8731-c6cd13de1841");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -109,6 +113,7 @@ TEST_F(CmdLineParserConfigFileOption_test, HelpLongOptionLeadsProgrammNotRunning
 
 TEST_F(CmdLineParserConfigFileOption_test, WrongOptionLeadsUnkownOptionResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "783406f2-26f3-4041-9b1f-3845dfb37ca8");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -125,6 +130,7 @@ TEST_F(CmdLineParserConfigFileOption_test, WrongOptionLeadsUnkownOptionResult)
 
 TEST_F(CmdLineParserConfigFileOption_test, UniqueIdOptionLeadsCallingCmdLineParserParseReturningNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4e709ad5-61a7-44d1-a656-0d29ed1078fb");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -144,6 +150,7 @@ TEST_F(CmdLineParserConfigFileOption_test, UniqueIdOptionLeadsCallingCmdLinePars
 
 TEST_F(CmdLineParserConfigFileOption_test, CmdLineParsingModeEqualToOneHandleOnlyTheFirstOptionReturningNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b55d7d0b-7dbe-4a86-9ece-9614ebc3d188");
     constexpr uint8_t NUMBER_OF_ARGS{5U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";

--- a/iceoryx_posh/test/moduletests/test_roudi_config_toml_file_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_config_toml_file_provider.cpp
@@ -44,6 +44,7 @@ class RoudiConfigTomlFileProvider_test : public TestWithParam<ParseErrorInputFil
 
 TEST_F(RoudiConfigTomlFileProvider_test, ParseDefaultConfigIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "37a5ad49-1af2-4e4e-a1ba-85826589d560");
     iox::roudi::ConfigFilePathString_t emptyConfigFilePath;
     m_cmdLineArgs.configFilePath = emptyConfigFilePath;
 
@@ -79,6 +80,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(RoudiConfigTomlFileProvider_test, ParseMalformedInputFileCausesError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a49e2732-df35-4e4d-b312-bb8b9b9fef52");
     const auto parseErrorInputFile = GetParam();
 
     m_cmdLineArgs.configFilePath.append(iox::cxx::TruncateToCapacity, parseErrorInputFile.second);

--- a/iceoryx_posh/test/moduletests/test_roudi_generic_memory_block.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_generic_memory_block.cpp
@@ -45,27 +45,32 @@ class GenericMemoryBlock_POD_Test : public Test
 
 TEST_F(GenericMemoryBlock_POD_Test, Initial)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d4eb7db4-8e19-450d-bee9-b9a82dbb7e08");
     EXPECT_THAT(sutPOD.value().has_value(), Eq(false));
 }
 
 TEST_F(GenericMemoryBlock_POD_Test, Size)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2a661e69-cf6f-4578-8348-86454a350856");
     EXPECT_THAT(sutPOD.size(), Eq(sizeof(PodType)));
 }
 
 TEST_F(GenericMemoryBlock_POD_Test, Alignment)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7acbafcd-1c4c-4c6a-976c-fc3ac8035cd3");
     EXPECT_THAT(sutPOD.size(), Eq(alignof(PodType)));
 }
 
 TEST_F(GenericMemoryBlock_POD_Test, EmplaceWithoutCreate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a6ded0ad-72e2-4c0a-b9ae-b359e0044350");
     constexpr uint32_t EXPECTED_VALUE{37};
     EXPECT_THAT(sutPOD.emplace(EXPECTED_VALUE).has_value(), Eq(false));
 }
 
 TEST_F(GenericMemoryBlock_POD_Test, EmplaceValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f9527cb7-33a9-40fe-b573-39c2b02033f9");
     constexpr uint32_t EXPECTED_VALUE{42};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sutPOD));
     IOX_DISCARD_RESULT(memoryProvider.create());
@@ -78,6 +83,7 @@ TEST_F(GenericMemoryBlock_POD_Test, EmplaceValue)
 
 TEST_F(GenericMemoryBlock_POD_Test, MultipleEmplaceValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cb0175fa-1f9f-4fc8-802f-4eee14fa9ad9");
     constexpr uint32_t FIRST_VALUE{13};
     constexpr uint32_t EXPECTED_VALUE{73};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sutPOD));
@@ -92,6 +98,7 @@ TEST_F(GenericMemoryBlock_POD_Test, MultipleEmplaceValue)
 
 TEST_F(GenericMemoryBlock_POD_Test, GetValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "01db1013-4df4-4e24-b1a6-9406153ac693");
     constexpr uint32_t EXPECTED_VALUE{42};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sutPOD));
     IOX_DISCARD_RESULT(memoryProvider.create());
@@ -151,6 +158,7 @@ class GenericMemoryBlock_NonTrivial_Test : public Test
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, EmplaceValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6758f87f-dd40-4d96-a593-3c8c5ad754a1");
     constexpr uint32_t EXPECTED_VALUE{142};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
     IOX_DISCARD_RESULT(memoryProvider.create());
@@ -164,6 +172,7 @@ TEST_F(GenericMemoryBlock_NonTrivial_Test, EmplaceValue)
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, MultipleEmplaceValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4894ac48-6f29-4f9f-b56d-ed559432d2e3");
     constexpr uint32_t FIRST_VALUE{113};
     constexpr uint32_t EXPECTED_VALUE{173};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
@@ -179,11 +188,13 @@ TEST_F(GenericMemoryBlock_NonTrivial_Test, MultipleEmplaceValue)
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, RunDestructorWithoutCreate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "58f06511-2ee9-43cd-903a-d621674328de");
     /// @note we just expect to not terminate
 }
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, RunDestructorWithoutEmplace)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f4861eae-7808-4a48-b9f1-46159cad301c");
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
     IOX_DISCARD_RESULT(memoryProvider.create());
     /// @note we just expect to not terminate
@@ -191,6 +202,7 @@ TEST_F(GenericMemoryBlock_NonTrivial_Test, RunDestructorWithoutEmplace)
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, DestroyWithEmplace)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e5a1568a-3b46-4c1c-96f0-c191de1b19b7");
     constexpr uint32_t EXPECTED_VALUE{111};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
     IOX_DISCARD_RESULT(memoryProvider.create());
@@ -205,6 +217,7 @@ TEST_F(GenericMemoryBlock_NonTrivial_Test, DestroyWithEmplace)
 
 TEST_F(GenericMemoryBlock_NonTrivial_Test, RepetitiveDestroyWithEmplace)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e8e07e99-7896-4cdc-b990-b24522d7d504");
     constexpr uint32_t EXPECTED_VALUE{42};
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
     IOX_DISCARD_RESULT(memoryProvider.create());

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
@@ -118,6 +118,7 @@ class IceoryxRoudiApp_test : public Test
 
 TEST_F(IceoryxRoudiApp_test, VerifyConstructorIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "530346f1-7405-4640-9f5f-37e45073f95d");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -136,6 +137,7 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorIsSuccessful)
 
 TEST_F(IceoryxRoudiApp_test, CreateTwoRoudiAppIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a095ea92-be03-4157-959a-72b1cb285b46");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -154,6 +156,7 @@ TEST_F(IceoryxRoudiApp_test, CreateTwoRoudiAppIsSuccessful)
 
 TEST_F(IceoryxRoudiApp_test, VerifyRunMethodWithFalseConditionReturnExitSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e25e69a5-4d41-4020-85ca-9f585ac09919");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -174,6 +177,7 @@ TEST_F(IceoryxRoudiApp_test, VerifyRunMethodWithFalseConditionReturnExitSuccess)
 
 TEST_F(IceoryxRoudiApp_test, ConstructorCalledWithArgUniqueIdTwoTimesReturnError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "72ec1d9e-7e29-4a9b-a8dd-cb4de82683cb");
     constexpr uint8_t NUMBER_OF_ARGS{3U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -204,6 +208,7 @@ TEST_F(IceoryxRoudiApp_test, ConstructorCalledWithArgUniqueIdTwoTimesReturnError
 
 TEST_F(IceoryxRoudiApp_test, ConstructorCalledWithArgVersionSetRunVariableToFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "207dd5ea-a00c-48f1-a8de-5ef5a0c5235b");
     constexpr uint8_t NUMBER_OF_ARGS{2U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -222,6 +227,7 @@ TEST_F(IceoryxRoudiApp_test, ConstructorCalledWithArgVersionSetRunVariableToFals
 
 TEST_F(IceoryxRoudiApp_test, VerifyConstructorWithEmptyConfigSetRunVariableToFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0a193ef0-b6c5-4e5b-998d-7f86102814e0");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";
@@ -244,6 +250,7 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorWithEmptyConfigSetRunVariableToFal
 
 TEST_F(IceoryxRoudiApp_test, VerifyConstructorUsingConfigWithSegmentWithoutMemPoolSetRunVariableToFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "542ff7f7-9365-40a4-a7ed-e67ba5735b9e");
     constexpr uint8_t NUMBER_OF_ARGS{1U};
     char* args[NUMBER_OF_ARGS];
     char appName[] = "./foo";

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoyx_roudi_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoyx_roudi_memory_manager.cpp
@@ -44,41 +44,48 @@ class IceoryxRoudiMemoryManager_test : public Test
 
 TEST_F(IceoryxRoudiMemoryManager_test, ConstructorSuccess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f435abe6-07da-44e8-9f1a-074fbcb66209");
     EXPECT_THAT(m_roudiMemoryManagerTest, Not(Eq(nullptr)));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, IntrospectionMemoryManagerNulloptWhenNotPresent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "49daf0d5-41d3-46f8-a1c5-88b37534d38e");
     auto result = m_roudiMemoryManagerTest->introspectionMemoryManager();
     EXPECT_THAT(result, Eq(iox::cxx::nullopt_t()));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, segmentManagerNulloptWhenNotPresent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "951b828b-a99c-4eb6-8ea0-34cb34cf7d28");
     auto resultTest = m_roudiMemoryManagerTest->segmentManager();
     EXPECT_THAT(resultTest, Eq(iox::cxx::nullopt_t()));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, portPoolNulloptWhenNotPresent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67677e21-cc46-4734-b2ae-b3ad0a8aa5e2");
     auto testResult = m_roudiMemoryManagerTest->portPool();
     EXPECT_THAT(testResult, Eq(iox::cxx::nullopt_t()));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, CreateAndAnnouceMemoryHasNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0ce16e0f-1194-4544-84a2-446f8f8b06a6");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     EXPECT_THAT(testResult.has_error(), Eq(false));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, MgmtMemoryProviderReturnNonNullPtr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e89c1ba8-34ca-410f-bb23-45fb41e24e77");
     auto testResult = m_roudiMemoryManagerTest->mgmtMemoryProvider();
     EXPECT_THAT(testResult, Not(Eq(nullptr)));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, AcquiringIntrospectionMemoryManagerAfterCreateAndAnnounceMemoryIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0b4d5286-288d-4bbc-b134-15437bafbbcd");
     auto tr = m_roudiMemoryManagerTest->createAndAnnounceMemory();
 
     EXPECT_THAT(tr.has_error(), Eq(false));
@@ -89,6 +96,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, AcquiringIntrospectionMemoryManagerAfterC
 
 TEST_F(IceoryxRoudiMemoryManager_test, AcquiringSegmentManagerAfterCreateAndAnnounceMemoryIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5c7fa6c4-d6db-41d8-9111-b6991fac0802");
     auto tr = m_roudiMemoryManagerTest->createAndAnnounceMemory();
 
     EXPECT_THAT(tr.has_error(), Eq(false));
@@ -99,6 +107,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, AcquiringSegmentManagerAfterCreateAndAnno
 
 TEST_F(IceoryxRoudiMemoryManager_test, AcquiringPortPoolAfterCreateAndAnnounceMemoryIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7131820d-950f-493a-8884-282380d80d05");
     auto tr = m_roudiMemoryManagerTest->createAndAnnounceMemory();
 
     EXPECT_THAT(tr.has_error(), Eq(false));
@@ -109,6 +118,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, AcquiringPortPoolAfterCreateAndAnnounceMe
 
 TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryReturnNoError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9928be24-88c1-4296-92a1-fd8e2cd860d8");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     EXPECT_FALSE(testResult.has_error());
 
@@ -119,6 +129,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryReturnNoError)
 
 TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryIntrospectionMemoryManagerReturnNullOpt)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b8085b0d-7557-4032-874e-dbd327e7db39");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     ASSERT_FALSE(testResult.has_error());
 
@@ -131,6 +142,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryIntrospectionMemoryManagerRe
 
 TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemorySegmentManagerReturnNullOpt)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "105509a6-21fd-4503-b431-1fdf069ac767");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     ASSERT_FALSE(testResult.has_error());
 
@@ -143,6 +155,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemorySegmentManagerReturnNullOpt)
 
 TEST_F(IceoryxRoudiMemoryManager_test, CreateAndAnnouceMemoryFailingAfterCalledTwoTimes)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2ac68454-77f3-4764-8198-e2ddb9c301fa");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     ASSERT_FALSE(testResult.has_error());
 
@@ -154,6 +167,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, CreateAndAnnouceMemoryFailingAfterCalledT
 
 TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryNotFailingAfterCalledTwoTimes)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe5bd74e-632d-47b6-ad77-92f2d97fa4ff");
     auto testResult = m_roudiMemoryManagerTest->createAndAnnounceMemory();
     ASSERT_FALSE(testResult.has_error());
 

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_block.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_block.cpp
@@ -50,11 +50,13 @@ class MemoryBlock_Test : public Test
 
 TEST_F(MemoryBlock_Test, Initial)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dfda9855-c226-4810-ba59-e75f0877dcd6");
     EXPECT_THAT(sut.memory().has_value(), Eq(false));
 }
 
 TEST_F(MemoryBlock_Test, MemoryAvailableAfterCreation)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8bc3906f-6d3f-453e-b3b2-339138a8d4fc");
     IOX_DISCARD_RESULT(memoryProvider.addMemoryBlock(&sut));
     IOX_DISCARD_RESULT(memoryProvider.create());
     EXPECT_THAT(memoryProvider.dummyMemory, Ne(nullptr));

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_manager.cpp
@@ -67,6 +67,7 @@ class RouDiMemoryManager_Test : public Test
 
 TEST_F(RouDiMemoryManager_Test, CallingCreateAndAnnounceMemoryWithoutMemoryProviderFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8048cd15-3786-4eaf-9c26-e1cd6dce753c");
     auto expectError = sut.createAndAnnounceMemory();
     ASSERT_THAT(expectError.has_error(), Eq(true));
     EXPECT_THAT(expectError.get_error(), Eq(RouDiMemoryManagerError::NO_MEMORY_PROVIDER_PRESENT));
@@ -74,6 +75,7 @@ TEST_F(RouDiMemoryManager_Test, CallingCreateAndAnnounceMemoryWithoutMemoryProvi
 
 TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderSucceeds)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0634d8d5-5ab9-448b-a7c6-031b58374366");
     uint64_t MEMORY_SIZE_1{16};
     uint64_t MEMORY_ALIGNMENT_1{8};
     uint64_t MEMORY_SIZE_2{32};
@@ -99,6 +101,7 @@ TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderSucceeds)
 
 TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b3d5a955-8dd3-40cb-9ac1-88021fbc52e1");
     ASSERT_FALSE(sut.addMemoryProvider(&memoryProvider1).has_error());
 
     // If no memory block is added to memory provider, Create and Announce Memory will return a error
@@ -110,6 +113,7 @@ TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderError)
 
 TEST_F(RouDiMemoryManager_Test, RouDiMemoryManagerDTorTriggersMemoryProviderDestroy)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bb14b892-9f78-4494-a269-0c361b6a88bd");
     uint64_t MEMORY_SIZE_1{16};
     uint64_t MEMORY_ALIGNMENT_1{8};
     EXPECT_CALL(memoryBlock1, size()).WillRepeatedly(Return(MEMORY_SIZE_1));
@@ -129,6 +133,7 @@ TEST_F(RouDiMemoryManager_Test, RouDiMemoryManagerDTorTriggersMemoryProviderDest
 
 TEST_F(RouDiMemoryManager_Test, AddMemoryProviderExceedsCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d80b71b8-7120-49f2-a77b-0f44a8abadde");
     MemoryProviderTestImpl memoryProvider[iox::MAX_NUMBER_OF_MEMORY_PROVIDER + 1];
     RouDiMemoryManager sutExhausting;
 
@@ -144,6 +149,7 @@ TEST_F(RouDiMemoryManager_Test, AddMemoryProviderExceedsCapacity)
 
 TEST_F(RouDiMemoryManager_Test, OperatorTest)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "67167a98-5ac2-498d-8062-47a61102a130");
     for (int16_t i = 0; i < nbTestCase; i++)
     {
         iox::log::LogStream logStream(loggerMock);

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -118,27 +118,32 @@ constexpr const char* MemoryProvider_Test::m_testResultGetErrorString[];
 
 TEST_F(MemoryProvider_Test, InitiallyMemoryIsNotAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25d5dc0c-4999-45b8-a26f-a18c5e2d2644");
     EXPECT_THAT(sut.isAvailable(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, InitiallyMemoryIsNotAvailableAnnounced)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "709ea86a-9480-4ef8-a471-982f5343e221");
     EXPECT_THAT(sut.isAvailableAnnounced(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, AddMemoryBlock)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c5588686-68c0-44d2-b637-7b78167aada8");
     EXPECT_THAT(sut.addMemoryBlock(&memoryBlock1).has_error(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, AddMemoryBlockDoesNotMakeMemoryAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b1462366-c357-4929-a4ee-d86e7058dd64");
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());
     EXPECT_THAT(sut.isAvailable(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, AddMemoryBlockExceedsCapacity)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5503e89e-d927-4669-a0ec-1fa048df373e");
     MemoryBlockMock memoryBlocks[iox::MAX_NUMBER_OF_MEMORY_BLOCKS_PER_MEMORY_PROVIDER + 1];
 
     for (uint32_t i = 0; i < iox::MAX_NUMBER_OF_MEMORY_BLOCKS_PER_MEMORY_PROVIDER; ++i)
@@ -153,6 +158,7 @@ TEST_F(MemoryProvider_Test, AddMemoryBlockExceedsCapacity)
 
 TEST_F(MemoryProvider_Test, CreateWithoutMemoryBlock)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "82f4bcac-3d44-4152-8d6a-ad72cb4ec834");
     EXPECT_CALL(sut, createMemoryMock(_, _)).Times(0);
     auto expectError = sut.create();
     ASSERT_THAT(expectError.has_error(), Eq(true));
@@ -164,6 +170,7 @@ TEST_F(MemoryProvider_Test, CreateWithoutMemoryBlock)
 
 TEST_F(MemoryProvider_Test, CreateWithCommonSetupOfOneMemoryBlockIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0d4a3cba-35c2-4787-b1aa-7c5325fe505c");
     auto expectSuccess = commonSetup();
 
     EXPECT_THAT(expectSuccess.has_error(), Eq(false));
@@ -174,6 +181,7 @@ TEST_F(MemoryProvider_Test, CreateWithCommonSetupOfOneMemoryBlockIsSuccessful)
 
 TEST_F(MemoryProvider_Test, CreationFailed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b47cd296-8fb2-4ae7-ad80-9c962eff687f");
     MemoryProviderFailingCreation sutFailure;
     ASSERT_FALSE(sutFailure.addMemoryBlock(&memoryBlock1).has_error());
     uint64_t MEMORY_SIZE{16};
@@ -191,6 +199,7 @@ TEST_F(MemoryProvider_Test, CreationFailed)
 
 TEST_F(MemoryProvider_Test, CreateAndAnnounceWithOneMemoryBlock)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a090b31e-7bb9-4461-b644-2ae0384824f6");
     ASSERT_FALSE(commonSetup().has_error());
 
     EXPECT_CALL(memoryBlock1, onMemoryAvailable(_)).Times(1);
@@ -201,6 +210,7 @@ TEST_F(MemoryProvider_Test, CreateAndAnnounceWithOneMemoryBlock)
 
 TEST_F(MemoryProvider_Test, CreateAndAnnounceWithMultipleMemoryBlocks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e4c13cc4-6596-4902-be7b-99b801a89cc0");
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock2).has_error());
     uint64_t MEMORY_SIZE_1{16};
@@ -228,6 +238,7 @@ TEST_F(MemoryProvider_Test, CreateAndAnnounceWithMultipleMemoryBlocks)
 
 TEST_F(MemoryProvider_Test, AddMemoryBlockAfterCreation)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "04e8514a-9ea5-4027-8415-7aaf1ffc5637");
     ASSERT_FALSE(commonSetup().has_error());
 
     auto expectError = sut.addMemoryBlock(&memoryBlock2);
@@ -237,6 +248,7 @@ TEST_F(MemoryProvider_Test, AddMemoryBlockAfterCreation)
 
 TEST_F(MemoryProvider_Test, MultipleCreates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e1c1168-da0c-4c20-b027-16b641683f30");
     ASSERT_FALSE(commonSetup().has_error());
 
     auto expectError = sut.create();
@@ -246,6 +258,7 @@ TEST_F(MemoryProvider_Test, MultipleCreates)
 
 TEST_F(MemoryProvider_Test, MultipleAnnouncesAreSuppressed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cfc04605-ad22-4e97-b587-0dd13db63765");
     ASSERT_FALSE(commonSetup().has_error());
 
     EXPECT_CALL(memoryBlock1, onMemoryAvailable(_)).Times(1);
@@ -257,6 +270,7 @@ TEST_F(MemoryProvider_Test, MultipleAnnouncesAreSuppressed)
 
 TEST_F(MemoryProvider_Test, MultipleDestroys)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "61f21297-511f-4c09-b560-c6e2a93cb20e");
     ASSERT_FALSE(commonSetup().has_error());
 
     EXPECT_THAT(sut.destroy().has_error(), Eq(false));
@@ -268,11 +282,13 @@ TEST_F(MemoryProvider_Test, MultipleDestroys)
 
 TEST_F(MemoryProvider_Test, IntialBaseAddressValueIsUnset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0de67825-644e-49ea-9cbb-48cd22855260");
     EXPECT_THAT(sut.baseAddress().has_value(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, BaseAddressValueAfterCreationIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "09e1ded2-658c-41fd-a9c1-7a257d30af2e");
     ASSERT_FALSE(commonSetup().has_error());
 
     auto baseAddress = sut.baseAddress();
@@ -282,6 +298,7 @@ TEST_F(MemoryProvider_Test, BaseAddressValueAfterCreationIsValid)
 
 TEST_F(MemoryProvider_Test, BaseAddressValueAfterDestructionIsUnset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "22c77eeb-5c27-4690-915e-bf9cd004ff89");
     ASSERT_FALSE(commonSetup().has_error());
 
     ASSERT_FALSE(sut.destroy().has_error());
@@ -291,11 +308,13 @@ TEST_F(MemoryProvider_Test, BaseAddressValueAfterDestructionIsUnset)
 
 TEST_F(MemoryProvider_Test, InitialSizeValueIsZero)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4dacac9e-6630-48b6-b050-ad5477586eaf");
     EXPECT_THAT(sut.size(), Eq(0u));
 }
 
 TEST_F(MemoryProvider_Test, SizeValueAfterCreationHasExpectedValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46d325f0-a384-497e-9ca1-991af5348a8b");
     ASSERT_FALSE(commonSetup().has_error());
 
     EXPECT_THAT(sut.size(), Eq(COMMON_SETUP_MEMORY_SIZE));
@@ -303,6 +322,7 @@ TEST_F(MemoryProvider_Test, SizeValueAfterCreationHasExpectedValue)
 
 TEST_F(MemoryProvider_Test, SizeValueAfterDestructionIsZero)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "28ef9db3-310f-46ab-88b6-253a1a56eb26");
     ASSERT_FALSE(commonSetup().has_error());
 
     ASSERT_FALSE(sut.destroy().has_error());
@@ -312,11 +332,13 @@ TEST_F(MemoryProvider_Test, SizeValueAfterDestructionIsZero)
 
 TEST_F(MemoryProvider_Test, InitialSegmentIdValueIsUnset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "237e15ad-7b32-4dc6-a447-e74092c4a411");
     EXPECT_THAT(sut.segmentId().has_value(), Eq(false));
 }
 
 TEST_F(MemoryProvider_Test, SegmentIdValueAfterCreationIsValid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "56307b8c-724b-4bb2-8619-a127205db184");
     constexpr uint64_t DummyMemorySize{1024};
     uint8_t dummy[DummyMemorySize];
     auto segmentIdOffset = iox::rp::BaseRelativePointer::registerPtr(dummy, DummyMemorySize);
@@ -332,6 +354,7 @@ TEST_F(MemoryProvider_Test, SegmentIdValueAfterCreationIsValid)
 
 TEST_F(MemoryProvider_Test, SegmentIdValueAfterDestructionIsUnset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c011594c-1a56-4857-ad23-65e91c5b99fd");
     ASSERT_FALSE(commonSetup().has_error());
 
     ASSERT_FALSE(sut.destroy().has_error());
@@ -341,6 +364,7 @@ TEST_F(MemoryProvider_Test, SegmentIdValueAfterDestructionIsUnset)
 
 TEST_F(MemoryProvider_Test, GetErrorString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "68b8d3b6-0d70-4aac-9c92-19f9f27a86d7");
     constexpr int32_t NUMBER_OF_TEST_CASES =
         sizeof(m_testCombinationMemoryProviderError) / sizeof(iox::roudi::MemoryProviderError);
 

--- a/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_mempool_introspection.cpp
@@ -190,6 +190,7 @@ class MemPoolIntrospection_test : public Test
 
 TEST_F(MemPoolIntrospection_test, CTOR)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9da5951c-cbff-41b5-95e3-ae6921ce9331");
     {
         EXPECT_CALL(callChecker(), offer()).Times(1);
 
@@ -202,6 +203,7 @@ TEST_F(MemPoolIntrospection_test, CTOR)
 
 TEST_F(MemPoolIntrospection_test, send_noSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "28af0288-b57e-4c49-b0a9-33809bf69c96");
     EXPECT_CALL(callChecker(), offer()).Times(1);
 
     MemPoolIntrospectionAccess introspectionAccess(
@@ -220,6 +222,7 @@ TEST_F(MemPoolIntrospection_test, send_noSubscribers)
 /// Should be realized as an integration test with a roudi environment and less mocking classes instead.
 TEST_F(MemPoolIntrospection_test, DISABLED_send_withSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "52c48ddb-e7b6-450d-b262-1e24401ac878");
     EXPECT_CALL(callChecker(), offer()).Times(1);
 
     MemPoolIntrospectionAccess introspectionAccess(

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -149,6 +149,7 @@ class PortIntrospection_test : public Test
 
 TEST_F(PortIntrospection_test, registerPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "41227e98-ac13-40b3-a7f4-8286d4b858ad");
     auto introspection = std::unique_ptr<iox::roudi::PortIntrospection<MockPublisherPortUser, MockSubscriberPortUser>>(
         new iox::roudi::PortIntrospection<MockPublisherPortUser, MockSubscriberPortUser>);
 
@@ -166,6 +167,7 @@ TEST_F(PortIntrospection_test, registerPublisherPort)
 
 TEST_F(PortIntrospection_test, sendPortData_EmptyList)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b599b9ca-8b7a-4e6d-b583-e142392d08f7");
     using Topic = iox::roudi::PortIntrospectionFieldTopic;
 
     auto chunk = std::unique_ptr<ChunkMock<Topic>>(new ChunkMock<Topic>);
@@ -188,6 +190,7 @@ TEST_F(PortIntrospection_test, sendPortData_EmptyList)
 
 TEST_F(PortIntrospection_test, addAndRemovePublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3d8a21e8-5cb0-4694-b8be-7b419f4c51ea");
     using PortData = iox::roudi::PublisherPortData;
     using Topic = iox::roudi::PortIntrospectionFieldTopic;
 
@@ -317,6 +320,7 @@ TEST_F(PortIntrospection_test, addAndRemovePublisher)
 
 TEST_F(PortIntrospection_test, addAndRemoveSubscriber)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "359527ee-78a6-4a98-acd8-b39d263d8e02");
     using PortData = iox::roudi::SubscriberPortData;
     using Topic = iox::roudi::PortIntrospectionFieldTopic;
 
@@ -450,6 +454,7 @@ TEST_F(PortIntrospection_test, addAndRemoveSubscriber)
 
 TEST_F(PortIntrospection_test, DISABLED_thread)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ae5b252d-0060-4bb7-a193-0c2ae0ebbb7a");
     using PortData = iox::roudi::PortIntrospectionFieldTopic;
     auto chunkPortData = std::unique_ptr<ChunkMock<PortData>>(new ChunkMock<PortData>);
 

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -212,6 +212,7 @@ void setDestroyFlagAndClearContainer(vector& container)
 
 TEST_F(PortManager_test, AcquirePubWithInvalidServiceDescriptionResultsInServiceDescriptionInvalidError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "314ccda9-962d-416c-a631-74d1c5b15b41");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
 
     auto result = m_portManager->acquirePublisherPortData(
@@ -227,6 +228,7 @@ TEST_F(PortManager_test, AcquirePubWithInvalidServiceDescriptionResultsInService
 
 TEST_F(PortManager_test, AcquireSubWithInvalidServiceDescriptionResultsInServiceDescriptionInvalidError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a821353-3300-47be-9ffe-367a3740df02");
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
 
     auto result = m_portManager->acquireSubscriberPortData(
@@ -241,6 +243,7 @@ TEST_F(PortManager_test, AcquireSubWithInvalidServiceDescriptionResultsInService
 
 TEST_F(PortManager_test, DoDiscoveryWithSingleShotPublisherFirst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f767cb6a-ae82-45e5-9969-d75be1077fc0");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
 
@@ -267,6 +270,7 @@ TEST_F(PortManager_test, DoDiscoveryWithSingleShotPublisherFirst)
 
 TEST_F(PortManager_test, DoDiscoveryWithSingleShotSubscriberFirst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bef1fc7f-3661-4dcc-98dd-fbf951ed275c");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
 
@@ -293,6 +297,7 @@ TEST_F(PortManager_test, DoDiscoveryWithSingleShotSubscriberFirst)
 
 TEST_F(PortManager_test, DoDiscoveryWithDiscoveryLoopInBetweenCreationOfSubscriberAndPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bbd475bd-23fd-4b8f-b2ae-88e41c39e6e2");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
 
@@ -319,6 +324,7 @@ TEST_F(PortManager_test, DoDiscoveryWithDiscoveryLoopInBetweenCreationOfSubscrib
 
 TEST_F(PortManager_test, DoDiscoveryWithSubscribersCreatedBeforeAndAfterCreationOfPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b1c5bf2e-066e-4f01-b92a-edab9197a5dd");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
 
@@ -353,6 +359,7 @@ TEST_F(PortManager_test, DoDiscoveryWithSubscribersCreatedBeforeAndAfterCreation
 
 TEST_F(PortManager_test, SubscribeOnCreateSubscribesWithoutDiscoveryLoopWhenPublisherAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a94cf82-d1f6-4129-88ca-34344d94e04e");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), false};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true};
     PublisherPortUser publisher(
@@ -373,6 +380,7 @@ TEST_F(PortManager_test, SubscribeOnCreateSubscribesWithoutDiscoveryLoopWhenPubl
 
 TEST_F(PortManager_test, OfferOnCreateSubscribesWithoutDiscoveryLoopWhenSubscriberAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f6cb4274-d137-4035-b38c-3644b8158006");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), true};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), false};
     SubscriberPortUser subscriber(
@@ -393,6 +401,7 @@ TEST_F(PortManager_test, OfferOnCreateSubscribesWithoutDiscoveryLoopWhenSubscrib
 
 TEST_F(PortManager_test, OfferOnCreateAndSubscribeOnCreateNeedsNoMoreDiscoveryLoopSubscriberFirst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "28798301-1630-458a-81b5-77f53e75d0fb");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), true};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true};
     SubscriberPortUser subscriber(
@@ -411,6 +420,7 @@ TEST_F(PortManager_test, OfferOnCreateAndSubscribeOnCreateNeedsNoMoreDiscoveryLo
 
 TEST_F(PortManager_test, OfferOnCreateAndSubscribeOnCreateNeedsNoMoreDiscoveryLoopPublisherFirst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8a51d940-fc35-428e-b4dd-b19c7e9d1f4a");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), true};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true};
     PublisherPortUser publisher(
@@ -431,6 +441,7 @@ TEST_F(PortManager_test, OfferOnCreateAndSubscribeOnCreateNeedsNoMoreDiscoveryLo
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfPublishersFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "617abda0-36f7-4f98-9eb9-572622e0ffa1");
     iox::RuntimeName_t runtimeName = "test1";
     PublisherOptions publisherOptions{1U, iox::NodeName_t("run1")};
 
@@ -460,6 +471,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfPublishersFails)
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfSubscribersFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5039eff5-f2d1-4f58-8bd2-fc9768a9bc92");
     iox::RuntimeName_t runtimeName1 = "test1";
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("run1")};
 
@@ -486,6 +498,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfSubscribersFails)
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfInterfacesFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "129706cc-18e5-4457-b314-d6b7ae347ea0");
     std::string runtimeName = "itf";
 
     // first aquire all possible Interfaces
@@ -507,6 +520,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfInterfacesFails)
 
 TEST_F(PortManager_test, DoDiscoveryPublisherCanWaitAndSubscriberRequestsBlockingLeadsToConnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "34380b13-5541-4fdf-b266-beccb90f5215");
     PublisherOptions publisherOptions{
         1U, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true, QueueFullPolicy::BLOCK_PUBLISHER};
@@ -527,6 +541,7 @@ TEST_F(PortManager_test, DoDiscoveryPublisherCanWaitAndSubscriberRequestsBlockin
 
 TEST_F(PortManager_test, DoDiscoveryBothDiscardOldestPolicyLeadsToConnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3cf03140-9ca6-47a1-b45b-8cfa70e3fd5c");
     PublisherOptions publisherOptions{
         1U, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA};
@@ -547,6 +562,7 @@ TEST_F(PortManager_test, DoDiscoveryBothDiscardOldestPolicyLeadsToConnect)
 
 TEST_F(PortManager_test, DoDiscoveryPublisherDoesNotAllowBlockingAndSubscriberRequestsBlockingLeadsToNoConnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "31d879bf-ca07-4f29-90cd-a46f09a98f7c");
     PublisherOptions publisherOptions{
         1U, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true, QueueFullPolicy::BLOCK_PUBLISHER};
@@ -566,6 +582,7 @@ TEST_F(PortManager_test, DoDiscoveryPublisherDoesNotAllowBlockingAndSubscriberRe
 
 TEST_F(PortManager_test, DoDiscoveryPublisherCanWaitAndSubscriberDiscardOldestLeadsToConnect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f2ea15a6-0672-4a98-8f80-f2900b247ac0");
     PublisherOptions publisherOptions{
         1U, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER};
     SubscriberOptions subscriberOptions{1U, 1U, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA};
@@ -587,6 +604,7 @@ TEST_F(PortManager_test, DoDiscoveryPublisherCanWaitAndSubscriberDiscardOldestLe
 
 TEST_F(PortManager_test, DeleteInterfacePortfromMaximumNumberAndAddOneIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e682da4-aea0-4c37-8895-4049506db936");
     std::string runtimeName = "itf";
 
     // first aquire all possible Interfaces
@@ -607,6 +625,7 @@ TEST_F(PortManager_test, DeleteInterfacePortfromMaximumNumberAndAddOneIsSuccessf
 
 TEST_F(PortManager_test, AcquireInterfacePortDataAfterDestroyingPreviouslyAcquiredOnesIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0a8a52c8-2c6f-44d3-ab32-0d92f6e285f1");
     std::vector<iox::popo::InterfacePortData*> interfaceContainer;
     std::string runtimeName = "itf";
 
@@ -623,6 +642,7 @@ TEST_F(PortManager_test, AcquireInterfacePortDataAfterDestroyingPreviouslyAcquir
 
 TEST_F(PortManager_test, DoDiscoveryWithInvalidServiceDescriptionInApplicationPortLeadsToTermination)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1f6973d5-aa2d-4781-b5b6-861793660c33");
     auto applicationPortData = m_portManager->acquireApplicationPortData(iox::RuntimeName_t("OhWieSchoenIsPanama"));
     ASSERT_NE(applicationPortData, nullptr);
 
@@ -637,6 +657,7 @@ TEST_F(PortManager_test, DoDiscoveryWithInvalidServiceDescriptionInApplicationPo
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfApplicationsFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0d13e636-2a8d-462d-a361-cbb62a922162");
     std::string runtimeName = "app";
 
     // first aquire all possible applications
@@ -658,6 +679,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfApplicationsFails)
 
 TEST_F(PortManager_test, DeleteApplicationPortfromMaximumNumberAndAddOneIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4512b3a6-3e23-49b4-90a5-9464ac2f0cde");
     std::string runtimeName = "app";
 
     // first aquire all possible applications
@@ -678,6 +700,7 @@ TEST_F(PortManager_test, DeleteApplicationPortfromMaximumNumberAndAddOneIsSucces
 
 TEST_F(PortManager_test, AcquireApplicationPortAfterDestroyingPreviouslyAcquiredOnesIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d4a59ba7-7858-4d6d-b43e-f4617e784590");
     std::vector<iox::popo::ApplicationPortData*> appContainer;
 
     std::string runtimeName = "app";
@@ -695,6 +718,7 @@ TEST_F(PortManager_test, AcquireApplicationPortAfterDestroyingPreviouslyAcquired
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfConditionVariablesFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b7f4106-cf38-4c89-9453-fca1e3887ee5");
     std::string runtimeName = "HypnoToadForEver";
 
     // first aquire all possible condition variables
@@ -717,6 +741,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfConditionVariablesFa
 
 TEST_F(PortManager_test, DeleteConditionVariablePortfromMaximumNumberAndAddOneIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "81de0f58-7bf8-43c4-a4ef-b365c0e74c47");
     std::string runtimeName = "HypnoToadForEver";
 
     // first aquire all possible condition variables
@@ -737,6 +762,7 @@ TEST_F(PortManager_test, DeleteConditionVariablePortfromMaximumNumberAndAddOneIs
 
 TEST_F(PortManager_test, AcquireConditionVariablesDataAfterDestroyingPreviouslyAcquiredOnesIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b82b069-b300-4018-88d6-83cca8157066");
     std::vector<iox::popo::ConditionVariableData*> condVarContainer;
 
     std::string runtimeName = "HypnoToadForEver";
@@ -754,6 +780,7 @@ TEST_F(PortManager_test, AcquireConditionVariablesDataAfterDestroyingPreviouslyA
 
 TEST_F(PortManager_test, AcquiringMaximumNumberOfNodesWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7c4e697e-c379-44f5-a081-5903d9b287f5");
     std::string runtimeName = "Process";
     std::string nodeName = iox::NodeName_t("node");
 
@@ -765,6 +792,7 @@ TEST_F(PortManager_test, AcquiringMaximumNumberOfNodesWorks)
 
 TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfNodesFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "012b526b-f3a0-43c3-bc71-278496caf16a");
     std::string runtimeName = "Process";
     std::string nodeName = iox::NodeName_t("node");
 
@@ -786,6 +814,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfNodesFails)
 
 TEST_F(PortManager_test, DeleteNodePortfromMaximumNumberandAddOneIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b43da28c-b1ad-43a4-82cb-e885ef9e6a89");
     std::string runtimeName = "Process";
     std::string nodeName = iox::NodeName_t("node");
 
@@ -808,6 +837,7 @@ TEST_F(PortManager_test, DeleteNodePortfromMaximumNumberandAddOneIsSuccessful)
 
 TEST_F(PortManager_test, AcquireNodeDataAfterDestroyingPreviouslyAcquiredOnesIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c2d64fbb-6aa5-42bc-aaea-3d8776da70ed");
     iox::RuntimeName_t runtimeName = "Humuhumunukunukuapua'a";
     iox::NodeName_t nodeName = "Taumatawhakatangihangakoauauotamateaturipukakapikimaungahoronukupokaiwhenuakitanatahu";
     std::vector<iox::runtime::NodeData*> nodeContainer;
@@ -828,6 +858,7 @@ TEST_F(PortManager_test, AcquireNodeDataAfterDestroyingPreviouslyAcquiredOnesIsS
 
 TEST_F(PortManager_test, UnblockRouDiShutdownMakesAllPublisherStopOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aa0cd25c-4e9d-476a-a8a6-d5c650fb9fff");
     PublisherOptions publisherOptions{1U, iox::NodeName_t("node"), true};
     iox::cxx::vector<PublisherPortUser, iox::MAX_PUBLISHERS> publisher;
 
@@ -856,6 +887,7 @@ TEST_F(PortManager_test, UnblockRouDiShutdownMakesAllPublisherStopOffer)
 
 TEST_F(PortManager_test, UnblockProcessShutdownMakesPublisherStopOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a013e699-2a6b-42e9-b6e8-5f65ea235c0a");
     const iox::RuntimeName_t publisherRuntimeName{"guiseppe"};
 
     // get publisher and subscriber
@@ -935,12 +967,14 @@ void PortManager_test::setupAndTestBlockingPublisher(const iox::RuntimeName_t& p
 
 TEST_F(PortManager_test, UnblockRouDiShutdownUnblocksBlockedPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5200e46f-5006-4a71-966a-a4aff8a0bf85");
     const iox::RuntimeName_t publisherRuntimeName{"guiseppe"};
     setupAndTestBlockingPublisher(publisherRuntimeName, [&] { m_portManager->unblockRouDiShutdown(); });
 }
 
 TEST_F(PortManager_test, UnblockProcessShutdownUnblocksBlockedPublisher)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2c5a3f87-20fb-4fd8-a3b5-033b79598800");
     const iox::RuntimeName_t publisherRuntimeName{"guiseppe"};
     setupAndTestBlockingPublisher(publisherRuntimeName,
                                   [&] { m_portManager->unblockProcessShutdown(publisherRuntimeName); });
@@ -948,6 +982,7 @@ TEST_F(PortManager_test, UnblockProcessShutdownUnblocksBlockedPublisher)
 
 TEST_F(PortManager_test, PortsDestroyInProcess2ChangeStatesOfPortsInProcess1)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "65815512-0298-46b7-9d19-64bc51079c1a");
     iox::RuntimeName_t runtimeName1 = "myApp1";
     iox::RuntimeName_t runtimeName2 = "myApp2";
     iox::capro::ServiceDescription cap1("1", "1", "1");
@@ -1067,6 +1102,7 @@ TEST_F(PortManager_test, PortsDestroyInProcess2ChangeStatesOfPortsInProcess1)
 
 TEST_F(PortManager_test, OfferPublisherServiceUpdatesServiceRegistryChangeCounter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25b44ea6-be56-40ec-9567-24b4e3ef486a");
     auto serviceCounter = m_portManager->serviceRegistryChangeCounter();
     ASSERT_NE(serviceCounter, nullptr);
 

--- a/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
@@ -50,6 +50,7 @@ class PortPool_test : public Test
 
 TEST_F(PortPool_test, AddNodeDataIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a917fe3d-08a4-4c8f-83a5-4b99b915c0dd");
     auto nodeData = sut.addNodeData(m_runtimeName, m_nodeName, m_nodeDeviceId);
 
     ASSERT_THAT(nodeData.has_error(), Eq(false));
@@ -60,6 +61,7 @@ TEST_F(PortPool_test, AddNodeDataIsSuccessful)
 
 TEST_F(PortPool_test, AddNodeDataWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1553d03e-4154-49e8-9f38-db6f52e6fa29");
     for (uint32_t i = 1U; i <= MAX_NODE_NUMBER; ++i)
     {
         auto nodeData = sut.addNodeData(m_runtimeName, m_nodeName, i);
@@ -73,6 +75,7 @@ TEST_F(PortPool_test, AddNodeDataWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddNodeDataWhenNodeListIsFullReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "23ff8250-6c1b-4a4e-b3e6-207883386edc");
     for (uint32_t i = 0U; i < MAX_NODE_NUMBER; ++i)
     {
         ASSERT_FALSE(sut.addNodeData(m_runtimeName, m_nodeName, i).has_error());
@@ -94,6 +97,7 @@ TEST_F(PortPool_test, AddNodeDataWhenNodeListIsFullReturnsError)
 
 TEST_F(PortPool_test, GetNodeDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a86e0ed-e61a-4f45-9aab-2b38a22730a9");
     ASSERT_FALSE(sut.addNodeData(m_runtimeName, m_nodeName, m_nodeDeviceId).has_error());
 
     auto nodeDataList = sut.getNodeDataList();
@@ -106,6 +110,7 @@ TEST_F(PortPool_test, GetNodeDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetNodeDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c5f629bd-b9ea-4d41-b991-5654e20dae3b");
     auto nodeDataList = sut.getNodeDataList();
 
     EXPECT_EQ(nodeDataList.size(), 0U);
@@ -113,6 +118,7 @@ TEST_F(PortPool_test, GetNodeDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetNodeDataListWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a43182d-f0fd-4cbf-931e-f803a0236180");
     for (uint32_t i = 1U; i <= MAX_NODE_NUMBER; ++i)
     {
         auto nodeData = sut.addNodeData(m_runtimeName, m_nodeName, i);
@@ -127,6 +133,7 @@ TEST_F(PortPool_test, GetNodeDataListWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, RemoveNodeDataIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b300e7a6-df97-417d-9f7a-df3b55dace41");
     auto nodeData = sut.addNodeData(m_runtimeName, m_nodeName, m_nodeDeviceId);
 
     sut.removeNodeData(nodeData.value());
@@ -137,6 +144,7 @@ TEST_F(PortPool_test, RemoveNodeDataIsSuccessful)
 
 TEST_F(PortPool_test, AddPublisherPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8e2271f5-65a9-41ea-bffa-7f1a55321cc0");
     auto publisherPort = sut.addPublisherPort(
         m_serviceDescription, &m_memoryManager, m_applicationName, m_publisherOptions, m_memoryInfo);
 
@@ -151,6 +159,7 @@ TEST_F(PortPool_test, AddPublisherPortIsSuccessful)
 
 TEST_F(PortPool_test, AddPublisherPortWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3328692a-77a7-42d4-8ec2-154e1e89f8cd");
     for (uint32_t i = 0U; i < MAX_PUBLISHERS; ++i)
     {
         RuntimeName_t applicationName = {cxx::TruncateToCapacity, "AppName" + cxx::convert::toString(i)};
@@ -170,6 +179,7 @@ TEST_F(PortPool_test, AddPublisherPortWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddPublisherPortWhenPublisherListOverflowsReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0dcb81c-d7cf-448a-bb6d-5c7feaa7da6c");
     auto addPublisherPort = [&](const uint32_t i) -> bool {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
@@ -205,6 +215,7 @@ TEST_F(PortPool_test, AddPublisherPortWhenPublisherListOverflowsReturnsError)
 
 TEST_F(PortPool_test, GetPublisherPortDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1650a6e0-8079-4ac4-ad03-723a7fc70217");
     auto publisherPortDataList = sut.getPublisherPortDataList();
 
     EXPECT_EQ(publisherPortDataList.size(), 0U);
@@ -218,6 +229,7 @@ TEST_F(PortPool_test, GetPublisherPortDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetPublisherPortDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "01fc41aa-4961-4bb6-98b7-a35ca3f93c1d");
     auto nodeDataList = sut.getPublisherPortDataList();
 
     EXPECT_EQ(nodeDataList.size(), 0U);
@@ -225,6 +237,7 @@ TEST_F(PortPool_test, GetPublisherPortDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetPublisherPortDataListCompletelyFilledSuccessfully)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1e0c7c72-6a67-4481-8873-afba04850d03");
     for (uint32_t i = 0U; i < MAX_PUBLISHERS; ++i)
     {
         std::string service = "service" + cxx::convert::toString(i);
@@ -247,6 +260,7 @@ TEST_F(PortPool_test, GetPublisherPortDataListCompletelyFilledSuccessfully)
 
 TEST_F(PortPool_test, RemovePublisherPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7c0e06c2-e07b-468e-bb95-1dcad99e29b4");
     auto publisherPort =
         sut.addPublisherPort(m_serviceDescription, &m_memoryManager, m_applicationName, m_publisherOptions);
     sut.removePublisherPort(publisherPort.value());
@@ -257,6 +271,7 @@ TEST_F(PortPool_test, RemovePublisherPortIsSuccessful)
 
 TEST_F(PortPool_test, AddSubscriberPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b4703d69-bec1-49cf-8f7b-00e805577d8f");
     auto subscriberPort =
         sut.addSubscriberPort(m_serviceDescription, m_applicationName, m_subscriberOptions, m_memoryInfo);
 
@@ -272,6 +287,7 @@ TEST_F(PortPool_test, AddSubscriberPortIsSuccessful)
 
 TEST_F(PortPool_test, AddSubscriberPortToMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "380fa9e5-8cf3-435f-ad33-04bc706a37a5");
     for (uint32_t i = 0U; i < MAX_SUBSCRIBERS; ++i)
     {
         std::string service = "service" + cxx::convert::toString(i);
@@ -294,6 +310,7 @@ TEST_F(PortPool_test, AddSubscriberPortToMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddSubscriberPortWhenSubscriberListOverflowsReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f7f13463-84d3-4434-ac43-5ee04e37b57f");
     auto addSubscriberPort = [&](const uint32_t i) -> bool {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
@@ -327,6 +344,7 @@ TEST_F(PortPool_test, AddSubscriberPortWhenSubscriberListOverflowsReturnsError)
 
 TEST_F(PortPool_test, GetSubscriberPortDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "391bba2f-e6f7-4dec-9ffb-67a69cd9a059");
     auto subscriberPort = sut.addSubscriberPort(m_serviceDescription, m_applicationName, m_subscriberOptions);
     EXPECT_FALSE(subscriberPort.has_error());
     auto subscriberPortDataList = sut.getSubscriberPortDataList();
@@ -336,6 +354,7 @@ TEST_F(PortPool_test, GetSubscriberPortDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetSubscriberPortDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a525a8b7-98f3-4c01-a85f-c8c7cc741e09");
     auto nodeDataList = sut.getSubscriberPortDataList();
 
     ASSERT_EQ(nodeDataList.size(), 0U);
@@ -343,6 +362,7 @@ TEST_F(PortPool_test, GetSubscriberPortDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetSubscriberPortDataListCompletelyFilledIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8c1e32ba-74e2-4c34-ae37-4c0d93b21283");
     for (uint32_t i = 0U; i < MAX_SUBSCRIBERS; ++i)
     {
         std::string service = "service" + cxx::convert::toString(i);
@@ -362,6 +382,7 @@ TEST_F(PortPool_test, GetSubscriberPortDataListCompletelyFilledIsSuccessful)
 
 TEST_F(PortPool_test, RemoveSubscriberPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1f642bba-561c-45bb-bb7a-b0f8b373483a");
     auto subscriberPort = sut.addSubscriberPort(m_serviceDescription, m_applicationName, m_subscriberOptions);
 
     sut.removeSubscriberPort(subscriberPort.value());
@@ -372,6 +393,7 @@ TEST_F(PortPool_test, RemoveSubscriberPortIsSuccessful)
 
 TEST_F(PortPool_test, AddInterfacePortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "28116302-dc19-4927-aab4-6d03c9befd88");
     auto interfacePortData = sut.addInterfacePort(m_applicationName, Interfaces::INTERNAL);
 
     ASSERT_THAT(interfacePortData.has_error(), Eq(false));
@@ -381,6 +403,7 @@ TEST_F(PortPool_test, AddInterfacePortIsSuccessful)
 
 TEST_F(PortPool_test, AddInterfacePortWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8f7690e5-c29e-4e7e-bc9d-f6ea61c3fd6c");
     for (uint32_t i = 1U; i <= MAX_INTERFACE_NUMBER; ++i)
     {
         auto interfacePortData = sut.addInterfacePort(m_applicationName, Interfaces::INTERNAL);
@@ -392,6 +415,7 @@ TEST_F(PortPool_test, AddInterfacePortWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddInterfacePortWhenInterfaceListOverflowsReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a35f7b3b-4b21-4bff-bc40-693a7064ffc5");
     for (uint32_t i = 0U; i < MAX_INTERFACE_NUMBER; ++i)
     {
         EXPECT_FALSE(sut.addInterfacePort(m_applicationName, Interfaces::INTERFACE_END).has_error());
@@ -412,6 +436,7 @@ TEST_F(PortPool_test, AddInterfacePortWhenInterfaceListOverflowsReturnsError)
 
 TEST_F(PortPool_test, GetInterfacePortDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0ed6bf52-2ffb-40f4-acab-a9f79532cde1");
     auto interfacePort = sut.addInterfacePort(m_applicationName, Interfaces::INTERNAL);
     EXPECT_FALSE(interfacePort.has_error());
     auto interfacePortDataList = sut.getInterfacePortDataList();
@@ -421,6 +446,7 @@ TEST_F(PortPool_test, GetInterfacePortDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetInterfacePortDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "80aab75f-5251-4c2e-9ab6-82b00c728a9c");
     auto interfacePortDataList = sut.getInterfacePortDataList();
 
     ASSERT_EQ(interfacePortDataList.size(), 0U);
@@ -428,6 +454,7 @@ TEST_F(PortPool_test, GetInterfacePortDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetInterfacePortDataListCompletelyFilledIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "460703f9-72d8-4b72-9c3a-761be22e6c9a");
     for (uint32_t i = 0U; i < MAX_INTERFACE_NUMBER; ++i)
     {
         RuntimeName_t applicationName = {cxx::TruncateToCapacity, "AppName" + cxx::convert::toString(i)};
@@ -440,6 +467,7 @@ TEST_F(PortPool_test, GetInterfacePortDataListCompletelyFilledIsSuccessful)
 
 TEST_F(PortPool_test, RemoveInterfacePortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "65db995b-46b1-44f5-bef0-09096faa4953");
     auto interfacePort = sut.addInterfacePort(m_applicationName, Interfaces::INTERNAL);
 
     sut.removeInterfacePort(interfacePort.value());
@@ -450,6 +478,7 @@ TEST_F(PortPool_test, RemoveInterfacePortIsSuccessful)
 
 TEST_F(PortPool_test, AddApplicationPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dda88a52-1f4f-4c78-a00e-1c456130cae7");
     auto applicationPortData = sut.addApplicationPort(m_applicationName);
 
     ASSERT_THAT(applicationPortData.has_error(), Eq(false));
@@ -458,6 +487,7 @@ TEST_F(PortPool_test, AddApplicationPortIsSuccessful)
 
 TEST_F(PortPool_test, AddApplicationPortWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ba0dbef5-79d4-4a24-9bbe-06dda49877ca");
     for (uint32_t i = 1U; i <= MAX_PROCESS_NUMBER; ++i)
     {
         auto applicationPortData = sut.addApplicationPort(m_applicationName);
@@ -469,6 +499,7 @@ TEST_F(PortPool_test, AddApplicationPortWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddApplicationPortWhenApplicationListOverflowsReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bea1c7dd-aa32-4e78-a26c-04f859c68048");
     for (uint32_t i = 0U; i < MAX_PROCESS_NUMBER; ++i)
     {
         EXPECT_FALSE(sut.addApplicationPort(m_applicationName).has_error());
@@ -489,6 +520,7 @@ TEST_F(PortPool_test, AddApplicationPortWhenApplicationListOverflowsReturnsError
 
 TEST_F(PortPool_test, GetApplicationPortDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6efeaf6c-559e-4ff1-abaf-4d013392ea5e");
     auto applicationPortDataList = sut.getApplicationPortDataList();
 
     ASSERT_EQ(applicationPortDataList.size(), 0U);
@@ -496,6 +528,7 @@ TEST_F(PortPool_test, GetApplicationPortDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetApplicationPortDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "faec13b6-d8c7-4b52-8ce0-e3d168314be8");
     ASSERT_FALSE(sut.addApplicationPort(m_applicationName).has_error());
     auto applicationPortDataList = sut.getApplicationPortDataList();
 
@@ -504,6 +537,7 @@ TEST_F(PortPool_test, GetApplicationPortDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetApplicationPortDataListCompletelyFilledIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "47602a54-bf90-4cb9-84d2-6d282f875f46");
     for (uint32_t i = 0U; i < MAX_PROCESS_NUMBER; ++i)
     {
         RuntimeName_t applicationName = {cxx::TruncateToCapacity, "AppName" + cxx::convert::toString(i)};
@@ -516,6 +550,7 @@ TEST_F(PortPool_test, GetApplicationPortDataListCompletelyFilledIsSuccessful)
 
 TEST_F(PortPool_test, RemoveApplicationPortIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d3c2ad3b-63bd-4952-a3a4-e00ac3fd70ed");
     auto applicationPortData = sut.addApplicationPort(m_applicationName);
 
     sut.removeApplicationPort(applicationPortData.value());
@@ -526,6 +561,7 @@ TEST_F(PortPool_test, RemoveApplicationPortIsSuccessful)
 
 TEST_F(PortPool_test, AddConditionVariableDataIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "08021def-be31-42f2-855f-38cac6120c3f");
     auto conditionVariableData = sut.addConditionVariableData(m_applicationName);
 
     ASSERT_THAT(conditionVariableData.has_error(), Eq(false));
@@ -534,6 +570,7 @@ TEST_F(PortPool_test, AddConditionVariableDataIsSuccessful)
 
 TEST_F(PortPool_test, AddConditionVariableDataWithMaxCapacityIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee38306e-93b6-4d07-a719-e2e169801f17");
     for (uint32_t i = 1U; i <= MAX_NUMBER_OF_CONDITION_VARIABLES; ++i)
     {
         auto conditionVariableData = sut.addConditionVariableData(m_applicationName);
@@ -545,6 +582,7 @@ TEST_F(PortPool_test, AddConditionVariableDataWithMaxCapacityIsSuccessful)
 
 TEST_F(PortPool_test, AddConditionVariableDataWhenContainerIsFullReturnsError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d1d351a-6a5e-47f2-8042-9a5f8d8a650d");
     for (uint32_t i = 0U; i < MAX_NUMBER_OF_CONDITION_VARIABLES; ++i)
     {
         EXPECT_FALSE(sut.addConditionVariableData(m_applicationName).has_error());
@@ -565,6 +603,7 @@ TEST_F(PortPool_test, AddConditionVariableDataWhenContainerIsFullReturnsError)
 
 TEST_F(PortPool_test, GetConditionVariableDataListIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b128487c-f808-4eef-9c74-7ddeab5415d9");
     ASSERT_FALSE(sut.addConditionVariableData(m_applicationName).has_error());
     auto condtionalVariableData = sut.getConditionVariableDataList();
 
@@ -573,6 +612,7 @@ TEST_F(PortPool_test, GetConditionVariableDataListIsSuccessful)
 
 TEST_F(PortPool_test, GetConditionVariableDataListWhenEmptyIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f70cc08d-9a50-4166-acfc-b2514bd7f571");
     auto condtionalVariableData = sut.getConditionVariableDataList();
 
     ASSERT_EQ(condtionalVariableData.size(), 0U);
@@ -580,6 +620,7 @@ TEST_F(PortPool_test, GetConditionVariableDataListWhenEmptyIsSuccessful)
 
 TEST_F(PortPool_test, GetConditionVariableDataListCompletelyFilledIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "42c58990-4dbe-485f-bbf6-7430cc878118");
     for (uint32_t i = 0U; i < MAX_NUMBER_OF_CONDITION_VARIABLES; ++i)
     {
         RuntimeName_t applicationName = {cxx::TruncateToCapacity, "AppName" + cxx::convert::toString(i)};
@@ -592,6 +633,7 @@ TEST_F(PortPool_test, GetConditionVariableDataListCompletelyFilledIsSuccessful)
 
 TEST_F(PortPool_test, RemoveConditionVariableDataIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7d876157-4d02-4374-ae16-fbff32ff683a");
     auto conditionVariableData = sut.addConditionVariableData(m_applicationName);
 
     sut.removeConditionVariableData(conditionVariableData.value());
@@ -602,6 +644,7 @@ TEST_F(PortPool_test, RemoveConditionVariableDataIsSuccessful)
 
 TEST_F(PortPool_test, GetServiceRegistryChangeCounterReturnsZeroAsInitialValue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5c028500-6589-4947-9e9c-68b691028244");
     auto serviceCounter = sut.serviceRegistryChangeCounter();
 
     EXPECT_EQ(serviceCounter->load(), 0U);
@@ -609,6 +652,7 @@ TEST_F(PortPool_test, GetServiceRegistryChangeCounterReturnsZeroAsInitialValue)
 
 TEST_F(PortPool_test, GetServiceRegistryChangeCounterIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "12c20e8b-f819-435c-b9c0-ca0acabacb8d");
     sut.serviceRegistryChangeCounter()->fetch_add(1, std::memory_order_relaxed);
     auto serviceCounter = sut.serviceRegistryChangeCounter();
 

--- a/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
@@ -65,6 +65,7 @@ class PosixShmMemoryProvider_Test : public Test
 
 TEST_F(PosixShmMemoryProvider_Test, CreateMemory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9808f2a5-4cd3-49fe-9a19-6e747183141d");
     PosixShmMemoryProvider sut(
         TEST_SHM_NAME, iox::posix::AccessMode::READ_WRITE, iox::posix::OpenMode::PURGE_AND_CREATE);
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());
@@ -82,6 +83,7 @@ TEST_F(PosixShmMemoryProvider_Test, CreateMemory)
 
 TEST_F(PosixShmMemoryProvider_Test, DestroyMemory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f864b99c-373d-4954-ac8b-61acc3c9c555");
     PosixShmMemoryProvider sut(
         TEST_SHM_NAME, iox::posix::AccessMode::READ_WRITE, iox::posix::OpenMode::PURGE_AND_CREATE);
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());
@@ -101,6 +103,7 @@ TEST_F(PosixShmMemoryProvider_Test, DestroyMemory)
 
 TEST_F(PosixShmMemoryProvider_Test, CreationFailedWithAlignmentExceedingPageSize)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6614de7e-0f4c-48ea-bd3c-dd500fa231f2");
     PosixShmMemoryProvider sut(
         TEST_SHM_NAME, iox::posix::AccessMode::READ_WRITE, iox::posix::OpenMode::PURGE_AND_CREATE);
     ASSERT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());

--- a/iceoryx_posh/test/moduletests/test_roudi_process.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process.cpp
@@ -57,36 +57,42 @@ class Process_test : public Test
 
 TEST_F(Process_test, getPid)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fbe9ea27-9e23-4ec7-bfe6-e2563d42c5e7");
     Process roudiproc(processname, pid, user, isMonitored, sessionId);
     EXPECT_THAT(roudiproc.getPid(), Eq(pid));
 }
 
 TEST_F(Process_test, getName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c2f3df1d-0aa9-480e-8c2e-dd76960a7717");
     Process roudiproc(processname, pid, user, isMonitored, sessionId);
     EXPECT_THAT(roudiproc.getName(), Eq(std::string(processname)));
 }
 
 TEST_F(Process_test, isMonitored)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d926282-c8f4-4b9c-a086-acc62e102c72");
     Process roudiproc(processname, pid, user, isMonitored, sessionId);
     EXPECT_THAT(roudiproc.isMonitored(), Eq(isMonitored));
 }
 
 TEST_F(Process_test, getSessionId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6986a49c-e23b-4cd6-ab63-269b32ff8d92");
     Process roudiproc(processname, pid, user, isMonitored, sessionId);
     EXPECT_THAT(roudiproc.getSessionId(), Eq(sessionId));
 }
 
 TEST_F(Process_test, sendViaIpcChannelPass)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "478cb320-7f4c-420c-a0d2-4a24e0db691c");
     iox::runtime::IpcMessage data{"MESSAGE_NOT_SUPPORTED"};
     EXPECT_CALL(ipcInterfaceUserMock, sendViaIpcChannel(_)).Times(1);
     ipcInterfaceUserMock.sendViaIpcChannel(data);
 }
 TEST_F(Process_test, sendViaIpcChannelFail)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c4d5c133-bf93-45a4-aa4f-9c3c2a50f91a");
     iox::runtime::IpcMessage data{""};
     iox::cxx::optional<iox::Error> sendViaIpcChannelStatusFail;
 
@@ -106,6 +112,7 @@ TEST_F(Process_test, sendViaIpcChannelFail)
 
 TEST_F(Process_test, TimeStamp)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5b527de2-699e-4d35-86ee-10ed28498e88");
     auto timestmp = iox::mepoo::BaseClock_t::now();
     Process roudiproc(processname, pid, user, isMonitored, sessionId);
     roudiproc.setTimestamp(timestmp);

--- a/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
@@ -86,6 +86,7 @@ class ProcessIntrospection_test : public Test
 
 TEST_F(ProcessIntrospection_test, CTOR)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "74c1c79f-3c99-406b-8ccf-9e85defbd71b");
     {
         ProcessIntrospectionAccess introspectionAccess;
         EXPECT_THAT(introspectionAccess.getPublisherPort().has_value(), Eq(false));
@@ -94,6 +95,7 @@ TEST_F(ProcessIntrospection_test, CTOR)
 
 TEST_F(ProcessIntrospection_test, registerPublisherPort)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fcacaa4a-7883-43d6-850f-04b78558e45b");
     {
         ProcessIntrospectionAccess introspectionAccess;
         introspectionAccess.registerPublisherPort(std::move(m_mockPublisherPortUserIntrospection));
@@ -103,6 +105,7 @@ TEST_F(ProcessIntrospection_test, registerPublisherPort)
 
 TEST_F(ProcessIntrospection_test, send)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7faf7880-c9be-4893-8f68-15cc77a4583c");
     {
         ProcessIntrospectionAccess introspectionAccess;
         introspectionAccess.registerPublisherPort(std::move(m_mockPublisherPortUserIntrospection));
@@ -116,6 +119,7 @@ TEST_F(ProcessIntrospection_test, send)
 
 TEST_F(ProcessIntrospection_test, addRemoveProcess)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "50d5090f-c89e-400f-b400-313df15d4193");
     {
         ProcessIntrospectionAccess introspectionAccess;
         introspectionAccess.registerPublisherPort(std::move(m_mockPublisherPortUserIntrospection));
@@ -152,6 +156,7 @@ TEST_F(ProcessIntrospection_test, addRemoveProcess)
 
 TEST_F(ProcessIntrospection_test, thread)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3b3419dd-cc3a-4011-bf63-e2a68ab8c20f");
     {
         const int PID = 42;
         const char PROCESS_NAME[] = "/chuck_norris";
@@ -196,6 +201,7 @@ TEST_F(ProcessIntrospection_test, thread)
 
 TEST_F(ProcessIntrospection_test, addRemoveNode)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "edae5283-400b-44c5-882c-60ad9bfb7957");
     {
         ProcessIntrospectionAccess introspectionAccess;
 

--- a/iceoryx_posh/test/moduletests/test_roudi_process_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_manager.cpp
@@ -71,6 +71,7 @@ class ProcessManager_test : public Test
 
 TEST_F(ProcessManager_test, RegisterProcessWithMonitorningWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "57311fb6-f993-4011-bbe9-e42df5e54d5e");
     auto result = m_sut->registerProcess(m_processname, m_pid, m_user, m_isMonitored, 1U, 1U, m_versionInfo);
 
     EXPECT_TRUE(result);
@@ -78,6 +79,7 @@ TEST_F(ProcessManager_test, RegisterProcessWithMonitorningWorks)
 
 TEST_F(ProcessManager_test, RegisterProcessWithoutMonitoringWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ce0fcf0e-564c-4330-86c8-13b33c2a64c8");
     constexpr bool isNotMonitored{false};
     auto result = m_sut->registerProcess(m_processname, m_pid, m_user, isNotMonitored, 1U, 1U, m_versionInfo);
 
@@ -86,6 +88,7 @@ TEST_F(ProcessManager_test, RegisterProcessWithoutMonitoringWorks)
 
 TEST_F(ProcessManager_test, RegisterSameProcessTwiceWithMonitoringWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d449513c-2f8f-4b77-b419-8d1b5743f02d");
     auto result1 = m_sut->registerProcess(m_processname, m_pid, m_user, m_isMonitored, 1U, 1U, m_versionInfo);
     auto result2 = m_sut->registerProcess(m_processname, m_pid, m_user, m_isMonitored, 1U, 1U, m_versionInfo);
 
@@ -95,6 +98,7 @@ TEST_F(ProcessManager_test, RegisterSameProcessTwiceWithMonitoringWorks)
 
 TEST_F(ProcessManager_test, RegisterSameProcessTwiceWithoutMonitoringWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "08d16887-72e5-4934-8447-a3b4760444e1");
     constexpr bool isNotMonitored{false};
     auto result1 = m_sut->registerProcess(m_processname, m_pid, m_user, isNotMonitored, 1U, 1U, m_versionInfo);
     auto result2 = m_sut->registerProcess(m_processname, m_pid, m_user, isNotMonitored, 1U, 1U, m_versionInfo);
@@ -105,6 +109,7 @@ TEST_F(ProcessManager_test, RegisterSameProcessTwiceWithoutMonitoringWorks)
 
 TEST_F(ProcessManager_test, UnregisterNonExistentProcessLeadsToError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "293cc3d1-727c-40ee-a298-3532a9e111a1");
     auto unregisterResult = m_sut->unregisterProcess(m_processname);
 
     EXPECT_FALSE(unregisterResult);
@@ -112,6 +117,7 @@ TEST_F(ProcessManager_test, UnregisterNonExistentProcessLeadsToError)
 
 TEST_F(ProcessManager_test, RegisterAndUnregisterWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "335f1487-38ab-4526-9a83-a4b496139c34");
     m_sut->registerProcess(m_processname, m_pid, m_user, m_isMonitored, 1U, 1U, m_versionInfo);
     auto unregisterResult = m_sut->unregisterProcess(m_processname);
 
@@ -120,6 +126,7 @@ TEST_F(ProcessManager_test, RegisterAndUnregisterWorks)
 
 TEST_F(ProcessManager_test, HandleProcessShutdownPreparationRequestWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "741669ec-111b-494b-b243-d28510b07782");
     m_sut->registerProcess(m_processname, m_pid, m_user, m_isMonitored, 1U, 1U, m_versionInfo);
 
     auto user = iox::posix::PosixUser::getUserOfCurrentProcess();

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -49,6 +49,7 @@ class ServiceRegistry_test : public Test
 
 TEST_F(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNothing)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3a050209-01d8-4d0e-9e70-c0662b9dbe76");
     sut.find(searchResults, Wildcard, Wildcard);
 
     EXPECT_THAT(searchResults.size(), Eq(0));
@@ -56,6 +57,7 @@ TEST_F(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNot
 
 TEST_F(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fa7d6416-4183-4942-a323-01f78c1bb6c1");
     iox::cxx::vector<ServiceDescription, ServiceRegistry::MAX_SERVICE_DESCRIPTIONS> services;
 
     for (uint64_t i = 0U; i < ServiceRegistry::MAX_SERVICE_DESCRIPTIONS; i++)
@@ -73,6 +75,7 @@ TEST_F(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 
 TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a911f654-8314-4ea3-b9b2-1afa121a2b21");
     iox::cxx::vector<ServiceDescription, ServiceRegistry::MAX_SERVICE_DESCRIPTIONS> services;
 
     for (uint64_t i = 0U; i < ServiceRegistry::MAX_SERVICE_DESCRIPTIONS; i++)
@@ -94,6 +97,7 @@ TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d8f61eb2-d082-4c26-9970-461427c3d200");
     auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result1.has_error());
 
@@ -109,6 +113,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturn
 
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6f8193ea-2d36-423f-a658-1dba30c1868d");
     auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result1.has_error());
 
@@ -126,18 +131,21 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsO
 
 TEST_F(ServiceRegistry_test, AddInvalidServiceDescriptionsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3cff55b0-d12f-48f5-8f0c-6501d0c2bf79");
     auto result = sut.add(ServiceDescription());
     ASSERT_FALSE(result.has_error());
 }
 
 TEST_F(ServiceRegistry_test, RemovingServiceDescriptionsWhichWasntAddedFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cf3e39f5-c29d-4b5f-8e01-af69681b2ea8");
     sut.remove(ServiceDescription("Sim", "Sa", "Lambim"));
     EXPECT_THAT(sut.getServices().size(), Eq(0));
 }
 
 TEST_F(ServiceRegistry_test, RemovingInvalidServiceDescriptionsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "523f2320-c0e5-4590-a1b0-604e756ecaa5");
     ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
     sut.remove(ServiceDescription());
     EXPECT_THAT(sut.getServices().size(), Eq(0));
@@ -145,6 +153,7 @@ TEST_F(ServiceRegistry_test, RemovingInvalidServiceDescriptionsWorks)
 
 TEST_F(ServiceRegistry_test, SingleInvalidServiceDescriptionsCanBeFoundWithWildcardSearch)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "be3e4b13-d930-47b2-aeaa-95c65f06deed");
     ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
     sut.find(searchResults, Wildcard, Wildcard);
 
@@ -154,6 +163,7 @@ TEST_F(ServiceRegistry_test, SingleInvalidServiceDescriptionsCanBeFoundWithWildc
 
 TEST_F(ServiceRegistry_test, SingleInvalidServiceDescriptionsCanBeFoundWithEmptyString)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1af0137f-6bf5-422e-a6ec-513f7d3f6191");
     ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
     sut.find(searchResults, "", "");
 
@@ -163,6 +173,7 @@ TEST_F(ServiceRegistry_test, SingleInvalidServiceDescriptionsCanBeFoundWithEmpty
 
 TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearch)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a12c9d39-6379-4296-8987-df56a87169f7");
     auto result = sut.add(ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_FALSE(result.has_error());
     sut.find(searchResults, Wildcard, Wildcard);
@@ -173,6 +184,7 @@ TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearc
 
 TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1dfaa836-f1da-466f-a794-a7ac1b599ce3");
     auto result = sut.add(ServiceDescription("Baz", "Bar", "Foo"));
     ASSERT_FALSE(result.has_error());
     sut.find(searchResults, Wildcard, "Bar");
@@ -183,6 +195,7 @@ TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
 
 TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0890013c-e14b-4ae2-89cb-757624c12b4e");
     iox::capro::ServiceDescription service1("a", "b", "c");
     ASSERT_FALSE(sut.add(service1).has_error());
     sut.find(searchResults, "a", Wildcard);
@@ -193,6 +206,7 @@ TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
 
 TEST_F(ServiceRegistry_test, ValidAndInvalidServiceDescriptionsCanAllBeFoundWithWildcardSearch)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4f34e604-5217-4e47-9c6f-26c5cbdcd3ec");
     ServiceDescription service1;
     ServiceDescription service2("alpha", "bravo", "charlie");
 
@@ -207,6 +221,7 @@ TEST_F(ServiceRegistry_test, ValidAndInvalidServiceDescriptionsCanAllBeFoundWith
 
 TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAllBeFound)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "251fe262-2e8f-4e32-a5f1-a4b1aaa812fd");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
@@ -237,6 +252,7 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAll
 
 TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceNameCanAllBeFound)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9b7a0897-46a7-457e-8746-0c3899e96653");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("c", "d", "d");
 
@@ -255,6 +271,7 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceNameC
 
 TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsSpecificService)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "557d6533-25a3-4c0c-adc0-e8ebb74785a0");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
@@ -270,6 +287,7 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsS
 
 TEST_F(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFindsCorrectServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "26187db1-299a-494c-bd85-eb646b8cf67b");
     iox::capro::ServiceDescription service1("a", "1", "moep");
     iox::capro::ServiceDescription service2("b", "2", "moep");
     iox::capro::ServiceDescription service3("c", "3", "moep");
@@ -292,6 +310,7 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFind
 
 TEST_F(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "183600f6-3d2d-4c0f-8c1d-d74acfb7fc50");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
@@ -306,6 +325,7 @@ TEST_F(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
 
 TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAndRemovingSpecificDoesNotFindSpecific)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b8230904-c14e-4e9f-a324-f92c67522271");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
@@ -323,6 +343,7 @@ TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAnd
 
 TEST_F(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegistry)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c5e67b1f-65f2-4973-9f76-73479dd1de9e");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("c", "d", "d");
@@ -340,6 +361,7 @@ TEST_F(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegis
 
 TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesNotFindAnything)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e7a7e160-813c-4daf-8c55-d0a85bb5f642");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
@@ -358,6 +380,7 @@ TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesN
 
 TEST_F(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNotReturnDuplicate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0348a73-4dbe-4464-b190-9274c2bd5031");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
@@ -56,6 +56,7 @@ class IpcInterfaceCreator_test : public Test
 
 TEST_F(IpcInterfaceCreator_test, CreateWithDifferentNameWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4fc22f1f-1333-41a1-8709-4b1ca791a2e1");
     IpcInterfaceCreator m_sut{goodName};
     IpcInterfaceCreator m_sut2{anotherGoodName};
     EXPECT_TRUE(m_sut.isInitialized());
@@ -64,6 +65,7 @@ TEST_F(IpcInterfaceCreator_test, CreateWithDifferentNameWorks)
 
 TEST_F(IpcInterfaceCreator_test, CreateWithSameNameLeadsToError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e8c15c8-1b7b-465b-aae5-6db24fc3c34a");
     IpcInterfaceCreator m_sut{goodName};
     EXPECT_DEATH({ IpcInterfaceCreator m_sut2{goodName}; }, ".*");
 }

--- a/iceoryx_posh/test/moduletests/test_version_info.cpp
+++ b/iceoryx_posh/test/moduletests/test_version_info.cpp
@@ -36,6 +36,7 @@ class VersionInfo_test : public Test
 
 TEST_F(VersionInfo_test, SerializationWorkingOnOurVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5d0ebc47-b5f8-4faa-bb32-9df50b071019");
     VersionInfo versionInfo1(VersionInfo::getCurrentVersion().operator iox::cxx::Serialization());
     EXPECT_TRUE(versionInfo1.isValid());
     EXPECT_TRUE(versionInfo1 == VersionInfo::getCurrentVersion());
@@ -43,6 +44,7 @@ TEST_F(VersionInfo_test, SerializationWorkingOnOurVersion)
 
 TEST_F(VersionInfo_test, ComparesWorkingForOurVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e9f5a81-a548-422b-aa87-5964ea720d77");
     VersionInfo versionInfo1(static_cast<iox::cxx::Serialization>(VersionInfo::getCurrentVersion()));
     VersionInfo versionInfo2(static_cast<iox::cxx::Serialization>(versionInfo1));
 
@@ -60,6 +62,7 @@ TEST_F(VersionInfo_test, ComparesWorkingForOurVersion)
 
 TEST_F(VersionInfo_test, CompareUnequalVersions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "539cd77f-e55b-4907-9a89-3f2941b9b435");
     const int versionInfosSize = 7;
     VersionInfo versionInfos[versionInfosSize] = {{11u, 22u, 33u, 44u, "abc", "efg"},
                                                   {0u, 22u, 33u, 44u, "abc", "efg"},
@@ -84,6 +87,7 @@ TEST_F(VersionInfo_test, CompareUnequalVersions)
 
 TEST_F(VersionInfo_test, ComparesVersionsSameVersionInfo)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2b716597-49a4-4dab-99a2-a9703c5871e0");
     VersionInfo versionInfo1(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfo2(1u, 2u, 3u, 4u, "a", "b");
 
@@ -97,6 +101,7 @@ TEST_F(VersionInfo_test, ComparesVersionsSameVersionInfo)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInMajorVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eaec3289-a869-4590-b28f-4716c79621d9");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalMajorVersion(0u, 2u, 3u, 4u, "a", "b");
 
@@ -112,6 +117,7 @@ TEST_F(VersionInfo_test, ComparesVersionsDifferInMajorVersion)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInMinorVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d8054eb9-d9ed-487d-939d-ab9ecf3be8ad");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalMinorVersion(1u, 0u, 3u, 4u, "a", "b");
 
@@ -127,6 +133,7 @@ TEST_F(VersionInfo_test, ComparesVersionsDifferInMinorVersion)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInPatchVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f335673c-c39b-4259-a5ed-e361ed31268d");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalPatchVersion(1u, 2u, 0u, 4u, "a", "b");
 
@@ -142,6 +149,7 @@ TEST_F(VersionInfo_test, ComparesVersionsDifferInPatchVersion)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInTweakVersion)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "678c72fa-35f5-43ab-9c00-24b1c38585a1");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalTweakVersion(1u, 2u, 3u, 0u, "a", "b");
 
@@ -157,6 +165,7 @@ TEST_F(VersionInfo_test, ComparesVersionsDifferInTweakVersion)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInCommitId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "92dcfcf1-8ba3-4d9f-a865-a18bc333aa4c");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalCommitId(1u, 2u, 3u, 4u, "a", "0");
 
@@ -170,6 +179,7 @@ TEST_F(VersionInfo_test, ComparesVersionsDifferInCommitId)
 
 TEST_F(VersionInfo_test, ComparesVersionsDifferInBuildDate)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53ae9050-59dc-4dfe-9c44-17ba1eb21d69");
     VersionInfo versionInfo(1u, 2u, 3u, 4u, "a", "b");
     VersionInfo versionInfoWithUnequalBuildDate(1u, 2u, 3u, 4u, "0", "b");
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
> Should be reviewed and merged after #1017 
* Add unique test IDs to iceoryx posh tests


## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #988 
