### PR TITLE
iox-#743 review docker example

### DIFF
--- a/iceoryx_examples/icedocker/README.md
+++ b/iceoryx_examples/icedocker/README.md
@@ -32,9 +32,9 @@ Every iceoryx application is registering itself at our central broker RouDi
 by sending a message to the unix domain socket located at
 `IOX_UDS_SOCKET_PATH_PREFIX/roudi` which is defined in the corresponding
 platform settings file `platform_settings.hpp`. In linux the socket file handle
-can be found at `/tmp/roudi`. While registering it announces its unix
-domain socket to roudi for the responses of application requests which were
-sent to roudi.
+can be found at `/tmp/roudi`. When the application registers at RouDi it 
+announces its unix domain socket as well to receive responses of requests which
+will be sent during runtime to RouDi.
 This socket is stored as well in `/tmp/IOX_RUNTIME_NAME`. The `iox-cpp-publisher`
 runtime has the same name as the binary which leads to the socket
 `/tmp/iox-cpp-publisher`.

--- a/iceoryx_examples/icedocker/README.md
+++ b/iceoryx_examples/icedocker/README.md
@@ -28,7 +28,7 @@ To demonstrate the setup we use the
 
 ### Shared Access to Unix Domain Sockets
 
-Every iceoryx application is registering itself at our central broker RouDi
+Every iceoryx application registers itself at our central broker RouDi
 by sending a message to the unix domain socket located at
 `IOX_UDS_SOCKET_PATH_PREFIX/roudi` which is defined in the corresponding
 platform settings file `platform_settings.hpp`. In linux the socket file handle


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #743 
