### PR TITLE
iox-#27 Refactor CaproMessageSubType to be able to use ServerPorts with InterfacePorts [stacked PR #1.5]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,22 @@ iox_pub_options_init(&options);
 options.subscriberTooSlowPolicy = ConsumerTooSlowPolicy_WAIT_FOR_CONSUMER;
 ```
 
+- The `CaproMessageSubType` enum is renamed to `CaproServiceType` and the values are renamed from `NOSUBTYPE`,
+  `SERVICE`, `EVENT` and `FIELD` to `NONE`, `PUBLISHER` and `SERVER`
+
+This change only affects `InterfacePorts` which used this enum to communicate whether the `CaproMessage`
+was from a `SERVICE`, `EVENT` or `FIELD`. This was quite ara::com specific and with the introduction of the `ServerPort`
+changes were needed. The distinction between a `FIELD` and an `EVENT` can be made by checking
+`CaproMessage::m_historyCapacity`.
+
+```cpp
+// old
+caproMessage.m_subType = CaproMessageSubType::EVENT;
+
+// new
+caproMessage.m_serviceType = CaproServiceType::PUBLISHER;
+```
+
 ## [v1.0.1](https://github.com/eclipse-iceoryx/iceoryx/tree/v1.0.0) (2021-06-15)
 
 [Full Changelog](https://github.com/eclipse-iceoryx/iceoryx/compare/v1.0.0...v1.0.1)

--- a/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
+++ b/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
@@ -70,7 +70,7 @@ inline void Iceoryx2DDSGateway<channel_t, gateway_t>::discover(const capro::Capr
     {
         return;
     }
-    if (msg.m_subType == capro::CaproMessageSubType::SERVICE)
+    if (msg.m_subType != capro::CaproMessageSubType::PUBLISHER)
     {
         return;
     }

--- a/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
+++ b/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
@@ -70,7 +70,7 @@ inline void Iceoryx2DDSGateway<channel_t, gateway_t>::discover(const capro::Capr
     {
         return;
     }
-    if (msg.m_subType != capro::CaproMessageSubType::PUBLISHER)
+    if (msg.m_serviceType != capro::CaproServiceType::PUBLISHER)
     {
         return;
     }

--- a/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
+++ b/iceoryx_dds/include/iceoryx_dds/internal/gateway/iox_to_dds.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
+++ b/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
@@ -112,7 +112,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresIntrospectionPorts)
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Introspection", "Foo", "Bar"});
-    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    msg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
 
     EXPECT_CALL(gw, addChannel(_, _)).Times(0);
 
@@ -126,7 +126,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresServerMessages)
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Foo", "Bar", "Baz"});
-    msg.m_subType = iox::capro::CaproMessageSubType::SERVER;
+    msg.m_serviceType = iox::capro::CaproServiceType::SERVER;
 
     EXPECT_CALL(gw, addChannel(_, _)).Times(0);
 
@@ -141,7 +141,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForDiscoveredServices)
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    msg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
 
     EXPECT_CALL(gw, findChannel(_)).WillOnce(Return(iox::cxx::nullopt_t()));
     EXPECT_CALL(gw, addChannel(_, _)).WillOnce(Return(channelFactory(testService, iox::popo::SubscriberOptions())));
@@ -161,7 +161,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromDiscoveredServices
 
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    msg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
 
     // Mock methods of the mock generic dds gateway base class
     ON_CALL(gw, findChannel(_)).WillByDefault(Return(iox::cxx::nullopt_t()));
@@ -182,7 +182,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForDiscovere
 
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    msg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
 
     // Mock methods of the mock generic dds gateway base class
     ON_CALL(gw, findChannel(_)).WillByDefault(Return(iox::cxx::nullopt_t()));
@@ -304,9 +304,9 @@ TEST_F(Iceoryx2DDSGatewayTest, DestroysCorrespondingSubscriberWhenAPublisherStop
 
     // Messages
     auto offerMsg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    offerMsg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    offerMsg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
     auto stopOfferMsg = iox::capro::CaproMessage(iox::capro::CaproMessageType::STOP_OFFER, testService);
-    stopOfferMsg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
+    stopOfferMsg.m_serviceType = iox::capro::CaproServiceType::PUBLISHER;
 
     // Get the test channels here as we need to use them in expectations
     auto testChannelOne = channelFactory(testService, iox::popo::SubscriberOptions());

--- a/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
+++ b/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
@@ -112,7 +112,7 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresIntrospectionPorts)
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Introspection", "Foo", "Bar"});
-    msg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
 
     EXPECT_CALL(gw, addChannel(_, _)).Times(0);
 
@@ -120,13 +120,13 @@ TEST_F(Iceoryx2DDSGatewayTest, IgnoresIntrospectionPorts)
     gw.discover(msg);
 }
 
-TEST_F(Iceoryx2DDSGatewayTest, IgnoresServiceMessages)
+TEST_F(Iceoryx2DDSGatewayTest, IgnoresServerMessages)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6894e3f2-6f41-4b8e-95e0-e375ab294d19");
     // === Setup
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, {"Foo", "Bar", "Baz"});
-    msg.m_subType = iox::capro::CaproMessageSubType::SERVICE;
+    msg.m_subType = iox::capro::CaproMessageSubType::SERVER;
 
     EXPECT_CALL(gw, addChannel(_, _)).Times(0);
 
@@ -141,7 +141,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ChannelsAreCreatedForDiscoveredServices)
     auto testService = iox::capro::ServiceDescription({"Radar", "Front-Right", "Reflections"});
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
 
     EXPECT_CALL(gw, findChannel(_)).WillOnce(Return(iox::cxx::nullopt_t()));
     EXPECT_CALL(gw, addChannel(_, _)).WillOnce(Return(channelFactory(testService, iox::popo::SubscriberOptions())));
@@ -161,7 +161,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelySubscribesToDataFromDiscoveredServices
 
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
 
     // Mock methods of the mock generic dds gateway base class
     ON_CALL(gw, findChannel(_)).WillByDefault(Return(iox::cxx::nullopt_t()));
@@ -182,7 +182,7 @@ TEST_F(Iceoryx2DDSGatewayTest, ImmediatelyConnectsCreatedDataWritersForDiscovere
 
     TestGateway gw{};
     auto msg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    msg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    msg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
 
     // Mock methods of the mock generic dds gateway base class
     ON_CALL(gw, findChannel(_)).WillByDefault(Return(iox::cxx::nullopt_t()));
@@ -304,9 +304,9 @@ TEST_F(Iceoryx2DDSGatewayTest, DestroysCorrespondingSubscriberWhenAPublisherStop
 
     // Messages
     auto offerMsg = iox::capro::CaproMessage(iox::capro::CaproMessageType::OFFER, testService);
-    offerMsg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    offerMsg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
     auto stopOfferMsg = iox::capro::CaproMessage(iox::capro::CaproMessageType::STOP_OFFER, testService);
-    stopOfferMsg.m_subType = iox::capro::CaproMessageSubType::EVENT;
+    stopOfferMsg.m_subType = iox::capro::CaproMessageSubType::PUBLISHER;
 
     // Get the test channels here as we need to use them in expectations
     auto testChannelOne = channelFactory(testService, iox::popo::SubscriberOptions());

--- a/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
+++ b/iceoryx_dds/test/moduletests/test_iox_to_dds.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
@@ -66,9 +66,9 @@ inline std::ostream& operator<<(std::ostream& stream, CaproMessageType value) no
 /// @return the reference to `stream` which was provided as input parameter
 inline log::LogStream& operator<<(log::LogStream& stream, CaproMessageType value) noexcept;
 
-enum class CaproMessageSubType : uint8_t
+enum class CaproServiceType : uint8_t
 {
-    NOSUBTYPE = 0,
+    NONE = 0,
     PUBLISHER,
     SERVER
 };
@@ -88,11 +88,11 @@ class CaproMessage
     /// @return                        Nothing
     CaproMessage(CaproMessageType type,
                  const ServiceDescription& serviceDescription,
-                 CaproMessageSubType subType = CaproMessageSubType::NOSUBTYPE,
+                 CaproServiceType serviceType = CaproServiceType::NONE,
                  void* chunkQueueData = nullptr) noexcept;
 
     CaproMessageType m_type{CaproMessageType::NOTYPE};
-    CaproMessageSubType m_subType{CaproMessageSubType::NOSUBTYPE};
+    CaproServiceType m_serviceType{CaproServiceType::NONE};
     ServiceDescription m_serviceDescription;
     void* m_chunkQueueData{nullptr};
     uint64_t m_historyCapacity{0u};

--- a/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
@@ -69,9 +69,8 @@ inline log::LogStream& operator<<(log::LogStream& stream, CaproMessageType value
 enum class CaproMessageSubType : uint8_t
 {
     NOSUBTYPE = 0,
-    SERVICE,
-    EVENT,
-    FIELD
+    PUBLISHER,
+    SERVER
 };
 
 /// @brief C'tors for CaPro messages

--- a/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/capro/capro_message.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/capro/capro_message.cpp
+++ b/iceoryx_posh/source/capro/capro_message.cpp
@@ -22,10 +22,10 @@ namespace capro
 {
 CaproMessage::CaproMessage(CaproMessageType type,
                            const ServiceDescription& serviceDescription,
-                           CaproMessageSubType subType,
+                           CaproServiceType serviceType,
                            void* chunkQueueData) noexcept
     : m_type(type)
-    , m_subType(subType)
+    , m_serviceType(serviceType)
     , m_serviceDescription(serviceDescription)
     , m_chunkQueueData(chunkQueueData)
 {

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -57,7 +57,7 @@ cxx::optional<capro::CaproMessage> PublisherPortRouDi::tryGetCaProMessage() noex
 
         const auto historyCapacity = m_chunkSender.getHistoryCapacity();
         caproMessage.m_historyCapacity = historyCapacity;
-        caproMessage.m_subType = capro::CaproMessageSubType::PUBLISHER;
+        caproMessage.m_serviceType = capro::CaproServiceType::PUBLISHER;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
@@ -69,7 +69,7 @@ cxx::optional<capro::CaproMessage> PublisherPortRouDi::tryGetCaProMessage() noex
         m_chunkSender.removeAllQueues();
 
         capro::CaproMessage caproMessage(capro::CaproMessageType::STOP_OFFER, this->getCaProServiceDescription());
-        caproMessage.m_subType = capro::CaproMessageSubType::PUBLISHER;
+        caproMessage.m_serviceType = capro::CaproServiceType::PUBLISHER;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
@@ -84,7 +84,7 @@ cxx::optional<capro::CaproMessage>
 PublisherPortRouDi::dispatchCaProMessageAndGetPossibleResponse(const capro::CaproMessage& caProMessage) noexcept
 {
     capro::CaproMessage responseMessage(
-        capro::CaproMessageType::NACK, this->getCaProServiceDescription(), capro::CaproMessageSubType::NOSUBTYPE);
+        capro::CaproMessageType::NACK, this->getCaProServiceDescription(), capro::CaproServiceType::NONE);
 
     if (getMembers()->m_offered.load(std::memory_order_relaxed))
     {

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -57,10 +57,7 @@ cxx::optional<capro::CaproMessage> PublisherPortRouDi::tryGetCaProMessage() noex
 
         const auto historyCapacity = m_chunkSender.getHistoryCapacity();
         caproMessage.m_historyCapacity = historyCapacity;
-
-        // provide additional AUTOSAR Adaptive like information
-        caproMessage.m_subType =
-            (0u < historyCapacity) ? capro::CaproMessageSubType::FIELD : capro::CaproMessageSubType::EVENT;
+        caproMessage.m_subType = capro::CaproMessageSubType::PUBLISHER;
 
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
@@ -72,6 +69,8 @@ cxx::optional<capro::CaproMessage> PublisherPortRouDi::tryGetCaProMessage() noex
         m_chunkSender.removeAllQueues();
 
         capro::CaproMessage caproMessage(capro::CaproMessageType::STOP_OFFER, this->getCaProServiceDescription());
+        caproMessage.m_subType = capro::CaproMessageSubType::PUBLISHER;
+
         return cxx::make_optional<capro::CaproMessage>(caproMessage);
     }
     else

--- a/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
@@ -56,6 +56,7 @@ cxx::optional<capro::CaproMessage> ServerPortRouDi::tryGetCaProMessage() noexcep
         if (!offeringRequested)
         {
             capro::CaproMessage caproMessage(capro::CaproMessageType::STOP_OFFER, this->getCaProServiceDescription());
+            caproMessage.m_subType = capro::CaproMessageSubType::SERVER;
             return dispatchCaProMessageAndGetPossibleResponse(caproMessage);
         }
     }
@@ -64,6 +65,7 @@ cxx::optional<capro::CaproMessage> ServerPortRouDi::tryGetCaProMessage() noexcep
         if (offeringRequested)
         {
             capro::CaproMessage caproMessage(capro::CaproMessageType::OFFER, this->getCaProServiceDescription());
+            caproMessage.m_subType = capro::CaproMessageSubType::SERVER;
             return dispatchCaProMessageAndGetPossibleResponse(caproMessage);
         }
     }

--- a/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
@@ -56,7 +56,7 @@ cxx::optional<capro::CaproMessage> ServerPortRouDi::tryGetCaProMessage() noexcep
         if (!offeringRequested)
         {
             capro::CaproMessage caproMessage(capro::CaproMessageType::STOP_OFFER, this->getCaProServiceDescription());
-            caproMessage.m_subType = capro::CaproMessageSubType::SERVER;
+            caproMessage.m_serviceType = capro::CaproServiceType::SERVER;
             return dispatchCaProMessageAndGetPossibleResponse(caproMessage);
         }
     }
@@ -65,7 +65,7 @@ cxx::optional<capro::CaproMessage> ServerPortRouDi::tryGetCaProMessage() noexcep
         if (offeringRequested)
         {
             capro::CaproMessage caproMessage(capro::CaproMessageType::OFFER, this->getCaProServiceDescription());
-            caproMessage.m_subType = capro::CaproMessageSubType::SERVER;
+            caproMessage.m_serviceType = capro::CaproServiceType::SERVER;
             return dispatchCaProMessageAndGetPossibleResponse(caproMessage);
         }
     }

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -284,10 +284,10 @@ void PortManager::handleInterfaces() noexcept
         /// StatusPort's
         /// @todo iox-#27 I guess this was necessary since a service could be offered via ServiceDiscovery;
         /// this was removed and I somehow have the feeling this breaks the interface ports with the changes from this
-        /// PR if the CaproMessageSubType is something different than NOSUBTYPE
+        /// PR if the CaproServiceType is something different than NON
         auto serviceVector = m_serviceRegistry.getServices();
 
-        caproMessage.m_subType = capro::CaproMessageSubType::NOSUBTYPE;
+        caproMessage.m_serviceType = capro::CaproServiceType::NONE;
 
         for (auto const& element : serviceVector)
         {

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -282,9 +282,12 @@ void PortManager::handleInterfaces() noexcept
         // also forward services from service registry
         /// @todo #415 do we still need this? yes but return a copy here to be stored in shared memory via new
         /// StatusPort's
+        /// @todo iox-#27 I guess this was necessary since a service could be offered via ServiceDiscovery;
+        /// this was removed and I somehow have the feeling this breaks the interface ports with the changes from this
+        /// PR if the CaproMessageSubType is something different than NOSUBTYPE
         auto serviceVector = m_serviceRegistry.getServices();
 
-        caproMessage.m_subType = capro::CaproMessageSubType::SERVICE;
+        caproMessage.m_subType = capro::CaproMessageSubType::NOSUBTYPE;
 
         for (auto const& element : serviceVector)
         {

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -42,11 +42,11 @@ TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
     iox::popo::SubscriberPortData recData{
         sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, iox::popo::SubscriberOptions()};
 
-    CaproMessage testObj(CaproMessageType::OFFER, sd, CaproMessageSubType::SERVICE, &recData);
+    CaproMessage testObj(CaproMessageType::OFFER, sd, CaproMessageSubType::PUBLISHER, &recData);
 
     EXPECT_EQ(&recData, testObj.m_chunkQueueData);
     EXPECT_EQ(CaproMessageType::OFFER, testObj.m_type);
-    EXPECT_EQ(CaproMessageSubType::SERVICE, testObj.m_subType);
+    EXPECT_EQ(CaproMessageSubType::PUBLISHER, testObj.m_subType);
     EXPECT_EQ(0U, testObj.m_historyCapacity);
     EXPECT_EQ(sd, testObj.m_serviceDescription);
 }

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -42,11 +42,11 @@ TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
     iox::popo::SubscriberPortData recData{
         sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, iox::popo::SubscriberOptions()};
 
-    CaproMessage testObj(CaproMessageType::OFFER, sd, CaproMessageSubType::PUBLISHER, &recData);
+    CaproMessage testObj(CaproMessageType::OFFER, sd, CaproServiceType::PUBLISHER, &recData);
 
     EXPECT_EQ(&recData, testObj.m_chunkQueueData);
     EXPECT_EQ(CaproMessageType::OFFER, testObj.m_type);
-    EXPECT_EQ(CaproMessageSubType::PUBLISHER, testObj.m_subType);
+    EXPECT_EQ(CaproServiceType::PUBLISHER, testObj.m_serviceType);
     EXPECT_EQ(0U, testObj.m_historyCapacity);
     EXPECT_EQ(sd, testObj.m_serviceDescription);
 }
@@ -57,7 +57,7 @@ TEST_F(CaproMessage_test, DefaultArgsOfCtor)
     ::testing::Test::RecordProperty("TEST_ID", "9192864e-3713-402e-9d92-1a5e803a93ee");
     CaproMessage testObj(CaproMessageType::OFFER, ServiceDescription("1", "2", "3"));
 
-    EXPECT_EQ(CaproMessageSubType::NOSUBTYPE, testObj.m_subType);
+    EXPECT_EQ(CaproServiceType::NONE, testObj.m_serviceType);
     EXPECT_EQ(nullptr, testObj.m_chunkQueueData);
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -180,7 +180,7 @@ TEST_F(PublisherPort_test, offerCallResultsInOfferCaProMessage)
     auto caproMessage = maybeCaproMessage.value();
     EXPECT_THAT(caproMessage.m_type, Eq(iox::capro::CaproMessageType::OFFER));
     EXPECT_THAT(caproMessage.m_serviceDescription, Eq(iox::capro::ServiceDescription("a", "b", "c")));
-    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::EVENT));
+    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::PUBLISHER));
     EXPECT_THAT(caproMessage.m_historyCapacity, Eq(0U));
 }
 
@@ -233,7 +233,7 @@ TEST_F(PublisherPort_test,
     auto caproMessage = maybeCaproMessage.value();
     EXPECT_THAT(caproMessage.m_type, Eq(iox::capro::CaproMessageType::OFFER));
     EXPECT_THAT(caproMessage.m_serviceDescription, Eq(iox::capro::ServiceDescription("x", "y", "z")));
-    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::FIELD));
+    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::PUBLISHER));
     EXPECT_THAT(caproMessage.m_historyCapacity, Eq(iox::MAX_PUBLISHER_HISTORY));
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -180,7 +180,7 @@ TEST_F(PublisherPort_test, offerCallResultsInOfferCaProMessage)
     auto caproMessage = maybeCaproMessage.value();
     EXPECT_THAT(caproMessage.m_type, Eq(iox::capro::CaproMessageType::OFFER));
     EXPECT_THAT(caproMessage.m_serviceDescription, Eq(iox::capro::ServiceDescription("a", "b", "c")));
-    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::PUBLISHER));
+    EXPECT_THAT(caproMessage.m_serviceType, Eq(iox::capro::CaproServiceType::PUBLISHER));
     EXPECT_THAT(caproMessage.m_historyCapacity, Eq(0U));
 }
 
@@ -233,7 +233,7 @@ TEST_F(PublisherPort_test,
     auto caproMessage = maybeCaproMessage.value();
     EXPECT_THAT(caproMessage.m_type, Eq(iox::capro::CaproMessageType::OFFER));
     EXPECT_THAT(caproMessage.m_serviceDescription, Eq(iox::capro::ServiceDescription("x", "y", "z")));
-    EXPECT_THAT(caproMessage.m_subType, Eq(iox::capro::CaproMessageSubType::PUBLISHER));
+    EXPECT_THAT(caproMessage.m_serviceType, Eq(iox::capro::CaproServiceType::PUBLISHER));
     EXPECT_THAT(caproMessage.m_historyCapacity, Eq(iox::MAX_PUBLISHER_HISTORY));
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_server_port_roudi.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server_port_roudi.cpp
@@ -66,7 +66,7 @@ TEST_F(ServerPort_test, TryGetCaProMessageOnOfferWhenPortIsNotOffering)
     sut.portRouDi.tryGetCaProMessage()
         .and_then([&](const auto& caproMessage) {
             EXPECT_THAT(caproMessage.m_type, Eq(CaproMessageType::OFFER));
-            EXPECT_THAT(caproMessage.m_subType, Eq(CaproMessageSubType::SERVER));
+            EXPECT_THAT(caproMessage.m_serviceType, Eq(CaproServiceType::SERVER));
         })
         .or_else([&]() { GTEST_FAIL() << "Expected CaPro message but got none"; });
 }
@@ -95,7 +95,7 @@ TEST_F(ServerPort_test, TryGetCaProMessageOnStopOfferWhenPortIsOffering)
     sut.portRouDi.tryGetCaProMessage()
         .and_then([&](const auto& caproMessage) {
             EXPECT_THAT(caproMessage.m_type, Eq(CaproMessageType::STOP_OFFER));
-            EXPECT_THAT(caproMessage.m_subType, Eq(CaproMessageSubType::SERVER));
+            EXPECT_THAT(caproMessage.m_serviceType, Eq(CaproServiceType::SERVER));
         })
         .or_else([&]() { GTEST_FAIL() << "Expected CaPro message but got none"; });
 }
@@ -135,7 +135,7 @@ TEST_F(ServerPort_test, StateNotOfferedWithAllRelevantCaProMessageTypesButOfferR
             .and_then([&](const auto& responseCaproMessage) {
                 EXPECT_THAT(responseCaproMessage.m_serviceDescription, Eq(sut.portData.m_serviceDescription));
                 EXPECT_THAT(responseCaproMessage.m_type, Eq(iox::capro::CaproMessageType::NACK));
-                EXPECT_THAT(responseCaproMessage.m_subType, Eq(CaproMessageSubType::NOSUBTYPE));
+                EXPECT_THAT(responseCaproMessage.m_serviceType, Eq(CaproServiceType::NONE));
             })
             .or_else([&]() { GTEST_FAIL() << "Expected CaPro message but got none"; });
     }
@@ -150,14 +150,14 @@ TEST_F(ServerPort_test, StateNotOfferedWithCaProMessageTypeOfferReactsWithOffer)
 
     // this is what tryGetCaProMessage does before it calls dispatchCaProMessageAndGetPossibleResponse
     auto caproMessage = CaproMessage{CaproMessageType::OFFER, sut.portData.m_serviceDescription};
-    caproMessage.m_subType = CaproMessageSubType::SERVER;
+    caproMessage.m_serviceType = CaproServiceType::SERVER;
 
     sut.portRouDi.dispatchCaProMessageAndGetPossibleResponse(caproMessage)
         .and_then([&](const auto& responseCaproMessage) {
             EXPECT_THAT(sut.portUser.isOffered(), Eq(true));
             EXPECT_THAT(responseCaproMessage.m_serviceDescription, Eq(sut.portData.m_serviceDescription));
             EXPECT_THAT(responseCaproMessage.m_type, Eq(iox::capro::CaproMessageType::OFFER));
-            EXPECT_THAT(responseCaproMessage.m_subType, Eq(CaproMessageSubType::SERVER));
+            EXPECT_THAT(responseCaproMessage.m_serviceType, Eq(CaproServiceType::SERVER));
         })
         .or_else([&]() { GTEST_FAIL() << "Expected CaPro message but got none"; });
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This commit renames the `CaproMessageSubType` enum values to more appropriate ones and discards the ara::com inspired naming.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #27
