### PR TITLE
iox-#743 Validation of iceoption example

### DIFF
--- a/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
@@ -76,9 +76,7 @@ int main()
         }
     });
 
-    while (!iox::posix::hasTerminationRequested())
-    {
-    }
+    iox::posix::waitForTerminationRequest();
 
     // this is optional, but since the iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER option is used,
     // a slow subscriber might block the shutdown and this call unblocks the publisher

--- a/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
@@ -51,7 +51,9 @@ int main()
     publisherOptions.subscriberTooSlowPolicy = iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER;
     //! [too slow policy]
 
+    //! [create publisher with options]
     iox::popo::Publisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"}, publisherOptions);
+    //! [create publisher with options]
 
     // we have to explicitely offer the publisher for making it visible to subscribers
     //! [offer]
@@ -59,16 +61,23 @@ int main()
     //! [offer]
 
     double ct = 0.0;
+
+    std::thread publishData([&]() {
+        while (!iox::posix::hasTerminationRequested())
+        {
+            ++ct;
+
+            // Retrieve a sample, construct it with the given arguments and publish it via a lambda.
+            publisher.loan(ct, ct, ct).and_then([](auto& sample) { sample.publish(); });
+
+            std::cout << APP_NAME << " sent value: " << ct << std::endl;
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(400));
+        }
+    });
+
     while (!iox::posix::hasTerminationRequested())
     {
-        ++ct;
-
-        // Retrieve a sample, construct it with the given arguments and publish it via a lambda.
-        publisher.loan(ct, ct, ct).and_then([](auto& sample) { sample.publish(); });
-
-        std::cout << APP_NAME << " sent value: " << ct << std::endl;
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(400));
     }
 
     // this is optional, but since the iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER option is used,
@@ -76,6 +85,8 @@ int main()
     //! [shutdown]
     iox::runtime::PoshRuntime::getInstance().shutdown();
     //! [shutdown]
+
+    publishData.join();
 
     return 0;
 }

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -66,7 +66,9 @@ int main()
     subscriberOptions.queueFullPolicy = iox::popo::QueueFullPolicy::BLOCK_PRODUCER;
     //! [queue full policy]
 
+    //! [create subscriber with options]
     iox::popo::Subscriber<RadarObject> subscriber({"Radar", "FrontLeft", "Object"}, subscriberOptions);
+    //! [create subscriber with options]
 
     // We have to explicitly call subscribe() otherwise the subscriber will not try to connect to publishers
     //! [subscribe]


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partially closes #743 
