### PR TITLE
iox-#1218 Remove potential dangerous usage of storage in binding C tests

### DIFF
--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -468,14 +468,15 @@ TIMING_TEST_F(iox_listener_test, NotifyingClientEventWithContextDataWorks, Repea
     EXPECT_CALL(*runtimeMock, getMiddlewareClient(_, _, _)).WillOnce(Return(&clientPortData));
 
     iox_client_t client = iox_client_init(&clientStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
 
     iox_listener_attach_client_event_with_context_data(
-        &m_sut, client, ClientEvent_RESPONSE_RECEIVED, &clientCallbackWithContextData, &clientStorage);
+        &m_sut, client, ClientEvent_RESPONSE_RECEIVED, &clientCallbackWithContextData, &someContextData);
 
     notifyClient(clientPortData);
     std::this_thread::sleep_for(TIMEOUT);
     TIMING_TEST_EXPECT_TRUE(g_clientCallbackArgument == client);
-    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&clientStorage));
+    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&someContextData));
 
     iox_listener_detach_client_event(&m_sut, client, ClientEvent_RESPONSE_RECEIVED);
 
@@ -518,14 +519,15 @@ TEST_F(iox_listener_test, AttachingServerWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareServer(_, _, _)).WillOnce(Return(&serverPortData));
 
     iox_server_t server = iox_server_init(&serverStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
 
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
     iox_listener_attach_server_event_with_context_data(
-        &m_sut, server, ServerEvent_REQUEST_RECEIVED, &serverCallbackWithContextData, &serverStorage);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1));
+        &m_sut, server, ServerEvent_REQUEST_RECEIVED, &serverCallbackWithContextData, &someContextData);
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1U));
 
     iox_listener_detach_server_event(&m_sut, server, ServerEvent_REQUEST_RECEIVED);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
 
     iox_server_deinit(server);
 }
@@ -554,14 +556,15 @@ TIMING_TEST_F(iox_listener_test, NotifyingServerEventWithContextDataWorks, Repea
     EXPECT_CALL(*runtimeMock, getMiddlewareServer(_, _, _)).WillOnce(Return(&serverPortData));
 
     iox_server_t server = iox_server_init(&serverStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
 
     iox_listener_attach_server_event_with_context_data(
-        &m_sut, server, ServerEvent_REQUEST_RECEIVED, &serverCallbackWithContextData, &serverStorage);
+        &m_sut, server, ServerEvent_REQUEST_RECEIVED, &serverCallbackWithContextData, &someContextData);
 
     notifyServer(serverPortData);
     std::this_thread::sleep_for(TIMEOUT);
     TIMING_TEST_EXPECT_TRUE(g_serverCallbackArgument == server);
-    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&serverStorage));
+    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&someContextData));
 
     iox_listener_detach_server_event(&m_sut, server, ServerEvent_REQUEST_RECEIVED);
 
@@ -580,14 +583,14 @@ TEST_F(iox_listener_test, AttachingServiceDiscoveryWorks)
 
     iox_service_discovery_t serviceDiscovery = iox_service_discovery_init(&serviceDiscoveryStorage);
 
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
     iox_listener_attach_service_discovery_event(
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED, &serviceDiscoveryCallback);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1U));
 
     iox_listener_detach_service_discovery_event(
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
 
     iox_service_discovery_deinit(serviceDiscovery);
 }
@@ -599,18 +602,19 @@ TEST_F(iox_listener_test, AttachingServiceDiscoveryWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareSubscriber(_, _, _)).WillOnce(Return(&m_subscriberPortData[0]));
 
     iox_service_discovery_t serviceDiscovery = iox_service_discovery_init(&serviceDiscoveryStorage);
+    uint64_t someContextData = 0U;
 
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
     iox_listener_attach_service_discovery_event_with_context_data(&m_sut,
                                                                   serviceDiscovery,
                                                                   ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED,
                                                                   &serviceDiscoveryCallbackWithContextData,
-                                                                  &serviceDiscoveryStorage);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1));
+                                                                  &someContextData);
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(1U));
 
     iox_listener_detach_service_discovery_event(
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);
-    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0));
+    EXPECT_THAT(iox_listener_size(&m_sut), Eq(0U));
 
     iox_service_discovery_deinit(serviceDiscovery);
 }
