### PR TITLE
iox-#1062 Implement stream operator for ChunkReceiveResult and AllocationError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add C++17 `std::perms` as `cxx::perms` to `iceoryx_hoofs/cxx/filesystem.hpp`. [#1059](https://github.com/eclipse-iceoryx/iceoryx/issues/1059)
 - Support FreeBSD as a representative for the UNIX platforms [#1054](https://github.com/eclipse-iceoryx/iceoryx/issues/1054)
 - Add event parameter to `findService` method [#415](https://github.com/eclipse-iceoryx/iceoryx/issues/415)
+- Overload stream operator for `ChunkReceiveResult` to be able to use it with ostream and LogStream [\#1062](https://github.com/eclipse-iceoryx/iceoryx/issues/1062)
 
 **Bugfixes:**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Add C++17 `std::perms` as `cxx::perms` to `iceoryx_hoofs/cxx/filesystem.hpp`. [#1059](https://github.com/eclipse-iceoryx/iceoryx/issues/1059)
 - Support FreeBSD as a representative for the UNIX platforms [#1054](https://github.com/eclipse-iceoryx/iceoryx/issues/1054)
 - Add event parameter to `findService` method [#415](https://github.com/eclipse-iceoryx/iceoryx/issues/415)
-- Overload stream operator for `ChunkReceiveResult` to be able to use it with ostream and LogStream [\#1062](https://github.com/eclipse-iceoryx/iceoryx/issues/1062)
+- Implement stream operator for `ChunkReceiveResult` and `AllocationError` to be able to use it with ostream and LogStream [\#1062](https://github.com/eclipse-iceoryx/iceoryx/issues/1062)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_signal_watcher.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_signal_watcher.cpp
@@ -58,12 +58,14 @@ class SignalWatcher_test : public Test
 
 TEST_F(SignalWatcher_test, SignalWasNotTriggeredWhenNotTriggeredBefore)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "fe493293-b64c-4f4f-a630-ea17cb5365da");
     EXPECT_FALSE(sut->wasSignalTriggered());
     EXPECT_FALSE(hasTerminationRequested());
 }
 
 TEST_F(SignalWatcher_test, SignalIsTriggeredWhenSIGINTWasTriggeredBefore)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "48e18aae-af21-43c4-a444-70fc371d328f");
     raise(SIGINT);
     EXPECT_TRUE(sut->wasSignalTriggered());
     EXPECT_TRUE(hasTerminationRequested());
@@ -71,6 +73,7 @@ TEST_F(SignalWatcher_test, SignalIsTriggeredWhenSIGINTWasTriggeredBefore)
 
 TEST_F(SignalWatcher_test, SignalIsTriggeredWhenSIGTERMWasTriggeredBefore)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "639708fa-3327-4573-92e2-cdbbff2cbdec");
     raise(SIGTERM);
     EXPECT_TRUE(sut->wasSignalTriggered());
     EXPECT_TRUE(hasTerminationRequested());
@@ -118,27 +121,32 @@ void unblocksWhenSignalWasRaisedForWaiters(SignalWatcher_test& test,
 
 TEST_F(SignalWatcher_test, UnblocksWhenSIGINTWasRaisedForOneWaiter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "52812e86-b6e8-4d04-9279-f5c5ecc04d35");
     unblocksWhenSignalWasRaisedForWaiters(*this, SIGINT, 1, [&] { sut->waitForSignal(); });
 }
 
 TEST_F(SignalWatcher_test, UnblocksWhenSIGTERMWasRaisedForOneWaiter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "f5ffc62f-3ce8-4835-8ae4-1805dda2aa59");
     unblocksWhenSignalWasRaisedForWaiters(*this, SIGTERM, 1, [&] { sut->waitForSignal(); });
 }
 
 
 TEST_F(SignalWatcher_test, UnblocksWhenSIGINTWasRaisedForMultipleWaiter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b63d4450-3a69-499f-b1f5-5c64360a259b");
     unblocksWhenSignalWasRaisedForWaiters(*this, SIGINT, 3, [&] { sut->waitForSignal(); });
 }
 
 TEST_F(SignalWatcher_test, UnblocksWhenSIGTERMWasRaisedForMultipleWaiter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6a46cbc6-5a72-4dd3-a60f-d90e7f10b849");
     unblocksWhenSignalWasRaisedForWaiters(*this, SIGTERM, 4, [&] { sut->waitForSignal(); });
 }
 
 TEST_F(SignalWatcher_test, UnblocksWhenSIGINTWasRaisedForOneWaiterWithConvenienceFunction)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "b051206b-15a0-46eb-9566-325bb59830ca");
     unblocksWhenSignalWasRaisedForWaiters(*this, SIGINT, 1, [&] { waitForTerminationRequest(); });
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.hpp
@@ -34,6 +34,23 @@ enum class ChunkReceiveResult
     NO_CHUNK_AVAILABLE
 };
 
+/// @brief Converts the ChunkReceiveResult to a string literal
+/// @param[in] value to convert to a string literal
+/// @return pointer to a string literal
+inline constexpr const char* asStringLiteral(const ChunkReceiveResult value) noexcept;
+
+/// @brief Convenience stream operator to easily use the `asStringLiteral` function with std::ostream
+/// @param[in] stream sink to write the message to
+/// @param[in] value to convert to a string literal
+/// @return the reference to `stream` which was provided as input parameter
+inline std::ostream& operator<<(std::ostream& stream, ChunkReceiveResult value) noexcept;
+
+/// @brief Convenience stream operator to easily use the `asStringLiteral` function with iox::log::LogStream
+/// @param[in] stream sink to write the message to
+/// @param[in] value to convert to a string literal
+/// @return the reference to `stream` which was provided as input parameter
+inline log::LogStream& operator<<(log::LogStream& stream, ChunkReceiveResult value) noexcept;
+
 /// @brief The ChunkReceiver is a building block of the shared memory communication infrastructure. It extends
 /// the functionality of a ChunkQueuePopper with the abililty to pass chunks to the user side (user process).
 /// Together with the ChunkSender, they are the next abstraction layer on top of ChunkDistributor and ChunkQueuePopper.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
@@ -24,6 +24,31 @@ namespace iox
 {
 namespace popo
 {
+inline constexpr const char* asStringLiteral(const ChunkReceiveResult value) noexcept
+{
+    switch (value)
+    {
+    case ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL:
+        return "ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL";
+    case ChunkReceiveResult::NO_CHUNK_AVAILABLE:
+        return "ChunkReceiveResult::NO_CHUNK_AVAILABLE";
+    }
+
+    return "[Undefined ChunkReceiveResult]";
+}
+
+inline std::ostream& operator<<(std::ostream& stream, ChunkReceiveResult value) noexcept
+{
+    stream << asStringLiteral(value);
+    return stream;
+}
+
+inline log::LogStream& operator<<(log::LogStream& stream, ChunkReceiveResult value) noexcept
+{
+    stream << asStringLiteral(value);
+    return stream;
+}
+
 template <typename ChunkReceiverDataType>
 inline ChunkReceiver<ChunkReceiverDataType>::ChunkReceiver(
     cxx::not_null<MemberType_t* const> chunkReceiverDataPtr) noexcept

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.hpp
@@ -51,6 +51,23 @@ from<mepoo::MemoryManager::Error, popo::AllocationError>(const mepoo::MemoryMana
 
 namespace popo
 {
+/// @brief Converts the AllocationError to a string literal
+/// @param[in] value to convert to a string literal
+/// @return pointer to a string literal
+inline constexpr const char* asStringLiteral(const AllocationError value) noexcept;
+
+/// @brief Convenience stream operator to easily use the `asStringLiteral` function with std::ostream
+/// @param[in] stream sink to write the message to
+/// @param[in] value to convert to a string literal
+/// @return the reference to `stream` which was provided as input parameter
+inline std::ostream& operator<<(std::ostream& stream, AllocationError value) noexcept;
+
+/// @brief Convenience stream operator to easily use the `asStringLiteral` function with iox::log::LogStream
+/// @param[in] stream sink to write the message to
+/// @param[in] value to convert to a string literal
+/// @return the reference to `stream` which was provided as input parameter
+inline log::LogStream& operator<<(log::LogStream& stream, AllocationError value) noexcept;
+
 /// @brief The ChunkSender is a building block of the shared memory communication infrastructure. It extends
 /// the functionality of a ChunkDistributor with the abililty to allocate and free memory chunks.
 /// For getting chunks of memory the MemoryManger is used. Together with the ChunkReceiver, they are the next

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
@@ -40,6 +40,37 @@ from<mepoo::MemoryManager::Error, popo::AllocationError>(const mepoo::MemoryMana
 
 namespace popo
 {
+inline constexpr const char* asStringLiteral(const AllocationError value) noexcept
+{
+    switch (value)
+    {
+    case AllocationError::UNDEFINED_ERROR:
+        return "AllocationError::UNDEFINED_ERROR";
+    case AllocationError::NO_MEMPOOLS_AVAILABLE:
+        return "AllocationError::NO_MEMPOOLS_AVAILABLE";
+    case AllocationError::RUNNING_OUT_OF_CHUNKS:
+        return "AllocationError::RUNNING_OUT_OF_CHUNKS";
+    case AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL:
+        return "AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL";
+    case AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER:
+        return "AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER";
+    }
+
+    return "[Undefined AllocationError]";
+}
+
+inline std::ostream& operator<<(std::ostream& stream, AllocationError value) noexcept
+{
+    stream << asStringLiteral(value);
+    return stream;
+}
+
+inline log::LogStream& operator<<(log::LogStream& stream, AllocationError value) noexcept
+{
+    stream << asStringLiteral(value);
+    return stream;
+}
+
 template <typename ChunkSenderDataType>
 inline ChunkSender<ChunkSenderDataType>::ChunkSender(cxx::not_null<MemberType_t* const> chunkSenderDataPtr) noexcept
     : Base_t(static_cast<typename ChunkSenderDataType::ChunkDistributorData_t* const>(chunkSenderDataPtr))

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -17,6 +17,7 @@
 
 #include "iceoryx_hoofs/error_handling/error_handling.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_queue_pusher.hpp"
@@ -265,6 +266,22 @@ TEST_F(ChunkReceiver_test, asStringLiteralConvertsChunkReceiveResultValuesToStri
 
     uint64_t expectedTestedEnumValues = (1U << loopCounter) - 1;
     EXPECT_EQ(testedEnumValues, expectedTestedEnumValues);
+}
+
+TEST_F(ChunkReceiver_test, LogStreamConvertsChunkReceiveResultValueToString)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a7238bd8-548d-453f-84aa-0f2e82f7a3bc");
+    Logger_Mock loggerMock;
+
+    auto sut = iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE;
+
+    {
+        auto logstream = iox::log::LogStream(loggerMock);
+        logstream << sut;
+    }
+
+    ASSERT_THAT(loggerMock.m_logs.size(), Eq(1U));
+    EXPECT_THAT(loggerMock.m_logs[0].message, StrEq(iox::popo::asStringLiteral(sut)));
 }
 
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -236,4 +236,35 @@ TEST_F(ChunkReceiver_test, Cleanup)
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks, Eq(0U));
 }
 
+TEST_F(ChunkReceiver_test, asStringLiteralConvertsChunkReceiveResultValuesToStrings)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5cbbda34-8a22-4eab-a8b6-20da345c1707");
+    using ChunkReceiveResult = iox::popo::ChunkReceiveResult;
+
+    // each bit corresponds to an enum value and must be set to true on test
+    uint64_t testedEnumValues{0U};
+    uint64_t loopCounter{0U};
+    for (const auto& sut :
+         {ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL, ChunkReceiveResult::NO_CHUNK_AVAILABLE})
+    {
+        auto enumString = iox::popo::asStringLiteral(sut);
+
+        switch (sut)
+        {
+        case ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL:
+            EXPECT_THAT(enumString, StrEq("ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL"));
+            break;
+        case ChunkReceiveResult::NO_CHUNK_AVAILABLE:
+            EXPECT_THAT(enumString, StrEq("ChunkReceiveResult::NO_CHUNK_AVAILABLE"));
+            break;
+        }
+
+        testedEnumValues |= 1U << static_cast<uint64_t>(sut);
+        ++loopCounter;
+    }
+
+    uint64_t expectedTestedEnumValues = (1U << loopCounter) - 1;
+    EXPECT_EQ(testedEnumValues, expectedTestedEnumValues);
+}
+
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -18,6 +18,7 @@
 #include "iceoryx_hoofs/cxx/generic_raii.hpp"
 #include "iceoryx_hoofs/error_handling/error_handling.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_distributor.hpp"
@@ -760,6 +761,22 @@ TEST_F(ChunkSender_test, asStringLiteralConvertsAllocationErrorValuesToStrings)
 
     uint64_t expectedTestedEnumValues = (1U << loopCounter) - 1;
     EXPECT_EQ(testedEnumValues, expectedTestedEnumValues);
+}
+
+TEST_F(ChunkSender_test, LogStreamConvertsAllocationErrorValueToString)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "eb01b980-4ccd-449e-b497-8755c7ef08a0");
+    Logger_Mock loggerMock;
+
+    auto sut = iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS;
+
+    {
+        auto logstream = iox::log::LogStream(loggerMock);
+        logstream << sut;
+    }
+
+    ASSERT_THAT(loggerMock.m_logs.size(), Eq(1U));
+    EXPECT_THAT(loggerMock.m_logs[0].message, StrEq(iox::popo::asStringLiteral(sut)));
 }
 
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -717,6 +717,49 @@ TEST_F(ChunkSender_test, Cleanup)
     m_chunkSenderWithHistory.releaseAll();
 
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks, Eq(0U));
+}
+
+TEST_F(ChunkSender_test, asStringLiteralConvertsAllocationErrorValuesToStrings)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "fdb713e1-0e2c-411e-a3ee-02c216d510d0");
+    using AllocationError = iox::popo::AllocationError;
+
+    // each bit corresponds to an enum value and must be set to true on test
+    uint64_t testedEnumValues{0U};
+    uint64_t loopCounter{0U};
+    for (const auto& sut : {AllocationError::UNDEFINED_ERROR,
+                            AllocationError::NO_MEMPOOLS_AVAILABLE,
+                            AllocationError::RUNNING_OUT_OF_CHUNKS,
+                            AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL,
+                            AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER})
+    {
+        auto enumString = iox::popo::asStringLiteral(sut);
+
+        switch (sut)
+        {
+        case AllocationError::UNDEFINED_ERROR:
+            EXPECT_THAT(enumString, StrEq("AllocationError::UNDEFINED_ERROR"));
+            break;
+        case AllocationError::NO_MEMPOOLS_AVAILABLE:
+            EXPECT_THAT(enumString, StrEq("AllocationError::NO_MEMPOOLS_AVAILABLE"));
+            break;
+        case AllocationError::RUNNING_OUT_OF_CHUNKS:
+            EXPECT_THAT(enumString, StrEq("AllocationError::RUNNING_OUT_OF_CHUNKS"));
+            break;
+        case AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL:
+            EXPECT_THAT(enumString, StrEq("AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL"));
+            break;
+        case AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER:
+            EXPECT_THAT(enumString, StrEq("AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER"));
+            break;
+        }
+
+        testedEnumValues |= 1U << static_cast<uint64_t>(sut);
+        ++loopCounter;
+    }
+
+    uint64_t expectedTestedEnumValues = (1U << loopCounter) - 1;
+    EXPECT_EQ(testedEnumValues, expectedTestedEnumValues);
 }
 
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR overloads `operator<<` for `ChunkReceiveResult` and `AllocationError` to be able to use it with `ostream` and `LogStream`. I need this for a follow up PR to have a nice gTest output on test failure

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1062
