### PR TITLE
iox-#1362 Clarify documentation of optionals

### DIFF
--- a/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
+++ b/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
@@ -10,7 +10,12 @@ introduce in the following sections.
 
 The type `iox::cxx::optional<T>` is used to indicate that there may or may not be a value of a specific type `T`
 available. This is essentially the 'maybe [monad](https://en.wikipedia.org/wiki/Monad_%28functional_programming%29)' in
-functional programming. Assuming we have some optional (usually the result of some computation)
+functional programming.
+
+The `iox::cxx::optional` behaves like the [`std::optional`](https://en.cppreference.com/w/cpp/utility/optional),
+except that it terminates the application where `std::optional` would throw an exception or exhibit undefined behavior.
+
+Assuming we have some optional (usually the result of some computation)
 
 ```cpp
 optional<int> result = someComputation();
@@ -65,8 +70,6 @@ result = iox::cxx::nullopt;
 
 For a complete list of available functions see
 [`optional.hpp`](../../../iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp).
-The `iox::cxx::optional` behaves like the [`std::optional`](https://en.cppreference.com/w/cpp/utility/optional)
-except that it does not throw exceptions and has no undefined behavior.
 
 ## Expected
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
@@ -72,13 +72,13 @@ class optional : public FunctionalInterface<optional<T>, T, void>
     using type = T;
 
     /// @brief Creates an optional which has no value. If you access such an
-    ///         optional via .value() or the arrow operator the behavior is
-    ///         undefined.
+    ///         optional via .value() or the arrow operator the application
+    ///         terminates.
     optional() noexcept;
 
     /// @brief Creates an optional which has no value. If you access such an
-    ///         optional via .value() or the arrow operator the behavior is
-    ///         defined in the cxx::Expects handling.
+    ///         optional via .value() or the arrow operator the application
+    ///         terminates.
     optional(const nullopt_t&) noexcept;
 
     /// @brief Creates an optional by forwarding value to the constructor of
@@ -154,25 +154,25 @@ class optional : public FunctionalInterface<optional<T>, T, void>
     typename std::enable_if<!std::is_same<U, optional<T>&>::value, optional>::type& operator=(U&& value) noexcept;
 
     /// @brief Returns a pointer to the underlying value. If the optional has no
-    ///         value the behavior is undefined. You need to verify that the
+    ///         value the application terminates. You need to verify that the
     ///         optional has a value by calling has_value() before using it.
     /// @return pointer of type const T to the underlying type
     const T* operator->() const noexcept;
 
     /// @brief Returns a reference to the underlying value. If the optional has no
-    ///         value the behavior is undefined. You need to verify that the
+    ///         value the application terminates. You need to verify that the
     ///         optional has a value by calling has_value() before using it.
     /// @return reference of type const T to the underlying type
     const T& operator*() const noexcept;
 
     /// @brief Returns a pointer to the underlying value. If the optional has no
-    ///         value the behavior is undefined. You need to verify that the
+    ///         value the application terminates. You need to verify that the
     ///         optional has a value by calling has_value() before using it.
     /// @return pointer of type T to the underlying type
     T* operator->() noexcept;
 
     /// @brief Returns a reference to the underlying value. If the optional has no
-    ///         value the behavior is undefined. You need to verify that the
+    ///         value the application terminates. You need to verify that the
     ///         optional has a value by calling has_value() before using it.
     /// @return reference of type T to the underlying type
     T& operator*() noexcept;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. ~~[ ] Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1362 
