### PR TITLE
Iox #1029 implement strict history capacity matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Extend cxx::optional constructor for in place construction so that copy/move for values inside the optional even could be deleted[\#967](https://github.com/eclipse-iceoryx/iceoryx/issues/967)
 - Add templated `from`/`into` free functions to formalize conversions from enums and other types [#992](https://github.com/eclipse-iceoryx/iceoryx/issues/992)
 - UniqueId class for unique IDs within a process [#1010](https://github.com/eclipse-iceoryx/iceoryx/issues/1010)
-- Add requirePublisherHistorySupport option at subscriber side (if set to true requires historyRequest <= historyCapacity to be eligible for connection)
+- Add requirePublisherHistorySupport option at subscriber side (if set to true requires historyRequest <= historyCapacity to be eligible for connection) [#1029](https://github.com/eclipse-iceoryx/iceoryx/issues/1029)
 
 **Bugfixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Extend cxx::optional constructor for in place construction so that copy/move for values inside the optional even could be deleted[\#967](https://github.com/eclipse-iceoryx/iceoryx/issues/967)
 - Add templated `from`/`into` free functions to formalize conversions from enums and other types [#992](https://github.com/eclipse-iceoryx/iceoryx/issues/992)
 - UniqueId class for unique IDs within a process [#1010](https://github.com/eclipse-iceoryx/iceoryx/issues/1010)
+- Add requirePublisherHistorySupport option at subscriber side (if set to true requires historyRequest <= historyCapacity to be eligible for connection)
 
 **Bugfixes:**
 

--- a/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
@@ -45,6 +45,11 @@ typedef struct
     /// @brief describes whether a publisher blocks when subscriber queue is full
     ENUM iox_QueueFullPolicy queueFullPolicy;
 
+    /// @brief Indicates whether we require the publisher to have historyCapacity >= historyRequest.
+    ///        If true and the condition is not met (i.e. historyCapacity < historyRequest), the subscriber will
+    ///        not be connected to the publisher.
+    bool requirePublisherHistorySupport;
+
     /// @brief this value will be set exclusively by iox_sub_options_init and is not supposed to be modified otherwise
     uint64_t initCheck;
 } iox_sub_options_t;

--- a/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -54,6 +54,7 @@ void iox_sub_options_init(iox_sub_options_t* options)
     options->nodeName = nullptr;
     options->subscribeOnCreate = subscriberOptions.subscribeOnCreate;
     options->queueFullPolicy = cpp2c::queueFullPolicy(subscriberOptions.queueFullPolicy);
+    options->requirePublisherHistorySupport = false;
 
     options->initCheck = SUBSCRIBER_OPTIONS_INIT_CHECK_CONSTANT;
 }
@@ -98,6 +99,7 @@ iox_sub_t iox_sub_init(iox_sub_storage_t* self,
         }
         subscriberOptions.subscribeOnCreate = options->subscribeOnCreate;
         subscriberOptions.queueFullPolicy = c2cpp::queueFullPolicy(options->queueFullPolicy);
+        subscriberOptions.requiresPublisherHistorySupport = options->requirePublisherHistorySupport;
     }
 
     me->m_portData =

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_examples/iceoptions/README.md
+++ b/iceoryx_examples/iceoptions/README.md
@@ -72,11 +72,20 @@ would encounter an overflow, the oldest sample is released to create space for t
 subscriberOptions.queueCapacity = 10U;
 ```
 
-`historyRequest` will enable a subscriber to receive the last n samples on subscription e.g. in case it was started later than the publisher. The publisher needs to have its `historyCapacity` enabled, too.
+`historyRequest` will enable a subscriber to receive the last n samples on subscription e.g. in case it was started later than the publisher.
+If the publisher does not have a sufficient `historyCapacity` (larger than `historyRequest`), it will still be connected but we will not be able to
+receive the requested amount of historical data (if it was available). Instead we will receive the largest amount of historical sample
+the publisher has available, i.e. best-effort.
+
+If we want to enforce the contract that the publisher needs to support a `historyCapacity` of at least `historyRequest`, we can do so by setting
+`requirePublisherHistorySupport` to `true`. In this case the subscriber will only connect if the publisher history support is at least as large as is request.
+By default this is set to `false` and best-effort behavior is used.
 
 <!--[geoffrey][iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp][history]-->
 ```cpp
 subscriberOptions.historyRequest = 5U;
+
+subscriberOptions.requiresPublisherHistorySupport = false;
 ```
 
 Topics are automatically subscribed on creation, if you want to disable that feature and control the subscription

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -41,8 +41,14 @@ int main()
     // publisher has send. The history request ensures that we at least get the last 5
     // samples sent by the publisher when we subscribe (if at least 5 were already sent
     // and the publisher has history enabled).
+
+    // we do not require the publisher to support the history we request,
+    // i.e. we will still connect even if its historyCapacity is smaller than what we request
+
     //! [history]
     subscriberOptions.historyRequest = 5U;
+
+    subscriberOptions.requiresPublisherHistorySupport = false;
     //! [history]
 
     // when the subscriber is created, no attempts are made to connect to any publishers that may exist

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_POSH_POPO_PORTS_PUB_SUB_PORT_TYPES_HPP
+#define IOX_POSH_POPO_PORTS_PUB_SUB_PORT_TYPES_HPP
+
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
+
+#include <cstdint>
+
+namespace iox
+{
+namespace popo
+{
+/// @todo iox#1051 move definitions for publish subscribe communication here
+
+using SubscriberChunkQueueData_t = ChunkQueueData<DefaultChunkQueueConfig, ThreadSafePolicy>;
+
+using SubscriberChunkReceiverData_t =
+    ChunkReceiverData<MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, SubscriberChunkQueueData_t>;
+
+} // namespace popo
+} // namespace iox
+
+#endif // IOX_POSH_POPO_PORTS_PUB_SUB_PORT_TYPES_HPP

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
@@ -50,6 +50,9 @@ struct PublisherPortData : public BasePortData
         ChunkSenderData<MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY, ChunkDistributorData_t>;
 
     ChunkSenderData_t m_chunkSenderData;
+
+    PublisherOptions m_options;
+
     std::atomic_bool m_offeringRequested{false};
     std::atomic_bool m_offered{false};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
@@ -45,9 +45,14 @@ class PublisherPortRouDi : public BasePort
     PublisherPortRouDi& operator=(PublisherPortRouDi&& rhs) noexcept = default;
     ~PublisherPortRouDi() = default;
 
+    /// @todo remove accessor and replace with getOptions where required
     /// @brief Returns behaviour in case of a full delivery queue
     /// @return SubScriberTooSlowPolicy What happens if the delivery queue is full
     SubscriberTooSlowPolicy getSubscriberTooSlowPolicy() const noexcept;
+
+    /// @brief Returns publisher options
+    /// @return publisher options
+    const PublisherOptions& getOptions() const noexcept;
 
     /// @brief get an optional CaPro message that changes the offer state of the publisher
     /// @return CaPro message with the new offer state, empty optional if no state change

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp
@@ -45,11 +45,6 @@ class PublisherPortRouDi : public BasePort
     PublisherPortRouDi& operator=(PublisherPortRouDi&& rhs) noexcept = default;
     ~PublisherPortRouDi() = default;
 
-    /// @todo remove accessor and replace with getOptions where required
-    /// @brief Returns behaviour in case of a full delivery queue
-    /// @return SubScriberTooSlowPolicy What happens if the delivery queue is full
-    SubscriberTooSlowPolicy getSubscriberTooSlowPolicy() const noexcept;
-
     /// @brief Returns publisher options
     /// @return publisher options
     const PublisherOptions& getOptions() const noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -24,6 +24,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 
 #include <atomic>
 
@@ -45,7 +46,9 @@ struct SubscriberPortData : public BasePortData
     using ChunkReceiverData_t = ChunkReceiverData<MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, ChunkQueueData_t>;
 
     ChunkReceiverData_t m_chunkReceiverData;
-    const uint64_t m_historyRequest;
+
+    SubscriberOptions m_options;
+
     std::atomic_bool m_subscribeRequested{false};
     std::atomic<SubscribeState> m_subscriptionState{SubscribeState::NOT_SUBSCRIBED};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -20,10 +20,8 @@
 
 #include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_posh/capro/service_description.hpp"
-#include "iceoryx_posh/iceoryx_posh_types.hpp"
-#include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
-#include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
+#include "iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp"
 #include "iceoryx_posh/popo/subscriber_options.hpp"
 
 #include <atomic>
@@ -42,8 +40,10 @@ struct SubscriberPortData : public BasePortData
                        const SubscriberOptions& subscriberOptions,
                        const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
-    using ChunkQueueData_t = ChunkQueueData<DefaultChunkQueueConfig, ThreadSafePolicy>;
-    using ChunkReceiverData_t = ChunkReceiverData<MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, ChunkQueueData_t>;
+    /// @todo iox#1051 remove these aliases here and only depend on pub_sub_port_types.hpp
+    ///       (move relevant types and constants there)
+    using ChunkQueueData_t = iox::popo::SubscriberChunkQueueData_t;
+    using ChunkReceiverData_t = iox::popo::SubscriberChunkReceiverData_t;
 
     ChunkReceiverData_t m_chunkReceiverData;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
@@ -45,9 +45,14 @@ class SubscriberPortRouDi : public BasePort
     SubscriberPortRouDi& operator=(SubscriberPortRouDi&& rhs) noexcept = default;
     virtual ~SubscriberPortRouDi() = default;
 
+    /// @todo remove accessor and replace with getOptions where required
     /// @brief Returns behaviour in case of a full delivery queue
     /// @return QueueFullPolicy What happens if the delivery queue is full
     QueueFullPolicy getQueueFullPolicy() const noexcept;
+
+    /// @brief Returns subscriber options
+    /// @return subscriber options
+    const SubscriberOptions& getOptions() const noexcept;
 
     /// @brief get an optional CaPro message that requests changes to the subscription state of the subscriber
     /// @return CaPro message with new subscription requet, empty optional if no state change

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp
@@ -45,11 +45,6 @@ class SubscriberPortRouDi : public BasePort
     SubscriberPortRouDi& operator=(SubscriberPortRouDi&& rhs) noexcept = default;
     virtual ~SubscriberPortRouDi() = default;
 
-    /// @todo remove accessor and replace with getOptions where required
-    /// @brief Returns behaviour in case of a full delivery queue
-    /// @return QueueFullPolicy What happens if the delivery queue is full
-    QueueFullPolicy getQueueFullPolicy() const noexcept;
-
     /// @brief Returns subscriber options
     /// @return subscriber options
     const SubscriberOptions& getOptions() const noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 #define IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 
-#include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "port_queue_policies.hpp"
 
 #include "iceoryx_hoofs/cxx/serialization.hpp"
@@ -33,7 +33,7 @@ struct SubscriberOptions
 {
     /// @brief The size of the receiver queue where chunks are stored before they are passed to the user
     /// @attention Depending on the underlying queue there can be a different overflow behavior
-    uint64_t queueCapacity{SubscriberPortData::ChunkQueueData_t::MAX_CAPACITY};
+    uint64_t queueCapacity{iox::MAX_SUBSCRIBER_QUEUE_CAPACITY};
 
     /// @brief The max number of chunks received after subscription if chunks are available
     uint64_t historyRequest{0U};
@@ -46,6 +46,10 @@ struct SubscriberOptions
 
     /// @brief The option whether the publisher should block when the subscriber queue is full
     QueueFullPolicy queueFullPolicy{QueueFullPolicy::DISCARD_OLDEST_DATA};
+
+    /// @brief indicates whether to enforce sufficient history support of the publisher,
+    ///        i.e. require historyCapacity >= historyRequest to be eligible to be connected
+    bool requiresPublisherHistorySupport{false};
 
     /// @brief serialization of the SubscriberOptions
     cxx::Serialization serialize() const noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -47,7 +47,7 @@ struct SubscriberOptions
     /// @brief The option whether the publisher should block when the subscriber queue is full
     QueueFullPolicy queueFullPolicy{QueueFullPolicy::DISCARD_OLDEST_DATA};
 
-    /// @brief indicates whether to enforce sufficient history support of the publisher,
+    /// @brief Indicates whether to enforce sufficient history support of the publisher,
     ///        i.e. require historyCapacity >= historyRequest to be eligible to be connected
     bool requiresPublisherHistorySupport{false};
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 #define IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 
-#include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp"
 #include "port_queue_policies.hpp"
 
 #include "iceoryx_hoofs/cxx/serialization.hpp"
@@ -33,7 +33,7 @@ struct SubscriberOptions
 {
     /// @brief The size of the receiver queue where chunks are stored before they are passed to the user
     /// @attention Depending on the underlying queue there can be a different overflow behavior
-    uint64_t queueCapacity{iox::MAX_SUBSCRIBER_QUEUE_CAPACITY};
+    uint64_t queueCapacity{SubscriberChunkQueueData_t::MAX_CAPACITY};
 
     /// @brief The max number of chunks received after subscription if chunks are available
     uint64_t historyRequest{0U};

--- a/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
@@ -29,6 +29,7 @@ PublisherPortData::PublisherPortData(const capro::ServiceDescription& serviceDes
     : BasePortData(serviceDescription, runtimeName, publisherOptions.nodeName)
     , m_chunkSenderData(
           memoryManager, publisherOptions.subscriberTooSlowPolicy, publisherOptions.historyCapacity, memoryInfo)
+    , m_options{publisherOptions}
     , m_offeringRequested(publisherOptions.offerOnCreate)
 {
 }

--- a/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -27,11 +27,6 @@ PublisherPortRouDi::PublisherPortRouDi(cxx::not_null<MemberType_t* const> publis
 {
 }
 
-SubscriberTooSlowPolicy PublisherPortRouDi::getSubscriberTooSlowPolicy() const noexcept
-{
-    return getMembers()->m_chunkSenderData.m_subscriberTooSlowPolicy;
-}
-
 const PublisherOptions& PublisherPortRouDi::getOptions() const noexcept
 {
     return getMembers()->m_options;

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -32,6 +32,11 @@ SubscriberTooSlowPolicy PublisherPortRouDi::getSubscriberTooSlowPolicy() const n
     return getMembers()->m_chunkSenderData.m_subscriberTooSlowPolicy;
 }
 
+const PublisherOptions& PublisherPortRouDi::getOptions() const noexcept
+{
+    return getMembers()->m_options;
+}
+
 const PublisherPortRouDi::MemberType_t* PublisherPortRouDi::getMembers() const noexcept
 {
     return reinterpret_cast<const MemberType_t*>(BasePort::getMembers());

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -29,7 +29,7 @@ SubscriberPortData::SubscriberPortData(const capro::ServiceDescription& serviceD
                                        const mepoo::MemoryInfo& memoryInfo) noexcept
     : BasePortData(serviceDescription, runtimeName, subscriberOptions.nodeName)
     , m_chunkReceiverData(queueType, subscriberOptions.queueFullPolicy, memoryInfo)
-    , m_historyRequest(subscriberOptions.historyRequest)
+    , m_options{subscriberOptions}
     , m_subscribeRequested(subscriberOptions.subscribeOnCreate)
 {
     m_chunkReceiverData.m_queue.setCapacity(subscriberOptions.queueCapacity);

--- a/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
@@ -39,7 +39,7 @@ cxx::optional<capro::CaproMessage> SubscriberPortMultiProducer::tryGetCaProMessa
 
         capro::CaproMessage caproMessage(capro::CaproMessageType::SUB, BasePort::getMembers()->m_serviceDescription);
         caproMessage.m_chunkQueueData = static_cast<void*>(&getMembers()->m_chunkReceiverData);
-        caproMessage.m_historyCapacity = getMembers()->m_historyRequest;
+        caproMessage.m_historyCapacity = getMembers()->m_options.historyRequest;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
@@ -69,7 +69,7 @@ cxx::optional<capro::CaproMessage> SubscriberPortMultiProducer::dispatchCaProMes
     {
         capro::CaproMessage caproMessage(capro::CaproMessageType::SUB, BasePort::getMembers()->m_serviceDescription);
         caproMessage.m_chunkQueueData = static_cast<void*>(&getMembers()->m_chunkReceiverData);
-        caproMessage.m_historyCapacity = getMembers()->m_historyRequest;
+        caproMessage.m_historyCapacity = getMembers()->m_options.historyRequest;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }

--- a/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
@@ -27,11 +27,6 @@ SubscriberPortRouDi::SubscriberPortRouDi(cxx::not_null<MemberType_t* const> subs
 {
 }
 
-QueueFullPolicy SubscriberPortRouDi::getQueueFullPolicy() const noexcept
-{
-    return getMembers()->m_chunkReceiverData.m_queueFullPolicy;
-}
-
 const SubscriberOptions& SubscriberPortRouDi::getOptions() const noexcept
 {
     return getMembers()->m_options;

--- a/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
@@ -32,6 +32,11 @@ QueueFullPolicy SubscriberPortRouDi::getQueueFullPolicy() const noexcept
     return getMembers()->m_chunkReceiverData.m_queueFullPolicy;
 }
 
+const SubscriberOptions& SubscriberPortRouDi::getOptions() const noexcept
+{
+    return getMembers()->m_options;
+}
+
 const SubscriberPortRouDi::MemberType_t* SubscriberPortRouDi::getMembers() const noexcept
 {
     return reinterpret_cast<const MemberType_t*>(BasePort::getMembers());

--- a/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
@@ -39,7 +39,7 @@ cxx::optional<capro::CaproMessage> SubscriberPortSingleProducer::tryGetCaProMess
 
         capro::CaproMessage caproMessage(capro::CaproMessageType::SUB, BasePort::getMembers()->m_serviceDescription);
         caproMessage.m_chunkQueueData = static_cast<void*>(&getMembers()->m_chunkReceiverData);
-        caproMessage.m_historyCapacity = getMembers()->m_historyRequest;
+        caproMessage.m_historyCapacity = getMembers()->m_options.historyRequest;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
@@ -76,7 +76,7 @@ cxx::optional<capro::CaproMessage> SubscriberPortSingleProducer::dispatchCaProMe
 
         capro::CaproMessage caproMessage(capro::CaproMessageType::SUB, BasePort::getMembers()->m_serviceDescription);
         caproMessage.m_chunkQueueData = static_cast<void*>(&getMembers()->m_chunkReceiverData);
-        caproMessage.m_historyCapacity = getMembers()->m_historyRequest;
+        caproMessage.m_historyCapacity = getMembers()->m_options.historyRequest;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }

--- a/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/subscriber_options.cpp
+++ b/iceoryx_posh/source/popo/subscriber_options.cpp
@@ -27,7 +27,8 @@ cxx::Serialization SubscriberOptions::serialize() const noexcept
                                       historyRequest,
                                       nodeName,
                                       subscribeOnCreate,
-                                      static_cast<std::underlying_type_t<QueueFullPolicy>>(queueFullPolicy));
+                                      static_cast<std::underlying_type_t<QueueFullPolicy>>(queueFullPolicy),
+                                      requiresPublisherHistorySupport);
 }
 
 cxx::expected<SubscriberOptions, cxx::Serialization::Error>
@@ -42,7 +43,8 @@ SubscriberOptions::deserialize(const cxx::Serialization& serialized) noexcept
                                                         subscriberOptions.historyRequest,
                                                         subscriberOptions.nodeName,
                                                         subscriberOptions.subscribeOnCreate,
-                                                        queueFullPolicy);
+                                                        queueFullPolicy,
+                                                        subscriberOptions.requiresPublisherHistorySupport);
 
     if (!deserializationSuccessful
         || queueFullPolicy > static_cast<QueueFullPolicyUT>(QueueFullPolicy::DISCARD_OLDEST_DATA))

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 - 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -314,8 +314,6 @@ void PortManager::handleConditionVariables() noexcept
 ///@todo consider making the matching function available in some interface
 bool isCompatible(const PublisherPortRouDiType& publisher, const SubscriberPortType& subscriber)
 {
-    std::cerr << "isCompatible " << std::endl;
-
     const bool servicesMatch = subscriber.getCaProServiceDescription() == publisher.getCaProServiceDescription();
 
     auto& pubOpts = publisher.getOptions();

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -311,7 +311,7 @@ void PortManager::handleConditionVariables() noexcept
     }
 }
 
-///@todo consider making the matching function available in some interface
+/// @todo consider making the matching function available in some interface
 bool isCompatible(const PublisherPortRouDiType& publisher, const SubscriberPortType& subscriber)
 {
     const bool servicesMatch = subscriber.getCaProServiceDescription() == publisher.getCaProServiceDescription();

--- a/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
+++ b/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
@@ -616,100 +616,97 @@ TEST_F(PublisherSubscriberCommunication_test, PublisherDoesNotBlockAndDiscardsSa
     EXPECT_THAT(**sample, Eq(string<128>("third a tiny black hole smells like butter")));
 }
 
-    TEST_F(PublisherSubscriberCommunication_test,
-           NoSubscriptionWhenSubscriberWantsBlockingAndPublisherDoesNotOfferBlocking)
-    {
-        ::testing::Test::RecordProperty("TEST_ID", "c0144704-6dd7-4354-a41d-d4e512633484");
-        auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
-        this->InterOpWait();
+TEST_F(PublisherSubscriberCommunication_test, NoSubscriptionWhenSubscriberWantsBlockingAndPublisherDoesNotOfferBlocking)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c0144704-6dd7-4354-a41d-d4e512633484");
+    auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
+    this->InterOpWait();
 
-        auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
-        this->InterOpWait();
+    auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
+    this->InterOpWait();
 
-        EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
-        this->InterOpWait();
+    EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
+    this->InterOpWait();
 
-        auto sample = subscriber->take();
-        EXPECT_THAT(sample.has_error(), Eq(true));
-    }
+    auto sample = subscriber->take();
+    EXPECT_THAT(sample.has_error(), Eq(true));
+}
 
-    TEST_F(PublisherSubscriberCommunication_test,
-           SubscriptionWhenSubscriberDoesNotRequireBlockingButPublisherSupportsIt)
-    {
-        ::testing::Test::RecordProperty("TEST_ID", "228ea848-8926-4779-9e38-4d92eeb87feb");
-        auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
-        this->InterOpWait();
+TEST_F(PublisherSubscriberCommunication_test, SubscriptionWhenSubscriberDoesNotRequireBlockingButPublisherSupportsIt)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "228ea848-8926-4779-9e38-4d92eeb87feb");
+    auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
+    this->InterOpWait();
 
-        auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
-        this->InterOpWait();
+    auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
+    this->InterOpWait();
 
-        EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
-        this->InterOpWait();
+    EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
+    this->InterOpWait();
 
-        auto sample = subscriber->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(string<128>("never kiss the hypnotoad")));
-    }
+    auto sample = subscriber->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(string<128>("never kiss the hypnotoad")));
+}
 
-    TEST_F(PublisherSubscriberCommunication_test, MixedOptionsSetupWorksWithBlocking)
-    {
-        ::testing::Test::RecordProperty("TEST_ID", "c60ade45-1765-40ca-bc4b-7452c82ba127");
-        auto publisherBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
-        auto publisherNonBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
-        this->InterOpWait();
+TEST_F(PublisherSubscriberCommunication_test, MixedOptionsSetupWorksWithBlocking)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c60ade45-1765-40ca-bc4b-7452c82ba127");
+    auto publisherBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
+    auto publisherNonBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
+    this->InterOpWait();
 
-        auto subscriberBlocking = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
-        auto subscriberNonBlocking = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
-        this->InterOpWait();
+    auto subscriberBlocking = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
+    auto subscriberNonBlocking = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
+    this->InterOpWait();
 
-        EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoads real name is Salsabarh Slimekirkdingle").has_error());
-        EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoad wants a cookie").has_error());
-        EXPECT_FALSE(publisherNonBlocking->publishCopyOf("hypnotoad has a sister named hypnoodle").has_error());
+    EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoads real name is Salsabarh Slimekirkdingle").has_error());
+    EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoad wants a cookie").has_error());
+    EXPECT_FALSE(publisherNonBlocking->publishCopyOf("hypnotoad has a sister named hypnoodle").has_error());
 
-        auto threadSyncSemaphore = posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U);
+    auto threadSyncSemaphore = posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U);
 
-        std::atomic_bool wasSampleDelivered{false};
-        std::thread t1([&] {
-            ASSERT_FALSE(threadSyncSemaphore->post().has_error());
-            EXPECT_FALSE(
-                publisherBlocking->publishCopyOf("chucky is the only one who can ride the hypnotoad").has_error());
-            wasSampleDelivered.store(true);
-        });
+    std::atomic_bool wasSampleDelivered{false};
+    std::thread t1([&] {
+        ASSERT_FALSE(threadSyncSemaphore->post().has_error());
+        EXPECT_FALSE(publisherBlocking->publishCopyOf("chucky is the only one who can ride the hypnotoad").has_error());
+        wasSampleDelivered.store(true);
+    });
 
-        constexpr int64_t TIMEOUT_IN_MS = 100;
+    constexpr int64_t TIMEOUT_IN_MS = 100;
 
-        ASSERT_FALSE(threadSyncSemaphore->wait().has_error());
-        std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_IN_MS));
-        EXPECT_FALSE(wasSampleDelivered.load());
+    ASSERT_FALSE(threadSyncSemaphore->wait().has_error());
+    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_IN_MS));
+    EXPECT_FALSE(wasSampleDelivered.load());
 
-        // verify blocking subscriber
-        auto sample = subscriberBlocking->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoads real name is Salsabarh Slimekirkdingle")));
-        t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the
-                   // read
-        EXPECT_TRUE(wasSampleDelivered.load());
+    // verify blocking subscriber
+    auto sample = subscriberBlocking->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoads real name is Salsabarh Slimekirkdingle")));
+    t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the
+               // read
+    EXPECT_TRUE(wasSampleDelivered.load());
 
-        EXPECT_FALSE(subscriberBlocking->hasMissedData()); // we don't loose samples here
-        sample = subscriberBlocking->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad wants a cookie")));
+    EXPECT_FALSE(subscriberBlocking->hasMissedData()); // we don't loose samples here
+    sample = subscriberBlocking->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad wants a cookie")));
 
-        sample = subscriberBlocking->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
-        EXPECT_THAT(subscriberBlocking->take().has_error(), Eq(true));
+    sample = subscriberBlocking->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
+    EXPECT_THAT(subscriberBlocking->take().has_error(), Eq(true));
 
-        // verify non blocking subscriber
-        EXPECT_TRUE(subscriberNonBlocking->hasMissedData()); // we do loose samples here
-        sample = subscriberNonBlocking->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad has a sister named hypnoodle")));
+    // verify non blocking subscriber
+    EXPECT_TRUE(subscriberNonBlocking->hasMissedData()); // we do loose samples here
+    sample = subscriberNonBlocking->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad has a sister named hypnoodle")));
 
-        sample = subscriberNonBlocking->take();
-        EXPECT_THAT(sample.has_error(), Eq(false));
-        EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
-        EXPECT_THAT(subscriberNonBlocking->take().has_error(), Eq(true));
-    }
+    sample = subscriberNonBlocking->take();
+    EXPECT_THAT(sample.has_error(), Eq(false));
+    EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
+    EXPECT_THAT(subscriberNonBlocking->take().has_error(), Eq(true));
+}
 
 } // namespace

--- a/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
+++ b/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
@@ -126,6 +126,25 @@ class PublisherSubscriberCommunication_test : public RouDi_GTest
         "PublisherSubscriberCommunication", "IntegrationTest", "AllHailHypnotoad"};
 };
 
+// intentional reference to unique pointer, we do not want to pass ownership in this helper function
+// and at call site we already have unique pointers
+template <typename T>
+void publishAndExpectReceivedData(const std::unique_ptr<iox::popo::Publisher<T>>& pub,
+                                  const std::unique_ptr<iox::popo::Subscriber<T>>& sub,
+                                  T data)
+{
+    ASSERT_FALSE(pub->loan()
+                     .and_then([&](auto& sample) {
+                         *sample = data;
+                         sample.publish();
+                     })
+                     .has_error());
+
+    auto result = sub->take();
+    ASSERT_FALSE(result.has_error());
+    EXPECT_EQ(*result.value().get(), data);
+}
+
 TEST_F(PublisherSubscriberCommunication_test, AllSubscriberInterfacesCanBeSubscribedToPublisherWithInternalInterface)
 {
     ::testing::Test::RecordProperty("TEST_ID", "aba18b27-bf64-49a7-8ad6-06a84b23a455");
@@ -157,109 +176,90 @@ TEST_F(PublisherSubscriberCommunication_test, AllSubscriberInterfacesCanBeSubscr
     }
 }
 
-TEST_F(PublisherSubscriberCommunication_test, SubscriberRequiringHistoryDoesNotConnectToPublisherWithoutHistorySupport)
+TEST_F(PublisherSubscriberCommunication_test,
+       SubscriberRequiringHistorySupportDoesNotConnectToPublisherWithoutHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "31cbd36d-32f1-4bc7-9980-0cdf5f248035");
 
     constexpr uint64_t historyRequest = 1;
     constexpr uint64_t historyCapacity = 0;
-    constexpr bool requireHistory = true;
+    constexpr bool requiresHistorySupport = true;
 
     auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
+    auto subscriber = createSubscriber<int>(historyRequest, requiresHistorySupport);
 
     ASSERT_TRUE(publisher);
     EXPECT_FALSE(publisher->hasSubscribers());
 }
 
-TEST_F(PublisherSubscriberCommunication_test, SubscriberRequiringNoHistoryDoesConnectToPublisherWithNoHistorySupport)
+TEST_F(PublisherSubscriberCommunication_test,
+       SubscriberNotRequiringHistorySupportDoesConnectToPublisherWithNoHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c47f5ebd-044c-480b-a4bb-d700655105ac");
 
     constexpr uint64_t historyRequest = 1;
     constexpr uint64_t historyCapacity = 0;
-    constexpr bool requireHistory = false;
+    constexpr bool requiresHistorySupport = false;
 
     auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
+    auto subscriber = createSubscriber<int>(historyRequest, requiresHistorySupport);
 
     ASSERT_TRUE(publisher);
     EXPECT_TRUE(publisher->hasSubscribers());
+
+    publishAndExpectReceivedData(publisher, subscriber, 73);
 }
 
 TEST_F(PublisherSubscriberCommunication_test,
-       SubscriberRequiringHistoryDoesConnectToPublisherWithSufficientHistorySupport)
+       SubscriberRequiringHistorySupportDoesConnectToPublisherWithSufficientHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0ca391fe-c4f6-48b5-bd36-96854513c6bb");
 
     constexpr uint64_t historyRequest = 3;
     constexpr uint64_t historyCapacity = 3;
-    constexpr bool requireHistory = true;
+    constexpr bool requiresHistorySupport = true;
 
     auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
+    auto subscriber = createSubscriber<int>(historyRequest, requiresHistorySupport);
 
     ASSERT_TRUE(publisher);
     EXPECT_TRUE(publisher->hasSubscribers());
+
+    publishAndExpectReceivedData(publisher, subscriber, 74);
 }
 
 TEST_F(PublisherSubscriberCommunication_test,
-       SubscriberRequiringHistoryDoesNotConnectToPublisherWithInSufficientHistorySupport)
+       SubscriberRequiringHistorySupportDoesNotConnectToPublisherWithInSufficientHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "46b917e6-75f1-4cd2-8ffa-1c254f3423a7");
 
     constexpr uint64_t historyRequest = 3;
     constexpr uint64_t historyCapacity = 2;
-    constexpr bool requireHistory = true;
+    constexpr bool requiresHistorySupport = true;
 
     auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
-
-    ASSERT_TRUE(publisher);
-    EXPECT_FALSE(publisher->hasSubscribers());
-}
-
-TEST_F(PublisherSubscriberCommunication_test, SubscriberRequiringHistoryDoesNotConnectToPublisherWithNoHistorySupport)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "46b917e6-75f1-4cd2-8ffa-1c254f3423a7");
-
-    constexpr uint64_t historyRequest = 3;
-    constexpr uint64_t historyCapacity = 0;
-    constexpr bool requireHistory = true;
-
-    auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
+    auto subscriber = createSubscriber<int>(historyRequest, requiresHistorySupport);
 
     ASSERT_TRUE(publisher);
     EXPECT_FALSE(publisher->hasSubscribers());
 }
 
 TEST_F(PublisherSubscriberCommunication_test,
-       SubscriberRequiringNoHistoryDoesConnectToPublisherWithInsufficientHistorySupport)
+       SubscriberNotRequiringHistorySupportDoesConnectToPublisherWithInsufficientHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b672c382-f81b-4cd4-8049-36d2691bb532");
 
     constexpr uint64_t historyRequest = 3;
     constexpr uint64_t historyCapacity = 2;
-    constexpr bool requireHistory = false;
+    constexpr bool requiresHistorySupport = false;
 
     auto publisher = createPublisher<int>(historyCapacity);
-    auto subscriber = createSubscriber<int>(historyRequest, requireHistory);
-
-    this->InterOpWait();
+    auto subscriber = createSubscriber<int>(historyRequest, requiresHistorySupport);
 
     ASSERT_TRUE(publisher);
     EXPECT_TRUE(publisher->hasSubscribers());
+
+    publishAndExpectReceivedData(publisher, subscriber, 75);
 }
 
 TEST_F(PublisherSubscriberCommunication_test, SubscriberCanOnlyBeSubscribedWhenInterfaceDiffersFromPublisher)
@@ -567,7 +567,8 @@ TEST_F(PublisherSubscriberCommunication_test, PublisherBlocksWhenBlockingActivat
     auto sample = subscriber->take();
     ASSERT_FALSE(sample.has_error());
     EXPECT_THAT(**sample, Eq(string<128>("start your day with a smile")));
-    t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the read
+    t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the
+               // read
     EXPECT_TRUE(wasSampleDelivered.load());
 
     EXPECT_FALSE(subscriber->hasMissedData());
@@ -615,96 +616,100 @@ TEST_F(PublisherSubscriberCommunication_test, PublisherDoesNotBlockAndDiscardsSa
     EXPECT_THAT(**sample, Eq(string<128>("third a tiny black hole smells like butter")));
 }
 
-TEST_F(PublisherSubscriberCommunication_test, NoSubscriptionWhenSubscriberWantsBlockingAndPublisherDoesNotOfferBlocking)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "c0144704-6dd7-4354-a41d-d4e512633484");
-    auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
-    this->InterOpWait();
+    TEST_F(PublisherSubscriberCommunication_test,
+           NoSubscriptionWhenSubscriberWantsBlockingAndPublisherDoesNotOfferBlocking)
+    {
+        ::testing::Test::RecordProperty("TEST_ID", "c0144704-6dd7-4354-a41d-d4e512633484");
+        auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
+        this->InterOpWait();
 
-    auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
-    this->InterOpWait();
+        auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
+        this->InterOpWait();
 
-    EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
-    this->InterOpWait();
+        EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
+        this->InterOpWait();
 
-    auto sample = subscriber->take();
-    EXPECT_THAT(sample.has_error(), Eq(true));
-}
+        auto sample = subscriber->take();
+        EXPECT_THAT(sample.has_error(), Eq(true));
+    }
 
-TEST_F(PublisherSubscriberCommunication_test, SubscriptionWhenSubscriberDoesNotRequireBlockingButPublisherSupportsIt)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "228ea848-8926-4779-9e38-4d92eeb87feb");
-    auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
-    this->InterOpWait();
+    TEST_F(PublisherSubscriberCommunication_test,
+           SubscriptionWhenSubscriberDoesNotRequireBlockingButPublisherSupportsIt)
+    {
+        ::testing::Test::RecordProperty("TEST_ID", "228ea848-8926-4779-9e38-4d92eeb87feb");
+        auto publisher = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
+        this->InterOpWait();
 
-    auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
-    this->InterOpWait();
+        auto subscriber = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
+        this->InterOpWait();
 
-    EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
-    this->InterOpWait();
+        EXPECT_FALSE(publisher->publishCopyOf("never kiss the hypnotoad").has_error());
+        this->InterOpWait();
 
-    auto sample = subscriber->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(string<128>("never kiss the hypnotoad")));
-}
+        auto sample = subscriber->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(string<128>("never kiss the hypnotoad")));
+    }
 
-TEST_F(PublisherSubscriberCommunication_test, MixedOptionsSetupWorksWithBlocking)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "c60ade45-1765-40ca-bc4b-7452c82ba127");
-    auto publisherBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
-    auto publisherNonBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
-    this->InterOpWait();
+    TEST_F(PublisherSubscriberCommunication_test, MixedOptionsSetupWorksWithBlocking)
+    {
+        ::testing::Test::RecordProperty("TEST_ID", "c60ade45-1765-40ca-bc4b-7452c82ba127");
+        auto publisherBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER);
+        auto publisherNonBlocking = createPublisher<string<128>>(SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA);
+        this->InterOpWait();
 
-    auto subscriberBlocking = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
-    auto subscriberNonBlocking = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
-    this->InterOpWait();
+        auto subscriberBlocking = createSubscriber<string<128>>(QueueFullPolicy::BLOCK_PUBLISHER, 2U);
+        auto subscriberNonBlocking = createSubscriber<string<128>>(QueueFullPolicy::DISCARD_OLDEST_DATA, 2U);
+        this->InterOpWait();
 
-    EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoads real name is Salsabarh Slimekirkdingle").has_error());
-    EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoad wants a cookie").has_error());
-    EXPECT_FALSE(publisherNonBlocking->publishCopyOf("hypnotoad has a sister named hypnoodle").has_error());
+        EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoads real name is Salsabarh Slimekirkdingle").has_error());
+        EXPECT_FALSE(publisherBlocking->publishCopyOf("hypnotoad wants a cookie").has_error());
+        EXPECT_FALSE(publisherNonBlocking->publishCopyOf("hypnotoad has a sister named hypnoodle").has_error());
 
-    auto threadSyncSemaphore = posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U);
+        auto threadSyncSemaphore = posix::Semaphore::create(posix::CreateUnnamedSingleProcessSemaphore, 0U);
 
-    std::atomic_bool wasSampleDelivered{false};
-    std::thread t1([&] {
-        ASSERT_FALSE(threadSyncSemaphore->post().has_error());
-        EXPECT_FALSE(publisherBlocking->publishCopyOf("chucky is the only one who can ride the hypnotoad").has_error());
-        wasSampleDelivered.store(true);
-    });
+        std::atomic_bool wasSampleDelivered{false};
+        std::thread t1([&] {
+            ASSERT_FALSE(threadSyncSemaphore->post().has_error());
+            EXPECT_FALSE(
+                publisherBlocking->publishCopyOf("chucky is the only one who can ride the hypnotoad").has_error());
+            wasSampleDelivered.store(true);
+        });
 
-    constexpr int64_t TIMEOUT_IN_MS = 100;
+        constexpr int64_t TIMEOUT_IN_MS = 100;
 
-    ASSERT_FALSE(threadSyncSemaphore->wait().has_error());
-    std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_IN_MS));
-    EXPECT_FALSE(wasSampleDelivered.load());
+        ASSERT_FALSE(threadSyncSemaphore->wait().has_error());
+        std::this_thread::sleep_for(std::chrono::milliseconds(TIMEOUT_IN_MS));
+        EXPECT_FALSE(wasSampleDelivered.load());
 
-    // verify blocking subscriber
-    auto sample = subscriberBlocking->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoads real name is Salsabarh Slimekirkdingle")));
-    t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the read
-    EXPECT_TRUE(wasSampleDelivered.load());
+        // verify blocking subscriber
+        auto sample = subscriberBlocking->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoads real name is Salsabarh Slimekirkdingle")));
+        t1.join(); // join needs to be before the load to ensure the wasSampleDelivered store happens before the
+                   // read
+        EXPECT_TRUE(wasSampleDelivered.load());
 
-    EXPECT_FALSE(subscriberBlocking->hasMissedData()); // we don't loose samples here
-    sample = subscriberBlocking->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad wants a cookie")));
+        EXPECT_FALSE(subscriberBlocking->hasMissedData()); // we don't loose samples here
+        sample = subscriberBlocking->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad wants a cookie")));
 
-    sample = subscriberBlocking->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
-    EXPECT_THAT(subscriberBlocking->take().has_error(), Eq(true));
+        sample = subscriberBlocking->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
+        EXPECT_THAT(subscriberBlocking->take().has_error(), Eq(true));
 
-    // verify non blocking subscriber
-    EXPECT_TRUE(subscriberNonBlocking->hasMissedData()); // we do loose samples here
-    sample = subscriberNonBlocking->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad has a sister named hypnoodle")));
+        // verify non blocking subscriber
+        EXPECT_TRUE(subscriberNonBlocking->hasMissedData()); // we do loose samples here
+        sample = subscriberNonBlocking->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(cxx::string<128>("hypnotoad has a sister named hypnoodle")));
 
-    sample = subscriberNonBlocking->take();
-    EXPECT_THAT(sample.has_error(), Eq(false));
-    EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
-    EXPECT_THAT(subscriberNonBlocking->take().has_error(), Eq(true));
-}
+        sample = subscriberNonBlocking->take();
+        EXPECT_THAT(sample.has_error(), Eq(false));
+        EXPECT_THAT(**sample, Eq(cxx::string<128>("chucky is the only one who can ride the hypnotoad")));
+        EXPECT_THAT(subscriberNonBlocking->take().has_error(), Eq(true));
+    }
 
 } // namespace

--- a/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
+++ b/iceoryx_posh/test/integrationtests/test_publisher_subscriber_communication.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -135,7 +135,7 @@ TEST_F(PublisherPort_test, initialStateIsNoSubscribers)
 TEST_F(PublisherPort_test, noWaitingForSubscriberWithDefaultOptions)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d1f74874-257a-4e8f-aabf-8eadad5b4367");
-    EXPECT_THAT(m_sutWithDefaultOptionsRouDiSide.getSubscriberTooSlowPolicy(),
+    EXPECT_THAT(m_sutWithDefaultOptionsRouDiSide.getOptions().subscriberTooSlowPolicy,
                 Eq(iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA));
 }
 
@@ -160,7 +160,7 @@ TEST_F(PublisherPort_test, initialStateReturnsNoCaProMessageWhenNoOfferOnCreate)
 TEST_F(PublisherPort_test, waitingForSubscriberWhenDesired)
 {
     ::testing::Test::RecordProperty("TEST_ID", "49526d1a-e81a-4e4a-8fb4-1a96dee83ae7");
-    EXPECT_THAT(m_sutWaitForSubscriberRouDiSide.getSubscriberTooSlowPolicy(),
+    EXPECT_THAT(m_sutWaitForSubscriberRouDiSide.getOptions().subscriberTooSlowPolicy,
                 Eq(iox::popo::SubscriberTooSlowPolicy::WAIT_FOR_SUBSCRIBER));
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_options.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_options.cpp
@@ -33,6 +33,7 @@ TEST(SubscriberOptions_test, SerializationRoundTripIsSuccessful)
     testOptions.nodeName = "hypnotoad";
     testOptions.subscribeOnCreate = false;
     testOptions.queueFullPolicy = iox::popo::QueueFullPolicy::BLOCK_PUBLISHER;
+    testOptions.requiresPublisherHistorySupport = true;
 
     iox::popo::SubscriberOptions::deserialize(testOptions.serialize())
         .and_then([&](auto& roundTripOptions) {
@@ -50,6 +51,8 @@ TEST(SubscriberOptions_test, SerializationRoundTripIsSuccessful)
 
             EXPECT_THAT(roundTripOptions.queueFullPolicy, Ne(defaultOptions.queueFullPolicy));
             EXPECT_THAT(roundTripOptions.queueFullPolicy, Eq(testOptions.queueFullPolicy));
+            EXPECT_THAT(roundTripOptions.requiresPublisherHistorySupport,
+                        Eq(testOptions.requiresPublisherHistorySupport));
         })
         .or_else([&](auto&) { FAIL() << "Serialization/Deserialization of SubscriberOptions failed!"; });
 }

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 // Copyright (c) 2020 - 2021 by Robert Bosch GmbH. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -445,7 +445,7 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberIsSuccessful)
 
     ASSERT_NE(nullptr, subscriberPort);
     EXPECT_EQ(iox::capro::ServiceDescription("99", "1", "20"), subscriberPort->m_serviceDescription);
-    EXPECT_EQ(subscriberOptions.historyRequest, subscriberPort->m_historyRequest);
+    EXPECT_EQ(subscriberOptions.historyRequest, subscriberPort->m_options.historyRequest);
     EXPECT_EQ(subscriberOptions.queueCapacity, subscriberPort->m_chunkReceiverData.m_queue.capacity());
 }
 

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 - 2021 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-
 #include "iceoryx_hoofs/cxx/convert.hpp"
 #include "iceoryx_hoofs/cxx/generic_raii.hpp"
 #include "iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp"
@@ -585,6 +584,163 @@ TEST_F(PortManager_test, DoDiscoveryPublisherCanWaitAndSubscriberDiscardOldestLe
     EXPECT_THAT(subscriber.getSubscriptionState(), Eq(iox::SubscribeState::SUBSCRIBED));
 }
 
+TEST_F(PortManager_test, SubscriberRequiringHistoryDoesNotConnectToPublisherWithoutHistorySupport)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "43f3ea1e-777a-4cc6-8478-13f981b7c941");
+
+    constexpr uint64_t historyRequest = 1;
+    constexpr uint64_t historyCapacity = 0;
+    constexpr bool requireHistory = true;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_FALSE(publisher.hasSubscribers());
+}
+
+TEST_F(PortManager_test, SubscriberRequiringNoHistoryDoesConnectToPublisherWithNoHistorySupport)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "080a94db-3a89-4d98-94a6-900015e608e2");
+
+    constexpr uint64_t historyRequest = 1;
+    constexpr uint64_t historyCapacity = 0;
+    constexpr bool requireHistory = false;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_TRUE(publisher.hasSubscribers());
+}
+
+TEST_F(PortManager_test, SubscriberRequiringHistoryDoesConnectToPublisherWithSufficientHistorySupport)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "e2567667-4583-482b-9999-029f91c0cb71");
+
+    constexpr uint64_t historyRequest = 3;
+    constexpr uint64_t historyCapacity = 3;
+    constexpr bool requireHistory = true;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_TRUE(publisher.hasSubscribers());
+}
+
+TEST_F(PortManager_test, SubscriberRequiringHistoryDoesNotConnectToPublisherWithInSufficientHistorySupport)
+{
+    // TODO: new test id
+    ::testing::Test::RecordProperty("TEST_ID", "31d879bf-ca07-4f29-90cd-a46f09a98f7c");
+
+    constexpr uint64_t historyRequest = 3;
+    constexpr uint64_t historyCapacity = 2;
+    constexpr bool requireHistory = true;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_FALSE(publisher.hasSubscribers());
+}
+
+TEST_F(PortManager_test, SubscriberRequiringHistoryDoesNotConnectToPublisherWithNoHistorySupport)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8f17d9cb-8f46-4742-99c3-b609a4d2319a");
+
+    constexpr uint64_t historyRequest = 3;
+    constexpr uint64_t historyCapacity = 0;
+    constexpr bool requireHistory = true;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_FALSE(publisher.hasSubscribers());
+}
+
+TEST_F(PortManager_test, SubscriberRequiringNoHistoryDoesConnectToPublisherWithInsufficientHistorySupport)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "e6c7cee4-cb4a-4a14-8790-4dbfce7d8584");
+
+    constexpr uint64_t historyRequest = 3;
+    constexpr uint64_t historyCapacity = 2;
+    constexpr bool requireHistory = false;
+
+    PublisherOptions publisherOptions{
+        historyCapacity, iox::NodeName_t("node"), true, iox::popo::SubscriberTooSlowPolicy::DISCARD_OLDEST_DATA};
+    SubscriberOptions subscriberOptions{
+        1U, historyRequest, iox::NodeName_t("node"), true, QueueFullPolicy::DISCARD_OLDEST_DATA, requireHistory};
+    PublisherPortUser publisher(
+        m_portManager
+            ->acquirePublisherPortData(
+                {"1", "1", "1"}, publisherOptions, "guiseppe", m_payloadDataSegmentMemoryManager, PortConfigInfo())
+            .value());
+    ASSERT_TRUE(publisher);
+    SubscriberPortUser subscriber(
+        m_portManager->acquireSubscriberPortData({"1", "1", "1"}, subscriberOptions, "schlomo", PortConfigInfo())
+            .value());
+    ASSERT_TRUE(subscriber);
+
+    ASSERT_TRUE(publisher.hasSubscribers());
+}
+
 TEST_F(PortManager_test, DeleteInterfacePortfromMaximumNumberAndAddOneIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2e682da4-aea0-4c37-8895-4049506db936");
@@ -762,6 +918,8 @@ TEST_F(PortManager_test, AcquireNodeDataAfterDestroyingPreviouslyAcquiredOnesIsS
     // so we should be able to get some more now
     acquireMaxNumberOfNodes(nodeName, runtimeName);
 }
+
+// MAKI tests
 
 TEST_F(PortManager_test, UnblockRouDiShutdownMakesAllPublisherStopOffer)
 {

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -666,7 +666,7 @@ TEST_F(PortManager_test, SubscriberRequiringHistorySupportDoesConnectToPublisher
     EXPECT_TRUE(publisher.hasSubscribers());
 }
 
-TEST_F(PortManager_test, SubscriberRequiringHistorySupportDoesNotConnectToPublisherWithInSufficientHistorySupport)
+TEST_F(PortManager_test, SubscriberRequiringHistorySupportDoesNotConnectToPublisherWithInsufficientHistorySupport)
 {
     ::testing::Test::RecordProperty("TEST_ID", "20749a22-2771-4ec3-92f8-81bbdbd4aab6");
 
@@ -674,25 +674,6 @@ TEST_F(PortManager_test, SubscriberRequiringHistorySupportDoesNotConnectToPublis
     auto subscriberOptions = createTestSubOptions();
 
     publisherOptions.historyCapacity = 2;
-    subscriberOptions.historyRequest = 3;
-    subscriberOptions.requiresPublisherHistorySupport = true;
-
-    auto publisher = createPublisher(publisherOptions);
-    auto subscriber = createSubscriber(subscriberOptions);
-
-    ASSERT_TRUE(publisher);
-    ASSERT_TRUE(subscriber);
-    EXPECT_FALSE(publisher.hasSubscribers());
-}
-
-TEST_F(PortManager_test, SubscriberRequiringHistorySupportDoesNotConnectToPublisherWithNoHistorySupport)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "8f17d9cb-8f46-4742-99c3-b609a4d2319a");
-
-    auto publisherOptions = createTestPubOptions();
-    auto subscriberOptions = createTestSubOptions();
-
-    publisherOptions.historyCapacity = 0;
     subscriberOptions.historyRequest = 3;
     subscriberOptions.requiresPublisherHistorySupport = true;
 

--- a/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2021 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
@@ -279,7 +279,7 @@ TEST_F(PortPool_test, AddSubscriberPortIsSuccessful)
     EXPECT_EQ(subscriberPort.value()->m_serviceDescription, m_serviceDescription);
     EXPECT_EQ(subscriberPort.value()->m_runtimeName, m_applicationName);
     EXPECT_EQ(subscriberPort.value()->m_nodeName, m_subscriberOptions.nodeName);
-    EXPECT_EQ(subscriberPort.value()->m_historyRequest, m_subscriberOptions.historyRequest);
+    EXPECT_EQ(subscriberPort.value()->m_options.historyRequest, m_subscriberOptions.historyRequest);
     EXPECT_EQ(subscriberPort.value()->m_chunkReceiverData.m_queue.capacity(), 256U);
     EXPECT_EQ(subscriberPort.value()->m_chunkReceiverData.m_memoryInfo.deviceId, DEFAULT_DEVICE_ID);
     EXPECT_EQ(subscriberPort.value()->m_chunkReceiverData.m_memoryInfo.memoryType, DEFAULT_MEMORY_TYPE);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1029
