### PR TITLE
iox-#1108 Fix potential segfault in string

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -22,6 +22,7 @@
 #include "optional.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -17,6 +17,8 @@
 #ifndef IOX_HOOFS_CXX_STRING_INL
 #define IOX_HOOFS_CXX_STRING_INL
 
+#include "iceoryx_hoofs/cxx/string.hpp"
+
 namespace iox
 {
 namespace cxx

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -98,7 +98,7 @@ inline string<Capacity>::string(const char (&other)[N]) noexcept
 
 template <uint64_t Capacity>
 inline string<Capacity>::string(TruncateToCapacity_t, const char* const other) noexcept
-    : string(TruncateToCapacity, other, strnlen(other, Capacity))
+    : string(TruncateToCapacity, other, [&]() -> uint64_t { return other ? strnlen(other, Capacity) : 0U; }())
 {
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -306,6 +306,17 @@ TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithSizeGreaterCapaResu
     string<STRINGCAP> testSubject(TruncateToCapacity, testChar);
     EXPECT_THAT(testSubject.capacity(), Eq(STRINGCAP));
     EXPECT_THAT(testSubject.size(), Eq(STRINGCAP));
+}
+
+TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithNullPtrResultsEmptyString)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c6bbcbc6-e049-4c2c-bf84-8d89dcf42ce8");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString::capacity();
+    string<STRINGCAP> fuu(TruncateToCapacity, nullptr);
+    EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
+    EXPECT_THAT(fuu.size(), Eq(0U));
+    EXPECT_THAT(fuu.c_str(), StrEq(""));
 }
 
 /// @note string(TruncateToCapacity_t, const std::string& other) noexcept


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes a potential segfault in `string(TruncateToCapacity_t, const char* const other)` when `other` is a `nullptr`. Actually `strnlen` should fail when called with a `nullptr` but it seems that it is not invoked before delegating to the other c'tor.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1108 
