### PR TITLE
Iox #27 add server support to service registry

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -127,6 +127,9 @@ class ServiceRegistry
     void getAll(ServiceDescriptionVector_t& searchResult) const noexcept;
 
     void applyToAll(cxx::function_ref<void(const ServiceDescriptionEntry&)> callable) const noexcept;
+
+    cxx::expected<Error> add(const capro::ServiceDescription& serviceDescription,
+                             ReferenceCounter_t ServiceDescriptionEntry::*count);
 };
 } // namespace roudi
 } // namespace iox

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -46,8 +46,13 @@ class ServiceRegistry
     {
         ServiceDescriptionEntry(const capro::ServiceDescription& serviceDescription);
 
-        capro::ServiceDescription serviceDescription{};
-        ReferenceCounter_t count{1U};
+        capro::ServiceDescription serviceDescription;
+
+        // it can be discussed whether the type of service (server or publisher)
+        // should be part of the ServiceDescription but this would lead to more
+        // exchanges (e.g. comparison semantics)
+        ReferenceCounter_t publisherCount{0U};
+        ReferenceCounter_t serverCount{0U};
     };
 
     /// @todo #415 #1074 set limits properly and define location for the limits,
@@ -65,6 +70,16 @@ class ServiceRegistry
     ///        in case of multiple occurrences only one occurrence is removed
     /// @param[in] serviceDescription, service to be removed
     void removePublisher(const capro::ServiceDescription& serviceDescription) noexcept;
+
+    /// @brief Adds a given server service description to registry
+    /// @param[in] serviceDescription, service to be added
+    /// @return ServiceRegistryError, error wrapped in cxx::expected
+    cxx::expected<Error> addServer(const capro::ServiceDescription& serviceDescription) noexcept;
+
+    /// @brief Removes a given server service description from registry if service is found,
+    ///        in case of multiple occurrences only one occurrence is removed
+    /// @param[in] serviceDescription, service to be removed
+    void removeServer(const capro::ServiceDescription& serviceDescription) noexcept;
 
     /// @brief Removes given service description from registry if service is found,
     ///        all occurences are removed

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -56,15 +56,15 @@ class ServiceRegistry
 
     using ServiceDescriptionVector_t = cxx::vector<ServiceDescriptionEntry, MAX_SERVICE_DESCRIPTIONS>;
 
-    /// @brief Adds given service description to registry
+    /// @brief Adds a given publisher service description to registry
     /// @param[in] serviceDescription, service to be added
     /// @return ServiceRegistryError, error wrapped in cxx::expected
-    cxx::expected<Error> add(const capro::ServiceDescription& serviceDescription) noexcept;
+    cxx::expected<Error> addPublisher(const capro::ServiceDescription& serviceDescription) noexcept;
 
-    /// @brief Removes given service description from registry if service is found,
+    /// @brief Removes a given publisher service description from registry if service is found,
     ///        in case of multiple occurrences only one occurrence is removed
     /// @param[in] serviceDescription, service to be removed
