### PR TITLE
Iox #208 add clear method to string

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -7,6 +7,7 @@
 **Features:**
 
 - optional inherits from FunctionalInterface, adds .expect() method [\#996](https://github.com/eclipse-iceoryx/iceoryx/issues/996)
+- Add clear method for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -409,6 +409,9 @@ class string
     /// @return true if size() == 0 otherwise false
     constexpr bool empty() const noexcept;
 
+    /// @brief clears the content of the string
+    void clear() noexcept;
+
     /// @brief converts the string to a std::string
     ///
     /// @return a std::string with data equivalent to those stored in the string

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -459,7 +459,7 @@ class string
     ///
     /// @return an optional containing the substring, iox::cxx::nullopt if pos is greater than the size of the original
     /// string
-    iox::cxx::optional<string<Capacity>> substr(const uint64_t pos, const uint64_t count) const noexcept;
+    optional<string<Capacity>> substr(const uint64_t pos, const uint64_t count) const noexcept;
 
     /// @brief creates a substring containing the characters from pos until size(); iox::cxx::nullopt is returned if pos
     /// is greater than the size of the original string
@@ -468,7 +468,7 @@ class string
     ///
     /// @return an optional containing the substring, iox::cxx::nullopt if pos is greater than the size of the original
     /// string
-    iox::cxx::optional<string<Capacity>> substr(const uint64_t pos = 0U) const noexcept;
+    optional<string<Capacity>> substr(const uint64_t pos = 0U) const noexcept;
 
     /// @brief finds the first occurence of the given character sequence; returns the position of the first character of
     /// the found substring, returns iox::cxx::nullopt if no substring is found or if pos is greater than this' size
@@ -481,7 +481,7 @@ class string
     template <typename T>
     typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                 || internal::IsCxxString<T>::value,
-                            iox::cxx::optional<uint64_t>>::type
+                            optional<uint64_t>>::type
     find(const T& t, const uint64_t pos = 0U) const noexcept;
 
     /// @brief finds the first occurence of a character equal to one of the characters of the given character sequence
@@ -496,7 +496,7 @@ class string
     template <typename T>
     typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                 || internal::IsCxxString<T>::value,
-                            iox::cxx::optional<uint64_t>>::type
+                            optional<uint64_t>>::type
     find_first_of(const T& t, const uint64_t pos = 0U) const noexcept;
 
     /// @brief finds the last occurence of a character equal to one of the characters of the given character sequence
@@ -510,7 +510,7 @@ class string
     template <typename T>
     typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                 || internal::IsCxxString<T>::value,
-                            iox::cxx::optional<uint64_t>>::type
+                            optional<uint64_t>>::type
     find_last_of(const T& t, const uint64_t pos = Capacity) const noexcept;
 
     template <uint64_t N>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -410,7 +410,7 @@ class string
     constexpr bool empty() const noexcept;
 
     /// @brief clears the content of the string
-    void clear() noexcept;
+    constexpr void clear() noexcept;
 
     /// @brief converts the string to a std::string
     ///

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -115,8 +115,7 @@ inline string<Capacity>::string(TruncateToCapacity_t, const char* const other, c
 {
     if (other == nullptr)
     {
-        m_rawstring[0U] = '\0';
-        m_rawstringSize = 0U;
+        clear();
     }
     else if (Capacity < count)
     {
@@ -332,8 +331,7 @@ inline string<Capacity>& string<Capacity>::move(string<N>&& rhs) noexcept
     std::memcpy(&(m_rawstring[0]), rhs.c_str(), strSize);
     m_rawstring[strSize] = '\0';
     m_rawstringSize = strSize;
-    rhs.m_rawstring[0U] = '\0';
-    rhs.m_rawstringSize = 0U;
+    rhs.clear();
     return *this;
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -296,7 +296,7 @@ inline constexpr bool string<Capacity>::empty() const noexcept
 }
 
 template <uint64_t Capacity>
-inline void string<Capacity>::clear() noexcept
+inline constexpr void string<Capacity>::clear() noexcept
 {
     m_rawstring[0U] = '\0';
     m_rawstringSize = 0U;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -504,12 +504,11 @@ inline
 }
 
 template <uint64_t Capacity>
-inline iox::cxx::optional<string<Capacity>> string<Capacity>::substr(const uint64_t pos,
-                                                                     const uint64_t count) const noexcept
+inline optional<string<Capacity>> string<Capacity>::substr(const uint64_t pos, const uint64_t count) const noexcept
 {
     if (pos > m_rawstringSize)
     {
-        return iox::cxx::nullopt;
+        return nullopt;
     }
 
     uint64_t length = std::min(count, m_rawstringSize - pos);
@@ -521,7 +520,7 @@ inline iox::cxx::optional<string<Capacity>> string<Capacity>::substr(const uint6
 }
 
 template <uint64_t Capacity>
-inline iox::cxx::optional<string<Capacity>> string<Capacity>::substr(const uint64_t pos) const noexcept
+inline optional<string<Capacity>> string<Capacity>::substr(const uint64_t pos) const noexcept
 {
     return substr(pos, m_rawstringSize);
 }
@@ -530,17 +529,17 @@ template <uint64_t Capacity>
 template <typename T>
 inline typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                    || internal::IsCxxString<T>::value,
-                               iox::cxx::optional<uint64_t>>::type
+                               optional<uint64_t>>::type
 string<Capacity>::find(const T& t, const uint64_t pos) const noexcept
 {
     if (pos > m_rawstringSize)
     {
-        return iox::cxx::nullopt;
+        return nullopt;
     }
     const char* found = std::strstr(c_str() + pos, internal::GetData<T>::call(t));
     if (found == nullptr)
     {
-        return iox::cxx::nullopt;
+        return nullopt;
     }
     return (found - c_str());
 }
@@ -549,12 +548,12 @@ template <uint64_t Capacity>
 template <typename T>
 inline typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                    || internal::IsCxxString<T>::value,
-                               iox::cxx::optional<uint64_t>>::type
+                               optional<uint64_t>>::type
 string<Capacity>::find_first_of(const T& t, const uint64_t pos) const noexcept
 {
     if (pos > m_rawstringSize)
     {
-        return iox::cxx::nullopt;
+        return nullopt;
     }
     const char* found = nullptr;
     const char* data = internal::GetData<T>::call(t);
@@ -566,19 +565,19 @@ string<Capacity>::find_first_of(const T& t, const uint64_t pos) const noexcept
             return p;
         }
     }
-    return iox::cxx::nullopt;
+    return nullopt;
 }
 
 template <uint64_t Capacity>
 template <typename T>
 inline typename std::enable_if<std::is_same<T, std::string>::value || internal::IsCharArray<T>::value
                                    || internal::IsCxxString<T>::value,
-                               iox::cxx::optional<uint64_t>>::type
+                               optional<uint64_t>>::type
 string<Capacity>::find_last_of(const T& t, const uint64_t pos) const noexcept
 {
     if (m_rawstringSize == 0U)
     {
-        return iox::cxx::nullopt;
+        return nullopt;
     }
 
     auto p = pos;
@@ -601,7 +600,7 @@ string<Capacity>::find_last_of(const T& t, const uint64_t pos) const noexcept
     {
         return 0U;
     }
-    return iox::cxx::nullopt;
+    return nullopt;
 }
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -297,6 +297,13 @@ inline constexpr bool string<Capacity>::empty() const noexcept
 }
 
 template <uint64_t Capacity>
+inline void string<Capacity>::clear() noexcept
+{
+    m_rawstring[0U] = '\0';
+    m_rawstringSize = 0U;
+}
+
+template <uint64_t Capacity>
 inline string<Capacity>::operator std::string() const noexcept
 {
     return std::string(c_str());

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -1305,12 +1305,8 @@ TYPED_TEST(stringTyped_test, ClearNotEmptyStringResultsInEmptyStringWithUnchange
 TYPED_TEST(stringTyped_test, ChangeStringAfterClearWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "58444d00-ec85-464f-8269-7838823f04c2");
-    using MyString = typename TestFixture::stringType;
-    constexpr auto STRINGCAP = MyString().capacity();
-
     this->testSubject.clear();
     this->testSubject = "M";
-    ASSERT_FALSE(this->testSubject.empty());
     EXPECT_THAT(this->testSubject.c_str(), StrEq("M"));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -1260,7 +1260,7 @@ TYPED_TEST(stringTyped_test, StreamInputOfSizeCapacityWorks)
     EXPECT_THAT(testStream.str(), Eq(testFixedString.c_str()));
 }
 
-/// @ note constexpr bool empty() const noexcept
+/// @note constexpr bool empty() const noexcept
 TYPED_TEST(stringTyped_test, NewlyCreatedStringIsEmpty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b76d10c1-46e2-4bc3-ab79-af187b85d584");
@@ -1275,6 +1275,43 @@ TYPED_TEST(stringTyped_test, StringWithContentIsNotEmtpy)
     using MyString = typename TestFixture::stringType;
     MyString sut(TruncateToCapacity, "Dr.SchluepferStrikesAgain!");
     EXPECT_THAT(sut.empty(), Eq(false));
+}
+
+/// @note void clear() noexcept
+TYPED_TEST(stringTyped_test, ClearEmptyStringDoesNotChangeString)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5109413a-6067-4f7f-ac35-8dd3a33a641f");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    this->testSubject.clear();
+    EXPECT_THAT(this->testSubject.empty(), Eq(true));
+    EXPECT_THAT(this->testSubject.capacity(), Eq(STRINGCAP));
+}
+
+TYPED_TEST(stringTyped_test, ClearNotEmptyStringResultsInEmptyStringWithUnchangedCapacity)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d25d2a74-6ea0-4892-b072-02177b31309e");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    this->testSubject = "M";
+    ASSERT_THAT(this->testSubject.empty(), Eq(false));
+
+    this->testSubject.clear();
+    EXPECT_THAT(this->testSubject.empty(), Eq(true));
+    EXPECT_THAT(this->testSubject.capacity(), Eq(STRINGCAP));
+}
+
+TYPED_TEST(stringTyped_test, ChangeStringAfterClearWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "58444d00-ec85-464f-8269-7838823f04c2");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    this->testSubject.clear();
+    this->testSubject = "M";
+    ASSERT_FALSE(this->testSubject.empty());
+    EXPECT_THAT(this->testSubject.c_str(), StrEq("M"));
 }
 
 /// @note template <uint64_t N>


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
Besides the clear method is added, the unnecessary `iox::cxx::` is removed.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partially closes #208 
