### PR TITLE
iox-#1194 Install includes to include/${PROJECT_NAME}

### DIFF
--- a/doc/website/release-notes/iceoryx-v2-0-0.md
+++ b/doc/website/release-notes/iceoryx-v2-0-0.md
@@ -46,6 +46,7 @@ servers (`iox::popo::MessagingPattern::REQ_RES`) [\#27](https://github.com/eclip
         - The DDS gateway is not aware of the new `Server` [\#1145](https://github.com/eclipse-iceoryx/iceoryx/issues/1145)
 - Set `MAX_NUMBER_OF_NOTIFIERS` to 256 and prepare configuration via CMake[\#1144](https://github.com/eclipse-iceoryx/iceoryx/issues/1144)
 - Reorganize code in publisher.hpp/.inl and subscriber.hpp/inl [\#1173](https://github.com/eclipse-iceoryx/iceoryx/issues/1173)
+- Install headers to `include/iceoryx/vX.Y.Z` by default and add CMake option `MAKE_UNIQUE_INCLUDEDIR` to control the behavior [\#1194](https://github.com/eclipse-iceoryx/iceoryx/issues/1194)
 
 **Bugfixes:**
 

--- a/iceoryx_binding_c/CMakeLists.txt
+++ b/iceoryx_binding_c/CMakeLists.txt
@@ -34,6 +34,20 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
+option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
+  "When ON headers are installed to a path ending with a folder called \
+  ${PROJECT_NAME}. This avoids include directory search order issues when \
+  overriding this package from a merged catkin, ament, or colcon workspace."
+  ON)
+
+if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+  if(PREFIX STREQUAL "")
+    set(PREFIX "${PROJECT_NAME}")
+  else()
+    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+  endif()
+endif()
+
 #
 ########## set variables for export ##########
 #

--- a/iceoryx_binding_c/CMakeLists.txt
+++ b/iceoryx_binding_c/CMakeLists.txt
@@ -34,17 +34,18 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
-option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
-  "When ON headers are installed to a path ending with a folder called \
-  ${PROJECT_NAME}. This avoids include directory search order issues when \
+option(MAKE_UNIQUE_INCLUDEDIR
+  "When ON headers are installed to a path ending with folders called \
+  iceoryx/vX.Y.Z/ . This avoids include directory search order issues when \
   overriding this package from a merged catkin, ament, or colcon workspace."
   ON)
 
-if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+if(MAKE_UNIQUE_INCLUDEDIR)
+  set(_unique_dir "iceoryx/v${IOX_VERSION_STRING}")
   if(PREFIX STREQUAL "")
-    set(PREFIX "${PROJECT_NAME}")
+    set(PREFIX "${_unique_dir}")
   else()
-    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+    set(PREFIX "${PREFIX}/${_unique_dir}")
   endif()
 endif()
 

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -28,6 +28,20 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
+option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
+  "When ON headers are installed to a path ending with a folder called \
+  ${PROJECT_NAME}. This avoids include directory search order issues when \
+  overriding this package from a merged catkin, ament, or colcon workspace."
+  ON)
+
+if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+  if(PREFIX STREQUAL "")
+    set(PREFIX "${PROJECT_NAME}")
+  else()
+    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+  endif()
+endif()
+
 if(CLANG_TIDY)
     find_program(
         CLANG_TIDY_EXE

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -28,17 +28,18 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
-option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
-  "When ON headers are installed to a path ending with a folder called \
-  ${PROJECT_NAME}. This avoids include directory search order issues when \
+option(MAKE_UNIQUE_INCLUDEDIR
+  "When ON headers are installed to a path ending with folders called \
+  iceoryx/vX.Y.Z/ . This avoids include directory search order issues when \
   overriding this package from a merged catkin, ament, or colcon workspace."
   ON)
 
-if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+if(MAKE_UNIQUE_INCLUDEDIR)
+  set(_unique_dir "iceoryx/v${IOX_VERSION_STRING}")
   if(PREFIX STREQUAL "")
-    set(PREFIX "${PROJECT_NAME}")
+    set(PREFIX "${_unique_dir}")
   else()
-    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+    set(PREFIX "${PREFIX}/${_unique_dir}")
   endif()
 endif()
 

--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -44,17 +44,18 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
-option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
-  "When ON headers are installed to a path ending with a folder called \
-  ${PROJECT_NAME}. This avoids include directory search order issues when \
+option(MAKE_UNIQUE_INCLUDEDIR
+  "When ON headers are installed to a path ending with folders called \
+  iceoryx/vX.Y.Z/ . This avoids include directory search order issues when \
   overriding this package from a merged catkin, ament, or colcon workspace."
   ON)
 
-if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+if(MAKE_UNIQUE_INCLUDEDIR)
+  set(_unique_dir "iceoryx/v${IOX_VERSION_STRING}")
   if(PREFIX STREQUAL "")
-    set(PREFIX "${PROJECT_NAME}")
+    set(PREFIX "${_unique_dir}")
   else()
-    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+    set(PREFIX "${PREFIX}/${_unique_dir}")
   endif()
 endif()
 

--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -35,7 +35,6 @@ if(TOML_CONFIG)
     find_package(cpptoml REQUIRED)
 endif()
 
-include(cmake/iceoryxversions.cmake)
 include(IceoryxPackageHelper)
 include(IceoryxPlatform)
 
@@ -45,6 +44,21 @@ if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
 
+option(APPEND_PROJECT_NAME_TO_INCLUDEDIR
+  "When ON headers are installed to a path ending with a folder called \
+  ${PROJECT_NAME}. This avoids include directory search order issues when \
+  overriding this package from a merged catkin, ament, or colcon workspace."
+  ON)
+
+if(APPEND_PROJECT_NAME_TO_INCLUDEDIR)
+  if(PREFIX STREQUAL "")
+    set(PREFIX "${PROJECT_NAME}")
+  else()
+    set(PREFIX "${PREFIX}/${PROJECT_NAME}")
+  endif()
+endif()
+
+include(cmake/iceoryxversions.cmake)
 
 if(CLANG_TIDY)
     find_program(


### PR DESCRIPTION
Adds a CMake option `APPEND_PROJECT_NAME_TO_INCLUDEDIR` defaulting to `ON`
that appends ${PROJECT_NAME} to the directory headers are installed. This is to support ros2/ros2#1150.

Pretty similar to https://github.com/eclipse-cyclonedds/cyclonedds/pull/1169
Relevant issue: https://github.com/eclipse-iceoryx/iceoryx/issues/1194

When using ROS 2 and Colcon it's possible to have two versions of a package installed: typically one from the debian packages (like `ros-[rosdistro]-iceoryx-binding-c`) and another in a from-source workspace. In Colcon terms this is called "overriding a package", and the `/opt/ros/[rosdistro]` folder would be called the underlay while the from-source workspace would be called the overlay. A user would do this when they want to try a newer version of a package without building everything from source.

When two or more packages install their headers to the same directory in an underlay, it becomes possible for packages in the overlay to accidentally find the headers of an overridden package in the underlay. This can cause build failures or undefined behavior at runtime depending on the differences between the headers in the overridden and overriding packages. The exact conditions this happens are a little complicated, so I'll skip writing it out here. In ROS 2 we're solving the issue by making every package install its headers to a unique folder using `${PROJECT_NAME}`.

Signed-off-by: Shane Loretz <shane.loretz@gmail.com>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1194