-    void remove(const capro::ServiceDescription& serviceDescription) noexcept;
+    void removePublisher(const capro::ServiceDescription& serviceDescription) noexcept;
 
     /// @brief Removes given service description from registry if service is found,
     ///        all occurences are removed

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -687,7 +687,7 @@ void PortManager::publishServiceRegistry() const noexcept
 
 void PortManager::addEntryToServiceRegistry(const capro::ServiceDescription& service) noexcept
 {
-    m_serviceRegistry.add(service).or_else([&](auto&) {
+    m_serviceRegistry.addPublisher(service).or_else([&](auto&) {
         LogWarn() << "Could not add service " << service.getServiceIDString() << " to service registry!";
         errorHandler(Error::kPOSH__PORT_MANAGER_COULD_NOT_ADD_SERVICE_TO_REGISTRY, nullptr, ErrorLevel::MODERATE);
     });
@@ -696,7 +696,7 @@ void PortManager::addEntryToServiceRegistry(const capro::ServiceDescription& ser
 
 void PortManager::removeEntryFromServiceRegistry(const capro::ServiceDescription& service) noexcept
 {
-    m_serviceRegistry.remove(service);
+    m_serviceRegistry.removePublisher(service);
     publishServiceRegistry();
 }
 

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -163,7 +163,6 @@ void ServiceRegistry::removeServer(const capro::ServiceDescription& serviceDescr
         {
             if (entry->serverCount >= 1U)
             {
-                entry->serverCount--;
                 if (--entry->serverCount >= 1U)
                 {
                     return;

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -26,7 +26,8 @@ ServiceRegistry::ServiceDescriptionEntry::ServiceDescriptionEntry(const capro::S
 {
 }
 
-cxx::expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceDescription& serviceDescription) noexcept
+cxx::expected<ServiceRegistry::Error>
+ServiceRegistry::addPublisher(const capro::ServiceDescription& serviceDescription) noexcept
 {
     auto index = findIndex(serviceDescription);
     if (index != NO_INDEX)
@@ -72,7 +73,7 @@ cxx::expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceD
     return cxx::error<Error>(Error::SERVICE_REGISTRY_FULL);
 }
 
-void ServiceRegistry::remove(const capro::ServiceDescription& serviceDescription) noexcept
+void ServiceRegistry::removePublisher(const capro::ServiceDescription& serviceDescription) noexcept
 {
     auto index = findIndex(serviceDescription);
     if (index != NO_INDEX)

--- a/iceoryx_posh/source/runtime/service_discovery.cpp
+++ b/iceoryx_posh/source/runtime/service_discovery.cpp
@@ -35,7 +35,10 @@ ServiceContainer ServiceDiscovery::findService(const cxx::optional<capro::IdStri
     ServiceContainer searchResult;
     for (auto& service : tempSearchResult)
     {
-        searchResult.push_back(service.serviceDescription);
+        if (service.publisherCount > 0)
+        {
+            searchResult.push_back(service.serviceDescription);
+        }
     }
 
     return searchResult;

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -113,7 +113,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturn
 
     ASSERT_THAT(searchResults.size(), Eq(1));
     EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
-    EXPECT_THAT(searchResults[0].count, Eq(2));
+    EXPECT_THAT(searchResults[0].publisherCount, Eq(2));
 }
 
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
@@ -131,7 +131,7 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsO
 
     ASSERT_THAT(searchResults.size(), Eq(1));
     EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
-    EXPECT_THAT(searchResults[0].count, Eq(1));
+    EXPECT_THAT(searchResults[0].publisherCount, Eq(1));
 }
 
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -73,7 +73,7 @@ TEST_F(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 
     for (auto& service : services)
     {
-        auto result = sut.add(service);
+        auto result = sut.addPublisher(service);
         ASSERT_FALSE(result.has_error());
     }
 }
@@ -91,11 +91,11 @@ TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 
     for (auto& service : services)
     {
-        auto result = sut.add(service);
+        auto result = sut.addPublisher(service);
         ASSERT_FALSE(result.has_error());
     }
 
-    auto result = sut.add(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
+    auto result = sut.addPublisher(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_TRUE(result.has_error());
     EXPECT_THAT(result.get_error(), Eq(ServiceRegistry::Error::SERVICE_REGISTRY_FULL));
 }
@@ -103,10 +103,10 @@ TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d8f61eb2-d082-4c26-9970-461427c3d200");
-    auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaer"));
+    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.add(ServiceDescription("Li", "La", "Launebaer"));
+    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result2.has_error());
 
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
@@ -119,13 +119,13 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturn
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6f8193ea-2d36-423f-a658-1dba30c1868d");
-    auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result2.has_error());
 
-    sut.remove(ServiceDescription("Li", "La", "Launebaerli"));
+    sut.removePublisher(ServiceDescription("Li", "La", "Launebaerli"));
 
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
@@ -137,10 +137,10 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsO
 TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3185b67f-b891-4a82-8f91-047e059ed68f");
-    auto result1 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.add(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result2.has_error());
 
     sut.purge(ServiceDescription("Li", "La", "Launebaerli"));
@@ -153,29 +153,29 @@ TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
 TEST_F(ServiceRegistry_test, AddEmptyServiceDescriptionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3cff55b0-d12f-48f5-8f0c-6501d0c2bf79");
-    auto result = sut.add(ServiceDescription());
+    auto result = sut.addPublisher(ServiceDescription());
     ASSERT_FALSE(result.has_error());
 }
 
 TEST_F(ServiceRegistry_test, RemovingServiceDescriptionsWhichWasntAddedFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cf3e39f5-c29d-4b5f-8e01-af69681b2ea8");
-    sut.remove(ServiceDescription("Sim", "Sa", "Lambim"));
+    sut.removePublisher(ServiceDescription("Sim", "Sa", "Lambim"));
     EXPECT_THAT(sut.getServices().size(), Eq(0));
 }
 
 TEST_F(ServiceRegistry_test, RemovingEmptyServiceDescriptionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "523f2320-c0e5-4590-a1b0-604e756ecaa5");
-    ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
-    sut.remove(ServiceDescription());
+    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
+    sut.removePublisher(ServiceDescription());
     EXPECT_THAT(sut.getServices().size(), Eq(0));
 }
 
 TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithWildcardSearch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "be3e4b13-d930-47b2-aeaa-95c65f06deed");
-    ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
+    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -185,7 +185,7 @@ TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithWildcar
 TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1af0137f-6bf5-422e-a6ec-513f7d3f6191");
-    ASSERT_FALSE(sut.add(ServiceDescription()).has_error());
+    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
     sut.find(searchResults, iox::capro::IdString_t(""), iox::capro::IdString_t(""), iox::capro::IdString_t(""));
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -195,7 +195,7 @@ TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmptySt
 TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a12c9d39-6379-4296-8987-df56a87169f7");
-    auto result = sut.add(ServiceDescription("Foo", "Bar", "Baz"));
+    auto result = sut.addPublisher(ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_FALSE(result.has_error());
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
@@ -207,7 +207,7 @@ TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithEventName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6df8fd7d-e4d1-4c51-8ad7-2fbe82e4ed09");
     iox::capro::ServiceDescription service("a", "b", "c");
-    ASSERT_FALSE(sut.add(service).has_error());
+    ASSERT_FALSE(sut.addPublisher(service).has_error());
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::IdString_t("c"));
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -218,7 +218,7 @@ TEST_F(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ba7785d1-08ec-4f7c-b341-dff033dae2c7");
     iox::capro::ServiceDescription service("Besser", "Wisser", "Girl");
-    ASSERT_FALSE(sut.add(service).has_error());
+    ASSERT_FALSE(sut.addPublisher(service).has_error());
     sut.find(searchResults,
              iox::capro::IdString_t("Besser"),
              iox::capro::IdString_t("Wisser"),
@@ -230,7 +230,7 @@ TEST_F(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch)
 TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1dfaa836-f1da-466f-a794-a7ac1b599ce3");
-    auto result = sut.add(ServiceDescription("Baz", "Bar", "Foo"));
+    auto result = sut.addPublisher(ServiceDescription("Baz", "Bar", "Foo"));
     ASSERT_FALSE(result.has_error());
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::IdString_t("Bar"), iox::capro::Wildcard);
 
@@ -242,7 +242,7 @@ TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0890013c-e14b-4ae2-89cb-757624c12b4e");
     iox::capro::ServiceDescription service("a", "b", "c");
-    ASSERT_FALSE(sut.add(service).has_error());
+    ASSERT_FALSE(sut.addPublisher(service).has_error());
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -255,8 +255,8 @@ TEST_F(ServiceRegistry_test, EmptyAndNotEmptyServiceDescriptionsCanAllBeFoundWit
     ServiceDescription service1;
     ServiceDescription service2("alpha", "bravo", "charlie");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
     sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
     ASSERT_THAT(searchResults.size(), Eq(2));
@@ -271,9 +271,9 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAll
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
     ASSERT_THAT(searchResults.size(), Eq(3));
@@ -301,8 +301,8 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceNameC
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("c", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -321,9 +321,9 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsS
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
 
     ASSERT_THAT(searchResults.size(), Eq(1));
@@ -339,14 +339,14 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFind
     iox::capro::ServiceDescription service4("d", "4", "moep");
     iox::capro::ServiceDescription service5("e", "5", "moep");
 
-    ASSERT_FALSE(sut.add(service5).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
-    ASSERT_FALSE(sut.add(service4).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service5).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service4).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
 
-    sut.remove(service5);
-    sut.remove(service1);
+    sut.removePublisher(service5);
+    sut.removePublisher(service1);
     EXPECT_THAT(sut.getServices().size(), Eq(3));
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
@@ -360,9 +360,9 @@ TEST_F(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("g"), iox::capro::IdString_t("f"));
 
     EXPECT_THAT(searchResults.size(), Eq(0));
@@ -375,11 +375,11 @@ TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAnd
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
 
-    sut.remove(service2);
+    sut.removePublisher(service2);
     EXPECT_THAT(sut.getServices().size(), Eq(2));
 
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
@@ -393,11 +393,11 @@ TEST_F(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegis
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("c", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
 
-    sut.remove(service2);
+    sut.removePublisher(service2);
     EXPECT_THAT(sut.getServices().size(), Eq(2));
 
     sut.find(searchResults, iox::capro::IdString_t("b"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
@@ -411,13 +411,13 @@ TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesN
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
 
-    sut.remove(service1);
-    sut.remove(service2);
-    sut.remove(service3);
+    sut.removePublisher(service1);
+    sut.removePublisher(service2);
+    sut.removePublisher(service3);
 
     sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
     EXPECT_THAT(searchResults.size(), Eq(0));
@@ -431,12 +431,12 @@ TEST_F(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNo
     iox::capro::ServiceDescription service3("a", "d", "d");
     iox::capro::ServiceDescription service4("e", "f", "f");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    // add same service a, instance c to check if in sut only one entry is created
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
-    ASSERT_FALSE(sut.add(service4).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    // addPublisher same service a, instance c to check if in sut only one entry is created
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service4).has_error());
 
     auto serviceDescriptionVector = sut.getServices();
 
@@ -506,7 +506,7 @@ TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
         // may (rarely) generate duplicates to be counted internally
         auto id = randomString();
         ServiceDescription sd(id, id, id);
-        auto result = sut.add(sd);
+        auto result = sut.addPublisher(sd);
         if (result.has_error())
         {
             break;
@@ -515,7 +515,7 @@ TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
     } while (true);
 
     // duplicates do not count to the max and may be generated randomly,
-    // but for the contract we only need to guarantee that we can at least add
+    // but for the contract we only need to guarantee that we can at least addPublisher
     // the configured max
     constexpr auto MAX = ServiceRegistry::MAX_SERVICE_DESCRIPTIONS;
     EXPECT_GE(numEntriesAdded, MAX);
@@ -535,7 +535,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
         auto id = randomString();
         ServiceDescription sd(fixedId, fixedId, id);
 
-        auto result = sut.add(sd);
+        auto result = sut.addPublisher(sd);
         if (result.has_error())
         {
             break;
@@ -543,7 +543,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
         lastAdded = sd;
     } while (true);
 
-    // remove the last and replace it with a unique service description
+    // removePublisher the last and replace it with a unique service description
     sut.purge(lastAdded);
 
     // is unique (random does not generate 0s) and last if a vector is used internally
@@ -552,7 +552,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     id.unsafe_append("0");
 
     ServiceDescription uniqueSd(fixedId, fixedId, id);
-    auto result = sut.add(uniqueSd);
+    auto result = sut.addPublisher(uniqueSd);
     EXPECT_FALSE(result.has_error());
 
     ServiceRegistry::ServiceDescriptionVector_t searchResult;
@@ -579,9 +579,9 @@ TEST_F(ServiceRegistry_test, FunctionIsAppliedToAllEntriesInSearchResult)
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("a", "b", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
 
     auto searchFunction = [&](const Entry& entry) { this->searchResults.emplace_back(entry); };
     sut.find(iox::capro::IdString_t("a"), iox::capro::IdString_t("b"), iox::capro::Wildcard, searchFunction);
@@ -598,9 +598,9 @@ TEST_F(ServiceRegistry_test, NoFunctionIsAppliedToEmptySearchResult)
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("a", "b", "d");
 
-    ASSERT_FALSE(sut.add(service1).has_error());
-    ASSERT_FALSE(sut.add(service2).has_error());
-    ASSERT_FALSE(sut.add(service3).has_error());
+    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(sut.addPublisher(service2).has_error());
+    ASSERT_FALSE(sut.addPublisher(service3).has_error());
 
     auto searchFunction = [&](const Entry& entry) { searchResults.emplace_back(entry); };
     sut.find(iox::capro::Wildcard, iox::capro::IdString_t("a"), iox::capro::Wildcard, searchFunction);
@@ -612,7 +612,7 @@ TEST_F(ServiceRegistry_test, FindWithEmptyCallableDoesNotDie)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4ac27528-8650-4d8a-8440-4c9bbcbee4fb");
     iox::capro::ServiceDescription service("ninjababy", "pow", "pow");
-    ASSERT_FALSE(sut.add(service).has_error());
+    ASSERT_FALSE(sut.addPublisher(service).has_error());
     iox::cxx::function_ref<void(const Entry&)> searchFunction;
     sut.find(iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard, searchFunction);
 }

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -29,7 +29,59 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::roudi;
+using iox::capro::ServiceDescription;
 
+struct PublisherTest
+{
+    auto add(const ServiceDescription& sd)
+    {
+        return registry.addPublisher(sd);
+    }
+
+    auto remove(const ServiceDescription& sd)
+    {
+        return registry.removePublisher(sd);
+    }
+
+    auto count(ServiceRegistry::ServiceDescriptionEntry& entry)
+    {
+        return entry.publisherCount;
+    }
+
+    auto operator->()
+    {
+        return &registry;
+    }
+
+    iox::roudi::ServiceRegistry registry;
+};
+
+struct ServerTest
+{
+    auto add(const ServiceDescription& sd)
+    {
+        return registry.addServer(sd);
+    }
+
+    auto remove(const ServiceDescription& sd)
+    {
+        return registry.removeServer(sd);
+    }
+
+    auto count(ServiceRegistry::ServiceDescriptionEntry& entry)
+    {
+        return entry.serverCount;
+    }
+
+    auto operator->()
+    {
+        return &registry;
+    }
+
+    iox::roudi::ServiceRegistry registry;
+};
+
+template <typename T>
 class ServiceRegistry_test : public Test
 {
   public:
@@ -47,20 +99,26 @@ class ServiceRegistry_test : public Test
             std::cout << output << std::endl;
         }
     }
-    iox::roudi::ServiceRegistry sut;
 
     iox::roudi::ServiceRegistry::ServiceDescriptionVector_t searchResults;
+    T sut;
 };
 
-TEST_F(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNothing)
+typedef ::testing::Types<PublisherTest, ServerTest> TestTypes;
+
+
+TYPED_TEST_SUITE(ServiceRegistry_test, TestTypes);
+
+
+TYPED_TEST(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNothing)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3a050209-01d8-4d0e-9e70-c0662b9dbe76");
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
+TYPED_TEST(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fa7d6416-4183-4942-a323-01f78c1bb6c1");
     iox::cxx::vector<ServiceDescription, ServiceRegistry::MAX_SERVICE_DESCRIPTIONS> services;
@@ -73,12 +131,12 @@ TEST_F(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 
     for (auto& service : services)
     {
-        auto result = sut.addPublisher(service);
+        auto result = this->sut.add(service);
         ASSERT_FALSE(result.has_error());
     }
 }
 
-TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
+TYPED_TEST(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a911f654-8314-4ea3-b9b2-1afa121a2b21");
     iox::cxx::vector<ServiceDescription, ServiceRegistry::MAX_SERVICE_DESCRIPTIONS> services;
@@ -91,198 +149,199 @@ TEST_F(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 
     for (auto& service : services)
     {
-        auto result = sut.addPublisher(service);
+        auto result = this->sut.add(service);
         ASSERT_FALSE(result.has_error());
     }
 
-    auto result = sut.addPublisher(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
+    auto result = this->sut.add(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_TRUE(result.has_error());
     EXPECT_THAT(result.get_error(), Eq(ServiceRegistry::Error::SERVICE_REGISTRY_FULL));
 }
 
-TEST_F(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)
+TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d8f61eb2-d082-4c26-9970-461427c3d200");
-    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaer"));
+    auto result1 = this->sut.add(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaer"));
+    auto result2 = this->sut.add(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result2.has_error());
 
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
-    EXPECT_THAT(searchResults[0].publisherCount, Eq(2));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
+    EXPECT_THAT(this->sut.count(this->searchResults[0]), Eq(2));
 }
 
-TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
+TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6f8193ea-2d36-423f-a658-1dba30c1868d");
-    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result1 = this->sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result2 = this->sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result2.has_error());
 
-    sut.removePublisher(ServiceDescription("Li", "La", "Launebaerli"));
+    this->sut.remove(ServiceDescription("Li", "La", "Launebaerli"));
 
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
-    EXPECT_THAT(searchResults[0].publisherCount, Eq(1));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
+    EXPECT_THAT(this->sut.count(this->searchResults[0]), Eq(1));
 }
 
-TEST_F(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
+TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3185b67f-b891-4a82-8f91-047e059ed68f");
-    auto result1 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result1 = this->sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result1.has_error());
 
-    auto result2 = sut.addPublisher(ServiceDescription("Li", "La", "Launebaerli"));
+    auto result2 = this->sut.add(ServiceDescription("Li", "La", "Launebaerli"));
     ASSERT_FALSE(result2.has_error());
 
-    sut.purge(ServiceDescription("Li", "La", "Launebaerli"));
+    this->sut->purge(ServiceDescription("Li", "La", "Launebaerli"));
 
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, AddEmptyServiceDescriptionsWorks)
+TYPED_TEST(ServiceRegistry_test, AddEmptyServiceDescriptionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3cff55b0-d12f-48f5-8f0c-6501d0c2bf79");
-    auto result = sut.addPublisher(ServiceDescription());
+    auto result = this->sut.add(ServiceDescription());
     ASSERT_FALSE(result.has_error());
 }
 
-TEST_F(ServiceRegistry_test, RemovingServiceDescriptionsWhichWasntAddedFails)
+TYPED_TEST(ServiceRegistry_test, RemovingServiceDescriptionsWhichWasntAddedFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cf3e39f5-c29d-4b5f-8e01-af69681b2ea8");
-    sut.removePublisher(ServiceDescription("Sim", "Sa", "Lambim"));
-    EXPECT_THAT(sut.getServices().size(), Eq(0));
+    this->sut.remove(ServiceDescription("Sim", "Sa", "Lambim"));
+    EXPECT_THAT(this->sut->getServices().size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, RemovingEmptyServiceDescriptionsWorks)
+TYPED_TEST(ServiceRegistry_test, RemovingEmptyServiceDescriptionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "523f2320-c0e5-4590-a1b0-604e756ecaa5");
-    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
-    sut.removePublisher(ServiceDescription());
-    EXPECT_THAT(sut.getServices().size(), Eq(0));
+    ASSERT_FALSE(this->sut.add(ServiceDescription()).has_error());
+    this->sut.remove(ServiceDescription());
+    EXPECT_THAT(this->sut->getServices().size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithWildcardSearch)
+TYPED_TEST(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithWildcardSearch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "be3e4b13-d930-47b2-aeaa-95c65f06deed");
-    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_FALSE(this->sut.add(ServiceDescription()).has_error());
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription()));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription()));
 }
 
-TEST_F(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmptyString)
+TYPED_TEST(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1af0137f-6bf5-422e-a6ec-513f7d3f6191");
-    ASSERT_FALSE(sut.addPublisher(ServiceDescription()).has_error());
-    sut.find(searchResults, iox::capro::IdString_t(""), iox::capro::IdString_t(""), iox::capro::IdString_t(""));
+    ASSERT_FALSE(this->sut.add(ServiceDescription()).has_error());
+    this->sut->find(
+        this->searchResults, iox::capro::IdString_t(""), iox::capro::IdString_t(""), iox::capro::IdString_t(""));
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription()));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription()));
 }
 
-TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearch)
+TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a12c9d39-6379-4296-8987-df56a87169f7");
-    auto result = sut.addPublisher(ServiceDescription("Foo", "Bar", "Baz"));
+    auto result = this->sut.add(ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_FALSE(result.has_error());
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Foo", "Bar", "Baz")));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Foo", "Bar", "Baz")));
 }
 
-TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithEventName)
+TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithEventName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6df8fd7d-e4d1-4c51-8ad7-2fbe82e4ed09");
     iox::capro::ServiceDescription service("a", "b", "c");
-    ASSERT_FALSE(sut.addPublisher(service).has_error());
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::IdString_t("c"));
+    ASSERT_FALSE(this->sut.add(service).has_error());
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::IdString_t("c"));
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service));
 }
 
-TEST_F(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch)
+TYPED_TEST(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ba7785d1-08ec-4f7c-b341-dff033dae2c7");
     iox::capro::ServiceDescription service("Besser", "Wisser", "Girl");
-    ASSERT_FALSE(sut.addPublisher(service).has_error());
-    sut.find(searchResults,
-             iox::capro::IdString_t("Besser"),
-             iox::capro::IdString_t("Wisser"),
-             iox::capro::IdString_t("Boy"));
+    ASSERT_FALSE(this->sut.add(service).has_error());
+    this->sut->find(this->searchResults,
+                    iox::capro::IdString_t("Besser"),
+                    iox::capro::IdString_t("Wisser"),
+                    iox::capro::IdString_t("Boy"));
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
+TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1dfaa836-f1da-466f-a794-a7ac1b599ce3");
-    auto result = sut.addPublisher(ServiceDescription("Baz", "Bar", "Foo"));
+    auto result = this->sut.add(ServiceDescription("Baz", "Bar", "Foo"));
     ASSERT_FALSE(result.has_error());
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::IdString_t("Bar"), iox::capro::Wildcard);
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::IdString_t("Bar"), iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(ServiceDescription("Baz", "Bar", "Foo")));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Baz", "Bar", "Foo")));
 }
 
