### PR TITLE
Iox #1130 replace high resolution clock with system clock and steady clock

### DIFF
--- a/doc/website/release-notes/iceoryx-v2-0-0.md
+++ b/doc/website/release-notes/iceoryx-v2-0-0.md
@@ -46,6 +46,7 @@
 - When posix mutex fails a correct error message is reported on the console [\#999](https://github.com/eclipse-iceoryx/iceoryx/issues/999)
 - Only use `std::result_of` for C++14 to be able to use iceoryx in C++20 projects [\#1076](https://github.com/eclipse-iceoryx/iceoryx/issues/1076)
 - Set stack size for windows in `singleprocess` example and posh tests [\#1082](https://github.com/eclipse-iceoryx/iceoryx/issues/1082)
+- Roudi console timestamps is out of date [#1130](https://github.com/eclipse-iceoryx/iceoryx/issues/1130)
 
 **Refactoring:**
 

--- a/iceoryx_examples/iceperf/base.cpp
+++ b/iceoryx_examples/iceperf/base.cpp
@@ -35,7 +35,7 @@ void IcePerfBase::releaseFollower() noexcept
 
 iox::units::Duration IcePerfBase::latencyPerfTestLeader(const uint64_t numRoundTrips) noexcept
 {
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
 
     // run the performance test
     for (auto i = 0U; i < numRoundTrips; ++i)
@@ -44,7 +44,7 @@ iox::units::Duration IcePerfBase::latencyPerfTestLeader(const uint64_t numRoundT
         sendPerfTopic(perfTopic.payloadSize, RunFlag::RUN);
     }
 
-    auto finish = std::chrono::high_resolution_clock::now();
+    auto finish = std::chrono::steady_clock::now();
 
     constexpr uint64_t TRANSMISSIONS_PER_ROUNDTRIP{2U};
     auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(finish - start);

--- a/iceoryx_hoofs/source/log/logstream.cpp
+++ b/iceoryx_hoofs/source/log/logstream.cpp
@@ -33,7 +33,7 @@ LogStream::LogStream(Logger& logger, LogLevel logLevel) noexcept
 {
     m_logEntry.level = logLevel;
     /// @todo do we want to do this only when loglevel is higher than global loglevel?
-    auto timePoint = std::chrono::high_resolution_clock::now();
+    auto timePoint = std::chrono::system_clock::now();
     m_logEntry.time = std::chrono::duration_cast<std::chrono::milliseconds>(timePoint.time_since_epoch());
 }
 

--- a/iceoryx_posh/source/runtime/ipc_runtime_interface.cpp
+++ b/iceoryx_posh/source/runtime/ipc_runtime_interface.cpp
@@ -75,10 +75,10 @@ IpcRuntimeInterface::IpcRuntimeInterface(const RuntimeName_t& roudiName,
         {
             using namespace units;
             using namespace std::chrono;
-            auto timestamp = duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+            auto timestamp = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
             while (transmissionTimestamp == timestamp)
             {
-                timestamp = duration_cast<microseconds>(high_resolution_clock::now().time_since_epoch()).count();
+                timestamp = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
             }
             transmissionTimestamp = timestamp;
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CHANGELOG.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

On most systems `std::chrono::high_resolution_clock` is just an alias to `std::chrono::system_clock`. On others it is an alias to `std::chrono::steady_clock`. This PR replaces  `std::chrono::high_resolution_clock` with `std::chrono::system_clock` where timestamps are used and with `std::chrono::steady_clock` where time differences are calculated

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1130
