### PR TITLE
Iox #299 fix clang tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,33 +8,114 @@
 
 Checks: '
 -*,
+
 readability-*,
 clang-analyzer-*,
 cert-*,
 bugprone-*,
+cppcoreguidelines-*,
+concurrency-*,
+performance-*,
+hicpp-*,
+
+-bugprone-use-after-move,
+-bugprone-easily-swappable-parameters,
+-bugprone-branch-clone,
+-bugprone-implicit-widening-of-multiplication-result,
+-concurrency-mt-unsafe,
 -readability-named-parameter,
 -readability-avoid-const-params-in-decls,
--readability-else-after-return,performance-*,
--readability-redundant-access-specifiers,hicpp-*,
+-readability-else-after-return,
+-readability-redundant-access-specifiers,
 -readability-magic-numbers,
+-readability-function-size,
+-readability-static-accessed-through-instance,
+-readability-qualified-auto,
+-readability-uppercase-literal-suffix,
+-readability-implicit-bool-conversion,
+-readability-convert-member-functions-to-static,
+-readability-inconsistent-declaration-parameter-name,
+-readability-container-size-empty,
+-readability-simplify-boolean-expr,
+-readability-make-member-function-const,
+-readability-const-return-type,
+-readability-function-cognitive-complexity,
+-readability-use-anyofallof,
 -hicpp-named-parameter,
--hicpp-avoid-c-arrays,cppcoreguidelines-*,
--hicpp-no-array-decay,-hicpp-signed-bitwise,
+-hicpp-avoid-c-arrays,
+-hicpp-no-array-decay,
+-hicpp-signed-bitwise,
 -hicpp-vararg,
 -hicpp-no-malloc,
 -hicpp-member-init,
+-hicpp-use-auto,
+-hicpp-uppercase-literal-suffix,
+-hicpp-use-equals-default,
+-hicpp-deprecated-headers,
+-cert-env33-c,
 -performance-move-const-arg,
+-performance-no-int-to-ptr,
+-performance-unnecessary-value-param,
+-performance-for-range-copy,
+-clang-analyzer-core.uninitialized.UndefReturn,
+-clang-analyzer-optin.cplusplus.VirtualCall,
 -cppcoreguidelines-avoid-c-arrays,
 -cppcoreguidelines-pro-bounds-constant-array-index,
 -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
--cppcoreguidelines-pro-type-vararg,concurrency-*,
+-cppcoreguidelines-pro-type-vararg,
 -cppcoreguidelines-macro-usage,
 -cppcoreguidelines-avoid-non-const-global-variables,
 -cppcoreguidelines-pro-type-reinterpret-cast,
--bugprone-use-after-move,
+-cppcoreguidelines-prefer-member-initializer,
+-cppcoreguidelines-avoid-magic-numbers,
+-cppcoreguidelines-pro-type-const-cast,
+-cppcoreguidelines-pro-type-member-init,
+-cppcoreguidelines-pro-bounds-pointer-arithmetic,
+-cppcoreguidelines-owning-memory,
+-cppcoreguidelines-init-variables,
 -hicpp-move-const-arg,
 -hicpp-invalid-access-moved'
 
