### PR TITLE
Iox #982 Add `StatusPort` design document

### DIFF
--- a/doc/design/diagrams/status-port/status-port-overview.puml
+++ b/doc/design/diagrams/status-port/status-port-overview.puml
@@ -1,0 +1,51 @@
+@startuml
+
+title StatusPort overview
+
+skinparam classAttributeIconSize 0
+
+enum ActiveChunk {
+  FIRST
+  SECOND
+}
+
+class Transaction {
+  +activeChunk: ActiveChunk
+  +abaCounter: uint32_t
+}
+
+class StatusPortData {
+  +latestTransaction: std::atomic<Transaction>
+  +serviceDescription: capro::ServiceDescription
+  +chunks: SharedChunk[2]
+}
+
+class StatusPortReader<T> {
+  +StatusPortReader(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +take(callable: cxx::function_ref<void(const T&)>): void
+  ' Open question if copyTake() is wanted
+  'copyTake(callable: cxx::function_ref<void(const T&)>): void)
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -enableEvent(triggerHandle: iox::popo::TriggerHandle&&, event: const MyTriggerClassEvents): void
+  -disableEvent(event: const MyTriggerClassEvents): void
+  ' Some more methods need to be implemented in the StatusPortReader to be attachable to a Listener
+  ' See https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_examples/waitset/ice_waitset_trigger.cpp
+  ' Open question if copyTake() is wanted
+  '-m_copyOfUserData: T
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+
+class StatusPortWriter<T> {
+  +StatusPortWriter(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +store(callable: cxx::function_ref<void(T&)>): void
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+StatusPortWriter ..> StatusPortData
+StatusPortReader ..> StatusPortData
+
+@enduml

--- a/doc/design/diagrams/status-port/status-port-overview.svg
+++ b/doc/design/diagrams/status-port/status-port-overview.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" contentScriptType="application/ecmascript" contentStyleType="text/css" height="329px" preserveAspectRatio="none" style="width:1400px;height:329px;background:#FFFFFF;" version="1.1" viewBox="0 0 1400 329" width="1400px" zoomAndPan="magnify"><defs><filter height="300%" id="f32jc310fnk9t" width="300%" x="-1" y="-1"><feGaussianBlur result="blurOut" stdDeviation="2.0"/><feColorMatrix in="blurOut" result="blurOut2" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 .4 0"/><feOffset dx="4.0" dy="4.0" in="blurOut2" result="blurOut3"/><feBlend in="SourceGraphic" in2="blurOut3" mode="normal"/></filter></defs><g><text fill="#000000" font-family="sans-serif" font-size="18" lengthAdjust="spacing" textLength="189" x="599.25" y="16.708">StatusPort overview</text><!--MD5=[e870bcedbd185a6d32a4679f8f1f1baa]
+class ActiveChunk--><rect codeLine="5" fill="#FEFECE" filter="url(#f32jc310fnk9t)" height="73.6094" id="ActiveChunk" style="stroke:#A80036;stroke-width:1.5;" width="105" x="7" y="62.9531"/><ellipse cx="22" cy="78.9531" fill="#EB937F" rx="11" ry="11" style="stroke:#A80036;stroke-width:1.0;"/><path d="M20.7969,79.8281 L22.25,79.8281 L22.25,79.9375 C22.25,80.3438 22.2813,80.5 22.3594,80.6563 C22.5156,80.9063 22.7969,81.0625 23.0938,81.0625 C23.3438,81.0625 23.6094,80.9219 23.7656,80.7031 C23.8906,80.5469 23.9219,80.3906 23.9219,79.9375 L23.9219,78.0156 C23.9219,77.8594 23.9219,77.8125 23.9063,77.6563 C23.8438,77.1875 23.5313,76.875 23.0781,76.875 C22.8281,76.875 22.5625,77.0156 22.3906,77.2344 C22.2813,77.4063 22.25,77.5625 22.25,78.0156 L22.25,78.1406 L20.7969,78.1406 L20.7969,75.7344 L24.7813,75.7344 L24.7813,76.5938 C24.7813,77 24.8125,77.1719 24.8906,77.3281 C25.0625,77.5781 25.3438,77.7344 25.625,77.7344 C25.8906,77.7344 26.1563,77.5938 26.3281,77.375 C26.4375,77.2031 26.4688,77.0625 26.4688,76.5938 L26.4688,74.0469 L18.8438,74.0469 C18.4063,74.0469 18.2813,74.0625 18.125,74.1563 C17.875,74.3125 17.7188,74.6094 17.7188,74.8906 C17.7188,75.1719 17.8594,75.4219 18.0781,75.5938 C18.2344,75.7031 18.4219,75.7344 18.8438,75.7344 L19.0938,75.7344 L19.0938,82.25 L18.8438,82.25 C18.4375,82.25 18.2813,82.2656 18.125,82.375 C17.875,82.5469 17.7188,82.8125 17.7188,83.1094 C17.7188,83.375 17.8594,83.625 18.0781,83.7813 C18.2188,83.9063 18.4531,83.9531 18.8438,83.9531 L26.8438,83.9531 L26.8438,81.375 C26.8438,80.9375 26.8125,80.7969 26.7344,80.6406 C26.5625,80.3906 26.2813,80.2344 26,80.2344 C25.7344,80.2344 25.4688,80.3438 25.2969,80.5938 C25.1875,80.75 25.1563,80.8906 25.1563,81.375 L25.1563,82.25 L20.7969,82.25 L20.7969,79.8281 Z " fill="#000000"/><text fill="#000000" font-family="sans-serif" font-size="12" lengthAdjust="spacing" textLength="73" x="36" y="83.1074">ActiveChunk</text><line style="stroke:#A80036;stroke-width:1.5;" x1="8" x2="111" y1="94.9531" y2="94.9531"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="31" x="13" y="109.1636">FIRST</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="49" x="13" y="121.9683">SECOND</text><line style="stroke:#A80036;stroke-width:1.5;" x1="8" x2="111" y1="128.5625" y2="128.5625"/><!--MD5=[4555bb1b0911a5adf28ce6dbe60fed2e]
+class Transaction--><rect codeLine="10" fill="#FEFECE" filter="url(#f32jc310fnk9t)" height="73.6094" id="Transaction" style="stroke:#A80036;stroke-width:1.5;" width="169" x="147" y="62.9531"/><ellipse cx="192.75" cy="78.9531" fill="#ADD1B2" rx="11" ry="11" style="stroke:#A80036;stroke-width:1.0;"/><path d="M195.0938,74.625 C194.1563,74.1875 193.5625,74.0469 192.6875,74.0469 C190.0625,74.0469 188.0625,76.125 188.0625,78.8438 L188.0625,79.9688 C188.0625,82.5469 190.1719,84.4375 193.0625,84.4375 C194.2813,84.4375 195.4375,84.1406 196.1875,83.5938 C196.7656,83.1875 197.0938,82.7344 197.0938,82.3438 C197.0938,81.8906 196.7031,81.5 196.2344,81.5 C196.0156,81.5 195.8125,81.5781 195.625,81.7656 C195.1719,82.25 195.1719,82.25 194.9844,82.3438 C194.5625,82.6094 193.875,82.7344 193.1094,82.7344 C191.0625,82.7344 189.7656,81.6406 189.7656,79.9375 L189.7656,78.8438 C189.7656,77.0625 191.0156,75.75 192.75,75.75 C193.3281,75.75 193.9375,75.9063 194.4063,76.1563 C194.8906,76.4375 195.0625,76.6563 195.1563,77.0625 C195.2188,77.4688 195.25,77.5938 195.3906,77.7188 C195.5313,77.8594 195.7656,77.9688 195.9844,77.9688 C196.25,77.9688 196.5156,77.8281 196.6875,77.6094 C196.7969,77.4531 196.8281,77.2656 196.8281,76.8438 L196.8281,75.4219 C196.8281,74.9844 196.8125,74.8594 196.7188,74.7031 C196.5625,74.4375 196.2813,74.2969 195.9844,74.2969 C195.6875,74.2969 195.4844,74.3906 195.2656,74.7031 L195.0938,74.625 Z " fill="#000000"/><text fill="#000000" font-family="sans-serif" font-size="12" lengthAdjust="spacing" textLength="69" x="213.25" y="83.1074">Transaction</text><line style="stroke:#A80036;stroke-width:1.5;" x1="148" x2="315" y1="94.9531" y2="94.9531"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="157" x="153" y="109.1636">+activeChunk: ActiveChunk</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="127" x="153" y="121.9683">+abaCounter: uint32_t</text><line style="stroke:#A80036;stroke-width:1.5;" x1="148" x2="315" y1="128.5625" y2="128.5625"/><!--MD5=[2117d519d2cc6f54209f240144727464]
+class StatusPortData--><rect codeLine="15" fill="#FEFECE" filter="url(#f32jc310fnk9t)" height="86.4141" id="StatusPortData" style="stroke:#A80036;stroke-width:1.5;" width="279" x="766" y="228.9531"/><ellipse cx="857.75" cy="244.9531" fill="#ADD1B2" rx="11" ry="11" style="stroke:#A80036;stroke-width:1.0;"/><path d="M860.0938,240.625 C859.1563,240.1875 858.5625,240.0469 857.6875,240.0469 C855.0625,240.0469 853.0625,242.125 853.0625,244.8438 L853.0625,245.9688 C853.0625,248.5469 855.1719,250.4375 858.0625,250.4375 C859.2813,250.4375 860.4375,250.1406 861.1875,249.5938 C861.7656,249.1875 862.0938,248.7344 862.0938,248.3438 C862.0938,247.8906 861.7031,247.5 861.2344,247.5 C861.0156,247.5 860.8125,247.5781 860.625,247.7656 C860.1719,248.25 860.1719,248.25 859.9844,248.3438 C859.5625,248.6094 858.875,248.7344 858.1094,248.7344 C856.0625,248.7344 854.7656,247.6406 854.7656,245.9375 L854.7656,244.8438 C854.7656,243.0625 856.0156,241.75 857.75,241.75 C858.3281,241.75 858.9375,241.9063 859.4063,242.1563 C859.8906,242.4375 860.0625,242.6563 860.1563,243.0625 C860.2188,243.4688 860.25,243.5938 860.3906,243.7188 C860.5313,243.8594 860.7656,243.9688 860.9844,243.9688 C861.25,243.9688 861.5156,243.8281 861.6875,243.6094 C861.7969,243.4531 861.8281,243.2656 861.8281,242.8438 L861.8281,241.4219 C861.8281,240.9844 861.8125,240.8594 861.7188,240.7031 C861.5625,240.4375 861.2813,240.2969 860.9844,240.2969 C860.6875,240.2969 860.4844,240.3906 860.2656,240.7031 L860.0938,240.625 Z " fill="#000000"/><text fill="#000000" font-family="sans-serif" font-size="12" lengthAdjust="spacing" textLength="87" x="878.25" y="249.1074">StatusPortData</text><line style="stroke:#A80036;stroke-width:1.5;" x1="767" x2="1044" y1="260.9531" y2="260.9531"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="257" x="772" y="275.1636">+latestTransaction: std::atomic&lt;Transaction&gt;</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="267" x="772" y="287.9683">+serviceDescription: capro::ServiceDescription</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="146" x="772" y="300.7729">+chunks: SharedChunk[2]</text><line style="stroke:#A80036;stroke-width:1.5;" x1="767" x2="1044" y1="307.3672" y2="307.3672"/><!--MD5=[e4852eab39d89213c276dbf6dd38a67d]
+class StatusPortReader--><rect codeLine="21" fill="#FEFECE" filter="url(#f32jc310fnk9t)" height="137.6328" id="StatusPortReader" style="stroke:#A80036;stroke-width:1.5;" width="574" x="351.5" y="30.9531"/><ellipse cx="577.25" cy="46.9531" fill="#ADD1B2" rx="11" ry="11" style="stroke:#A80036;stroke-width:1.0;"/><path d="M579.5938,42.625 C578.6563,42.1875 578.0625,42.0469 577.1875,42.0469 C574.5625,42.0469 572.5625,44.125 572.5625,46.8438 L572.5625,47.9688 C572.5625,50.5469 574.6719,52.4375 577.5625,52.4375 C578.7813,52.4375 579.9375,52.1406 580.6875,51.5938 C581.2656,51.1875 581.5938,50.7344 581.5938,50.3438 C581.5938,49.8906 581.2031,49.5 580.7344,49.5 C580.5156,49.5 580.3125,49.5781 580.125,49.7656 C579.6719,50.25 579.6719,50.25 579.4844,50.3438 C579.0625,50.6094 578.375,50.7344 577.6094,50.7344 C575.5625,50.7344 574.2656,49.6406 574.2656,47.9375 L574.2656,46.8438 C574.2656,45.0625 575.5156,43.75 577.25,43.75 C577.8281,43.75 578.4375,43.9063 578.9063,44.1563 C579.3906,44.4375 579.5625,44.6563 579.6563,45.0625 C579.7188,45.4688 579.75,45.5938 579.8906,45.7188 C580.0313,45.8594 580.2656,45.9688 580.4844,45.9688 C580.75,45.9688 581.0156,45.8281 581.1875,45.6094 C581.2969,45.4531 581.3281,45.2656 581.3281,44.8438 L581.3281,43.4219 C581.3281,42.9844 581.3125,42.8594 581.2188,42.7031 C581.0625,42.4375 580.7813,42.2969 580.4844,42.2969 C580.1875,42.2969 579.9844,42.3906 579.7656,42.7031 L579.5938,42.625 Z " fill="#000000"/><text fill="#000000" font-family="sans-serif" font-size="12" lengthAdjust="spacing" textLength="103" x="597.75" y="51.1074">StatusPortReader</text><rect fill="#FFFFFF" height="15.9688" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:2.0,2.0;" width="9" x="919.5" y="27.9531"/><text fill="#000000" font-family="sans-serif" font-size="12" font-style="italic" lengthAdjust="spacing" textLength="7" x="920.5" y="40.0918">T</text><line style="stroke:#A80036;stroke-width:1.5;" x1="352.5" x2="924.5" y1="62.9531" y2="62.9531"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="214" x="357.5" y="77.1636">-m_statusPortDataPtr: StatusPortData*</text><line style="stroke:#A80036;stroke-width:1.5;" x1="352.5" x2="924.5" y1="83.7578" y2="83.7578"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="421" x="357.5" y="97.9683">+StatusPortReader(statusPortDataPtr: cxx::not_null&lt;StatusPortData* const)</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="317" x="357.5" y="110.7729">+take(callable: cxx::function_ref&lt;void(const T&amp;)&gt;): void</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="249" x="357.5" y="123.5776">-getMembers() const: const StatusPortData*</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="181" x="357.5" y="136.3823">-getMembers(): StatusPortData*</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="562" x="357.5" y="149.187">-enableEvent(triggerHandle: iox::popo::TriggerHandle&amp;&amp;, event: const MyTriggerClassEvents): void</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="317" x="357.5" y="161.9917">-disableEvent(event: const MyTriggerClassEvents): void</text><!--MD5=[915f390fbb167d78df2e7a4f7ea074f0]
+class StatusPortWriter--><rect codeLine="38" fill="#FEFECE" filter="url(#f32jc310fnk9t)" height="112.0234" id="StatusPortWriter" style="stroke:#A80036;stroke-width:1.5;" width="426" x="960.5" y="43.9531"/><ellipse cx="1115.25" cy="59.9531" fill="#ADD1B2" rx="11" ry="11" style="stroke:#A80036;stroke-width:1.0;"/><path d="M1117.5938,55.625 C1116.6563,55.1875 1116.0625,55.0469 1115.1875,55.0469 C1112.5625,55.0469 1110.5625,57.125 1110.5625,59.8438 L1110.5625,60.9688 C1110.5625,63.5469 1112.6719,65.4375 1115.5625,65.4375 C1116.7813,65.4375 1117.9375,65.1406 1118.6875,64.5938 C1119.2656,64.1875 1119.5938,63.7344 1119.5938,63.3438 C1119.5938,62.8906 1119.2031,62.5 1118.7344,62.5 C1118.5156,62.5 1118.3125,62.5781 1118.125,62.7656 C1117.6719,63.25 1117.6719,63.25 1117.4844,63.3438 C1117.0625,63.6094 1116.375,63.7344 1115.6094,63.7344 C1113.5625,63.7344 1112.2656,62.6406 1112.2656,60.9375 L1112.2656,59.8438 C1112.2656,58.0625 1113.5156,56.75 1115.25,56.75 C1115.8281,56.75 1116.4375,56.9063 1116.9063,57.1563 C1117.3906,57.4375 1117.5625,57.6563 1117.6563,58.0625 C1117.7188,58.4688 1117.75,58.5938 1117.8906,58.7188 C1118.0313,58.8594 1118.2656,58.9688 1118.4844,58.9688 C1118.75,58.9688 1119.0156,58.8281 1119.1875,58.6094 C1119.2969,58.4531 1119.3281,58.2656 1119.3281,57.8438 L1119.3281,56.4219 C1119.3281,55.9844 1119.3125,55.8594 1119.2188,55.7031 C1119.0625,55.4375 1118.7813,55.2969 1118.4844,55.2969 C1118.1875,55.2969 1117.9844,55.3906 1117.7656,55.7031 L1117.5938,55.625 Z " fill="#000000"/><text fill="#000000" font-family="sans-serif" font-size="12" lengthAdjust="spacing" textLength="97" x="1135.75" y="64.1074">StatusPortWriter</text><rect fill="#FFFFFF" height="15.9688" style="stroke:#000000;stroke-width:1.0;stroke-dasharray:2.0,2.0;" width="9" x="1380.5" y="40.9531"/><text fill="#000000" font-family="sans-serif" font-size="12" font-style="italic" lengthAdjust="spacing" textLength="7" x="1381.5" y="53.0918">T</text><line style="stroke:#A80036;stroke-width:1.5;" x1="961.5" x2="1385.5" y1="75.9531" y2="75.9531"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="214" x="966.5" y="90.1636">-m_statusPortDataPtr: StatusPortData*</text><line style="stroke:#A80036;stroke-width:1.5;" x1="961.5" x2="1385.5" y1="96.7578" y2="96.7578"/><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="414" x="966.5" y="110.9683">+StatusPortWriter(statusPortDataPtr: cxx::not_null&lt;StatusPortData* const)</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="287" x="966.5" y="123.7729">+store(callable: cxx::function_ref&lt;void(T&amp;)&gt;): void</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="249" x="966.5" y="136.5776">-getMembers() const: const StatusPortData*</text><text fill="#000000" font-family="sans-serif" font-size="11" lengthAdjust="spacing" textLength="181" x="966.5" y="149.3823">-getMembers(): StatusPortData*</text><!--MD5=[1c349052685a2ecfad447ed2875943c9]
+link StatusPortWriter to StatusPortData--><path codeLine="46" d="M1086.49,156.1471 C1050.94,178.6941 1010.35,204.4441 976.625,225.8365 " fill="none" id="StatusPortWriter-to-StatusPortData" style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#A80036" points="972.125,228.6909,981.8675,227.2472,976.347,226.0124,977.5819,220.492,972.125,228.6909" style="stroke:#A80036;stroke-width:1.0;"/><!--MD5=[aab4846237946138debd8883b654271c]
+link StatusPortReader to StatusPortData--><path codeLine="47" d="M745.561,169.1191 C775.72,188.3221 807.755,208.7181 835.17,226.1737 " fill="none" id="StatusPortReader-to-StatusPortData" style="stroke:#A80036;stroke-width:1.0;stroke-dasharray:7.0,7.0;"/><polygon fill="#A80036" points="839.529,228.9494,834.0859,220.7413,835.3115,226.2638,829.789,227.4894,839.529,228.9494" style="stroke:#A80036;stroke-width:1.0;"/><!--MD5=[8bd731835f196777e63cb2bd33fd09a6]
+@startuml
+title StatusPort overview
+
+skinparam classAttributeIconSize 0
+
+enum ActiveChunk {
+  FIRST
+  SECOND
+}
+
+class Transaction {
+  +activeChunk: ActiveChunk
+  +abaCounter: uint32_t
+}
+
+class StatusPortData {
+  +latestTransaction: std::atomic<Transaction>
+  +serviceDescription: capro::ServiceDescription
+  +chunks: SharedChunk[2]
+}
+
+class StatusPortReader<T> {
+  +StatusPortReader(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +take(callable: cxx::function_ref<void(const T&)>): void
+  ' Open question if copyTake() is wanted
+  'copyTake(callable: cxx::function_ref<void(const T&)>): void)
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -enableEvent(triggerHandle: iox::popo::TriggerHandle&&, event: const MyTriggerClassEvents): void
+  -disableEvent(event: const MyTriggerClassEvents): void
+  ' Some more methods need to be implemented in the StatusPortReader to be attachable to a Listener
+  ' See https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_examples/waitset/ice_waitset_trigger.cpp
+  ' Open question if copyTake() is wanted
+  '-m_copyOfUserData: T
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+
+class StatusPortWriter<T> {
+  +StatusPortWriter(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +store(callable: cxx::function_ref<void(T&)>): void
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+StatusPortWriter ..> StatusPortData
+StatusPortReader ..> StatusPortData
+@enduml
+
+@startuml
+title StatusPort overview
+
+skinparam classAttributeIconSize 0
+
+enum ActiveChunk {
+  FIRST
+  SECOND
+}
+
+class Transaction {
+  +activeChunk: ActiveChunk
+  +abaCounter: uint32_t
+}
+
+class StatusPortData {
+  +latestTransaction: std::atomic<Transaction>
+  +serviceDescription: capro::ServiceDescription
+  +chunks: SharedChunk[2]
+}
+
+class StatusPortReader<T> {
+  +StatusPortReader(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +take(callable: cxx::function_ref<void(const T&)>): void
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -enableEvent(triggerHandle: iox::popo::TriggerHandle&&, event: const MyTriggerClassEvents): void
+  -disableEvent(event: const MyTriggerClassEvents): void
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+
+class StatusPortWriter<T> {
+  +StatusPortWriter(statusPortDataPtr: cxx::not_null<StatusPortData* const)
+  +store(callable: cxx::function_ref<void(T&)>): void
+  -getMembers() const: const StatusPortData*
+  -getMembers(): StatusPortData*
+  -m_statusPortDataPtr: StatusPortData*
+}
+
+StatusPortWriter ..> StatusPortData
+StatusPortReader ..> StatusPortData
+@enduml
+
+PlantUML version 1.2022.2beta1(Unknown compile time)
+(GPL source distribution)
+Java Runtime: Java(TM) SE Runtime Environment
+JVM: Java HotSpot(TM) 64-Bit Server VM
+Default Encoding: UTF-8
+Language: en
+Country: US
+--></g></svg>

--- a/doc/design/status_port.md
+++ b/doc/design/status_port.md
@@ -1,0 +1,453 @@
+# StatusPort
+
+## Summary and requirements
+
+The `StatusPort` is an alternative to the publish subscriber communication in `iceoryx_posh`.
+
+The target of the `StatusPort` are use-case with the following properties:
+
+* Data is transferred once or is rarely updated
+* There are many readers which are interested in the data
+* Data can be persistent
+    * The lifetime of the transferred data is bound to the lifetime of `StatusPortData`
+* Readers don't access the data directly but via a lambda
+    * Preventing torn reads, since the `StatusPortReader` detects if the data
+    changed during `take()` operation (Frankenstein check) and re-executes the lambda
+* Has to be attachable to `Listener`
+* `StatusPort` could potentially be used to communicate between different ASIL domains
+
+Potential applications are:
+
+* Introspection topics
+* Service discovery
+
+## Design
+
+### Terminology
+
+* Transaction: Atomic state of the world, which is changed by a write operation
+* Current transaction: Transaction in local scope, read in the beginning of each operation
+* Latest transaction: Transaction in the shared memory managment segment
+* Chunk: Untyped piece of memory located in the shared memory payload segment
+* Read position: The chunk, which was used the last time to write data
+* Write position: The opposite chunk, not currently being used by the `StatusPortReader`s
+
+### Contract & properties
+
+* 1:n communication aka broadcast
+* Two memory chunks from shared memory payload segment are used
+* Data exchanged needs to be trivially-copyable
+* Storing a chunk cannot fail
+* Reading a chunk cannot fail
+    * If no data was sent yet, `callable` is not called
+    * If data was updated in-between read, re-call `callable`
+* Not part of the user API in the first version, only used internally
+    * Might become user API for freedom-from-interference separation
+* Reader only needs write access to the data structure and no read access
+* Writing and Reading will be tried indefinitely till possible, hence starvation
+is possible
+* `StatusPortData` is created in the shared memory segment if either a `StatusPortWriter`
+or `StatusPortReader` is created
+    * Two chunks in the shared memory payload segment are bound to the lifetime
+    of the `StatusPortData` (either via `StatusPortData` c'tor or
+    `StatusPort{Writer,Reader}` c'tor)
+
+### Discarded ideas & design alternatives
+
+#### Atomic pointer
+
+The pointer to the currently active chunk could also be stored in an `std::atomic`.
+
+```cpp
+std::atomic<T*> activeChunk{nullptr}
+```
+
+However, it would need the full 64-bit and which is not needed when managing
+just two chunks. Hence an `abaCounter` would need to be stored in a separate
+`std::atomic` variable.
+
+#### Omit `ServiceDescription` and discovery
+
+Methods like `offer()` or `stopOffer()` are not needed to keep things simple.
+However, omitting the `ServiceDescription` completely is not possible as it is
+needed to associate the right `StatusPortData` in shared memory with the correct
+writer or reader object on the stack. The `StatusPort` shall follow the
+service-based design.
+
+#### `atomic<T>::exchange` in `StatusPortReader::take()`
+
+A [CAS](https://en.wikipedia.org/wiki/Compare-and-swap) operation is not possible
+because CAS needs write access and a `StatusPortReader` shall not be allowed to
+write data into shared memory.
+
+#### Differentiate between Writer/Reader between RouDi/User?
+
+To be consistent with the previously available publisher and subscribers one
+could argue to follow the same naming. However, the `StatusPort` might be used to
+communicate between ASIL domains in future and hence become user API. As a result
+the naming shall stay Writer/Reader.
+
+#### Can part of the previous port infrastructure be re-used?
+
+Potential candidates:
+
+1. `BasePort`
+   1. The previously available publisher and subscribers follow a much more complex
+   communication pattern. Hence, most of the data in `BasePort` is irrelevant and
+   `StatusPortData` shall stay separate.
+1. `popo::Sample`
+   1. Due to the fact that data is accessed solely via `callable`'s there is no
+   benefit in using the non-owning `popo::Sample` view.
+
+### Solution
+
+#### Class structure
+
+Depicted below is the class diagram.
+
+![StatusPort class diagram](diagrams/status-port/status-port-overview.svg)
+
+The `StatusPortWriter` is a template where `T` is the transferred data type.
+It has a constructor which takes a pointer to the `StatusPortData`
+object in the shared memory management segment. The pointer is acquired in the
+same manner as previous publishers and subscribers via RouDi's unix domain
+socket. The only difference is that one `StatusPortData` object is shared between
+`StatusPortReader` and `StatusPortWriter`. `store()` takes a `function_ref` to
+be able to manipulate the type in-place in shared memory.
+`StatusPortReader` is a template as well and has the same constructor. The first
+and single argument of`take()` is a `function_ref`, which is executed as long as
+the `take()` was unsuccessful. Furthermore, the `StatusPortReader` has the methods
+necessary to be attachable to a `popo::Listener` (e.g. `{enable,disable}Event`).
+
+`StatusPortData` stores the latest atomic `Transaction` as well as two pointers
+to `SharedChunk`s in the shared memory payload segment. The lifetime of the two
+chunks is bound to the lifetime of the `StatusPortData` object. To be able to to
+associate the correct readers and writers a `ServiceDescription` is used.
+
+#### Frankenstein object corner cases
+
+How can we ensure in `StatusPortWriter::store()` that there is no `StatusPortReader`
+reading the chunk to which we want to write to? This could be for example a slow
+`StatusPortReader`. Is a reference counter needed? No, this is not the case. Instead
+the `StatusPortReader` checks if his view of on the world (aka the two chunks)
+has changed in-between.
+
+To illustrate this, let's assume that that there is one `StatusPortWriter` and one
+`StatusPortReader` in this scenario. Further assume that the type transferred via
+the `StatusPort` is
+
+```cpp
+T = cxx::string<36>
+```
+
+The following samples are transmitted by the `StatusPortWriter`
+
+1. "Time And Relative Dimension In Space"
+2. "Twin Ion Engines Fighter"
+3. "USS Enterprise"
+
+After the second transaction the `StatusPortReader` see's the latest transaction
+below and starts reading the `chunk[1]` aka `SECOND`.
+
+```text
+Latest transaction in shared memory managment segment
++----------------------------------+
+|       ActiveChunk::SECOND        |
+|       abaCounter: 1              |
++----------------------------------+
+```
+
+Now the the `StatusPortWriter` starts writing concurrently the third sample and
+overtakes the slower `StatusPortReader`.
+Due the latest transaction depicted below, `writePosition` is calculated to
+`chunks[1]` aka `SECOND`. Below you can find the location `^` at which the writer
+is currently writing and the reader is reading. As a result the strings are mixed
+up at this very moment in time, a so called Frankenstein object. While in this
+case, the reader might still read uncorrupted data if he finished before the
+writer, one can easily imagine that this can lead to very subtile, nasty bugs.
+To avoid this problem the `StatusPortReader` compares the initial transaction
+with the latest transaction and  re-calls the callable as long as they are not
+the same.
+
+```text
+Shared memory payload segment
++----------------------------------------------------+
+|        SharedChunk chunks[2]                       |
+|        +----------------------------------------+  |
+| FIRST  | "Twin Ion Engines Fighter"             |  |
+|        +----------------------------------------+  |
+| SECOND | "USS Enterprlative Dimension In Space" |  |
+|        +----------------------------------------+  |
+|                      ^                 ^           |
+|                      Writer            Slow reader |
++----------------------------------------------------+
+
+Latest transaction in shared memory managment segment
++----------------------------------+
+|       ActiveChunk::FIRST         |
+|       abaCounter: 2              |
++----------------------------------+
+```
+
+> ***
+> Special care has to be taken, when writing the `callable`!
+> ***
+>
+> It must be ensured that the `callable` does not crash or ends up in an endless
+> loop, when working on the data
+
+The memory order ``std::memory_order_release` and `std::memory_order_acquire`
+ensure that the operations below the `load()` "happened-before" and the memory of
+`chunks[]` is synchronized.
+
+```text
+// Write data via callable
+callable(*(m_statusPortDataPtr->chunks[currentWritePosition]));
+        \         /
+         \       /
+          \     /
+           \   /
+            \ /
+    latestTransaction.store(newTransaction,   ----------+
+       std::memory_order_release)                       |
+                                                        +--------->   latestTransaction.load(std::memory_order_acquire)
+                                                                                / \
+                                                                               /   \
+                                                                              /     \
+                                                                             /       \
+                                                                            /         \
+                                                        // Read sychronized data via callable
+                                                        callable(*(m_statusPortDataPtr->chunks[currentReadPosition].data));
+```
+
+### Code example
+
+```cpp
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_POSH_POPO_STATUS_PORT_HPP
+#define IOX_POSH_POPO_STATUS_PORT_HPP
+
+#include "iceoryx_hoofs/cxx/function_ref.hpp"
+#include "iceoryx_hoofs/cxx/helplets.hpp"
+#include "iceoryx_hoofs/cxx/optional.hpp"
+#include "iceoryx_hoofs/cxx/type_traits.hpp"
+#include "iceoryx_posh/capro/service_description.hpp"
+
+#include <atomic>
+#include <cstring>
+
+namespace iox
+{
+namespace popo
+{
+/// @todo #982 Create common .hpp for ActiveChunk and Transaction
+enum class ActiveChunk : uint32_t
+{
+    FIRST = 0,
+    SECOND = 1
+};
+
+struct Transaction
+{
+    ActiveChunk activeChunk{ActiveChunk::FIRST};
+    // We need a world-view counter to detect if StatusPortWriter::store operation overtook a
+    // StatusPortReader::take operation
+    uint32_t abaCounter{0U};
+
+    bool operator==(const Transaction& rhs) const
+    {
+        return (activeChunk == rhs.activeChunk) && (abaCounter == rhs.abaCounter);
+    }
+
+    bool operator!=(const Transaction& rhs) const
+    {
+        return !operator==(rhs);
+    }
+};
+
+/// @todo #982 Remove, will be raw shared memory
+template <typename T>
+struct ChunkInSharedMemory
+{
+    cxx::optional<T> data{cxx::nullopt_t()};
+};
+
+/// @todo #982 StatusPortData is untyped in shared memory payload segment
+template <typename T>
+struct StatusPortData
+{
+    static_assert(std::is_trivially_copyable<T>::value);
+    StatusPortData() noexcept
+    {
+        // Lifetime of two chunks are bound to the lifetime of a StatusPortData object
+        // chunks[0] = m_memoryMgr->getChunk(sizeOfDataType);
+        // chunks[1] = m_memoryMgr->getChunk(sizeOfDataType);
+        // The SharedChunk d'tor will free memory via RAII & a reference counter
+        // once a StatusPortData object is destroyed
+    }
+    ~StatusPortData() noexcept = default;
+    StatusPortData(StatusPortData&& rhs) = delete;
+    StatusPortData& operator=(StatusPortData&& rhs) = delete;
+    StatusPortData(const StatusPortData&) = delete;
+    StatusPortData& operator=(const StatusPortData&) = delete;
+
+    // This data needs to live in payload segement acquired via memory manager
+    ChunkInSharedMemory<T> chunks[2];
+
+    std::atomic<Transaction> latestTransaction;
+    capro::ServiceDescription serviceDescription;
+};
+
+template <typename T>
+class StatusPortReader
+{
+  public:
+    StatusPortReader(cxx::not_null<StatusPortData<T>* const> statusPortDataPtr) noexcept
+        : m_statusPortDataPtr(statusPortDataPtr)
+    /// @todo #982 Replace once the RouDi infrastructure is ready
+    // m_statusPortDataPtr(iox::runtime::PoshRuntime::getInstance().getMiddlewareStatusPort(sizeof(T)))
+    {
+        cxx::Expects(m_statusPortDataPtr->latestTransaction.is_lock_free());
+    }
+
+    StatusPortReader(StatusPortReader&& rhs) = delete;
+    StatusPortReader& operator=(StatusPortReader&& rhs) = delete;
+    StatusPortReader(const StatusPortReader&) = delete;
+    StatusPortReader& operator=(const StatusPortReader&) = delete;
+
+    void take(cxx::function_ref<void(const T&)> callable) const noexcept
+    {
+        // The user needs to provide a callable which can deal with Frankenstein objects (half-written data)
+        Transaction currentTransaction;
+
+        do
+        {
+            // Get current world view
+            currentTransaction = m_statusPortDataPtr->latestTransaction.load(std::memory_order_acquire);
+            auto currentReadPosition =
+                static_cast<std::underlying_type<ActiveChunk>::type>(currentTransaction.activeChunk);
+
+            if (!m_statusPortDataPtr->chunks[currentReadPosition].data.has_value())
+            {
+                return;
+            }
+
+            // Do we have to tell the StatusPortWriter that we took ownership of the chunk?
+            // Nope, we just need to detect if the StatusPortWriter has stored something in the meantime aka the world a
+            // turned one step further. In such a case, we'll just copy the data again and re-call the callable
+
+            callable(*(m_statusPortDataPtr->chunks[currentReadPosition].data));
+
+            // Re-call the callable if the world changed in the meantime
+        } while (currentTransaction != m_statusPortDataPtr->latestTransaction.load(std::memory_order_acquire));
+    }
+
+  private:
+    StatusPortData<T>* m_statusPortDataPtr;
+    /// @todo #982 add getMembers() when integrating into RouDi infrastructure
+};
+
+template <typename T>
+class StatusPortWriter
+{
+  public:
+    StatusPortWriter(cxx::not_null<StatusPortData<T>*> statusPortDataPtr) noexcept
+        : m_statusPortDataPtr(statusPortDataPtr)
+    /// @todo #982 Replace once the RouDi infrastructure is ready
+    // m_statusPortDataPtr(iox::runtime::PoshRuntime::getInstance().getMiddlewareStatusPort(sizeof(T)))
+    {
+    }
+
+    StatusPortWriter(StatusPortWriter&& rhs) = delete;
+    StatusPortWriter& operator=(StatusPortWriter&& rhs) = delete;
+    StatusPortWriter(const StatusPortWriter&) = delete;
+    StatusPortWriter& operator=(const StatusPortWriter&) = delete;
+
+    void store(cxx::function_ref<void(T&)> callable) noexcept
+    {
+        // Against what do we have to protect us in store?
+        // Against nothing we are the boss and the single entitiy changing latestTransaction, hence no CAS is needed
+
+        // Get current world view
+        auto currentTransaction = m_statusPortDataPtr->latestTransaction.load(std::memory_order_relaxed);
+        // Get the readPosition and toggle it to get write position
+        auto currentWritePosition =
+            1 xor static_cast<std::underlying_type<ActiveChunk>::type>(currentTransaction.activeChunk);
+
+        /// @todo #982 Later we'll directly pass the dereferenced raw shared memory pointer
+        // callable(*(m_statusPortDataPtr->chunks[currentWritePosition].data));
+
+        // Update our new world view, it can't fail because we're the only writer
+        T valueToStore;
+        callable(valueToStore);
+        m_statusPortDataPtr->chunks[currentWritePosition].data.emplace(valueToStore);
+
+        Transaction newTransaction{static_cast<ActiveChunk>(currentWritePosition), ++currentTransaction.abaCounter};
+        m_statusPortDataPtr->latestTransaction.store(newTransaction, std::memory_order_release);
+        // Store operation aka world view is now observable for all readers
+    }
+
+  private:
+    StatusPortData<T>* m_statusPortDataPtr;
+    /// @todo #982 add getMembers() when integrating into RouDi infrastructure
+};
+
+#endif // IOX_POSH_POPO_STATUS_PORT_HPP
+
+} // namespace popo
+} // namespace iox
+```
+
+## Open issues
+
+* Naming
+    * `StatusPort{Writer,Reader}` or just `StatusReader` and `StatusWriter`?
+* Does `copyTake()` make sense as an additional contract with the user?
+    * It would be possible that the user provides an arbitrary lambda, that does
+    not need to be written with care
+
+```cpp
+void copyTake(cxx::function_ref<void(const T&)> callable) const noexcept
+{
+    Transaction currentTransaction;
+    T copyOfUserData;
+
+    do
+    {
+        // Get current world view
+        currentTransaction = m_statusPortDataPtr->latestTransaction.load(std::memory_order_acquire);
+        auto currentReadPosition =
+            static_cast<std::underlying_type<ActiveChunk>::type>(currentTransaction.activeChunk);
+
+        if (!m_statusPortDataPtr->chunks[currentReadPosition].data.has_value())
+        {
+            return;
+        }
+
+        // To prevent crashes due to Frankenstein objects (half-written data), we copy the data to our class
+        // beforehand. memcpy can never crash when copying Frankenstein objects
+        std::memcpy(reinterpret_cast<void*>(&copyOfUserData),
+                    &m_statusPortDataPtr->chunks[currentReadPosition].data.value(),
+                    sizeof(T));
+
+        // Re-call the callable if the world changed in the meantime
+    } while (currentTransaction != m_statusPortDataPtr->latestTransaction.load(std::memory_order_acquire));
+    // Now we are sure that data isn't corrupted
+    callable(copyOfUserData);
+}
+```


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
* Add design `StatusPort` design document
 
## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
    - [ ] Each unit test case has a unique UUID
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes partly #982
- Related to #415 
