### PR TITLE
Iox #208 add at method and subscript operator

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -8,6 +8,7 @@
 
 - optional inherits from FunctionalInterface, adds .expect() method [\#996](https://github.com/eclipse-iceoryx/iceoryx/issues/996)
 - Add clear method for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
+- Add at method and operator[] for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -513,6 +513,18 @@ class string
                             optional<uint64_t>>::type
     find_last_of(const T& t, const uint64_t pos = Capacity) const noexcept;
 
+    /// @brief returns a reference to the character stored at pos
+    /// @param[in] pos position of character to return
+    /// @return reference to the character
+    /// @note out of bounds access leads to program termination
+    constexpr char& at(const uint64_t pos) noexcept;
+
+    /// @brief returns a reference to the character stored at pos
+    /// @param[in] pos position of character to return
+    /// @return const reference to the character
+    /// @note out of bounds access leads to program termination
+    constexpr const char& at(const uint64_t pos) const noexcept;
+
     template <uint64_t N>
     friend class string;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -525,6 +525,18 @@ class string
     /// @note out of bounds access leads to program termination
     constexpr const char& at(const uint64_t pos) const noexcept;
 
+    /// @brief returns a reference to the character stored at pos
+    /// @param[in] pos position of the character to return
+    /// @return reference to the character
+    /// @note out of bounds access leads to program termination
+    constexpr char& operator[](const uint64_t pos) noexcept;
+
+    /// @brief returns a const reference to the character stored at pos
+    /// @param[in] pos position of the character to return
+    /// @return const reference to the character
+    /// @note out of bounds access leads to program termination
+    constexpr const char& operator[](const uint64_t pos) const noexcept;
+
     template <uint64_t N>
     friend class string;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -615,6 +615,18 @@ inline constexpr const char& string<Capacity>::at(const uint64_t pos) const noex
     Expects(pos < size() && "Out of bounds access!");
     return m_rawstring[pos];
 }
+
+template <uint64_t Capacity>
+inline constexpr char& string<Capacity>::operator[](const uint64_t pos) noexcept
+{
+    return at(pos);
+}
+
+template <uint64_t Capacity>
+inline constexpr const char& string<Capacity>::operator[](const uint64_t pos) const noexcept
+{
+    return at(pos);
+}
 } // namespace cxx
 } // namespace iox
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -602,6 +602,19 @@ string<Capacity>::find_last_of(const T& t, const uint64_t pos) const noexcept
     }
     return nullopt;
 }
+
+template <uint64_t Capacity>
+inline constexpr char& string<Capacity>::at(const uint64_t pos) noexcept
+{
+    return const_cast<char&>(const_cast<const string<Capacity>*>(this)->at(pos));
+}
+
+template <uint64_t Capacity>
+inline constexpr const char& string<Capacity>::at(const uint64_t pos) const noexcept
+{
+    Expects(pos < size() && "Out of bounds access!");
+    return m_rawstring[pos];
+}
 } // namespace cxx
 } // namespace iox
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -2426,4 +2426,82 @@ TYPED_TEST(stringTyped_test, AccessMaxPositionOfNotEmptyStringViaConstAtSucceeds
 
     EXPECT_THAT(sut.at(STRINGCAP - 1), Eq('M'));
 }