@@ -646,17 +650,18 @@ TIMING_TEST_F(iox_listener_test, NotifyingServiceDiscoveryEventWithContextDataWo
     EXPECT_CALL(*runtimeMock, getMiddlewareSubscriber(_, _, _)).WillOnce(Return(&m_subscriberPortData[0]));
 
     iox_service_discovery_t serviceDiscovery = iox_service_discovery_init(&serviceDiscoveryStorage);
+    uint64_t someContextData = 0U;
 
     iox_listener_attach_service_discovery_event_with_context_data(&m_sut,
                                                                   serviceDiscovery,
                                                                   ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED,
                                                                   &serviceDiscoveryCallbackWithContextData,
-                                                                  &serviceDiscoveryStorage);
+                                                                  &someContextData);
 
     notifyServiceDiscovery(m_subscriberPortData[0]);
     std::this_thread::sleep_for(TIMEOUT);
     TIMING_TEST_EXPECT_TRUE(g_serviceDiscoveryCallbackArgument == serviceDiscovery);
-    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&serviceDiscoveryStorage));
+    TIMING_TEST_EXPECT_TRUE(g_contextData == static_cast<void*>(&someContextData));
 
     iox_listener_detach_service_discovery_event(
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);

--- a/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
@@ -830,8 +830,9 @@ TEST_F(iox_ws_test, NotifyingClientEventWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareClient(_, _, _)).WillOnce(Return(&clientPortData));
 
     iox_client_t client = iox_client_init(&clientStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
     iox_ws_attach_client_event_with_context_data(
-        m_sut, client, ClientEvent_RESPONSE_RECEIVED, 89123, &clientCallbackWithContextData, &clientStorage);
+        m_sut, client, ClientEvent_RESPONSE_RECEIVED, 89123, &clientCallbackWithContextData, &someContextData);
 
     notifyClient(clientPortData);
 
@@ -843,7 +844,7 @@ TEST_F(iox_ws_test, NotifyingClientEventWithContextDataWorks)
     iox_notification_info_call(m_eventInfoStorage[0]);
 
     EXPECT_THAT(m_callbackOrigin, Eq(static_cast<void*>(client)));
-    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&clientStorage)));
+    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&someContextData)));
 
     iox_ws_detach_client_event(m_sut, client, ClientEvent_RESPONSE_RECEIVED);
 
@@ -899,8 +900,9 @@ TEST_F(iox_ws_test, NotifyingClientStateWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareClient(_, _, _)).WillOnce(Return(&clientPortData));
 
     iox_client_t client = iox_client_init(&clientStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
     iox_ws_attach_client_state_with_context_data(
-        m_sut, client, ClientState_HAS_RESPONSE, 0, &clientCallbackWithContextData, &clientStorage);
+        m_sut, client, ClientState_HAS_RESPONSE, 0, &clientCallbackWithContextData, &someContextData);
 
     notifyClient(clientPortData);
 
@@ -911,7 +913,7 @@ TEST_F(iox_ws_test, NotifyingClientStateWithContextDataWorks)
     iox_notification_info_call(m_eventInfoStorage[0]);
 
     EXPECT_THAT(m_callbackOrigin, Eq(static_cast<void*>(client)));
-    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&clientStorage)));
+    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&someContextData)));
 
     iox_ws_detach_client_state(m_sut, client, ClientState_HAS_RESPONSE);
 
@@ -954,10 +956,11 @@ TEST_F(iox_ws_test, AttachingServerEventWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareServer(_, _, _)).WillOnce(Return(&serverPortData));
 
     iox_server_t server = iox_server_init(&serverStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
 
     EXPECT_THAT(iox_ws_size(m_sut), Eq(0));
     iox_ws_attach_server_event_with_context_data(
-        m_sut, server, ServerEvent_REQUEST_RECEIVED, 0, serverCallbackWithContextData, &clientStorage);
+        m_sut, server, ServerEvent_REQUEST_RECEIVED, 0, serverCallbackWithContextData, &someContextData);
     EXPECT_THAT(iox_ws_size(m_sut), Eq(1));
 
     iox_ws_detach_server_event(m_sut, server, ServerEvent_REQUEST_RECEIVED);
