### PR TITLE
Iox #415 refactor service registry

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/capro/service_description.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/capro/service_description.hpp
@@ -30,7 +30,8 @@ namespace iox
 namespace capro
 {
 /// @brief Used to search for any string
-constexpr iox::cxx::nullopt_t Wildcard;
+using Wildcard_t = iox::cxx::nullopt_t;
+constexpr Wildcard_t Wildcard;
 
 static constexpr int32_t MAX_NUMBER_OF_CHARS = 64;
 static constexpr size_t CLASS_HASH_ELEMENT_COUNT{4U};

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -131,7 +131,8 @@ constexpr uint32_t MAX_PROCESS_NUMBER = 300U;
 /// This limitation is coming due to the fixed capacity of the cxx::vector (This doesn't limit the offered number of
 /// instances)
 /// @todo #415 increase number back to 50 once service registry is available via shared memory
-constexpr uint32_t MAX_NUMBER_OF_SERVICES = 100U;
+/// @todo #1074 define and set the limits concerning the service discovery
+constexpr uint32_t MAX_NUMBER_OF_SERVICES = 10U;
 
 // Nodes
 constexpr uint32_t MAX_NODE_NUMBER = 1000U;

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -131,7 +131,7 @@ constexpr uint32_t MAX_PROCESS_NUMBER = 300U;
 /// This limitation is coming due to the fixed capacity of the cxx::vector (This doesn't limit the offered number of
 /// instances)
 /// @todo #415 increase number back to 50 once service registry is available via shared memory
-constexpr uint32_t MAX_NUMBER_OF_SERVICES = 10U;
+constexpr uint32_t MAX_NUMBER_OF_SERVICES = 100U;
 
 // Nodes
 constexpr uint32_t MAX_NODE_NUMBER = 1000U;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -22,8 +22,6 @@
 #include "iceoryx_hoofs/cxx/vector.hpp"
 #include "iceoryx_posh/capro/service_description.hpp"
 
-#include "iceoryx_hoofs/internal/objectpool/objectpool.hpp"
-
 #include <cstdint>
 #include <map>
 #include <utility>
@@ -53,7 +51,7 @@ class ServiceRegistry
     };
 
     /// @todo #415 should be connected with iox::MAX_NUMBER_OF_SERVICES
-    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = 100U;
+    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = 2000U;
     static constexpr uint32_t NO_INDEX = MAX_SERVICE_DESCRIPTIONS;
 
 
@@ -61,17 +59,21 @@ class ServiceRegistry
 
     using Entry_t = cxx::optional<ServiceDescriptionEntry>;
     using ServiceDescriptionContainer_t = cxx::vector<Entry_t, MAX_SERVICE_DESCRIPTIONS>;
-    // using ServiceDescriptionPool_t = cxx::ObjectPool<cxx::optional<ServiceDescriptionEntry>,
-    // MAX_SERVICE_DESCRIPTIONS>;
 
     /// @brief Adds given service description to registry
     /// @param[in] serviceDescription, service to be added
     /// @return ServiceRegistryError, error wrapped in cxx::expected
     cxx::expected<Error> add(const capro::ServiceDescription& serviceDescription) noexcept;
 
-    /// @brief Removes given service description from registry if service is found
+    /// @brief Removes given service description from registry if service is found,
+    ///        in case of multiple occurences only one is removed
     /// @param[in] serviceDescription, service to be removed
     void remove(const capro::ServiceDescription& serviceDescription) noexcept;
+
+    /// @brief Removes given service description from registry if service is found,
+    ///        all occurences are removed
+    /// @param[in] serviceDescription, service to be removed
+    void removeAll(const capro::ServiceDescription& serviceDescription) noexcept;
 
     /// @brief Searches for given service description in registry
     /// @param[in] searchResult, reference to the vector which will be filled with the results
@@ -88,12 +90,6 @@ class ServiceRegistry
     const ServiceDescriptionVector_t getServices() const noexcept;
 
   private:
