### PR TITLE
Iox #1078 transform duration inline namespace into normal namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix linker error on QNX [\#1013](https://github.com/eclipse-iceoryx/iceoryx/issues/1013)
 - When posix mutex fails a correct error message is reported on the console [\#999](https://github.com/eclipse-iceoryx/iceoryx/issues/999)
 - Only use `std::result_of` for C++14 to be able to use iceoryx in C++20 projects [\#1076](https://github.com/eclipse-iceoryx/iceoryx/issues/1076)
+- Turn `inline namespace duration_literals` into normal namespace to solve MSVC inline namespace issue [\#1078](https://github.com/eclipse-iceoryx/iceoryx/issues/1078)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -38,7 +38,7 @@ enum class TimeSpecReference
 
 class Duration;
 
-inline namespace duration_literals
+namespace duration_literals
 {
 /// @brief Constructs a new Duration object from nanoseconds
 constexpr Duration operator"" _ns(unsigned long long int) noexcept; // PRQA S 48

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -76,37 +76,37 @@ inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(con
 template <typename T>
 constexpr Duration Duration::fromNanoseconds(const T value) noexcept
 {
-    return operator"" _ns(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _ns(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromMicroseconds(const T value) noexcept
 {
-    return operator"" _us(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _us(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromMilliseconds(const T value) noexcept
 {
-    return operator"" _ms(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _ms(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromSeconds(const T value) noexcept
 {
-    return operator"" _s(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _s(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromMinutes(const T value) noexcept
 {
-    return operator"" _m(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _m(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromHours(const T value) noexcept
 {
-    return operator"" _h(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _h(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 template <typename T>
 constexpr Duration Duration::fromDays(const T value) noexcept
 {
-    return operator"" _d(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
+    return duration_literals::operator"" _d(positiveValueOrClampToZero(value, __PRETTY_FUNCTION__));
 }
 
 inline constexpr Duration::Duration(const struct timeval& value) noexcept
@@ -455,7 +455,7 @@ inline constexpr Duration Duration::operator*(const T& rhs) const noexcept
     return multiplyWith<T>(rhs);
 }
 
-inline namespace duration_literals
+namespace duration_literals
 {
 inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept // PRQA S 48
 {

--- a/iceoryx_hoofs/test/moduletests/test_ipc_channel.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_ipc_channel.cpp
@@ -28,6 +28,7 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::posix;
+using namespace iox::units::duration_literals;
 
 #if defined(__APPLE__)
 using IpcChannelTypes = Types<UnixDomainSocket>;

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -22,6 +22,7 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::units;
+using namespace iox::units::duration_literals;
 
 constexpr uint64_t SECONDS_PER_MINUTE = Duration::SECS_PER_MINUTE;
 constexpr uint64_t SECONDS_PER_HOUR = Duration::SECS_PER_HOUR;

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -35,6 +35,7 @@ using namespace ::testing;
 using namespace iox;
 using namespace iox::units;
 using namespace iox::posix;
+using namespace iox::units::duration_literals;
 
 using iox::runtime::IpcInterfaceBase;
 using iox::runtime::IpcMessage;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
    - [ ] Each unit test case has a unique UUID
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