-TEST_F(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
+TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0890013c-e14b-4ae2-89cb-757624c12b4e");
     iox::capro::ServiceDescription service("a", "b", "c");
-    ASSERT_FALSE(sut.addPublisher(service).has_error());
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_FALSE(this->sut.add(service).has_error());
+    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service));
 }
 
-TEST_F(ServiceRegistry_test, EmptyAndNotEmptyServiceDescriptionsCanAllBeFoundWithWildcardSearch)
+TYPED_TEST(ServiceRegistry_test, EmptyAndNotEmptyServiceDescriptionsCanAllBeFoundWithWildcardSearch)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4f34e604-5217-4e47-9c6f-26c5cbdcd3ec");
     ServiceDescription service1;
     ServiceDescription service2("alpha", "bravo", "charlie");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    sut.find(searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(2));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service1));
-    EXPECT_THAT(searchResults[1].serviceDescription, Eq(service2));
+    ASSERT_THAT(this->searchResults.size(), Eq(2));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
+    EXPECT_THAT(this->searchResults[1].serviceDescription, Eq(service2));
 }
 
-TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAllBeFound)
+TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAllBeFound)
 {
     ::testing::Test::RecordProperty("TEST_ID", "251fe262-2e8f-4e32-a5f1-a4b1aaa812fd");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(3));