-    /// @todo #859 replace std::multimap with prefix tree
-    ::std::multimap<capro::IdString_t, uint64_t> m_serviceMap;
-    ::std::multimap<capro::IdString_t, uint64_t> m_instanceMap;
-    ::std::multimap<capro::IdString_t, uint64_t> m_eventMap;
-    ServiceDescriptionVector_t m_serviceDescriptionVector;
-
     ServiceDescriptionContainer_t m_serviceDescriptions;
     // ServiceDescriptionPool_t m_serviceDescriptions;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -25,7 +25,6 @@
 
 
 #include <cstdint>
-#include <map>
 #include <utility>
 
 namespace iox
@@ -91,9 +90,6 @@ class ServiceRegistry
 
     static constexpr uint32_t NO_INDEX = MAX_SERVICE_DESCRIPTIONS;
 
-    // tag type for internal overloads
-    using Wildcard_t = iox::capro::Wildcard_t;
-
     ServiceDescriptionContainer_t m_serviceDescriptions;
 
     // store the last known free Index (if any is known)
@@ -102,45 +98,7 @@ class ServiceRegistry
     uint32_t m_freeIndex{NO_INDEX};
 
   private:
-    // functions for the different search cases
-    // tag types are not needed in all cases to distinguish overloads but kept for consistency
-
     uint32_t findIndex(const capro::ServiceDescription& serviceDescription) const noexcept;
