### PR TITLE
Iox #1144 do not merge

### DIFF
--- a/iceoryx_binding_c/include/iceoryx_binding_c/types.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/types.h
@@ -76,7 +76,7 @@ struct iox_listener_storage_t_
     // the value of the array size is the result of the following formula:
     // sizeof(Listener) / 8
 #if defined(__APPLE__)
-    uint64_t do_not_touch_me[5000];
+    uint64_t do_not_touch_me[5226];
 #else
     uint64_t do_not_touch_me[4478];
 #endif

--- a/iceoryx_binding_c/include/iceoryx_binding_c/types.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/types.h
@@ -35,7 +35,7 @@ struct iox_ws_storage_t_
 {
     // the value of the array size is the result of the following formula:
     // sizeof(WaitSet) / 8
-    uint64_t do_not_touch_me[2965];
+    uint64_t do_not_touch_me[5902];
 };
 typedef struct iox_ws_storage_t_ iox_ws_storage_t;
 
@@ -76,9 +76,9 @@ struct iox_listener_storage_t_
     // the value of the array size is the result of the following formula:
     // sizeof(Listener) / 8
 #if defined(__APPLE__)
-    uint64_t do_not_touch_me[2643];
+    uint64_t do_not_touch_me[5000];
 #else
-    uint64_t do_not_touch_me[2567];
+    uint64_t do_not_touch_me[4478];
 #endif
 };
 typedef struct iox_listener_storage_t_ iox_listener_storage_t;

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -106,13 +106,13 @@ namespace popo
 using WaitSetIsConditionSatisfiedCallback = cxx::ConstMethodCallback<bool>;
 }
 constexpr uint32_t MAX_NUMBER_OF_CONDITION_VARIABLES = 1024U;
-constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 128U;
-constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 128U;
+constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 256U;
+constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 256U;
 static_assert(MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The WaitSet capacity is restricted by the maximum amount of notifiers per condition variable.");
 // Listener
-constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 128U;
-constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 128U;
+constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 256U;
+constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 256U;
 static_assert(MAX_NUMBER_OF_EVENTS_PER_LISTENER <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The Listener capacity is restricted by the maximum amount of notifiers per condition variable.");
 //--------- Communication Resources End---------------------

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -106,13 +106,13 @@ namespace popo
 using WaitSetIsConditionSatisfiedCallback = cxx::ConstMethodCallback<bool>;
 }
 constexpr uint32_t MAX_NUMBER_OF_CONDITION_VARIABLES = 1024U;
-constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 256U;
-constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 256U;
+constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 255U;
+constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 255U;
 static_assert(MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The WaitSet capacity is restricted by the maximum amount of notifiers per condition variable.");
 // Listener
-constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 256U;
-constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 256U;
+constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 255U;
+constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 255U;
 static_assert(MAX_NUMBER_OF_EVENTS_PER_LISTENER <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The Listener capacity is restricted by the maximum amount of notifiers per condition variable.");
 //--------- Communication Resources End---------------------

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -106,13 +106,12 @@ namespace popo
 using WaitSetIsConditionSatisfiedCallback = cxx::ConstMethodCallback<bool>;
 }
 constexpr uint32_t MAX_NUMBER_OF_CONDITION_VARIABLES = 1024U;
-constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 255U;
-constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 255U;
+constexpr uint32_t MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE = 254;
+constexpr uint32_t MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET = 254;
 static_assert(MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The WaitSet capacity is restricted by the maximum amount of notifiers per condition variable.");
 // Listener
-constexpr uint8_t MAX_NUMBER_OF_EVENT_VARIABLES = 255U;
-constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 255U;
+constexpr uint8_t MAX_NUMBER_OF_EVENTS_PER_LISTENER = 254U;
 static_assert(MAX_NUMBER_OF_EVENTS_PER_LISTENER <= MAX_NUMBER_OF_NOTIFIERS_PER_CONDITION_VARIABLE,
               "The Listener capacity is restricted by the maximum amount of notifiers per condition variable.");
 //--------- Communication Resources End---------------------

--- a/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark_optional_and_expected.cpp
+++ b/iceoryx_utils/test/stresstests/benchmark_optional_and_expected/benchmark_optional_and_expected.cpp
@@ -133,7 +133,7 @@ uint64_t complexErrorValueImpl(uint64_t& value)
 
 void complexErrorValue()
 {
-    uint64_t maybeValue;
+    uint64_t maybeValue{0};
     uint64_t returnValue = complexErrorValueImpl(maybeValue);
     if (returnValue == 0)
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
    - [ ] Each unit test case has a unique UUID
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