@@ -999,8 +1002,9 @@ TEST_F(iox_ws_test, NotifyingServerEventWithContextDataWorks)
 
     iox_server_t server = iox_server_init(&serverStorage, "ServiceA", "InstanceA", "EventA", nullptr);
     constexpr uint64_t SOME_EVENT_ID = 5123901293;
+    uint64_t someContextData = 0U;
     iox_ws_attach_server_event_with_context_data(
-        m_sut, server, ServerEvent_REQUEST_RECEIVED, SOME_EVENT_ID, &serverCallbackWithContextData, &serverStorage);
+        m_sut, server, ServerEvent_REQUEST_RECEIVED, SOME_EVENT_ID, &serverCallbackWithContextData, &someContextData);
 
     notifyServer(serverPortData);
 
@@ -1012,7 +1016,7 @@ TEST_F(iox_ws_test, NotifyingServerEventWithContextDataWorks)
     iox_notification_info_call(m_eventInfoStorage[0]);
 
     EXPECT_THAT(m_callbackOrigin, Eq(static_cast<void*>(server)));
-    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&serverStorage)));
+    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&someContextData)));
 
     iox_ws_detach_server_event(m_sut, server, ServerEvent_REQUEST_RECEIVED);
 
@@ -1069,8 +1073,9 @@ TEST_F(iox_ws_test, NotifyingServerStateWithContextDataWorks)
 
     constexpr uint64_t SOME_EVENT_ID = 912371012314;
     iox_server_t server = iox_server_init(&serverStorage, "ServiceA", "InstanceA", "EventA", nullptr);
+    uint64_t someContextData = 0U;
     iox_ws_attach_server_state_with_context_data(
-        m_sut, server, ServerState_HAS_REQUEST, SOME_EVENT_ID, &serverCallbackWithContextData, &serverStorage);
+        m_sut, server, ServerState_HAS_REQUEST, SOME_EVENT_ID, &serverCallbackWithContextData, &someContextData);
 
     notifyServer(serverPortData);
 
@@ -1082,7 +1087,7 @@ TEST_F(iox_ws_test, NotifyingServerStateWithContextDataWorks)
     iox_notification_info_call(m_eventInfoStorage[0]);
 
     EXPECT_THAT(m_callbackOrigin, Eq(static_cast<void*>(server)));
-    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&serverStorage)));
+    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&someContextData)));
 
     iox_ws_detach_server_state(m_sut, server, ServerState_HAS_REQUEST);
 
@@ -1175,13 +1180,14 @@ TEST_F(iox_ws_test, NotifyingServiceDiscoveryEventWithContextDataWorks)
     EXPECT_CALL(*runtimeMock, getMiddlewareSubscriber(_, _, _)).WillOnce(Return(&m_portDataVector[0]));
 
     iox_service_discovery_t serviceDiscovery = iox_service_discovery_init(&serviceDiscoveryStorage);
+    uint64_t someContextData = 0U;
 
     iox_ws_attach_service_discovery_event_with_context_data(m_sut,
                                                             serviceDiscovery,
                                                             ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED,
                                                             EVENT_ID,
                                                             &serviceDiscoveryCallbackWithContextData,
-                                                            &serviceDiscoveryStorage);
+                                                            &someContextData);
 
     notifyServiceDiscovery(m_portDataVector[0]);
 
@@ -1193,7 +1199,7 @@ TEST_F(iox_ws_test, NotifyingServiceDiscoveryEventWithContextDataWorks)
     iox_notification_info_call(m_eventInfoStorage[0]);
 
     EXPECT_THAT(m_callbackOrigin, Eq(static_cast<void*>(serviceDiscovery)));
-    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&serviceDiscoveryStorage)));
+    EXPECT_THAT(m_contextData, Eq(static_cast<void*>(&someContextData)));
 
     iox_ws_detach_service_discovery_event(m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Some of the tests used the storage for context data in waitset and listener tests. This is potentially dangerous if in the future someone uses the context data and overlooks the usage of the storage

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues
2. [x] The one who merges this pull request will offer free cookies to all

## References

- Closes #1218