-
-    void find(const capro::IdString_t& service,
-              Wildcard_t,
-              Wildcard_t,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(Wildcard_t,
-              const capro::IdString_t& instance,
-              Wildcard_t,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(Wildcard_t,
-              Wildcard_t,
-              const capro::IdString_t& event,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(const capro::IdString_t& service,
-              const capro::IdString_t& instance,
-              Wildcard_t,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(const capro::IdString_t& service,
-              Wildcard_t,
-              const capro::IdString_t& event,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(Wildcard_t,
-              const capro::IdString_t& instance,
-              const capro::IdString_t& event,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
-
-    void find(const capro::IdString_t& service,
-              const capro::IdString_t& instance,
-              const capro::IdString_t& event,
-              ServiceDescriptionVector_t& searchResult) const noexcept;
 
     void getAll(ServiceDescriptionVector_t& searchResult) const noexcept;
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -53,12 +53,10 @@ class ServiceRegistry
     };
 
     /// @todo #415 should be connected with iox::MAX_NUMBER_OF_SERVICES
-    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = 5000U;
+    ///            increase limit to at least >= 1000
+    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = 100U;
 
     using ServiceDescriptionVector_t = cxx::vector<ServiceDescriptionEntry, MAX_SERVICE_DESCRIPTIONS>;
-
-    using Entry_t = cxx::optional<ServiceDescriptionEntry>;
-    using ServiceDescriptionContainer_t = cxx::vector<Entry_t, MAX_SERVICE_DESCRIPTIONS>;
 
     /// @brief Adds given service description to registry
     /// @param[in] serviceDescription, service to be added
@@ -90,6 +88,9 @@ class ServiceRegistry
     const ServiceDescriptionVector_t getServices() const noexcept;
 
   private:
+    using Entry_t = cxx::optional<ServiceDescriptionEntry>;
+    using ServiceDescriptionContainer_t = cxx::vector<Entry_t, MAX_SERVICE_DESCRIPTIONS>;
+
     static constexpr uint32_t NO_INDEX = MAX_SERVICE_DESCRIPTIONS;
 
     // tag type for internal overloads

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -50,8 +50,9 @@ class ServiceRegistry
         ReferenceCounter_t count{1U};
     };
 
-    /// @todo #415 increase limit to at least >= 1000
-    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = iox::MAX_NUMBER_OF_SERVICES;
+    /// @todo #415 #1074 set limits properly and define location for the limits,
+    ///       e.g posh_types.hpp
+    static constexpr uint32_t MAX_SERVICE_DESCRIPTIONS = iox::MAX_PUBLISHERS;
 
     using ServiceDescriptionVector_t = cxx::vector<ServiceDescriptionEntry, MAX_SERVICE_DESCRIPTIONS>;
 

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -109,41 +109,20 @@ void ServiceRegistry::find(ServiceDescriptionVector_t& searchResult,
                            const cxx::optional<capro::IdString_t>& instance,
                            const cxx::optional<capro::IdString_t>& event) const noexcept
 {
-    constexpr Wildcard_t WILDCARD;
-
-    // all search cases have complexity O(n)
-    // there are 8 cases and we dispatch with as little case-checking as possible
-    if (service)
+    for (auto& entry : m_serviceDescriptions)
     {
-        if (instance)
+        if (entry)
         {
-            if (event)
+            bool match = (service) ? (entry->serviceDescription.getServiceIDString() == *service) : true;
+            match &= (instance) ? (entry->serviceDescription.getInstanceIDString() == *instance) : true;
+            match &= (event) ? (entry->serviceDescription.getEventIDString() == *event) : true;
+
+            if (match)
             {
-                return find(*service, *instance, *event, searchResult);
+                searchResult.emplace_back(*entry);
             }
-            return find(*service, *instance, WILDCARD, searchResult);
         }
-        if (event)
-        {
-            return find(*service, WILDCARD, *event, searchResult);
-        }
-        return find(*service, WILDCARD, WILDCARD, searchResult);
     }
-
-    if (instance)
-    {
-        if (event)
-        {
-            return find(WILDCARD, *instance, *event, searchResult);
-        }
-        return find(WILDCARD, *instance, WILDCARD, searchResult);
-    }
-    if (event)
-    {
-        return find(WILDCARD, WILDCARD, *event, searchResult);
-    }
-
-    return getAll(searchResult);
 }
 
 const ServiceRegistry::ServiceDescriptionVector_t ServiceRegistry::getServices() const noexcept
@@ -164,110 +143,6 @@ uint32_t ServiceRegistry::findIndex(const capro::ServiceDescription& serviceDesc
         }
     }
     return NO_INDEX;
-}
-
-
-void ServiceRegistry::find(const capro::IdString_t& service,
-                           Wildcard_t,
-                           Wildcard_t,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getServiceIDString() == service)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(Wildcard_t,
-                           const capro::IdString_t& instance,
-                           Wildcard_t,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getInstanceIDString() == instance)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(Wildcard_t,
-                           Wildcard_t,
-                           const capro::IdString_t& event,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getEventIDString() == event)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(const capro::IdString_t& service,
-                           const capro::IdString_t& instance,
-                           Wildcard_t,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getServiceIDString() == service
-            && entry->serviceDescription.getInstanceIDString() == instance)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(const capro::IdString_t& service,
-                           Wildcard_t,
-                           const capro::IdString_t& event,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getServiceIDString() == service
-            && entry->serviceDescription.getEventIDString() == event)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(Wildcard_t,
-                           const capro::IdString_t& instance,
-                           const capro::IdString_t& event,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getInstanceIDString() == instance
-            && entry->serviceDescription.getEventIDString() == event)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
-}
-
-void ServiceRegistry::find(const capro::IdString_t& service,
-                           const capro::IdString_t& instance,
-                           const capro::IdString_t& event,
-                           ServiceDescriptionVector_t& searchResult) const noexcept
-{
-    for (auto& entry : m_serviceDescriptions)
-    {
-        if (entry && entry->serviceDescription.getServiceIDString() == service
-            && entry->serviceDescription.getInstanceIDString() == instance
-            && entry->serviceDescription.getEventIDString() == event)
-        {
-            searchResult.emplace_back(*entry);
-        }
-    }
 }
 
 void ServiceRegistry::getAll(ServiceDescriptionVector_t& searchResult) const noexcept

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -17,9 +17,6 @@
 
 #include "iceoryx_posh/internal/roudi/service_registry.hpp"
 
-#include <algorithm>
-#include <iterator>
-
 namespace iox
 {
 namespace roudi
@@ -31,18 +28,18 @@ cxx::expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceD
     {
         // entry exists, increment counter
         auto& entry = m_serviceDescriptions[index];
-        entry->referenceCounter++;
+        entry->count++;
         return cxx::success<>();
     }
 
     // entry does not exist, find a free slot if it exists
 
-    // fast path to a free slot (previously removed)
-    // note: we prefer entries close to the front
+    // fast path to a free slot (which was occupied by previously removed entry),
+    // prefer to fill entries close to the front
     if (m_freeIndex != NO_INDEX)
     {
         auto& entry = m_serviceDescriptions[m_freeIndex];
-        entry.emplace(serviceDescription, 1);
+        entry.emplace(serviceDescription, 1U);
         m_freeIndex = NO_INDEX;
         return cxx::success<>();
     }
@@ -52,16 +49,16 @@ cxx::expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceD
     {
         if (!entry)
         {
-            entry.emplace(serviceDescription, 1);
+            entry.emplace(serviceDescription, 1U);
             return cxx::success<>();
         }
     }
 
-    // append new entry at the end
+    // append new entry at the end (the size only grows up to capacity)
     if (m_serviceDescriptions.emplace_back())
     {
         auto& entry = m_serviceDescriptions.back();
-        entry.emplace(serviceDescription, 1);
+        entry.emplace(serviceDescription, 1U);
         return cxx::success<>();
     }
 
@@ -75,13 +72,14 @@ void ServiceRegistry::remove(const capro::ServiceDescription& serviceDescription
     {
         auto& entry = m_serviceDescriptions[index];
 
-        if (entry->referenceCounter > 1)
+        if (entry->count > 1)
         {
-            entry->referenceCounter--;
+            entry->count--;
         }
         else
         {
             entry.reset();
+            // reuse the slot in the next insertion
             m_freeIndex = index;
         }
     }
@@ -94,6 +92,7 @@ void ServiceRegistry::removeAll(const capro::ServiceDescription& serviceDescript
     {
         auto& entry = m_serviceDescriptions[index];
         entry.reset();
+        // reuse the slot in the next insertion
         m_freeIndex = index;
     }
 }
@@ -103,49 +102,178 @@ void ServiceRegistry::find(ServiceDescriptionVector_t& searchResult,
                            const cxx::optional<capro::IdString_t>& instance,
                            const cxx::optional<capro::IdString_t>& event) const noexcept
 {
-    // all search cases have complexity O(n)
-
     constexpr Wildcard WILDCARD;
 
-    // as little case-checking as possible, as much compile time dispatch via tag types as possible
+    // all search cases have complexity O(n)
+    // there are 8 cases and we dispatch with as little case-checking as possible
     if (service)
     {
         if (instance)
         {
             if (event)
             {
-                return find_(*service, *instance, *event, searchResult);
+                return find(*service, *instance, *event, searchResult);
             }
-            return find_(*service, *instance, WILDCARD, searchResult);
+            return find(*service, *instance, WILDCARD, searchResult);
         }
         if (event)
         {
-            return find_(*service, WILDCARD, *event, searchResult);
+            return find(*service, WILDCARD, *event, searchResult);
         }
-        return find_(*service, WILDCARD, WILDCARD, searchResult);
+        return find(*service, WILDCARD, WILDCARD, searchResult);
     }
 
     if (instance)
     {
         if (event)
         {
-            return find_(WILDCARD, *instance, *event, searchResult);
+            return find(WILDCARD, *instance, *event, searchResult);
         }
-        return find_(WILDCARD, *instance, WILDCARD, searchResult);
+        return find(WILDCARD, *instance, WILDCARD, searchResult);
     }
     if (event)
     {
-        return find_(WILDCARD, WILDCARD, *event, searchResult);
+        return find(WILDCARD, WILDCARD, *event, searchResult);
     }
 
-    return find_all(searchResult);
+    return findAll(searchResult);
 }
 
 const ServiceRegistry::ServiceDescriptionVector_t ServiceRegistry::getServices() const noexcept
 {
     ServiceDescriptionVector_t allEntries;
-    find_all(allEntries);
+    findAll(allEntries);
     return allEntries;
 }
+
+uint32_t ServiceRegistry::find(const capro::ServiceDescription& serviceDescription) const noexcept
+{
+    for (uint32_t i = 0; i < m_serviceDescriptions.size(); ++i)
+    {
+        auto& entry = m_serviceDescriptions[i];
+        if (entry && entry->serviceDescription == serviceDescription)
+        {
+            return i;
+        }
+    }
+    return NO_INDEX;
+}
+
+
+void ServiceRegistry::find(const capro::IdString_t& service,
+                           Wildcard,
+                           Wildcard,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getServiceIDString() == service)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(Wildcard,
+                           const capro::IdString_t& instance,
+                           Wildcard,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getInstanceIDString() == instance)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(Wildcard,
+                           Wildcard,
+                           const capro::IdString_t& event,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getEventIDString() == event)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(const capro::IdString_t& service,
+                           const capro::IdString_t& instance,
+                           Wildcard,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getServiceIDString() == service
+            && entry->serviceDescription.getInstanceIDString() == instance)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(const capro::IdString_t& service,
+                           Wildcard,
+                           const capro::IdString_t& event,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getServiceIDString() == service
+            && entry->serviceDescription.getEventIDString() == event)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(Wildcard,
+                           const capro::IdString_t& instance,
+                           const capro::IdString_t& event,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getInstanceIDString() == instance
+            && entry->serviceDescription.getEventIDString() == event)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::find(const capro::IdString_t& service,
+                           const capro::IdString_t& instance,
+                           const capro::IdString_t& event,
+                           ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry && entry->serviceDescription.getServiceIDString() == service
+            && entry->serviceDescription.getInstanceIDString() == instance
+            && entry->serviceDescription.getEventIDString() == event)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+void ServiceRegistry::findAll(ServiceDescriptionVector_t& searchResult) const noexcept
+{
+    for (auto& entry : m_serviceDescriptions)
+    {
+        if (entry)
+        {
+            searchResult.emplace_back(*entry);
+        }
+    }
+}
+
+
 } // namespace roudi
 } // namespace iox

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -38,6 +38,7 @@ cxx::expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceD
     // entry does not exist, find a free slot if it exists
 
     // fast path to a free slot (previously removed)
+    // note: we prefer entries close to the front
     if (m_freeIndex != NO_INDEX)
     {
         auto& entry = m_serviceDescriptions[m_freeIndex];
@@ -72,7 +73,6 @@ void ServiceRegistry::remove(const capro::ServiceDescription& serviceDescription
     auto index = find(serviceDescription);
     if (index != NO_INDEX)
     {
-        // entry exists, increment counter
         auto& entry = m_serviceDescriptions[index];
 
         if (entry->referenceCounter > 1)
@@ -84,6 +84,17 @@ void ServiceRegistry::remove(const capro::ServiceDescription& serviceDescription
             entry.reset();
             m_freeIndex = index;
         }
+    }
+}
+
+void ServiceRegistry::removeAll(const capro::ServiceDescription& serviceDescription) noexcept
+{
+    auto index = find(serviceDescription);
+    if (index != NO_INDEX)
+    {
+        auto& entry = m_serviceDescriptions[index];
+        entry.reset();
+        m_freeIndex = index;
     }
 }
 
@@ -132,9 +143,9 @@ void ServiceRegistry::find(ServiceDescriptionVector_t& searchResult,
 
 const ServiceRegistry::ServiceDescriptionVector_t ServiceRegistry::getServices() const noexcept
 {
-    ServiceDescriptionVector_t allServices;
-    find_all(allServices);
-    return allServices;
+    ServiceDescriptionVector_t allEntries;
+    find_all(allEntries);
+    return allEntries;
 }
 } // namespace roudi
 } // namespace iox

--- a/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
+++ b/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
@@ -478,6 +478,9 @@ TEST_F(ServiceDiscovery_test, FindServiceReturnsMaxServices)
     EXPECT_TRUE(serviceContainer.value() == serviceContainerExp);
 }
 