+    ASSERT_THAT(this->searchResults.size(), Eq(3));
 
     bool hasFoundB = false;
     bool hasFoundC = false;
     bool hasFoundD = false;
 
-    for (auto& e : searchResults)
+    for (auto& e : this->searchResults)
     {
         if (e.serviceDescription == service1)
             hasFoundB = true;
@@ -295,42 +354,43 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAll
     EXPECT_THAT(hasFoundB && hasFoundC && hasFoundD, Eq(true));
 }
 
-TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceNameCanAllBeFound)
+TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceNameCanAllBeFound)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9b7a0897-46a7-457e-8746-0c3899e96653");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("c", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service1));
-    searchResults.clear();
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
+    this->searchResults.clear();
 
-    sut.find(searchResults, iox::capro::IdString_t("c"), iox::capro::Wildcard, iox::capro::Wildcard);
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service2));
+    this->sut->find(this->searchResults, iox::capro::IdString_t("c"), iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service2));
 }
 
-TEST_F(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsSpecificService)
+TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsSpecificService)
 {
     ::testing::Test::RecordProperty("TEST_ID", "557d6533-25a3-4c0c-adc0-e8ebb74785a0");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    this->sut->find(
+        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
 
-    ASSERT_THAT(searchResults.size(), Eq(1));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service2));
+    ASSERT_THAT(this->searchResults.size(), Eq(1));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service2));
 }
 
-TEST_F(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFindsCorrectServices)
+TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFindsCorrectServices)
 {
     ::testing::Test::RecordProperty("TEST_ID", "26187db1-299a-494c-bd85-eb646b8cf67b");
     iox::capro::ServiceDescription service1("a", "1", "moep");
@@ -339,91 +399,94 @@ TEST_F(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFind
     iox::capro::ServiceDescription service4("d", "4", "moep");
     iox::capro::ServiceDescription service5("e", "5", "moep");
 
-    ASSERT_FALSE(sut.addPublisher(service5).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
-    ASSERT_FALSE(sut.addPublisher(service4).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service5).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service4).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
 
-    sut.removePublisher(service5);
-    sut.removePublisher(service1);
-    EXPECT_THAT(sut.getServices().size(), Eq(3));
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut.remove(service5);
+    this->sut.remove(service1);
+    EXPECT_THAT(this->sut->getServices().size(), Eq(3));
+    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
+TYPED_TEST(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "183600f6-3d2d-4c0f-8c1d-d74acfb7fc50");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("g"), iox::capro::IdString_t("f"));
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    this->sut->find(
+        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("g"), iox::capro::IdString_t("f"));
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAndRemovingSpecificDoesNotFindSpecific)
+TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAndRemovingSpecificDoesNotFindSpecific)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b8230904-c14e-4e9f-a324-f92c67522271");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    sut.removePublisher(service2);
-    EXPECT_THAT(sut.getServices().size(), Eq(2));
+    this->sut.remove(service2);
+    EXPECT_THAT(this->sut->getServices().size(), Eq(2));
 
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    this->sut->find(
+        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegistry)
+TYPED_TEST(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegistry)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c5e67b1f-65f2-4973-9f76-73479dd1de9e");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("c", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    sut.removePublisher(service2);
-    EXPECT_THAT(sut.getServices().size(), Eq(2));
+    this->sut.remove(service2);
+    EXPECT_THAT(this->sut->getServices().size(), Eq(2));
 
