### PR TITLE
Add unique test id's to C binding tests

### DIFF
--- a/iceoryx_binding_c/test/moduletests/test_c2cpp_enum_translation.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_c2cpp_enum_translation.cpp
@@ -32,6 +32,7 @@ struct EnumMapping
 
 TEST(c2cpp_enum_translation_test, SubscriberState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7f942bb1-be58-4aff-b05c-2e78c4648be3");
     constexpr EnumMapping<iox::popo::SubscriberState, iox_SubscriberState> SUBSCRIBER_STATES[]{
         {iox::popo::SubscriberState::HAS_DATA, SubscriberState_HAS_DATA}};
 
@@ -68,6 +69,7 @@ TEST(c2cpp_enum_translation_test, SubscriberState)
 
 TEST(c2cpp_enum_translation_test, SubscriberEvent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eac05952-7bb1-4265-bd96-1c9c2b5f7327");
     constexpr EnumMapping<iox::popo::SubscriberEvent, iox_SubscriberEvent> SUBSCRIBER_EVENTS[]{
         {iox::popo::SubscriberEvent::DATA_RECEIVED, SubscriberEvent_DATA_RECEIVED}};
 

--- a/iceoryx_binding_c/test/moduletests/test_chunk.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_chunk.cpp
@@ -48,6 +48,7 @@ class Chunk_test : public RouDi_GTest
 
 TEST_F(Chunk_test, GettingChunkHeaderFromNonConstUserPayloadWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a044b28d-ad7e-45ed-a0e2-e431ef1eacf0");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     void* userPayload{nullptr};
     ASSERT_EQ(iox_pub_loan_chunk(publisher, &userPayload, USER_PAYLOAD_SIZE), AllocationResult_SUCCESS);
@@ -63,6 +64,7 @@ TEST_F(Chunk_test, GettingChunkHeaderFromNonConstUserPayloadWorks)
 
 TEST_F(Chunk_test, GettingChunkHeaderFromConstUserPayloadWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9f7bb07a-f0dd-4b58-af84-5daec365d9e2");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     void* userPayload{nullptr};
     ASSERT_EQ(iox_pub_loan_chunk(publisher, &userPayload, USER_PAYLOAD_SIZE), AllocationResult_SUCCESS);
@@ -79,6 +81,7 @@ TEST_F(Chunk_test, GettingChunkHeaderFromConstUserPayloadWorks)
 
 TEST_F(Chunk_test, UserPayloadChunkHeaderUserPayloadRoundtripWorksForNonConst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ea220aac-4d7d-41c2-92ea-7f929b824555");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     void* userPayload{nullptr};
     ASSERT_EQ(iox_pub_loan_chunk(publisher, &userPayload, USER_PAYLOAD_SIZE), AllocationResult_SUCCESS);
@@ -92,6 +95,7 @@ TEST_F(Chunk_test, UserPayloadChunkHeaderUserPayloadRoundtripWorksForNonConst)
 
 TEST_F(Chunk_test, UserPayloadChunkHeaderUserPayloadRoundtripWorksForConst)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e094616d-6d99-4b7f-a619-dd98ec7d1e44");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     void* userPayload{nullptr};
     ASSERT_EQ(iox_pub_loan_chunk(publisher, &userPayload, USER_PAYLOAD_SIZE), AllocationResult_SUCCESS);
@@ -104,6 +108,7 @@ TEST_F(Chunk_test, UserPayloadChunkHeaderUserPayloadRoundtripWorksForConst)
 
 TEST_F(Chunk_test, GettingUserHeaderFromNonConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0df7284-a377-4c6a-b22b-454d3f7c7b88");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT(64U);
     constexpr uint32_t USER_HEADER_SIZE = 16U;
@@ -129,6 +134,7 @@ TEST_F(Chunk_test, GettingUserHeaderFromNonConstChunkHeaderWorks)
 
 TEST_F(Chunk_test, GettingUserHeaderFromConstChunkHeaderWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "77f4a193-7f44-43ce-8bd8-f9916b8d83dd");
     constexpr uint32_t USER_PAYLOAD_SIZE(42U);
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT(64U);
     constexpr uint32_t USER_HEADER_SIZE = 16U;

--- a/iceoryx_binding_c/test/moduletests/test_config.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_config.cpp
@@ -28,6 +28,7 @@ using namespace iox;
 
 TEST(iox_cfg, valuesAreCorrectlyConnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d62b1b3c-60c6-461b-8ca4-80c850fa65a0");
     EXPECT_EQ(iox_cfg_max_publishers(), iox::MAX_PUBLISHERS);
     EXPECT_EQ(iox_cfg_max_subscribers_per_publisher(), iox::MAX_SUBSCRIBERS_PER_PUBLISHER);
     EXPECT_EQ(iox_cfg_max_chunks_allocated_per_publisher_simultaneously(),

--- a/iceoryx_binding_c/test/moduletests/test_cpp2c_enum_translation.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_cpp2c_enum_translation.cpp
@@ -33,6 +33,7 @@ struct EnumMapping
 
 TEST(cpp2c_enum_translation_test, SubscribeStateCorrectAndFullTranslation)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "47d1e613-b9cf-492f-af0a-7da9d46399ba");
     constexpr EnumMapping<iox::SubscribeState, iox_SubscribeState> SUBSCRIBE_STATES[]{
         {iox::SubscribeState::NOT_SUBSCRIBED, SubscribeState_NOT_SUBSCRIBED},
         {iox::SubscribeState::SUBSCRIBE_REQUESTED, SubscribeState_SUBSCRIBE_REQUESTED},
@@ -73,6 +74,7 @@ TEST(cpp2c_enum_translation_test, SubscribeStateCorrectAndFullTranslation)
 
 TEST(cpp2c_enum_translation_test, ChunkReceiveResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "873adad3-9eb4-496f-9ecc-a941e225d0cb");
     constexpr EnumMapping<iox::popo::ChunkReceiveResult, iox_ChunkReceiveResult> CHUNK_RECEIVE_RESULTS[]{
         {iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE, ChunkReceiveResult_NO_CHUNK_AVAILABLE},
         {iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL,
@@ -103,6 +105,7 @@ TEST(cpp2c_enum_translation_test, ChunkReceiveResult)
 
 TEST(cpp2c_enum_translation_test, AllocationResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "43296599-2b53-4b9d-8e37-2911bbd1b397");
     constexpr EnumMapping<iox::popo::AllocationError, iox_AllocationResult> ALLOCATION_ERRORS[]{
         {iox::popo::AllocationError::UNDEFINED_ERROR, AllocationResult_UNDEFINED_ERROR},
         {iox::popo::AllocationError::NO_MEMPOOLS_AVAILABLE, AllocationResult_NO_MEMPOOLS_AVAILABLE},
@@ -145,6 +148,7 @@ TEST(cpp2c_enum_translation_test, AllocationResult)
 
 TEST(cpp2c_enum_translation_test, WaitSetResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0b2fbd01-38b4-414d-be21-70d00d2d8fbf");
     constexpr EnumMapping<iox::popo::WaitSetError, iox_WaitSetResult> WAIT_SET_ERRORS[]{
         {iox::popo::WaitSetError::WAIT_SET_FULL, WaitSetResult_WAIT_SET_FULL},
         {iox::popo::WaitSetError::ALREADY_ATTACHED, WaitSetResult_ALREADY_ATTACHED}};
@@ -173,6 +177,7 @@ TEST(cpp2c_enum_translation_test, WaitSetResult)
 
 TEST(cpp2c_enum_translation_test, ListenerResult)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2e46311d-4579-4437-adf7-0f5c3adcd511");
     constexpr EnumMapping<iox::popo::ListenerError, iox_ListenerResult> LISTENER_ERRORS[]{
         {iox::popo::ListenerError::LISTENER_FULL, ListenerResult_LISTENER_FULL},
         {iox::popo::ListenerError::EVENT_ALREADY_ATTACHED, ListenerResult_EVENT_ALREADY_ATTACHED},
@@ -209,6 +214,7 @@ TEST(cpp2c_enum_translation_test, ListenerResult)
 
 TEST(cpp2c_enum_translation_test, SubscriberTooSlowPolicy)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "aad706c2-5216-4835-b29f-8a89829d7238");
     EXPECT_EQ(cpp2c::subscriberTooSlowPolicy(iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER),
               SubscriberTooSlowPolicy_WAIT_FOR_SUBSCRIBER);
     EXPECT_EQ(cpp2c::subscriberTooSlowPolicy(iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA),
@@ -223,6 +229,7 @@ TEST(cpp2c_enum_translation_test, SubscriberTooSlowPolicy)
 
 TEST(cpp2c_enum_translation_test, QueueFullPolicy)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "067a164b-b143-47c7-8bab-962dbe519726");
     EXPECT_EQ(cpp2c::queueFullPolicy(iox::popo::QueueFullPolicy::BLOCK_PUBLISHER), QueueFullPolicy_BLOCK_PUBLISHER);
     EXPECT_EQ(cpp2c::queueFullPolicy(iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA),
               QueueFullPolicy_DISCARD_OLDEST_DATA);

--- a/iceoryx_binding_c/test/moduletests/test_cpp2c_service_description_translation.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_cpp2c_service_description_translation.cpp
@@ -26,6 +26,7 @@ using namespace iox::capro;
 
 TEST(iox_service_description_translation_test, TranslatesStringCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0f3c056e-0f3c-4266-85dd-6d9021616c16");
     iox::capro::ServiceDescription service(
         IdString_t("SomeService"), IdString_t("FunkyInstance"), IdString_t("BumbleBeeSighted"));
     auto cServiceDescription = TranslateServiceDescription(service);

--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -172,21 +172,25 @@ constexpr std::chrono::milliseconds iox_listener_test::TIMEOUT;
 
 TEST_F(iox_listener_test, InitListenerWithNullptrForStorageReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ee5f8898-c178-4546-9bb4-6e3329f1b632");
     EXPECT_EQ(iox_listener_init(nullptr), nullptr);
 }
 
 TEST_F(iox_listener_test, CapacityIsCorrect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0fa5465e-f757-4b04-abc2-ca6f346d66ec");
     EXPECT_THAT(iox_listener_capacity(&m_sut), Eq(MAX_NUMBER_OF_EVENTS_PER_LISTENER));
 }
 
 TEST_F(iox_listener_test, SizeIsZeroWhenCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ab82bb49-476d-4edc-8d39-25656b1e5ca8");
     EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
 }
 
 TEST_F(iox_listener_test, SizeIsOneWhenOneClassIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6b5a685d-eb8b-4efa-9e4b-6bc764c156b9");
     EXPECT_THAT(iox_listener_attach_user_trigger_event(&m_sut, m_userTrigger[0U], &userTriggerCallback),
                 Eq(iox_ListenerResult::ListenerResult_SUCCESS));
     EXPECT_THAT(iox_listener_size(&m_sut), Eq(1U));
@@ -194,12 +198,14 @@ TEST_F(iox_listener_test, SizeIsOneWhenOneClassIsAttached)
 
 TEST_F(iox_listener_test, SizeEqualsCapacityWhenMaximumIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1d1c1fa4-1e47-4b96-99d1-5766ef068a74");
     AttachAllUserTrigger();
     EXPECT_THAT(iox_listener_size(&m_sut), Eq(iox_listener_capacity(&m_sut)));
 }
 
 TEST_F(iox_listener_test, SizeDecreasesWhenUserTriggersAreDetached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "907f0ea4-6ad9-4744-8f38-b1619fa62cfc");
     AttachAllUserTrigger();
 
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_EVENTS_PER_LISTENER; ++i)
@@ -211,6 +217,7 @@ TEST_F(iox_listener_test, SizeDecreasesWhenUserTriggersAreDetached)
 
 TEST_F(iox_listener_test, FullListenerReturnsLISTENER_FULLWhenAnotherUserTriggerIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9392e16c-52e9-4754-b332-12da0022b346");
     AttachAllUserTrigger();
 
     EXPECT_THAT(iox_listener_attach_user_trigger_event(
@@ -220,6 +227,7 @@ TEST_F(iox_listener_test, FullListenerReturnsLISTENER_FULLWhenAnotherUserTrigger
 
 TEST_F(iox_listener_test, AttachingTheSameUserTriggerTwiceLeadsToEVENT_ALREADY_ATTACHED)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f3e25bef-7f69-4cdc-a70c-98f24bccb177");
     EXPECT_THAT(iox_listener_attach_user_trigger_event(&m_sut, m_userTrigger[0U], &userTriggerCallback),
                 Eq(iox_ListenerResult::ListenerResult_SUCCESS));
     EXPECT_THAT(iox_listener_attach_user_trigger_event(&m_sut, m_userTrigger[0U], &userTriggerCallback),
@@ -228,6 +236,7 @@ TEST_F(iox_listener_test, AttachingTheSameUserTriggerTwiceLeadsToEVENT_ALREADY_A
 
 TEST_F(iox_listener_test, AttachingSubscriberEventWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3863617a-8483-4f38-afd4-25436158bc45");
     EXPECT_THAT(iox_listener_attach_subscriber_event(
                     &m_sut, &m_subscriber[0U], iox_SubscriberEvent::SubscriberEvent_DATA_RECEIVED, &subscriberCallback),
                 Eq(iox_ListenerResult::ListenerResult_SUCCESS));
@@ -235,6 +244,7 @@ TEST_F(iox_listener_test, AttachingSubscriberEventWorks)
 
 TEST_F(iox_listener_test, AttachingSubscriberEventWithNullptrCallbackFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "db39c3ef-1518-4769-942e-642d0f58abdb");
     EXPECT_THAT(iox_listener_attach_subscriber_event(
                     &m_sut, &m_subscriber[0U], iox_SubscriberEvent::SubscriberEvent_DATA_RECEIVED, NULL),
                 Eq(iox_ListenerResult::ListenerResult_EMPTY_EVENT_CALLBACK));
@@ -242,17 +252,20 @@ TEST_F(iox_listener_test, AttachingSubscriberEventWithNullptrCallbackFails)
 
 TEST_F(iox_listener_test, AttachingUserTriggerEventWithNullptrCallbackFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "990e8f3c-36f0-4687-8246-ce8a02f969ae");
     EXPECT_THAT(iox_listener_attach_user_trigger_event(&m_sut, m_userTrigger[0U], NULL),
                 Eq(iox_ListenerResult::ListenerResult_EMPTY_EVENT_CALLBACK));
 }
 
 TEST_F(iox_listener_test, AttachingSubscriberTillListenerFullWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "11636d73-8850-416e-ac84-357d8bf73477");
     AttachAllSubscriber();
 }
 
 TEST_F(iox_listener_test, FullListenerReturnsLISTENER_FULLWhenAnotherSubscriberIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ec1d34c1-d5bb-4648-845b-4a89e5ef2c74");
     AttachAllSubscriber();
     EXPECT_THAT(iox_listener_attach_subscriber_event(&m_sut,
                                                      &m_subscriber[MAX_NUMBER_OF_EVENTS_PER_LISTENER],
@@ -263,6 +276,7 @@ TEST_F(iox_listener_test, FullListenerReturnsLISTENER_FULLWhenAnotherSubscriberI
 
 TEST_F(iox_listener_test, DetachingSubscriberTillListenerEmptyWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "af90d50f-1b01-46e5-8a82-3c8a5e1d00e8");
     AttachAllSubscriber();
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_EVENTS_PER_LISTENER; ++i)
     {
@@ -274,6 +288,7 @@ TEST_F(iox_listener_test, DetachingSubscriberTillListenerEmptyWorks)
 
 TEST_F(iox_listener_test, AttachingSubscriberEventTwiceFailsWithEVENT_ALREADY_ATTACHED)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6d84fd37-b170-4028-99f2-848f41de0b35");
     EXPECT_THAT(iox_listener_attach_subscriber_event(
                     &m_sut, &m_subscriber[0U], iox_SubscriberEvent::SubscriberEvent_DATA_RECEIVED, &subscriberCallback),
                 Eq(iox_ListenerResult::ListenerResult_SUCCESS));

--- a/iceoryx_binding_c/test/moduletests/test_log.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_log.cpp
@@ -29,6 +29,7 @@ using namespace iox::log;
 
 TEST(iox_log_test, LogLevelIsSetCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cbfc1b9d-d770-441c-b53d-11b1685ca0b4");
     auto& logManager = iox::log::LogManager::GetLogManager();
 
     iox_set_loglevel(Iceoryx_LogLevel_Off);

--- a/iceoryx_binding_c/test/moduletests/test_node.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_node.cpp
@@ -49,6 +49,7 @@ class iox_node_test : public RouDi_GTest
 
 TEST_F(iox_node_test, createdNodeHasCorrectNodeName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e104fa1c-675f-4488-b19b-09063da8ed73");
     char name[100];
     ASSERT_EQ(iox_node_get_name(m_sut, name, 100), m_nodeName.size());
     EXPECT_EQ(std::string(name), m_nodeName);
@@ -56,6 +57,7 @@ TEST_F(iox_node_test, createdNodeHasCorrectNodeName)
 
 TEST_F(iox_node_test, getNodeNameBufferIsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b35feed7-15e4-4b0b-a87e-8df8b8453c4b");
     auto nameLength = iox_node_get_name(m_sut, nullptr, 100);
 
     ASSERT_THAT(nameLength, Eq(0U));
@@ -63,6 +65,7 @@ TEST_F(iox_node_test, getNodeNameBufferIsNullptr)
 
 TEST_F(iox_node_test, getNodeNameBufferIsLessThanNodeNameLength)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "19dd16d9-b1ee-4275-9df7-4027dd469645");
     constexpr uint64_t NODE_NAME_BUFFER_LENGTH{10};
     char truncatedNodeName[NODE_NAME_BUFFER_LENGTH];
     for (auto& c : truncatedNodeName)
@@ -79,6 +82,7 @@ TEST_F(iox_node_test, getNodeNameBufferIsLessThanNodeNameLength)
 
 TEST_F(iox_node_test, createdNodeHasCorrectProcessName)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ae0d1b9e-38b1-4b50-bf36-770ee32cf518");
     char name[100];
     ASSERT_EQ(iox_node_get_runtime_name(m_sut, name, 100), m_runtimeName.size());
     EXPECT_EQ(std::string(name), m_runtimeName);
@@ -86,6 +90,7 @@ TEST_F(iox_node_test, createdNodeHasCorrectProcessName)
 
 TEST_F(iox_node_test, getNodeRuntimeNameBufferIsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a684e40b-4ac9-4f79-945f-e94aee778e82");
     auto nameLength = iox_node_get_runtime_name(m_sut, nullptr, 100);
 
     ASSERT_THAT(nameLength, Eq(0U));
@@ -93,6 +98,7 @@ TEST_F(iox_node_test, getNodeRuntimeNameBufferIsNullptr)
 
 TEST_F(iox_node_test, getNodeRuntimeNameBufferIsLessThanNodeProcessNameLength)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e9ef5e9c-353f-4c7d-8a30-13a277e1adcd");
     constexpr uint64_t PROCESS_NAME_BUFFER_LENGTH{9};
     char truncatedProcessName[PROCESS_NAME_BUFFER_LENGTH];
     for (auto& c : truncatedProcessName)

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -119,6 +119,7 @@ UserTrigger* iox_notification_info_test::m_lastNotificationCallbackArgument = nu
 
 TEST_F(iox_notification_info_test, notificationInfoHasCorrectId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "72799415-e149-42ee-84c9-3764f59e342e");
     constexpr uint64_t ARBITRARY_EVENT_ID = 123U;
     ASSERT_FALSE(m_waitSet.attachEvent(m_userTrigger, ARBITRARY_EVENT_ID).has_error());
     m_userTrigger.trigger();
@@ -131,6 +132,7 @@ TEST_F(iox_notification_info_test, notificationInfoHasCorrectId)
 
 TEST_F(iox_notification_info_test, notificationOriginIsUserTriggerPointerWhenItsOriginatingFromThem)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e11b79d7-94f4-43e4-91c1-5364bd5e8834");
     constexpr uint64_t ARBITRARY_EVENT_ID = 124U;
     ASSERT_FALSE(m_waitSet.attachEvent(m_userTrigger, ARBITRARY_EVENT_ID).has_error());
     m_userTrigger.trigger();
@@ -143,6 +145,7 @@ TEST_F(iox_notification_info_test, notificationOriginIsUserTriggerPointerWhenIts
 
 TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsOriginatingFromThemStateBased)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "942d1187-86ac-4bc6-8378-5c70e7efaa1d");
     iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
@@ -155,6 +158,7 @@ TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsO
 
 TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsOriginatingFromThemEventBased)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "afbf8b47-4a8d-4bd8-bb5a-c4ee22c89c4d");
     iox_ws_attach_subscriber_event(
         &m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
@@ -168,6 +172,7 @@ TEST_F(iox_notification_info_test, notificationOriginIsSubscriberPointerWhenItsO
 
 TEST_F(iox_notification_info_test, getOriginReturnsPointerToUserTriggerWhenOriginatingFromThem)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1c70e972-0a75-4c22-a14e-b943dd529f23");
     constexpr uint64_t ARBITRARY_EVENT_ID = 89121U;
     ASSERT_FALSE(m_waitSet.attachEvent(m_userTrigger, ARBITRARY_EVENT_ID).has_error());
     m_userTrigger.trigger();
@@ -180,6 +185,7 @@ TEST_F(iox_notification_info_test, getOriginReturnsPointerToUserTriggerWhenOrigi
 
 TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOriginatingFromThemStateBased)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4b83b81b-8b64-4775-a720-456dfc7430ca");
     iox_ws_attach_subscriber_state(&m_waitSet, m_subscriberHandle, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
@@ -192,6 +198,7 @@ TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOrigin
 
 TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOriginatingFromThemEventBased)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bd27cf8b-48de-46cb-a365-f877802f23c9");
     iox_ws_attach_subscriber_event(
         &m_waitSet, m_subscriberHandle, SubscriberEvent_DATA_RECEIVED, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
@@ -205,6 +212,7 @@ TEST_F(iox_notification_info_test, getOriginReturnsPointerToSubscriberWhenOrigin
 
 TEST_F(iox_notification_info_test, callbackCanBeCalledOnce)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "44fee15b-f48f-4168-8fb1-2437f1d233d8");
     constexpr uint64_t ARBITRARY_EVENT_ID = 80U;
     ASSERT_FALSE(m_waitSet
                      .attachEvent(m_userTrigger,
@@ -221,6 +229,7 @@ TEST_F(iox_notification_info_test, callbackCanBeCalledOnce)
 
 TEST_F(iox_notification_info_test, callbackCanBeCalledMultipleTimes)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2be7bad5-9edc-46f2-8086-535ca73e8ad4");
     constexpr uint64_t ARBITRARY_EVENT_ID = 180U;
     ASSERT_FALSE(m_waitSet
                      .attachEvent(m_userTrigger,

--- a/iceoryx_binding_c/test/moduletests/test_publisher.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_publisher.cpp
@@ -126,6 +126,7 @@ class iox_pub_test : public Test
 
 TEST_F(iox_pub_test, initPublisherWithNullptrForStorageReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8ac8921a-957a-4bd4-8943-7294defc78d3");
     iox_pub_options_t options;
     iox_pub_options_init(&options);
 
@@ -135,6 +136,7 @@ TEST_F(iox_pub_test, initPublisherWithNullptrForStorageReturnsNullptr)
 // this crashes if the fixture is used, therefore a test without a fixture
 TEST(iox_pub_test_DeathTest, initPublisherWithNotInitializedPublisherOptionsTerminates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c8768fd8-e02c-4f87-99a0-32a2c36af4b1");
     iox_pub_options_t options;
     iox_pub_storage_t storage;
 
@@ -143,6 +145,7 @@ TEST(iox_pub_test_DeathTest, initPublisherWithNotInitializedPublisherOptionsTerm
 
 TEST_F(iox_pub_test, initPublisherWithDefaultOptionsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d2e677cd-2fcc-47a2-80e6-2d08245b7c1a");
     iox::roudi::RouDiEnvironment roudiEnv;
 
     iox_runtime_init("hypnotoad");
@@ -156,6 +159,7 @@ TEST_F(iox_pub_test, initPublisherWithDefaultOptionsWorks)
 
 TEST_F(iox_pub_test, initialStateOfIsOfferedIsAsExpected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fa757a54-a8df-420e-b32d-a9d5724a7d20");
     PublisherOptions iGotOptions;
     auto expectedIsOffered = iGotOptions.offerOnCreate;
     EXPECT_EQ(expectedIsOffered, iox_pub_is_offered(&m_sut));
@@ -163,12 +167,14 @@ TEST_F(iox_pub_test, initialStateOfIsOfferedIsAsExpected)
 
 TEST_F(iox_pub_test, is_offeredAfterOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "719c76be-e6b5-48a7-bd87-a7daea702983");
     iox_pub_offer(&m_sut);
     EXPECT_TRUE(iox_pub_is_offered(&m_sut));
 }
 
 TEST_F(iox_pub_test, isNotOfferedAfterStopOffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0da3afd6-a8f5-489d-b44a-83c89a626e82");
     iox_pub_offer(&m_sut);
     iox_pub_stop_offer(&m_sut);
     EXPECT_FALSE(iox_pub_is_offered(&m_sut));
@@ -176,11 +182,13 @@ TEST_F(iox_pub_test, isNotOfferedAfterStopOffer)
 
 TEST_F(iox_pub_test, initialStateIsNoSubscribers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1cd0f66b-cab8-4b2f-8e53-679b415dc745");
     EXPECT_FALSE(iox_pub_has_subscribers(&m_sut));
 }
 
 TEST_F(iox_pub_test, has_subscribersAfterSubscription)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b970de58-c253-4e07-a6a0-61df061e8173");
     iox_pub_offer(&m_sut);
     this->Subscribe(&m_publisherPortData);
     EXPECT_TRUE(iox_pub_has_subscribers(&m_sut));
@@ -188,6 +196,7 @@ TEST_F(iox_pub_test, has_subscribersAfterSubscription)
 
 TEST_F(iox_pub_test, noSubscribersAfterUnsubscribe)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d3de1ea2-64ed-48b6-bc1c-967e010fee32");
     iox_pub_offer(&m_sut);
     this->Subscribe(&m_publisherPortData);
     this->Unsubscribe(&m_publisherPortData);
@@ -196,12 +205,14 @@ TEST_F(iox_pub_test, noSubscribersAfterUnsubscribe)
 
 TEST_F(iox_pub_test, allocateChunkForOneChunkIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4a8f2275-f153-469e-8699-f36a136608a1");
     void* chunk = nullptr;
     EXPECT_EQ(AllocationResult_SUCCESS, iox_pub_loan_chunk(&m_sut, &chunk, sizeof(DummySample)));
 }
 
 TEST_F(iox_pub_test, allocateChunkUserPayloadAlignmentIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c6e7e2ea-fa76-43e7-b217-5bfc4b94837c");
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     void* chunk = nullptr;
     ASSERT_EQ(AllocationResult_SUCCESS,
@@ -212,6 +223,7 @@ TEST_F(iox_pub_test, allocateChunkUserPayloadAlignmentIsSuccessful)
 
 TEST_F(iox_pub_test, allocateChunkWithUserHeaderIsSuccessful)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53c07218-2ac9-4e2b-8ca3-7df856cd1cc5");
     constexpr uint32_t USER_HEADER_SIZE = 4U;
     constexpr uint32_t USER_HEADER_ALIGNMENT = 2U;
 
@@ -228,6 +240,7 @@ TEST_F(iox_pub_test, allocateChunkWithUserHeaderIsSuccessful)
 
 TEST_F(iox_pub_test, allocateChunkWithUserHeaderAndUserPayloadAlignmentFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a2bcb0d4-b207-436f-9909-9e67815f525a");
     constexpr uint32_t USER_PAYLOAD_ALIGNMENT{128U};
     constexpr uint32_t USER_HEADER_SIZE = 4U;
     constexpr uint32_t USER_HEADER_ALIGNMENT = 3U;
@@ -241,6 +254,7 @@ TEST_F(iox_pub_test, allocateChunkWithUserHeaderAndUserPayloadAlignmentFails)
 
 TEST_F(iox_pub_test, chunkHeaderCanBeObtainedFromChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a4b620af-4ec8-4638-b81b-6759ed048d36");
     void* chunk = nullptr;
     ASSERT_EQ(AllocationResult_SUCCESS, iox_pub_loan_chunk(&m_sut, &chunk, sizeof(DummySample)));
     auto chunkHeader = iox_chunk_header_from_user_payload(chunk);
@@ -249,6 +263,7 @@ TEST_F(iox_pub_test, chunkHeaderCanBeObtainedFromChunk)
 
 TEST_F(iox_pub_test, chunkHeaderCanBeConvertedBackToUserPayload)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "01dbfd4c-7345-4291-aa2c-2404f15c4bda");
     void* chunk = nullptr;
     ASSERT_EQ(AllocationResult_SUCCESS, iox_pub_loan_chunk(&m_sut, &chunk, sizeof(DummySample)));
     auto chunkHeader = iox_chunk_header_from_user_payload(chunk);
@@ -258,6 +273,7 @@ TEST_F(iox_pub_test, chunkHeaderCanBeConvertedBackToUserPayload)
 
 TEST_F(iox_pub_test, allocate_chunkFailsWhenHoldingToManyChunksInParallel)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "77271a1c-242d-438b-8f52-e4819fdf1033");
     void* chunk = nullptr;
     for (uint32_t i = 0U; i < iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY; ++i)
     {
@@ -269,6 +285,7 @@ TEST_F(iox_pub_test, allocate_chunkFailsWhenHoldingToManyChunksInParallel)
 
 TEST_F(iox_pub_test, allocate_chunkFailsWhenOutOfChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7563ed4c-a6d5-487d-9c6c-937d8e8c3d1d");
     constexpr uint32_t USER_PAYLOAD_SIZE{100U};
 
     auto chunkSettingsResult = ChunkSettings::create(USER_PAYLOAD_SIZE, iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
@@ -288,6 +305,7 @@ TEST_F(iox_pub_test, allocate_chunkFailsWhenOutOfChunks)
 
 TEST_F(iox_pub_test, allocatingChunkAcquiresMemory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a779236-0302-48b5-add7-0a2c33a9d86b");
     void* chunk = nullptr;
     iox_pub_loan_chunk(&m_sut, &chunk, 100);
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks, Eq(1u));
@@ -295,6 +313,7 @@ TEST_F(iox_pub_test, allocatingChunkAcquiresMemory)
 
 TEST_F(iox_pub_test, freeingAnAllocatedChunkReleasesTheMemory)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8d3901bc-28a1-4a6d-9d81-d3a456e1f806");
     void* chunk = nullptr;
     iox_pub_loan_chunk(&m_sut, &chunk, 100);
     iox_pub_release_chunk(&m_sut, chunk);
@@ -303,6 +322,7 @@ TEST_F(iox_pub_test, freeingAnAllocatedChunkReleasesTheMemory)
 
 TEST_F(iox_pub_test, sendDeliversChunk)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "187d552a-6903-40cd-88a0-7722eb2a40a8");
     void* chunk = nullptr;
     iox_pub_offer(&m_sut);
     this->Subscribe(&m_publisherPortData);
@@ -320,6 +340,7 @@ TEST_F(iox_pub_test, sendDeliversChunk)
 
 TEST_F(iox_pub_test, correctServiceDescriptionReturned)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4f91cb12-fbfa-4bad-ad59-ab2579f83fbe");
     auto serviceDescription = iox_pub_get_service_description(&m_sut);
 
     EXPECT_THAT(std::string(serviceDescription.serviceString), Eq("a"));
@@ -329,6 +350,7 @@ TEST_F(iox_pub_test, correctServiceDescriptionReturned)
 
 TEST(iox_pub_options_test, publisherOptionsAreInitializedCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dfc9e8b7-efb8-4fe6-a5a3-ebd9c2ad45ac");
     iox_pub_options_t sut;
     sut.historyCapacity = 37;
     sut.nodeName = "Dr.Gonzo";
@@ -349,6 +371,7 @@ TEST(iox_pub_options_test, publisherOptionsAreInitializedCorrectly)
 
 TEST(iox_pub_options_test, publisherOptionsInitializationCheckReturnsTrueAfterDefaultInit)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e95c8f2b-c15a-4fb5-9de8-719b2c61a926");
     iox_pub_options_t sut;
     iox_pub_options_init(&sut);
     EXPECT_TRUE(iox_pub_options_is_initialized(&sut));
@@ -356,6 +379,7 @@ TEST(iox_pub_options_test, publisherOptionsInitializationCheckReturnsTrueAfterDe
 
 TEST(iox_pub_options_test, publisherOptionsInitializationCheckReturnsFalseWithoutDefaultInit)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f3c7c69e-6946-4da4-9c9e-93129cae9d61");
     iox_pub_options_t sut;
 #if (defined(__GNUC__) && __GNUC__ >= 7 && !defined(__clang__))
 #pragma GCC diagnostic push
@@ -369,6 +393,7 @@ TEST(iox_pub_options_test, publisherOptionsInitializationCheckReturnsFalseWithou
 
 TEST(iox_pub_options_test, publisherOptionInitializationWithNullptrDoesNotCrash)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe415d38-eaaf-466e-b7d8-d220612cb344");
     EXPECT_EXIT(
         {
             iox_pub_options_init(nullptr);

--- a/iceoryx_binding_c/test/moduletests/test_runtime.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_runtime.cpp
@@ -40,6 +40,7 @@ class BindingC_Runtime_test : public RouDi_GTest
 
 TEST_F(BindingC_Runtime_test, SuccessfulRegistration)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "335dc136-b2de-4db9-bdfc-db034012be7c");
     constexpr char EXPECTED_RUNTIME_NAME[iox::MAX_RUNTIME_NAME_LENGTH + 1] = "chucky";
     iox_runtime_init(EXPECTED_RUNTIME_NAME);
 
@@ -52,6 +53,7 @@ TEST_F(BindingC_Runtime_test, SuccessfulRegistration)
 
 TEST_F(BindingC_Runtime_test, RuntimeNameLengthIsMax)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "854a471d-936e-4c98-b56e-ba8a7d83460e");
     std::string maxName(iox::MAX_RUNTIME_NAME_LENGTH, 's');
 
     iox_runtime_init(maxName.c_str());
@@ -64,6 +66,7 @@ TEST_F(BindingC_Runtime_test, RuntimeNameLengthIsMax)
 
 TEST_F(BindingC_Runtime_test, RuntimeNameLengthIsOutOfLimit)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8fd6735d-f331-4c9c-9a91-3f06d3856d15");
     std::string tooLongName(iox::MAX_RUNTIME_NAME_LENGTH + 1, 's');
 
     EXPECT_DEATH({ iox_runtime_init(tooLongName.c_str()); }, "Runtime name has more than 100 characters!");
@@ -71,11 +74,13 @@ TEST_F(BindingC_Runtime_test, RuntimeNameLengthIsOutOfLimit)
 
 TEST_F(BindingC_Runtime_test, RuntimeNameIsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "eb1b76c9-5420-42a9-88b3-db2e36e332de");
     EXPECT_DEATH({ iox_runtime_init(nullptr); }, "Runtime name is a nullptr!");
 }
 
 TEST_F(BindingC_Runtime_test, GetInstanceNameIsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84ebe40f-fcc8-4143-8330-b5178d4569a1");
     constexpr char EXPECTED_RUNTIME_NAME[iox::MAX_RUNTIME_NAME_LENGTH + 1] = "chucky";
     iox_runtime_init(EXPECTED_RUNTIME_NAME);
 
@@ -87,6 +92,7 @@ TEST_F(BindingC_Runtime_test, GetInstanceNameIsNullptr)
 
 TEST_F(BindingC_Runtime_test, GetInstanceNameLengthIsLessThanRuntimeNameLength)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "82d0e0e8-ae68-43d1-b684-dea9e7cf3582");
     constexpr char ACTUAL_RUNTIME_NAME[iox::MAX_RUNTIME_NAME_LENGTH + 1] = "chucky";
     constexpr char EXPECTED_RUNTIME_NAME[iox::MAX_RUNTIME_NAME_LENGTH + 1] = "chuck";
     iox_runtime_init(ACTUAL_RUNTIME_NAME);

--- a/iceoryx_binding_c/test/moduletests/test_service_description.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_service_description.cpp
@@ -32,6 +32,7 @@ using namespace iox::capro;
 
 TEST(iox_service_description_test, StringSizesAreCorrect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f32a6d19-9ff7-4913-a1d8-39d46267b114");
     EXPECT_THAT(sizeof(decltype(std::declval<iox_service_description_t>().serviceString)),
                 Eq(iox::capro::IdString_t().capacity()));
     EXPECT_THAT(sizeof(decltype(std::declval<iox_service_description_t>().instanceString)),

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -125,6 +125,7 @@ iox_sub_t iox_sub_test::m_triggerCallbackLatestArgument = nullptr;
 
 TEST_F(iox_sub_test, initSubscriberWithNullptrForStorageReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2732d00b-5e31-4b31-9170-3dff0d1b693e");
     iox_sub_options_t options;
     iox_sub_options_init(&options);
 
@@ -134,6 +135,7 @@ TEST_F(iox_sub_test, initSubscriberWithNullptrForStorageReturnsNullptr)
 // this crashes if the fixture is used, therefore a test without a fixture
 TEST(iox_sub_test_DeathTest, initSubscriberWithNotInitializedPublisherOptionsTerminates)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a33309e-fe21-45f6-815a-eebe0136c572");
     iox_sub_options_t options;
     iox_sub_storage_t storage;
 
@@ -142,6 +144,7 @@ TEST(iox_sub_test_DeathTest, initSubscriberWithNotInitializedPublisherOptionsTer
 
 TEST_F(iox_sub_test, initSubscriberWithDefaultOptionsWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "40eaa006-4781-46cd-bde3-40fa7d572f29");
     iox::roudi::RouDiEnvironment roudiEnv;
 
     iox_runtime_init("hypnotoad");
@@ -155,11 +158,13 @@ TEST_F(iox_sub_test, initSubscriberWithDefaultOptionsWorks)
 
 TEST_F(iox_sub_test, initialStateNotSubscribed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "766cb6ed-02a9-44aa-9cdf-9803d3821b97");
     EXPECT_EQ(iox_sub_get_subscription_state(m_sut), SubscribeState_NOT_SUBSCRIBED);
 }
 
 TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4259d716-ba7b-413a-8c2f-d61f81ca9a16");
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -169,6 +174,7 @@ TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 
 TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "25233413-4ec2-4fad-ac9f-8bde1b83e26f");
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -180,6 +186,7 @@ TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 
 TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c34b4fb2-4f90-463e-a849-ab4b239af224");
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -191,6 +198,7 @@ TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 
 TEST_F(iox_sub_test, UnsubscribeLeadsToUnscribeRequestedState)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2d57dbac-b658-436f-b1ce-37cd318723f6");
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -206,12 +214,14 @@ TEST_F(iox_sub_test, UnsubscribeLeadsToUnscribeRequestedState)
 
 TEST_F(iox_sub_test, initialStateNoChunksAvailable)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "99974a57-6a0d-41eb-87fa-cabedef4f83d");
     const void* chunk = nullptr;
     EXPECT_EQ(iox_sub_take_chunk(m_sut, &chunk), ChunkReceiveResult_NO_CHUNK_AVAILABLE);
 }
 
 TEST_F(iox_sub_test, receiveChunkWhenThereIsOne)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b42a8093-10a0-4fdb-9a46-4235a08850a3");
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -221,6 +231,7 @@ TEST_F(iox_sub_test, receiveChunkWhenThereIsOne)
 
 TEST_F(iox_sub_test, receiveChunkWithContent)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "34cbca17-60b9-4f55-b576-87b82f14d764");
     this->Subscribe(&m_portPtr);
     struct data_t
     {
@@ -239,6 +250,7 @@ TEST_F(iox_sub_test, receiveChunkWithContent)
 
 TEST_F(iox_sub_test, constChunkHeaderCanBeObtainedFromChunkAfterTake)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b5d2462e-933d-426f-a5d8-40ac9a0d1773");
     this->Subscribe(&m_portPtr);
     auto sharedChunk = getChunkFromMemoryManager();
     m_chunkPusher.push(sharedChunk);
@@ -254,6 +266,7 @@ TEST_F(iox_sub_test, constChunkHeaderCanBeObtainedFromChunkAfterTake)
 
 TEST_F(iox_sub_test, receiveChunkWhenToManyChunksAreHold)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ce2a7a6a-e170-4bc3-b7c0-d50088e2997c");
     this->Subscribe(&m_portPtr);
     const void* chunk = nullptr;
     for (uint64_t i = 0U; i < MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY + 1U; ++i)
@@ -268,6 +281,7 @@ TEST_F(iox_sub_test, receiveChunkWhenToManyChunksAreHold)
 
 TEST_F(iox_sub_test, releaseChunkWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53619897-cad8-4377-a877-4ec6971308fa");
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -281,6 +295,7 @@ TEST_F(iox_sub_test, releaseChunkWorks)
 
 TEST_F(iox_sub_test, releaseChunkQueuedChunksWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6e32b17f-7454-40fe-bf97-f742249fb7de");
     this->Subscribe(&m_portPtr);
     for (uint64_t i = 0U; i < MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY; ++i)
     {
@@ -294,11 +309,13 @@ TEST_F(iox_sub_test, releaseChunkQueuedChunksWorks)
 
 TEST_F(iox_sub_test, initialStateHasNewChunksFalse)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ced8e035-7748-4322-bf2f-517c5d1468d7");
     EXPECT_FALSE(iox_sub_has_chunks(m_sut));
 }
 
 TEST_F(iox_sub_test, receivingChunkLeadsToHasNewChunksTrue)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "966ee341-9809-4cde-9bc0-e460f1b7e367");
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
 
@@ -307,11 +324,13 @@ TEST_F(iox_sub_test, receivingChunkLeadsToHasNewChunksTrue)
 
 TEST_F(iox_sub_test, initialStateHasNoLostChunks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2bea8341-92bd-4135-8b3a-c3393780209f");
     EXPECT_FALSE(iox_sub_has_lost_chunks(m_sut));
 }
 
 TEST_F(iox_sub_test, sendingTooMuchLeadsToOverflow)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1192619e-c8c6-4da3-adb8-bdf7a0c2db92");
     this->Subscribe(&m_portPtr);
     for (uint64_t i = 0U; i < DefaultChunkQueueConfig::MAX_QUEUE_CAPACITY; ++i)
     {
@@ -325,6 +344,7 @@ TEST_F(iox_sub_test, sendingTooMuchLeadsToOverflow)
 
 TEST_F(iox_sub_test, attachingToWaitSetWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "84480013-15d8-44ac-a371-52c79cb861de");
     EXPECT_EQ(iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback),
               WaitSetResult_SUCCESS);
     EXPECT_EQ(m_waitSet->size(), 1U);
@@ -332,6 +352,7 @@ TEST_F(iox_sub_test, attachingToWaitSetWorks)
 
 TEST_F(iox_sub_test, attachingToAnotherWaitsetCleansupAtOriginalWaitset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cfc150f3-aa6d-41a1-a68e-7b21711ef5c3");
     WaitSetMock m_waitSet2{m_condVar};
     iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback);
 
@@ -343,6 +364,7 @@ TEST_F(iox_sub_test, attachingToAnotherWaitsetCleansupAtOriginalWaitset)
 
 TEST_F(iox_sub_test, detachingFromWaitSetWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "07a62461-e7ec-4db0-a847-b52ef333701f");
     iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, triggerCallback);
     iox_ws_detach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA);
     EXPECT_EQ(m_waitSet->size(), 0U);
@@ -350,6 +372,7 @@ TEST_F(iox_sub_test, detachingFromWaitSetWorks)
 
 TEST_F(iox_sub_test, hasDataTriggersWaitSetWithCorrectNotificationId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f67bb084-ebe3-4480-8efc-80a902f4fe87");
     iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 587U, triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
@@ -362,6 +385,7 @@ TEST_F(iox_sub_test, hasDataTriggersWaitSetWithCorrectNotificationId)
 
 TEST_F(iox_sub_test, hasDataTriggersWaitSetWithCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8d31e5f3-a052-42fb-a521-83a9dd624dbe");
     iox_ws_attach_subscriber_state(m_waitSet.get(), m_sut, SubscriberState_HAS_DATA, 0U, iox_sub_test::triggerCallback);
     this->Subscribe(&m_portPtr);
     m_chunkPusher.push(getChunkFromMemoryManager());
@@ -375,6 +399,7 @@ TEST_F(iox_sub_test, hasDataTriggersWaitSetWithCorrectCallback)
 
 TEST_F(iox_sub_test, deinitSubscriberDetachesTriggerFromWaitSet)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "93e350fb-5430-43ff-982b-b43c6ae9b890");
     // malloc is used since iox_sub_deinit calls the d'tor of cpp2c_Subscriber
     cpp2c_Subscriber* subscriber = static_cast<cpp2c_Subscriber*>(malloc(sizeof(cpp2c_Subscriber)));
     new (subscriber) cpp2c_Subscriber();
@@ -392,6 +417,7 @@ TEST_F(iox_sub_test, deinitSubscriberDetachesTriggerFromWaitSet)
 
 TEST_F(iox_sub_test, correctServiceDescriptionReturned)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "bbd568af-49c3-445f-a852-ac0e5d249627");
     auto serviceDescription = iox_sub_get_service_description(m_sut);
 
     EXPECT_THAT(std::string(serviceDescription.serviceString), Eq("a"));
@@ -401,6 +427,7 @@ TEST_F(iox_sub_test, correctServiceDescriptionReturned)
 
 TEST(iox_sub_options_test, subscriberOptionsAreInitializedCorrectly)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ef45f9da-ef2a-4d48-9c05-23cec0837444");
     iox_sub_options_t sut;
     sut.queueCapacity = 37;
     sut.historyRequest = 73;
@@ -423,6 +450,7 @@ TEST(iox_sub_options_test, subscriberOptionsAreInitializedCorrectly)
 
 TEST(iox_sub_options_test, subscriberOptionsInitializationCheckReturnsTrueAfterDefaultInit)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7f5365c9-e86f-4a7f-8b44-ba7c449cd770");
     iox_sub_options_t sut;
     iox_sub_options_init(&sut);
     EXPECT_TRUE(iox_sub_options_is_initialized(&sut));
@@ -430,6 +458,7 @@ TEST(iox_sub_options_test, subscriberOptionsInitializationCheckReturnsTrueAfterD
 
 TEST(iox_sub_options_test, subscriberOptionsInitializationCheckReturnsFalseWithoutDefaultInit)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "059e83e4-b64b-4104-844f-4f69a44cea20");
     iox_sub_options_t sut;
 #if (defined(__GNUC__) && __GNUC__ >= 7 && !defined(__clang__))
 #pragma GCC diagnostic push
@@ -443,6 +472,7 @@ TEST(iox_sub_options_test, subscriberOptionsInitializationCheckReturnsFalseWitho
 
 TEST(iox_sub_options_test, subscriberOptionInitializationWithNullptrDoesNotCrash)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4c8eeb6e-5681-4551-865b-11b6a599edf5");
     EXPECT_EXIT(
         {
             iox_sub_options_init(nullptr);

--- a/iceoryx_binding_c/test/moduletests/test_types.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_types.cpp
@@ -36,30 +36,35 @@ using namespace ::testing;
 
 TEST(iox_types_test, WaitSetStorageSizeFits)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2b010bf2-9ba7-401f-a0c0-fb5d802f33d6");
     EXPECT_THAT(sizeof(WaitSet<>), Le(sizeof(iox_ws_storage_t)));
     EXPECT_THAT(alignof(WaitSet<>), Le(alignof(iox_ws_storage_t)));
 }
 
 TEST(iox_types_test, ListenerStorageSizeFits)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "612beb6a-a778-4cc6-94eb-42856c2fee6f");
     EXPECT_THAT(sizeof(Listener), Le(sizeof(iox_listener_storage_t)));
     EXPECT_THAT(alignof(Listener), Le(alignof(iox_listener_storage_t)));
 }
 
 TEST(iox_types_test, UserTriggerStorageSizeFits)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53e7081c-fa0d-4f2d-9dbf-81e7803cbcc6");
     EXPECT_THAT(sizeof(UserTrigger), Le(sizeof(iox_user_trigger_storage_t)));
     EXPECT_THAT(alignof(UserTrigger), Le(alignof(iox_user_trigger_storage_t)));
 }
 
 TEST(iox_types_test, cpp2c_SubscriberStorageSizeFits)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7fbe6908-0a4b-44f8-b369-4998dab2c7ba");
     EXPECT_THAT(sizeof(cpp2c_Subscriber), Le(sizeof(iox_sub_storage_t)));
     EXPECT_THAT(alignof(cpp2c_Subscriber), Le(alignof(iox_sub_storage_t)));
 }
 
 TEST(iox_types_test, cpp2c_PublisherStorageSizeFits)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2b216e64-1310-4016-961d-fc54ab1ef6ea");
     EXPECT_THAT(sizeof(cpp2c_Publisher), Le(sizeof(iox_pub_storage_t)));
     EXPECT_THAT(alignof(cpp2c_Publisher), Le(alignof(iox_pub_storage_t)));
 }

--- a/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_user_trigger.cpp
@@ -63,22 +63,26 @@ bool iox_user_trigger_test::wasTriggerCallbackCalled = false;
 
 TEST_F(iox_user_trigger_test, initUserTriggerWithNullptrForStorageReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f1529267-af64-43eb-a0f8-4db6a8557b6e");
     EXPECT_EQ(iox_user_trigger_init(nullptr), nullptr);
 }
 
 TEST_F(iox_user_trigger_test, isNotTriggeredWhenCreated)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "10fbcb9f-f9ef-4886-b154-757f62a5ec2f");
     EXPECT_FALSE(iox_user_trigger_has_triggered(m_sut));
 }
 
 TEST_F(iox_user_trigger_test, cannotBeTriggeredWhenNotAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d988e34b-8b45-4dcb-b663-32eee5f9d9df");
     iox_user_trigger_trigger(m_sut);
     EXPECT_FALSE(iox_user_trigger_has_triggered(m_sut));
 }
 
 TEST_F(iox_user_trigger_test, canBeTriggeredWhenAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d48b92b0-ab26-4a36-9c83-68699ca3e1b0");
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
     iox_user_trigger_trigger(m_sut);
     EXPECT_TRUE(iox_user_trigger_has_triggered(m_sut));
@@ -86,6 +90,7 @@ TEST_F(iox_user_trigger_test, canBeTriggeredWhenAttached)
 
 TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectNotificationId)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "03858b17-f08c-4fba-b973-03a651fcb3c6");
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 88191U, triggerCallback);
     iox_user_trigger_trigger(m_sut);
 
@@ -97,6 +102,7 @@ TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectNotificationId)
 
 TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectCallback)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "cfb59955-a3dd-4514-805d-9718072bd99b");
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, iox_user_trigger_test::triggerCallback);
     iox_user_trigger_trigger(m_sut);
 
@@ -110,6 +116,7 @@ TEST_F(iox_user_trigger_test, triggeringWaitSetResultsInCorrectCallback)
 
 TEST_F(iox_user_trigger_test, attachingToAnotherWaitSetCleansupFirstWaitset)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8fb7b119-b0ca-4bcc-9776-189a4468822e");
     WaitSetMock m_waitSet2{m_condVar};
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
 
@@ -121,6 +128,7 @@ TEST_F(iox_user_trigger_test, attachingToAnotherWaitSetCleansupFirstWaitset)
 
 TEST_F(iox_user_trigger_test, disable_trigger_eventingItFromWaitsetCleansup)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "10d8d416-57f5-4c9f-aa71-7ee917e3d97e");
     WaitSetMock m_waitSet2{m_condVar};
     iox_ws_attach_user_trigger_event(&m_waitSet, m_sut, 0U, triggerCallback);
 

--- a/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
@@ -127,21 +127,25 @@ void userTriggerCallbackWithContextData(iox::popo::UserTrigger* userTrigger, voi
 
 TEST_F(iox_ws_test, InitWaitSetWithNullptrForStorageReturnsNullptr)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c0f6b413-de1f-441f-916e-aa158fbfdde3");
     EXPECT_EQ(iox_ws_init(nullptr), nullptr);
 }
 
 TEST_F(iox_ws_test, CapacityIsCorrect)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ab5c64d3-0f74-4aa5-8e8d-8419c3ad71ed");
     EXPECT_EQ(iox_ws_capacity(m_sut), MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET);
 }
 
 TEST_F(iox_ws_test, SizeIsZeroWhenConstructed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "64bf992a-0089-43ba-a3ef-bfd411843b27");
     EXPECT_EQ(iox_ws_size(m_sut), 0U);
 }
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneUserTriggerIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3fd08c7e-7eda-4586-a737-e803ca3ba995");
     EXPECT_EQ(iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 0U, userTriggerCallback),
               iox_WaitSetResult::WaitSetResult_SUCCESS);
     EXPECT_EQ(iox_ws_size(m_sut), 1U);
@@ -149,6 +153,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneUserTriggerIsAttached)
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberStateIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "401d63e6-0708-49a2-b8b1-f8447d82e660");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(iox_ws_attach_subscriber_state(
                   m_sut, &m_subscriberVector[0U], SubscriberState_HAS_DATA, customId, subscriberCallback),
@@ -158,6 +163,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberStateIsAttached)
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneUserTriggerWithNullptrCallBackIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3bb92cc8-a3cf-4ac8-8df8-6047ea1228c2");
     EXPECT_EQ(iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 0U, NULL),
               iox_WaitSetResult::WaitSetResult_SUCCESS);
     EXPECT_EQ(iox_ws_size(m_sut), 1U);
@@ -165,6 +171,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneUserTriggerWithNullptrCallBackIsAttached)
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberStateWithNullptrCallBackIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dd04bf28-3ae5-4903-b46b-f09da31b46ce");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(iox_ws_attach_subscriber_state(m_sut, &m_subscriberVector[0U], SubscriberState_HAS_DATA, customId, NULL),
               iox_WaitSetResult::WaitSetResult_SUCCESS);
@@ -173,6 +180,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberStateWithNullptrCallBackIsAttached
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberEventIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2becf5a5-f6ba-4e65-abfb-8880b1f0789d");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(iox_ws_attach_subscriber_event(
                   m_sut, &m_subscriberVector[0U], SubscriberEvent_DATA_RECEIVED, customId, subscriberCallback),
@@ -182,6 +190,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberEventIsAttached)
 
 TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberEventWithNullptrCallBackIsAttached)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b6aafb13-8da0-4058-bcbf-d84d4dc39aa5");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(
         iox_ws_attach_subscriber_event(m_sut, &m_subscriberVector[0U], SubscriberEvent_DATA_RECEIVED, customId, NULL),
@@ -191,6 +200,7 @@ TEST_F(iox_ws_test, SizeIsOneWhenOneSubscriberEventWithNullptrCallBackIsAttached
 
 TEST_F(iox_ws_test, AttachingMoreUserTriggerThanCapacityAvailableFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c696900b-7ef0-4f32-8666-7340b52cef1e");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         EXPECT_EQ(iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback),
@@ -204,6 +214,7 @@ TEST_F(iox_ws_test, AttachingMoreUserTriggerThanCapacityAvailableFails)
 
 TEST_F(iox_ws_test, AttachingMoreSubscriberStatesThanCapacityAvailableFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f69eb949-255a-483d-bcde-9af45ec67ab8");
     constexpr uint64_t customId = 123U;
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
@@ -222,6 +233,7 @@ TEST_F(iox_ws_test, AttachingMoreSubscriberStatesThanCapacityAvailableFails)
 
 TEST_F(iox_ws_test, AttachingMoreSubscriberEventsThanCapacityAvailableFails)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "555dd52c-222a-40da-8311-15046db418eb");
     constexpr uint64_t customId = 123U;
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
@@ -240,6 +252,7 @@ TEST_F(iox_ws_test, AttachingMoreSubscriberEventsThanCapacityAvailableFails)
 
 TEST_F(iox_ws_test, SizeDecreasesWhenAttachedUserTriggerIsDeinitialized)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "7d1dccce-0712-4242-b6c9-54060d4827f6");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 0U, userTriggerCallback);
     iox_ws_detach_user_trigger_event(m_sut, m_userTrigger[0U]);
     EXPECT_EQ(iox_ws_size(m_sut), 0U);
@@ -247,6 +260,7 @@ TEST_F(iox_ws_test, SizeDecreasesWhenAttachedUserTriggerIsDeinitialized)
 
 TEST_F(iox_ws_test, SizeDecreasesWhenAttachedSubscriberStateIsDeinitialized)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a985dee5-7e4f-43f5-b6f3-7f8a2a500202");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(iox_ws_attach_subscriber_state(
                   m_sut, &m_subscriberVector[0U], SubscriberState_HAS_DATA, customId, subscriberCallback),
@@ -257,6 +271,7 @@ TEST_F(iox_ws_test, SizeDecreasesWhenAttachedSubscriberStateIsDeinitialized)
 
 TEST_F(iox_ws_test, SizeDecreasesWhenAttachedSubscriberEventIsDeinitialized)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f332215a-d2b6-49c9-a2bd-ba71c7ee3612");
     constexpr uint64_t customId = 123U;
     EXPECT_EQ(iox_ws_attach_subscriber_event(
                   m_sut, &m_subscriberVector[0U], SubscriberEvent_DATA_RECEIVED, customId, subscriberCallback),
@@ -267,6 +282,7 @@ TEST_F(iox_ws_test, SizeDecreasesWhenAttachedSubscriberEventIsDeinitialized)
 
 TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsOneWhenOneWasTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b1fbf9fd-fbae-439d-94f5-41e5d9756fd2");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 0U, userTriggerCallback);
     iox_user_trigger_trigger(m_userTrigger[0U]);
 
@@ -275,6 +291,7 @@ TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsOneWhenOneWasTriggered)
 
 TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsCorrectWhenMultipleWereTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "da1f3eaa-fbdd-4ab1-844e-ba48ba6989f9");
     for (uint64_t i = 0U; i < 10U; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -286,6 +303,7 @@ TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsCorrectWhenMultipleWereTriggere
 
 TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsCorrectWhenAllWereTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "74a629b1-bd15-4acb-8ae0-4ee926c594a8");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -298,6 +316,7 @@ TEST_F(iox_ws_test, NumberOfTriggeredConditionsIsCorrectWhenAllWereTriggered)
 
 TEST_F(iox_ws_test, SingleTriggerCaseWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dd35162d-a076-43b3-bc3b-fcc574c6b5cf");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0], 5678U, userTriggerCallback);
     iox_user_trigger_trigger(m_userTrigger[0U]);
 
@@ -311,6 +330,7 @@ TEST_F(iox_ws_test, SingleTriggerCaseWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, MultiTriggerCaseWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "c3bfe540-950b-4f70-bb8b-7f7c1500de29");
     for (uint64_t i = 0U; i < 8; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 1337U + i, userTriggerCallback);
@@ -329,6 +349,7 @@ TEST_F(iox_ws_test, MultiTriggerCaseWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, MaxTriggerCaseWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a76d77ee-cc02-4532-b792-209794200bf8");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 42U * i + 1U, userTriggerCallback);
@@ -347,6 +368,7 @@ TEST_F(iox_ws_test, MaxTriggerCaseWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsOneWhenOneWasTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6648bcce-acfc-4e2c-b2ed-1e8ad3284a51");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 0U, userTriggerCallback);
     iox_user_trigger_trigger(m_userTrigger[0U]);
 
@@ -357,6 +379,7 @@ TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsOneWhenOneWasTriggered
 
 TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsCorrectWhenMultipleWereTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3630ed3f-3cbe-4724-b802-c45556e5d7ba");
     for (uint64_t i = 0U; i < 10U; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -370,6 +393,7 @@ TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsCorrectWhenMultipleWer
 
 TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsCorrectWhenAllWereTriggered)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "028f2b58-42b7-4300-8da9-b1ed036a51d8");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -383,6 +407,7 @@ TEST_F(iox_ws_test, TimedWaitNumberOfTriggeredConditionsIsCorrectWhenAllWereTrig
 
 TEST_F(iox_ws_test, SingleTriggerCaseTimedWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6fae144f-056b-4ac6-a849-3cd47135e2db");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0U], 5678U, userTriggerCallback);
     iox_user_trigger_trigger(m_userTrigger[0U]);
 
@@ -396,6 +421,7 @@ TEST_F(iox_ws_test, SingleTriggerCaseTimedWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, MultiTriggerCaseTimedWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f1e8811e-117d-4a73-a46f-7ecbb26b0bf5");
     for (uint64_t i = 0U; i < 8U; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 1337U + i, userTriggerCallback);
@@ -414,6 +440,7 @@ TEST_F(iox_ws_test, MultiTriggerCaseTimedWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, MaxTriggerCaseTimedWaitReturnsCorrectTrigger)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "343429f9-acba-498f-8b9b-20379960daf6");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 42U * i + 1U, userTriggerCallback);
@@ -432,6 +459,7 @@ TEST_F(iox_ws_test, MaxTriggerCaseTimedWaitReturnsCorrectTrigger)
 
 TEST_F(iox_ws_test, MissedElementsIsZeroWhenNothingWasMissed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "4080a285-1b64-4be2-9a50-909c102f05cd");
     for (uint64_t i = 0U; i < 12U; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -445,6 +473,7 @@ TEST_F(iox_ws_test, MissedElementsIsZeroWhenNothingWasMissed)
 
 TEST_F(iox_ws_test, MissedElementsIsCorrectWhenSomethingWasMissed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3b0fa82f-3358-4faa-b83e-569e71fad362");
     for (uint64_t i = 0U; i < 12U; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -458,6 +487,7 @@ TEST_F(iox_ws_test, MissedElementsIsCorrectWhenSomethingWasMissed)
 
 TEST_F(iox_ws_test, MissedElementsIsCorrectWhenAllWereMissed)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "502a351f-3388-40a2-bf77-96c019b986f1");
     for (uint64_t i = 0U; i < MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET; ++i)
     {
         iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[i], 0U, userTriggerCallback);
@@ -562,6 +592,7 @@ TIMING_TEST_F(iox_ws_test, TimedWaitBlocksTillTimeout, Repeat(5), [&] {
 
 TEST_F(iox_ws_test, SubscriberEventCallbackIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "431a93cb-a3ac-4ec8-9f7d-1739cd8bb748");
     iox_ws_attach_subscriber_event(
         m_sut, &m_subscriberVector[0], iox_SubscriberEvent::SubscriberEvent_DATA_RECEIVED, 0, &subscriberCallback);
 
@@ -576,6 +607,7 @@ TEST_F(iox_ws_test, SubscriberEventCallbackIsCalled)
 
 TEST_F(iox_ws_test, NullptrSubscriberEventCallbackIsCalledWithoutError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5a1ad4d9-cfdb-4e3c-b3b9-82a42e8f2e31");
     iox_ws_attach_subscriber_event(
         m_sut, &m_subscriberVector[0], iox_SubscriberEvent::SubscriberEvent_DATA_RECEIVED, 0, NULL);
 
@@ -590,6 +622,7 @@ TEST_F(iox_ws_test, NullptrSubscriberEventCallbackIsCalledWithoutError)
 
 TEST_F(iox_ws_test, SubscriberEventCallbackWithContextDataIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9ae20a03-cd0a-4e42-bfa0-83ef77dc5ea3");
     uint64_t someContextData = 0U;
     iox_ws_attach_subscriber_event_with_context_data(m_sut,
                                                      &m_subscriberVector[0],
@@ -610,6 +643,7 @@ TEST_F(iox_ws_test, SubscriberEventCallbackWithContextDataIsCalled)
 
 TEST_F(iox_ws_test, SubscriberStateCallbackIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1c4443a6-c3f8-441e-baad-ee7058eadbb6");
     iox_ws_attach_subscriber_state(
         m_sut, &m_subscriberVector[0], iox_SubscriberState::SubscriberState_HAS_DATA, 0, &subscriberCallback);
 
@@ -625,6 +659,7 @@ TEST_F(iox_ws_test, SubscriberStateCallbackIsCalled)
 
 TEST_F(iox_ws_test, SubscriberStateCallbackWithContextDataIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "3cb801d8-6ae3-40d9-ac0c-92bcc65b29b5");
     uint64_t someContextData = 0U;
     iox_ws_attach_subscriber_state_with_context_data(m_sut,
                                                      &m_subscriberVector[0],
@@ -647,6 +682,7 @@ TEST_F(iox_ws_test, SubscriberStateCallbackWithContextDataIsCalled)
 
 TEST_F(iox_ws_test, UserTriggerCallbackIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f0e72c64-1da7-48c3-8677-79cc0c441b8a");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0], 0, &userTriggerCallback);
     iox_user_trigger_trigger(m_userTrigger[0]);
 
@@ -660,6 +696,7 @@ TEST_F(iox_ws_test, UserTriggerCallbackIsCalled)
 
 TEST_F(iox_ws_test, NullptrUserTriggerCallbackIsCalledWithoutError)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "dcaa2891-b5b3-4c6e-9344-74cef54a6520");
     iox_ws_attach_user_trigger_event(m_sut, m_userTrigger[0], 0, NULL);
     iox_user_trigger_trigger(m_userTrigger[0]);
 
@@ -673,6 +710,7 @@ TEST_F(iox_ws_test, NullptrUserTriggerCallbackIsCalledWithoutError)
 
 TEST_F(iox_ws_test, UserTriggerCallbackWithContextDataIsCalled)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "901ceeb3-8c3c-4007-a980-f8928044fa83");
     uint64_t someContextData = 0U;
     iox_ws_attach_user_trigger_event_with_context_data(
         m_sut, m_userTrigger[0], 0, &userTriggerCallbackWithContextData, &someContextData);

--- a/tools/ci/build-ubuntu-with-latest-clang-gcc.sh
+++ b/tools/ci/build-ubuntu-with-latest-clang-gcc.sh
@@ -35,10 +35,10 @@ if [ "$COMPILER" == "clang" ]; then
     msg "installing latest stable clang"
     wget https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
     chmod +x /tmp/llvm.sh
-    # set LLVM_VERSION
+    # set CURRENT_LLVM_STABLE
     # shellcheck disable=SC2002
-    eval "$(cat /tmp/llvm.sh | grep LLVM_VERSION= -m 1)"
-    sudo /tmp/llvm.sh "${LLVM_VERSION}"
+    eval "$(cat /tmp/llvm.sh | grep CURRENT_LLVM_STABLE= -m 1)"
+    sudo /tmp/llvm.sh "${CURRENT_LLVM_STABLE}"
 fi
 
 msg "creating local test users and groups for testing access control"
@@ -52,7 +52,7 @@ if [ "$COMPILER" == "gcc" ]; then
 fi
 
 if [ "$COMPILER" == "clang" ]; then
-    export CC=clang-${LLVM_VERSION}
-    export CXX=clang++-${LLVM_VERSION}
+    export CC=clang-${CURRENT_LLVM_STABLE}
+    export CXX=clang++-${CURRENT_LLVM_STABLE}
     ./tools/iceoryx_build_test.sh clean clang release build-all out-of-tree build-shared test-add-user
 fi


### PR DESCRIPTION
Signed-off-by: Simon Hoinkis <simon.hoinkis@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
* Add unique test id's to C binding tests

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #988