+/// @todo #415 #1074 this test is affected by the limits we set for service discovery,
+/// if the container capacity is larger than what we can send with sockets
+/// we will never cause an overflow
 TEST_F(ServiceDiscovery_test, FindServiceReturnsContainerOverflowErrorWhenMoreThanMaxServicesAreFound)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f2f8d8c0-8712-4e7a-9e33-2b2a918f8a71");

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -113,7 +113,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturn
 
     ASSERT_THAT(searchResults.size(), Eq(1));
     EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
-    EXPECT_THAT(searchResults[0].referenceCounter, Eq(2));
+    EXPECT_THAT(searchResults[0].count, Eq(2));
 }
 
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
@@ -131,7 +131,23 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsO
 
     ASSERT_THAT(searchResults.size(), Eq(1));
     EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
-    EXPECT_THAT(searchResults[0].referenceCounter, Eq(1));
+    EXPECT_THAT(searchResults[0].count, Eq(1));
+}
+
+TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveAllReturnsNoResult)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3185b67f-b891-4a82-8f91-047e059ed68f");
+    auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    ASSERT_FALSE(result1.has_error());
+
+    auto result2 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    ASSERT_FALSE(result2.has_error());
+
+    sut.removeAll(ServiceDescription("Li", "La", "Launebaerli"));
+
+    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+
+    EXPECT_THAT(searchResults.size(), Eq(0));
 }
 
 TEST_F(ServiceRegistry_test, AddEmptyServiceDescriptionsWorks)