-    sut.find(searchResults, iox::capro::IdString_t("b"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    this->sut->find(
+        this->searchResults, iox::capro::IdString_t("b"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesNotFindAnything)
+TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesNotFindAnything)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e7a7e160-813c-4daf-8c55-d0a85bb5f642");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("a", "c", "c");
     iox::capro::ServiceDescription service3("a", "d", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    sut.removePublisher(service1);
-    sut.removePublisher(service2);
-    sut.removePublisher(service3);
+    this->sut.remove(service1);
+    this->sut.remove(service2);
+    this->sut.remove(service3);
 
-    sut.find(searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNotReturnDuplicate)
+TYPED_TEST(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNotReturnDuplicate)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a0348a73-4dbe-4464-b190-9274c2bd5031");
     iox::capro::ServiceDescription service1("a", "b", "b");
@@ -431,14 +494,14 @@ TEST_F(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNo
     iox::capro::ServiceDescription service3("a", "d", "d");
     iox::capro::ServiceDescription service4("e", "f", "f");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
     // addPublisher same service a, instance c to check if in sut only one entry is created
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
-    ASSERT_FALSE(sut.addPublisher(service4).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service4).has_error());
 
-    auto serviceDescriptionVector = sut.getServices();
+    auto serviceDescriptionVector = this->sut->getServices();
 
     bool service1Found = false;
     bool service2Found = false;
@@ -497,7 +560,7 @@ string_t randomString(uint64_t size = string_t::capacity())
     return s;
 }
 
-TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
+TYPED_TEST(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
 {
     ::testing::Test::RecordProperty("TEST_ID", "76aef6cb-7886-4d64-9188-09bd1be2d335");
     uint32_t numEntriesAdded = 0U;
@@ -506,7 +569,7 @@ TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
         // may (rarely) generate duplicates to be counted internally
         auto id = randomString();
         ServiceDescription sd(id, id, id);
-        auto result = sut.addPublisher(sd);
+        auto result = this->sut.add(sd);
         if (result.has_error())
         {
             break;
@@ -521,7 +584,7 @@ TEST_F(ServiceRegistry_test, CanAddMaximumNumberOfDifferentServiceDescriptions)
     EXPECT_GE(numEntriesAdded, MAX);
 }
 
-TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
+TYPED_TEST(ServiceRegistry_test, SearchInFullRegistryWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5c4519d4-1873-4837-a3eb-0367106fb9b5");
 
@@ -535,7 +598,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
         auto id = randomString();
         ServiceDescription sd(fixedId, fixedId, id);
 
-        auto result = sut.addPublisher(sd);
+        auto result = this->sut.add(sd);
         if (result.has_error())
         {
             break;
@@ -544,7 +607,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     } while (true);
 
     // removePublisher the last and replace it with a unique service description
-    sut.purge(lastAdded);
+    this->sut->purge(lastAdded);
 
     // is unique (random does not generate 0s) and last if a vector is used internally
     // for almost worst case search (search on last string will terminate early whp)
@@ -552,7 +615,7 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     id.unsafe_append("0");
 
     ServiceDescription uniqueSd(fixedId, fixedId, id);
-    auto result = sut.addPublisher(uniqueSd);
+    auto result = this->sut.add(uniqueSd);
     EXPECT_FALSE(result.has_error());
 
     ServiceRegistry::ServiceDescriptionVector_t searchResult;
@@ -566,55 +629,55 @@ TEST_F(ServiceRegistry_test, SearchInFullRegistryWorks)
     // It could also be achieved with determinstic string enumeration instead of randomness,
     // but it is more cumbersome and not required here.
 
-    sut.find(searchResult, service, instance, event);
+    this->sut->find(searchResult, service, instance, event);
     ASSERT_EQ(searchResult.size(), 1);
 }
 
 using Entry = iox::roudi::ServiceRegistry::ServiceDescriptionEntry;
 
-TEST_F(ServiceRegistry_test, FunctionIsAppliedToAllEntriesInSearchResult)
+TYPED_TEST(ServiceRegistry_test, FunctionIsAppliedToAllEntriesInSearchResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b7828085-d879-43b7-9fee-e5e88cf36995");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("a", "b", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
 
     auto searchFunction = [&](const Entry& entry) { this->searchResults.emplace_back(entry); };
-    sut.find(iox::capro::IdString_t("a"), iox::capro::IdString_t("b"), iox::capro::Wildcard, searchFunction);
+    this->sut->find(iox::capro::IdString_t("a"), iox::capro::IdString_t("b"), iox::capro::Wildcard, searchFunction);
 
-    ASSERT_THAT(searchResults.size(), Eq(2));
-    EXPECT_THAT(searchResults[0].serviceDescription, Eq(service1));
-    EXPECT_THAT(searchResults[1].serviceDescription, Eq(service3));
+    ASSERT_THAT(this->searchResults.size(), Eq(2));
+    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
+    EXPECT_THAT(this->searchResults[1].serviceDescription, Eq(service3));
 }
 
-TEST_F(ServiceRegistry_test, NoFunctionIsAppliedToEmptySearchResult)
+TYPED_TEST(ServiceRegistry_test, NoFunctionIsAppliedToEmptySearchResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "220213cb-8fdf-4fd0-b8e2-24a96f11bfbc");
     iox::capro::ServiceDescription service1("a", "b", "b");
     iox::capro::ServiceDescription service2("b", "c", "c");
     iox::capro::ServiceDescription service3("a", "b", "d");
 
-    ASSERT_FALSE(sut.addPublisher(service1).has_error());
-    ASSERT_FALSE(sut.addPublisher(service2).has_error());
-    ASSERT_FALSE(sut.addPublisher(service3).has_error());
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.add(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    auto searchFunction = [&](const Entry& entry) { searchResults.emplace_back(entry); };
-    sut.find(iox::capro::Wildcard, iox::capro::IdString_t("a"), iox::capro::Wildcard, searchFunction);
+    auto searchFunction = [&](const Entry& entry) { this->searchResults.emplace_back(entry); };
+    this->sut->find(iox::capro::Wildcard, iox::capro::IdString_t("a"), iox::capro::Wildcard, searchFunction);
 
-    EXPECT_THAT(searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResults.size(), Eq(0));
 }
 
-TEST_F(ServiceRegistry_test, FindWithEmptyCallableDoesNotDie)
+TYPED_TEST(ServiceRegistry_test, FindWithEmptyCallableDoesNotDie)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4ac27528-8650-4d8a-8440-4c9bbcbee4fb");
     iox::capro::ServiceDescription service("ninjababy", "pow", "pow");
-    ASSERT_FALSE(sut.addPublisher(service).has_error());
+    ASSERT_FALSE(this->sut.add(service).has_error());
     iox::cxx::function_ref<void(const Entry&)> searchFunction;
-    sut.find(iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard, searchFunction);
+    this->sut->find(iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard, searchFunction);
 }
 
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -30,12 +30,18 @@ namespace
 using namespace ::testing;
 using namespace iox::roudi;
 using iox::capro::ServiceDescription;
+using SearchResult_t = iox::roudi::ServiceRegistry::ServiceDescriptionVector_t;
 
 struct PublisherTest
 {
     auto add(const ServiceDescription& sd)
     {
         return registry.addPublisher(sd);
+    }
+
+    auto otherAdd(const ServiceDescription& sd)
+    {
+        return registry.addServer(sd);
     }
 
     auto remove(const ServiceDescription& sd)
@@ -46,6 +52,19 @@ struct PublisherTest
     auto count(ServiceRegistry::ServiceDescriptionEntry& entry)
     {
         return entry.publisherCount;
+    }
+
+    auto filter(const SearchResult_t& result)
+    {
+        SearchResult_t filtered;
+        for (auto& entry : result)
+        {
+            if (entry.publisherCount > 0)
+            {
+                filtered.emplace_back(entry);
+            }
+        }
+        return filtered;
     }
 
     auto operator->()
@@ -63,6 +82,11 @@ struct ServerTest
         return registry.addServer(sd);
     }
 
+    auto otherAdd(const ServiceDescription& sd)
+    {
+        return registry.addPublisher(sd);
+    }
+
     auto remove(const ServiceDescription& sd)
     {
         return registry.removeServer(sd);
@@ -71,6 +95,19 @@ struct ServerTest
     auto count(ServiceRegistry::ServiceDescriptionEntry& entry)
     {
         return entry.serverCount;
+    }
+
+    auto filter(const SearchResult_t& result)
+    {
+        SearchResult_t filtered;
+        for (auto& entry : result)
+        {
+            if (entry.serverCount > 0)
+            {
+                filtered.emplace_back(entry);
+            }
+        }
+        return filtered;
     }
 
     auto operator->()
@@ -100,7 +137,7 @@ class ServiceRegistry_test : public Test
         }
     }
 
-    iox::roudi::ServiceRegistry::ServiceDescriptionVector_t searchResults;
+    SearchResult_t searchResult;
     T sut;
 };
 
@@ -113,9 +150,9 @@ TYPED_TEST_SUITE(ServiceRegistry_test, TestTypes);
 TYPED_TEST(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNothing)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3a050209-01d8-4d0e-9e70-c0662b9dbe76");
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
@@ -139,39 +176,17 @@ TYPED_TEST(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
 TYPED_TEST(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a911f654-8314-4ea3-b9b2-1afa121a2b21");
-    iox::cxx::vector<ServiceDescription, ServiceRegistry::MAX_SERVICE_DESCRIPTIONS> services;
-
-    for (uint64_t i = 0U; i < ServiceRegistry::MAX_SERVICE_DESCRIPTIONS; i++)
-    {
-        services.push_back(iox::capro::ServiceDescription(
-            "Foo", "Bar", iox::capro::IdString_t(iox::cxx::TruncateToCapacity, iox::cxx::convert::toString(i))));
-    }
-
-    for (auto& service : services)
-    {
-        auto result = this->sut.add(service);
-        ASSERT_FALSE(result.has_error());
-    }
-
-    auto result = this->sut.add(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
-    ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ServiceRegistry::Error::SERVICE_REGISTRY_FULL));
-}
-
-TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "d8f61eb2-d082-4c26-9970-461427c3d200");
     auto result1 = this->sut.add(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result1.has_error());
 
     auto result2 = this->sut.add(ServiceDescription("Li", "La", "Launebaer"));
     ASSERT_FALSE(result2.has_error());
 
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
-    EXPECT_THAT(this->sut.count(this->searchResults[0]), Eq(2));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaer")));
+    EXPECT_THAT(this->sut.count(this->searchResult[0]), Eq(2));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndReturnsOneResult)
@@ -185,11 +200,11 @@ TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndRemoveOnceAndRetu
 
     this->sut.remove(ServiceDescription("Li", "La", "Launebaerli"));
 
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
-    EXPECT_THAT(this->sut.count(this->searchResults[0]), Eq(1));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription("Li", "La", "Launebaerli")));
+    EXPECT_THAT(this->sut.count(this->searchResult[0]), Eq(1));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoResult)
@@ -203,9 +218,9 @@ TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsTwiceAndPurgeReturnsNoRes
 
     this->sut->purge(ServiceDescription("Li", "La", "Launebaerli"));
 
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddEmptyServiceDescriptionsWorks)
@@ -234,10 +249,10 @@ TYPED_TEST(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithWil
 {
     ::testing::Test::RecordProperty("TEST_ID", "be3e4b13-d930-47b2-aeaa-95c65f06deed");
     ASSERT_FALSE(this->sut.add(ServiceDescription()).has_error());
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription()));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription()));
 }
 
 TYPED_TEST(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmptyString)
