### PR TITLE
iox-#988 Add unique test identifiers to ASPICE example and Cylcone DDS gateway

### DIFF
--- a/doc/aspice_swe3_4/example/iceoryx_component/test/moduletests/test_example_base_class.cpp
+++ b/doc/aspice_swe3_4/example/iceoryx_component/test/moduletests/test_example_base_class.cpp
@@ -38,12 +38,14 @@ class ExampleBaseClass_test : public Test
 /// @note name of the Testcase shall describe the test case in detail to avoid additional comments
 TEST_F(ExampleBaseClass_test, FirstUnitTestCase)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "2c612537-21ec-4dde-95a9-c91010ec8bdd");
     EXPECT_THAT(sut.simplerMethod(), Eq(99U));
 }
 
 /// @note name of the Testcase shall describe the test case in detail to avoid additional comments
 TEST_F(ExampleBaseClass_test, GetMemberVariableFromCtor)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "839725bf-1ae8-4a81-b574-15114a657a7e");
     example::ExampleBaseClass<uint32_t> sut2(100);
     EXPECT_THAT(sut2.getMemberVariable(), Eq(99U));
 }

--- a/iceoryx_dds/test/moduletests/test_cyclone_data_reader.cpp
+++ b/iceoryx_dds/test/moduletests/test_cyclone_data_reader.cpp
@@ -53,6 +53,7 @@ class CycloneDataReaderTest : public Test
 // ======================================== Tests ======================================== //
 TEST_F(CycloneDataReaderTest, DoesNotAttemptToReadWhenDisconnected)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46fc99d7-9f7b-4b77-94c7-06778e3461f7");
     // ===== Setup
     ChunkMock<DummyPayload> chunkMock;
     iox::dds::IoxChunkDatagramHeader datagramHeader;
@@ -72,6 +73,7 @@ TEST_F(CycloneDataReaderTest, DoesNotAttemptToReadWhenDisconnected)
 
 TEST_F(CycloneDataReaderTest, ReturnsErrorWhenAttemptingToReadIntoANullBuffer)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "ddd6e55a-b4ca-4e10-838e-5a532ccadb50");
     // ===== Setup
     ChunkMock<DummyPayload, DummyUserHeader> chunkMock;
     iox::dds::IoxChunkDatagramHeader datagramHeader;

--- a/iceoryx_dds/test/moduletests/test_dds_to_iox.cpp
+++ b/iceoryx_dds/test/moduletests/test_dds_to_iox.cpp
@@ -41,6 +41,7 @@ class DDS2IceoryxGatewayTest : public DDSGatewayTestFixture<MockPublisher, MockD
 // ======================================== Tests ======================================== //
 TEST_F(DDS2IceoryxGatewayTest, ChannelsAreCreatedForConfiguredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "8c439c96-4777-47a2-aebf-a01898b39c1d");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     iox::config::GatewayConfig config{};
@@ -57,6 +58,7 @@ TEST_F(DDS2IceoryxGatewayTest, ChannelsAreCreatedForConfiguredServices)
 
 TEST_F(DDS2IceoryxGatewayTest, ImmediatelyOffersConfiguredPublishers)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e51ff9c2-d5cf-45eb-bc04-78973d99d9e5");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 
@@ -78,6 +80,7 @@ TEST_F(DDS2IceoryxGatewayTest, ImmediatelyOffersConfiguredPublishers)
 
 TEST_F(DDS2IceoryxGatewayTest, ImmediatelyConnectsConfiguredDataReaders)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "edbfd533-90aa-417c-9a39-3e7ab7ed15fb");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 
@@ -101,6 +104,7 @@ TEST_F(DDS2IceoryxGatewayTest, ImmediatelyConnectsConfiguredDataReaders)
 #if 0
 TEST_F(DDS2IceoryxGatewayTest, PublishesMemoryChunksContainingSamplesToNetwork)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "1024b7c2-c2ed-4371-a1df-5990dc913a97");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 

--- a/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
+++ b/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
@@ -52,6 +52,7 @@ class Iceoryx2DDSGatewayTest : public DDSGatewayTestFixture<MockSubscriber, Mock
 // ======================================== Tests ======================================== //
 TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForConfiguredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "9e5b3965-2d27-4ec9-a708-5a0c17b47040");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     iox::config::GatewayConfig config{};
@@ -67,6 +68,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForConfiguredServices)
 
 TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromConfiguredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d32dac2b-ef86-418d-91d3-6df9d6c79b50");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     iox::config::GatewayConfig config{};
@@ -86,6 +88,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromConfiguredServices
 
 TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForConfiguredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "d9590f9d-f601-4a00-b96d-843a2271483b");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     iox::config::GatewayConfig config{};
@@ -105,6 +108,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForConfigure
 
 TEST_F(Iceoryx2DDSGatewayTest, IgnoresIntrospectionPorts)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "46a4fd43-721c-4c69-a2e2-014ad794cc78");
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Introspection", "Foo", "Bar"});
@@ -118,6 +122,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresIntrospectionPorts)
 
 TEST_F(Iceoryx2DDSGatewayTest, IgnoresServiceMessages)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "6894e3f2-6f41-4b8e-95e0-e375ab294d19");
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Foo", "Bar", "Baz"});
@@ -131,6 +136,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresServiceMessages)
 
 TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForDiscoveredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "0f356ca7-8f0f-442e-8888-592578145e59");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     TestGateway gw{};
@@ -146,6 +152,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForDiscoveredServices)
 
 TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromDiscoveredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "53e36923-1e39-43c5-a094-651f1ca4c08c");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     auto mockSubscriber = createMockIceoryxTerminal(testService, iox::popo::SubscriberOptions());
@@ -166,6 +173,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromDiscoveredServices
 
 TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForDiscoveredServices)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "334d8d97-672a-40ab-958c-e90ec9a726f5");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     auto mockWriter = createMockDDSTerminal(testService);
@@ -188,6 +196,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForDiscovere
 #if 0
 TEST_F(Iceoryx2DDSGatewayTest, ForwardsChunkFromSubscriberToDataWriter)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "51527674-ccc7-4817-bae9-64eebe766fff");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 
@@ -216,6 +225,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ForwardsChunkFromSubscriberToDataWriter)
 
 TEST_F(Iceoryx2DDSGatewayTest, IgnoresMemoryChunksWithNoPayload)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "e73d405e-a8a5-43d7-bc5e-6130b1fa2747");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 
@@ -243,6 +253,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresMemoryChunksWithNoPayload)
 
 TEST_F(Iceoryx2DDSGatewayTest, ReleasesReferenceToMemoryChunkAfterSend)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "39f081c9-2ce7-4e00-b6c4-5cc1596fa699");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 
@@ -275,6 +286,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ReleasesReferenceToMemoryChunkAfterSend)
 
 TEST_F(Iceoryx2DDSGatewayTest, DestroysCorrespondingSubscriberWhenAPublisherStopsOffering)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "a0150430-c947-4735-8474-aea14d2cadbd");
     // === Setup
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
* Add unique test identifiers
   * ASPICE example
   * Cylcone DDS gateway

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #988
