### PR TITLE
iox-#1076 replace result_of with invoke_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Catch deserialization errors for enums in publisher and subscriber options [\#989](https://github.com/eclipse-iceoryx/iceoryx/issues/989)
 - Fix linker error on QNX [\#1013](https://github.com/eclipse-iceoryx/iceoryx/issues/1013)
 - When posix mutex fails a correct error message is reported on the console [\#999](https://github.com/eclipse-iceoryx/iceoryx/issues/999)
+- Only use `std::result_of` for C++14 to be able to use iceoryx in C++20 projects [\#1076](https://github.com/eclipse-iceoryx/iceoryx/issues/1076)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,7 +63,12 @@ struct is_invocable
     // This variant is chosen when Callable(ArgTypes) successfully resolves to a valid type, i.e. is invocable.
     /// @note result_of is deprecated, switch to invoke_result in C++17
     template <typename C, typename... As>
+#if __cplusplus < 201703L
     static constexpr std::true_type test(typename std::result_of<C(As...)>::type*) noexcept
+    // use std::invoke_result so that iceoryx can be used in c++20 projects
+#elif __cplusplus >= 201703L
+    static constexpr std::true_type test(typename std::invoke_result<C, As...>::type*) noexcept
+#endif
     {
         return {};
     }
@@ -90,7 +95,13 @@ struct is_invocable_r
 {
     template <typename C, typename... As>
     static constexpr std::true_type
+#if __cplusplus < 201703L
     test(std::enable_if_t<std::is_convertible<typename std::result_of<C(As...)>::type, ReturnType>::value>*) noexcept
+    // use std::invoke_result so that iceoryx can be used in c++20 projects
+#elif __cplusplus >= 201703L
+    test(
+        std::enable_if_t<std::is_convertible<typename std::invoke_result<C, As...>::type, ReturnType>::value>*) noexcept
+#endif
     {
         return {};
     }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
Iceoryx cannot be used in C++20>= projects since we are using the deprecated `std::result_of` and the replacement `std::invoke_result` was introduced in C++17.
I adjusted the code so that `std::result_of` is only used for C++14, in C++17 and later `std::invoke_result` is used.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1076 