@@ -245,10 +260,10 @@ TYPED_TEST(ServiceRegistry_test, SingleEmptyServiceDescriptionsCanBeFoundWithEmp
     ::testing::Test::RecordProperty("TEST_ID", "1af0137f-6bf5-422e-a6ec-513f7d3f6191");
     ASSERT_FALSE(this->sut.add(ServiceDescription()).has_error());
     this->sut->find(
-        this->searchResults, iox::capro::IdString_t(""), iox::capro::IdString_t(""), iox::capro::IdString_t(""));
+        this->searchResult, iox::capro::IdString_t(""), iox::capro::IdString_t(""), iox::capro::IdString_t(""));
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription()));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription()));
 }
 
 TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardSearch)
@@ -256,10 +271,10 @@ TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithWildcardS
     ::testing::Test::RecordProperty("TEST_ID", "a12c9d39-6379-4296-8987-df56a87169f7");
     auto result = this->sut.add(ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_FALSE(result.has_error());
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Foo", "Bar", "Baz")));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription("Foo", "Bar", "Baz")));
 }
 
 TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithEventName)
@@ -267,10 +282,10 @@ TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithEventName
     ::testing::Test::RecordProperty("TEST_ID", "6df8fd7d-e4d1-4c51-8ad7-2fbe82e4ed09");
     iox::capro::ServiceDescription service("a", "b", "c");
     ASSERT_FALSE(this->sut.add(service).has_error());
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::IdString_t("c"));
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::IdString_t("c"));
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service));
 }
 
 TYPED_TEST(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch)
@@ -278,12 +293,12 @@ TYPED_TEST(ServiceRegistry_test, ServiceDescriptionNotFoundWhenEventDoesNotMatch
     ::testing::Test::RecordProperty("TEST_ID", "ba7785d1-08ec-4f7c-b341-dff033dae2c7");
     iox::capro::ServiceDescription service("Besser", "Wisser", "Girl");
     ASSERT_FALSE(this->sut.add(service).has_error());
-    this->sut->find(this->searchResults,
+    this->sut->find(this->searchResult,
                     iox::capro::IdString_t("Besser"),
                     iox::capro::IdString_t("Wisser"),
                     iox::capro::IdString_t("Boy"));
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceName)
@@ -291,10 +306,10 @@ TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithInstanceN
     ::testing::Test::RecordProperty("TEST_ID", "1dfaa836-f1da-466f-a794-a7ac1b599ce3");
     auto result = this->sut.add(ServiceDescription("Baz", "Bar", "Foo"));
     ASSERT_FALSE(result.has_error());
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::IdString_t("Bar"), iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::IdString_t("Bar"), iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(ServiceDescription("Baz", "Bar", "Foo")));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(ServiceDescription("Baz", "Bar", "Foo")));
 }
 
 TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceName)
@@ -302,10 +317,10 @@ TYPED_TEST(ServiceRegistry_test, SingleServiceDescriptionCanBeFoundWithServiceNa
     ::testing::Test::RecordProperty("TEST_ID", "0890013c-e14b-4ae2-89cb-757624c12b4e");
     iox::capro::ServiceDescription service("a", "b", "c");
     ASSERT_FALSE(this->sut.add(service).has_error());
-    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service));
 }
 
 TYPED_TEST(ServiceRegistry_test, EmptyAndNotEmptyServiceDescriptionsCanAllBeFoundWithWildcardSearch)
@@ -316,11 +331,11 @@ TYPED_TEST(ServiceRegistry_test, EmptyAndNotEmptyServiceDescriptionsCanAllBeFoun
 
     ASSERT_FALSE(this->sut.add(service1).has_error());
     ASSERT_FALSE(this->sut.add(service2).has_error());
-    this->sut->find(this->searchResults, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(2));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
-    EXPECT_THAT(this->searchResults[1].serviceDescription, Eq(service2));
+    ASSERT_THAT(this->searchResult.size(), Eq(2));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service1));
+    EXPECT_THAT(this->searchResult[1].serviceDescription, Eq(service2));
 }
 
 TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCanAllBeFound)
@@ -333,15 +348,15 @@ TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameCa
     ASSERT_FALSE(this->sut.add(service1).has_error());
     ASSERT_FALSE(this->sut.add(service2).has_error());
     ASSERT_FALSE(this->sut.add(service3).has_error());
-    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(3));
+    ASSERT_THAT(this->searchResult.size(), Eq(3));
 
     bool hasFoundB = false;
     bool hasFoundC = false;
     bool hasFoundD = false;
 
-    for (auto& e : this->searchResults)
+    for (auto& e : this->searchResult)
     {
         if (e.serviceDescription == service1)
             hasFoundB = true;
@@ -362,15 +377,15 @@ TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithDifferentServiceN
 
     ASSERT_FALSE(this->sut.add(service1).has_error());
     ASSERT_FALSE(this->sut.add(service2).has_error());
-    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
-    this->searchResults.clear();
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service1));
+    this->searchResult.clear();
 