@@ -459,11 +475,10 @@ T uniform(T max)
 }
 
 using string_t = iox::capro::IdString_t;
-using search_result_t = ServiceRegistry::ServiceDescriptionVector_t;
 
 string_t randomString(uint64_t size = string_t::capacity())
 {
-    // deliberately contains no `0`
+    // deliberately contains no `0` (need to exclude some char)
     static const char chars[] = "123456789"
                                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                 "abcdefghijklmnopqrstuvwxyz";
@@ -484,6 +499,7 @@ string_t randomString(uint64_t size = string_t::capacity())
 
 TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "76aef6cb-7886-4d64-9188-09bd1be2d335");
     uint32_t numEntriesAdded = 0;
     do
     {
@@ -507,6 +523,8 @@ TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
 
 TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "5c4519d4-1873-4837-a3eb-0367106fb9b5");
+
     constexpr auto CAP = string_t::capacity();
 
     string_t fixedId(iox::cxx::TruncateToCapacity, std::string(CAP, '0'));
@@ -537,7 +555,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     auto result = sut.add(uniqueSd);
     EXPECT_FALSE(result.has_error());
 
-    search_result_t searchResult;
+    ServiceRegistry::ServiceDescriptionVector_t searchResult;
     auto& service = uniqueSd.getServiceIDString();
     auto& instance = uniqueSd.getInstanceIDString();
     auto& event = uniqueSd.getEventIDString();

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -29,7 +29,7 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::roudi;
-/// @todo #415 Replace Wildcards once service registry has its new data structure
+
 class ServiceRegistry_test : public Test
 {
   public:
@@ -134,7 +134,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsO
     EXPECT_THAT(searchResults[0].count, Eq(1));
 }
 
-TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveAllReturnsNoResult)
+TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3185b67f-b891-4a82-8f91-047e059ed68f");
     auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
@@ -143,7 +143,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveAllReturnsNoRes
     auto result2 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result2.has_error());
 
-    sut.removeAll(ServiceDescription("Li", "La", "Launebaerli"));
+    sut.purge(ServiceDescription("Li", "La", "Launebaerli"));
 
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
@@ -487,7 +487,7 @@ string_t randomString(uint64_t size = string_t::capacity())
     size = std::min(N, size);
 
     char a[N + 1];
-    for (uint64_t i = 0; i < size; ++i)
+    for (uint64_t i = 0U; i < size; ++i)
     {
         a[i] = chars[uniform(sizeof(chars) - 1)];
     }
@@ -500,7 +500,7 @@ string_t randomString(uint64_t size = string_t::capacity())
 TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
 {
     ::testing::Test::RecordProperty("TEST_ID", "76aef6cb-7886-4d64-9188-09bd1be2d335");
-    uint32_t numEntriesAdded = 0;
+    uint32_t numEntriesAdded = 0U;
     do
     {
         // may (rarely) generate duplicates to be counted internally
@@ -544,7 +544,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     } while (true);
 
     // remove the last and replace it with a unique service description
-    sut.removeAll(lastAdded);
+    sut.purge(lastAdded);
 
     // is unique (random does not generate 0s) and last if a vector is used internally
     // for almost worst case search (search on last string will terminate early whp)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Reviewer notes

Only change the internal implementation of `ServiceRegistry` to use a vector, but NOT the interface (except for extension with one method `removeAll`).

## References

- Closes nothing