+
+/// @note constexpr char& operator[](const uint64_t pos) noexcept
+TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaSubscriptOperatorFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "95ced457-1aec-47e9-a496-0197ea3f4600");
+    EXPECT_DEATH({ this->testSubject[0U]; }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaSubscriptOperatorFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "ab52924e-1d6a-41e1-a8a9-8cfd9ab2120d");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    EXPECT_DEATH({ this->testSubject[STRINGCAP]; }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaSubscriptOperatorReturnsCorrectCharacter)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "86a984b9-8345-4413-a25c-e9a1c74c5cef");
+    this->testSubject = "L";
+    EXPECT_THAT(this->testSubject[0U], Eq('L'));
+}
+
+TYPED_TEST(stringTyped_test, AccessAndAssignToMaxPositionOfNotEmptyStringViaSubscriptOperatorSucceeds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "9e2dd8ba-6053-4532-895b-f18a9ae0adf6");
+    constexpr char START_CHARACTER = 'F';
+    constexpr char NEW_CHARACTER = 'S';
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    std::string testSTDString(STRINGCAP, START_CHARACTER);
+    ASSERT_THAT(this->testSubject.unsafe_assign(testSTDString), Eq(true));
+
+    this->testSubject[STRINGCAP - 1] = NEW_CHARACTER;
+    testSTDString[STRINGCAP - 1] = NEW_CHARACTER;
+    EXPECT_THAT(this->testSubject.c_str(), StrEq(testSTDString));
+}
+
+/// @note constexpr const char& operator[](const uint64_t pos) const noexcept
+TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaConstSubscriptOperatorFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "7ca75e53-8e26-4451-8712-a86bfe5bd32c");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut;
+    EXPECT_DEATH({ sut[0U]; }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstSubscriptOperatorFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5498e314-d321-464a-a667-400ee0c4d81f");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut;
+    EXPECT_DEATH({ sut[STRINGCAP]; }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaConstSubscriptOperatorReturnsCorrectCharacter)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "7ea474cc-db27-43cd-a2f8-dfa2ba196404");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut("L");
+    EXPECT_THAT(sut[0U], Eq('L'));
+}
+
+TYPED_TEST(stringTyped_test, AccessMaxPositionOfNotEmptyStringViaConstSubscriptOperatorSucceeds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "43ca0e71-7ac6-4039-a0fb-ebe84f7c0bad");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    std::string testSTDString(STRINGCAP, 'L');
+    const string<STRINGCAP> sut(TruncateToCapacity, testSTDString);
+
+    EXPECT_THAT(sut[STRINGCAP - 1], Eq('L'));
+}
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -2348,4 +2348,82 @@ TEST(String100, FindLastOfForNotIncludedSTDStringFails)
     res = testString.find_last_of(testStdString, 50U);
     EXPECT_THAT(res.has_value(), Eq(false));
 }
+
+/// @note constexpr char& at(const uint64_t pos) noexcept
+TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaAtFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "89817818-f05a-4ceb-8663-9727d227048c");
+    EXPECT_DEATH({ this->testSubject.at(0U); }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaAtFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "68035709-5f8d-4bcb-80ce-ad5619aba84a");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    EXPECT_DEATH({ this->testSubject.at(STRINGCAP); }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessFirstPositionOfNonEmptyStringViaAtReturnsCorrectCharacter)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8f096ca8-6951-43d4-86a8-3cf94de2977a");
+    this->testSubject = "M";
+    EXPECT_THAT(this->testSubject.at(0U), Eq('M'));
+}
+
+TYPED_TEST(stringTyped_test, AccessAndAssignToMaxPositionOfNotEmptyStringViaAtSucceeds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "9b9d106d-bfc5-40fe-876d-5beb1725e3fa");
+    constexpr char START_CHARACTER = 'M';
+    constexpr char NEW_CHARACTER = 'L';
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    std::string testSTDString(STRINGCAP, START_CHARACTER);
+    ASSERT_THAT(this->testSubject.unsafe_assign(testSTDString), Eq(true));
+
+    this->testSubject.at(STRINGCAP - 1) = NEW_CHARACTER;
+    testSTDString.at(STRINGCAP - 1) = NEW_CHARACTER;
+    EXPECT_THAT(this->testSubject.c_str(), StrEq(testSTDString));
+}
+
+/// @note constexpr const char& at(const uint64_t pos) const noexcept
+TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaConstAtFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5cf6d322-6ee9-41ce-bbf6-4e0d193fa938");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut;
+    EXPECT_DEATH({ sut.at(0U); }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstAtFails)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "90a986f4-b29b-4ce7-ad55-79cc4b7b2b29");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut;
+    EXPECT_DEATH({ sut.at(STRINGCAP); }, ".*");
+}
+
+TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaConstAtReturnsCorrectCharacter)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "661fb674-3edf-4ac3-adb7-c7767153040d");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+    const string<STRINGCAP> sut("M");
+    EXPECT_THAT(sut.at(0U), Eq('M'));
+}
+
+TYPED_TEST(stringTyped_test, AccessMaxPositionOfNotEmptyStringViaConstAtSucceeds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "78f13867-8633-4d90-9f04-a9a47ab492b1");
+    using MyString = typename TestFixture::stringType;
+    constexpr auto STRINGCAP = MyString().capacity();
+
+    std::string testSTDString(STRINGCAP, 'M');
+    const string<STRINGCAP> sut(TruncateToCapacity, testSTDString);
+
+    EXPECT_THAT(sut.at(STRINGCAP - 1), Eq('M'));
+}
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
Contrary to the `std::string` I added a boundary check also to `operator[]`.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
    - [ ] Each unit test case has a unique UUID
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Partially closes #208 