-    this->sut->find(this->searchResults, iox::capro::IdString_t("c"), iox::capro::Wildcard, iox::capro::Wildcard);
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service2));
+    this->sut->find(this->searchResult, iox::capro::IdString_t("c"), iox::capro::Wildcard, iox::capro::Wildcard);
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service2));
 }
 
 TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFindsSpecificService)
@@ -384,10 +399,10 @@ TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionWithSameServiceNameFi
     ASSERT_FALSE(this->sut.add(service2).has_error());
     ASSERT_FALSE(this->sut.add(service3).has_error());
     this->sut->find(
-        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+        this->searchResult, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
 
-    ASSERT_THAT(this->searchResults.size(), Eq(1));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service2));
+    ASSERT_THAT(this->searchResult.size(), Eq(1));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service2));
 }
 
 TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrderFindsCorrectServices)
@@ -408,9 +423,9 @@ TYPED_TEST(ServiceRegistry_test, MultipleServiceDescriptionAddedInNonLinearOrder
     this->sut.remove(service5);
     this->sut.remove(service1);
     EXPECT_THAT(this->sut->getServices().size(), Eq(3));
-    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    this->sut->find(this->searchResult, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
@@ -424,9 +439,9 @@ TYPED_TEST(ServiceRegistry_test, FindSpecificNonExistingServiceDescriptionFails)
     ASSERT_FALSE(this->sut.add(service2).has_error());
     ASSERT_FALSE(this->sut.add(service3).has_error());
     this->sut->find(
-        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("g"), iox::capro::IdString_t("f"));
+        this->searchResult, iox::capro::IdString_t("a"), iox::capro::IdString_t("g"), iox::capro::IdString_t("f"));
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameServicesAndRemovingSpecificDoesNotFindSpecific)
@@ -444,8 +459,8 @@ TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionWithSameService
     EXPECT_THAT(this->sut->getServices().size(), Eq(2));
 
     this->sut->find(
-        this->searchResults, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+        this->searchResult, iox::capro::IdString_t("a"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceRegistry)
@@ -463,8 +478,8 @@ TYPED_TEST(ServiceRegistry_test, ServiceNotFoundAfterAddingAndRemovingToServiceR
     EXPECT_THAT(this->sut->getServices().size(), Eq(2));
 
     this->sut->find(
-        this->searchResults, iox::capro::IdString_t("b"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+        this->searchResult, iox::capro::IdString_t("b"), iox::capro::IdString_t("c"), iox::capro::IdString_t("c"));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllDoesNotFindAnything)
@@ -482,8 +497,8 @@ TYPED_TEST(ServiceRegistry_test, AddingMultipleServiceDescriptionAndRemovingAllD
     this->sut.remove(service2);
     this->sut.remove(service3);
 
-    this->sut->find(this->searchResults, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    this->sut->find(this->searchResult, iox::capro::IdString_t("a"), iox::capro::Wildcard, iox::capro::Wildcard);
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddingVariousServiceDescriptionAndGetServicesDoesNotReturnDuplicate)
@@ -646,12 +661,12 @@ TYPED_TEST(ServiceRegistry_test, FunctionIsAppliedToAllEntriesInSearchResult)
     ASSERT_FALSE(this->sut.add(service2).has_error());
     ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    auto searchFunction = [&](const Entry& entry) { this->searchResults.emplace_back(entry); };
+    auto searchFunction = [&](const Entry& entry) { this->searchResult.emplace_back(entry); };
     this->sut->find(iox::capro::IdString_t("a"), iox::capro::IdString_t("b"), iox::capro::Wildcard, searchFunction);
 
-    ASSERT_THAT(this->searchResults.size(), Eq(2));
-    EXPECT_THAT(this->searchResults[0].serviceDescription, Eq(service1));
-    EXPECT_THAT(this->searchResults[1].serviceDescription, Eq(service3));
+    ASSERT_THAT(this->searchResult.size(), Eq(2));
+    EXPECT_THAT(this->searchResult[0].serviceDescription, Eq(service1));
+    EXPECT_THAT(this->searchResult[1].serviceDescription, Eq(service3));
 }
 
 TYPED_TEST(ServiceRegistry_test, NoFunctionIsAppliedToEmptySearchResult)
@@ -665,10 +680,10 @@ TYPED_TEST(ServiceRegistry_test, NoFunctionIsAppliedToEmptySearchResult)
     ASSERT_FALSE(this->sut.add(service2).has_error());
     ASSERT_FALSE(this->sut.add(service3).has_error());
 
-    auto searchFunction = [&](const Entry& entry) { this->searchResults.emplace_back(entry); };
+    auto searchFunction = [&](const Entry& entry) { this->searchResult.emplace_back(entry); };
     this->sut->find(iox::capro::Wildcard, iox::capro::IdString_t("a"), iox::capro::Wildcard, searchFunction);
 
-    EXPECT_THAT(this->searchResults.size(), Eq(0));
+    EXPECT_THAT(this->searchResult.size(), Eq(0));
 }
 
 TYPED_TEST(ServiceRegistry_test, FindWithEmptyCallableDoesNotDie)
@@ -678,6 +693,33 @@ TYPED_TEST(ServiceRegistry_test, FindWithEmptyCallableDoesNotDie)
     ASSERT_FALSE(this->sut.add(service).has_error());
     iox::cxx::function_ref<void(const Entry&)> searchFunction;
     this->sut->find(iox::capro::Wildcard, iox::capro::Wildcard, iox::capro::Wildcard, searchFunction);
+}
+
+TYPED_TEST(ServiceRegistry_test, FindWithMixOfPublishersAndServersWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "220213cb-8fdf-4fd0-b8e2-24a96f11bfbc");
+    iox::capro::ServiceDescription service1("a", "a", "a");
+    iox::capro::ServiceDescription service2("a", "b", "b");
+    iox::capro::ServiceDescription service3("a", "a", "c");
+    iox::capro::ServiceDescription service4("a", "a", "d");
+
+    ASSERT_FALSE(this->sut.add(service1).has_error());
+    ASSERT_FALSE(this->sut.otherAdd(service2).has_error());
+    ASSERT_FALSE(this->sut.add(service3).has_error());
+    ASSERT_FALSE(this->sut.otherAdd(service4).has_error());
+
+    auto searchFunction = [&](const Entry& entry) { this->searchResult.emplace_back(entry); };
+    this->sut->find(iox::capro::Wildcard, iox::capro::IdString_t("a"), iox::capro::Wildcard, searchFunction);
+
+    EXPECT_THAT(this->searchResult.size(), Eq(3U));
+
+    auto filtered = this->sut.filter(this->searchResult);
+
+    // only service1 and service3 match the category (server or publisher),
+    // the other match (service 4) is of a different category
+    ASSERT_EQ(filtered.size(), 2U);
+    EXPECT_EQ(filtered[0].serviceDescription, service1);
+    EXPECT_EQ(filtered[1].serviceDescription, service3);
 }
 
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
    - [ ] Each unit test case has a unique UUID
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes Nothing
