### PR TITLE
iox-#1192 clamp history request

### DIFF
--- a/doc/website/release-notes/iceoryx-v2-0-0.md
+++ b/doc/website/release-notes/iceoryx-v2-0-0.md
@@ -82,6 +82,7 @@ fb913bf0de288ba84fe98f7a23d35edfdb22381
 - Application can't create publisher repeatedly with previous one already destroyed [\#938](https://github.com/eclipse-iceoryx/iceoryx/issues/938)
 - Prevent creation of `popo::Publisher`'s with internal `ServiceDescription` [\#1120](https://github.com/eclipse-iceoryx/iceoryx/issues/1120)
 - RelativePointer is now type safe, i.e. can only be constructed from pointers with a valid convertion to the raw pointer [\#1121](https://github.com/eclipse-iceoryx/iceoryx/issues/1121)
+- Clamping `historyRequest` to `queueCapacity` [\#1192](https://github.com/eclipse-iceoryx/iceoryx/issues/1192)
 
 **Refactoring:**
 

--- a/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
@@ -212,6 +212,13 @@ PoshRuntimeImpl::getMiddlewareSubscriber(const capro::ServiceDescription& servic
         options.queueCapacity = 1U;
     }
 
+    if (subscriberOptions.historyRequest > subscriberOptions.queueCapacity)
+    {
+        LogWarn() << "Requested historyRequest for " << service
+                  << " is larger than queueCapacity. Clamping historyRequest to queueCapacity!";
+        options.historyRequest = subscriberOptions.queueCapacity;
+    }
+
     if (options.nodeName.empty())
     {
         options.nodeName = m_appName;

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -517,6 +517,22 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithQueueCapacityZeroClampsQueue
     EXPECT_EQ(1U, subscriberPort->m_chunkReceiverData.m_queue.capacity());
 }
 
+TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithHistoryRequestLargerThanQueueCapacityClampsToQueueCapacity)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "77ca8d29-ffcb-4860-bf07-0af30b352e5c");
+    iox::popo::SubscriberOptions subscriberOptions;
+    constexpr uint64_t EXPECTED_HISTORY_REQUEST = 1U;
+    subscriberOptions.queueCapacity = EXPECTED_HISTORY_REQUEST;
+    subscriberOptions.historyRequest = 42U;
+
+    auto subscriberPort =
+        m_runtime->getMiddlewareSubscriber(iox::capro::ServiceDescription("Harder", "Better", "Faster"),
+                                           subscriberOptions,
+                                           iox::runtime::PortConfigInfo(33U, 11U, 22U));
+
+    EXPECT_EQ(EXPECTED_HISTORY_REQUEST, subscriberPort->m_options.historyRequest);
+}
+
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberDefaultArgs)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e06b999c-e237-4e32-b826-a5ffdb6bb737");


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
* Clamps `historyRequest` to `queueCapacity`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1192 