+## Those warnings should be enabled
+## They are disabled since they require a heavy API refactoring and when we enable it we clutter the code with // NOLINT comments
+# -bugprone-easily-swappable-parameters
+#
+## the LineThreshold, StatementThreshold, BranchThreshold contains random number
+## here we have to do some heavy refactoring
+# -readability-function-size
+# -readability-function-cognitive-complexity
+#
+## is it working correctly? produces hard to understand warning
+# -clang-analyzer-core.uninitialized.UndefReturn 
+# -clang-analyzer-optin.cplusplus.VirtualCall
+#
+###########################################
+#### A lot of code changes but easy effort:
+###########################################
+# -readability-qualified-auto
+# -readability-convert-member-functions-to-static
+# -readability-container-size-empty
+# -readability-simplify-boolean-expr
+# -readability-const-return-type
+# -readability-use-anyofallof
+# -cppcoreguidelines-avoid-magic-numbers
+# -cppcoreguidelines-init-variables
+# -hicpp-use-auto
+# -readability-qualified-auto
+# -hicpp-uppercase-literal-suffix
+# -readability-uppercase-literal-suffix
+# -readability-implicit-bool-conversion
+# -bugprone-branch-clone
+# -hicpp-use-equals-default
+# -hicpp-deprecated-headers
+# -cppcoreguidelines-prefer-member-initializer
+# -readability-convert-member-functions-to-static
+# -cppcoreguidelines-pro-type-const-cast
+# -cppcoreguidelines-pro-type-member-init
+# -bugprone-implicit-widening-of-multiplication-result
+# -readability-inconsistent-declaration-parameter-name
+# -performance-for-range-copy
+# -readability-make-member-function-const
 
 WarningsAsErrors:     '' # Treat all Checks from above as errors
 HeaderFilterRegex:    ''

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -215,8 +215,8 @@ bool ProcessManager::registerProcess(const RuntimeName_t& name,
             LogWarn() << "Application " << name << " crashed. Re-registering application";
 
             // remove the existing process and add the new process afterwards, we do not send ack to new process
-            constexpr TerminationFeedback terminationFeedback{TerminationFeedback::DO_NOT_SEND_ACK_TO_PROCESS};
-            if (!this->searchForProcessAndRemoveIt(name, terminationFeedback))
+            constexpr TerminationFeedback TERMINATION_FEEDBACK{TerminationFeedback::DO_NOT_SEND_ACK_TO_PROCESS};
+            if (!this->searchForProcessAndRemoveIt(name, TERMINATION_FEEDBACK))
             {
                 LogWarn() << "Application " << name << " could not be removed";
                 return;
@@ -282,8 +282,8 @@ bool ProcessManager::addProcess(const RuntimeName_t& name,
 
 bool ProcessManager::unregisterProcess(const RuntimeName_t& name) noexcept
 {
-    constexpr TerminationFeedback feedback{TerminationFeedback::SEND_ACK_TO_PROCESS};
-    if (!searchForProcessAndRemoveIt(name, feedback))
+    constexpr TerminationFeedback FEEDBACK{TerminationFeedback::SEND_ACK_TO_PROCESS};
+    if (!searchForProcessAndRemoveIt(name, FEEDBACK))
     {
         LogError() << "Application " << name << " could not be unregistered!";
         return false;

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -29,20 +29,20 @@ namespace config
 cxx::expected<CmdLineArgs_t, CmdLineParserResult>
 CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cmdLineParsingMode) noexcept
 {
-    constexpr option longOptions[] = {{"help", no_argument, nullptr, 'h'},
-                                      {"version", no_argument, nullptr, 'v'},
-                                      {"monitoring-mode", required_argument, nullptr, 'm'},
-                                      {"log-level", required_argument, nullptr, 'l'},
-                                      {"unique-roudi-id", required_argument, nullptr, 'u'},
-                                      {"compatibility", required_argument, nullptr, 'x'},
-                                      {"kill-delay", required_argument, nullptr, 'k'},
-                                      {nullptr, 0, nullptr, 0}};
+    constexpr option LONG_OPTIONS[] = {{"help", no_argument, nullptr, 'h'},
+                                       {"version", no_argument, nullptr, 'v'},
+                                       {"monitoring-mode", required_argument, nullptr, 'm'},
+                                       {"log-level", required_argument, nullptr, 'l'},
+                                       {"unique-roudi-id", required_argument, nullptr, 'u'},
+                                       {"compatibility", required_argument, nullptr, 'x'},
+                                       {"kill-delay", required_argument, nullptr, 'k'},
+                                       {nullptr, 0, nullptr, 0}};
 
     // colon after shortOption means it requires an argument, two colons mean optional argument
-    constexpr const char* shortOptions = "hvm:l:u:x:k:";
+    constexpr const char* SHORT_OPTIONS = "hvm:l:u:x:k:";
     int32_t index;
     int32_t opt{-1};
-    while ((opt = getopt_long(argc, argv, shortOptions, longOptions, &index), opt != -1))
+    while ((opt = getopt_long(argc, argv, SHORT_OPTIONS, LONG_OPTIONS, &index), opt != -1))
     {
         switch (opt)
         {

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
@@ -29,15 +29,15 @@ namespace config
 cxx::expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::parse(
     int argc, char* argv[], const CmdLineArgumentParsingMode cmdLineParsingMode) noexcept
 {
-    constexpr option longOptions[] = {{"help", no_argument, nullptr, 'h'},
-                                      {"config-file", required_argument, nullptr, 'c'},
-                                      {nullptr, 0, nullptr, 0}};
+    constexpr option LONG_OPTIONS[] = {{"help", no_argument, nullptr, 'h'},
+                                       {"config-file", required_argument, nullptr, 'c'},
+                                       {nullptr, 0, nullptr, 0}};
 
     // colon after shortOption means it requires an argument, two colons mean optional argument
-    constexpr const char* shortOptions = ":hc:";
+    constexpr const char* SHORT_OPTIONS = ":hc:";
     int32_t index;
     int32_t opt{-1};
-    while (opt = getopt_long(argc, argv, shortOptions, longOptions, &index), opt != -1)
+    while (opt = getopt_long(argc, argv, SHORT_OPTIONS, LONG_OPTIONS, &index), opt != -1)
     {
         switch (opt)
         {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
I disabled all clang-tidy warnings which are currently active in iceoryx, except naming. Those I fixed right away.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #299 
