### PR TITLE
iox-#751 create unnamed semaphore

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -14,6 +14,8 @@
 - Add insert method for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - Extend compare method of `iox::cxx::string` to compare additionally with std::string and char array [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - Add compare method for `iox::cxx::string` and chars [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
+- Refactor semaphore [\#751](https://github.com/eclipse-iceoryx/iceoryx/issues/751)
+    - Introduce `UnnamedSemaphore`
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(iceoryx_hoofs
     source/posix_wrapper/system_configuration.cpp
     source/posix_wrapper/thread.cpp
     source/posix_wrapper/timer.cpp
+    source/posix_wrapper/unnamed_semaphore.cpp
     source/posix_wrapper/unix_domain_socket.cpp
     source/relocatable_pointer/base_relative_pointer.cpp
     source/relocatable_pointer/relative_pointer_data.cpp

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(iceoryx_hoofs
     source/posix_wrapper/named_pipe.cpp
     source/posix_wrapper/posix_access_rights.cpp
     source/posix_wrapper/semaphore.cpp
+    source/posix_wrapper/semaphore_interface.cpp
     source/posix_wrapper/shared_memory_object.cpp
     source/posix_wrapper/shared_memory_object/allocator.cpp
     source/posix_wrapper/shared_memory_object/memory_map.cpp

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -42,17 +42,11 @@ class SemaphoreInterface
     SemaphoreInterface& operator=(SemaphoreInterface&&) noexcept = delete;
     ~SemaphoreInterface() noexcept = default;
 
-    void post() noexcept;
-    cxx::expected<SemaphoreError> postUnsafe() noexcept;
-
-    SemaphoreState getState() noexcept;
-    cxx::expected<SemaphoreState, SemaphoreError> getStateUnsafe() noexcept;
-
-    SemaphoreWaitState timedWait(const units::Duration& timeout) noexcept;
-    cxx::expected<SemaphoreWaitState, SemaphoreError> timedWaitUnsafe(const units::Duration& timeout) noexcept;
-
-    bool tryWait() noexcept;
-    cxx::expected<bool, SemaphoreError> tryWaitUnsafe() noexcept;
+    cxx::expected<SemaphoreError> post() noexcept;
+    cxx::expected<SemaphoreState, SemaphoreError> getState() noexcept;
+    cxx::expected<SemaphoreError> wait() noexcept;
+    cxx::expected<bool, SemaphoreError> tryWait() noexcept;
+    cxx::expected<SemaphoreWaitState, SemaphoreError> timedWait(const units::Duration& timeout) noexcept;
 
   protected:
     SemaphoreInterface() noexcept = default;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -27,16 +27,6 @@ namespace posix
 {
 namespace internal
 {
-/// @brief Represent the state of a semaphore
-struct SemaphoreState
-{
-    /// @brief current value of the semaphore
-    uint32_t value = 0U;
-
-    /// @brief states the number of threads waiting in wait, or timedWait
-    uint32_t numberOfBlockedWait = 0U;
-};
-
 /// @brief Defines the interface of a named and unnamed semaphore.
 template <typename SemaphoreChild>
 class SemaphoreInterface
@@ -53,9 +43,9 @@ class SemaphoreInterface
     ///         semaphore was removed from outside the process
     cxx::expected<SemaphoreError> post() noexcept;
 
-    /// @brief Returns the state of the semaphore
+    /// @brief Returns the value of the semaphore
     /// @return Fails when semaphore was removed from outside the process
-    cxx::expected<SemaphoreState, SemaphoreError> getState() noexcept;
+    cxx::expected<uint32_t, SemaphoreError> getValue() noexcept;
 
     /// @brief Decrements the semaphore by one. When the semaphore value is zero
     ///        it blocks until the semaphore value is greater zero

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_HOOFS_POSIX_WRAPPER_SEMAPHORE_INTERFACE_HPP
+#define IOX_HOOFS_POSIX_WRAPPER_SEMAPHORE_INTERFACE_HPP
+
+#include "iceoryx_hoofs/cxx/expected.hpp"
+#include "iceoryx_hoofs/internal/units/duration.hpp"
+#include "iceoryx_hoofs/posix_wrapper/semaphore.hpp"
+
+namespace iox
+{
+namespace posix
+{
+namespace internal
+{
+struct SemaphoreState
+{
+    uint32_t value = 0U;
+    uint32_t numberOfBlockedWait = 0U;
+};
+
+template <typename SemaphoreChild>
+class SemaphoreInterface
+{
+  public:
+    SemaphoreInterface(const SemaphoreInterface&) noexcept = delete;
+    SemaphoreInterface(SemaphoreInterface&&) noexcept = delete;
+    SemaphoreInterface& operator=(const SemaphoreInterface&) noexcept = delete;
+    SemaphoreInterface& operator=(SemaphoreInterface&&) noexcept = delete;
+    ~SemaphoreInterface() noexcept = default;
+
+    void post() noexcept;
+    cxx::expected<SemaphoreError> postUnsafe() noexcept;
+
+    SemaphoreState getState() noexcept;
+    cxx::expected<SemaphoreState, SemaphoreError> getStateUnsafe() noexcept;
+
+    SemaphoreWaitState timedWait(const units::Duration& timeout) noexcept;
+    cxx::expected<SemaphoreWaitState, SemaphoreError> timedWaitUnsafe(const units::Duration& timeout) noexcept;
+
+    bool tryWait() noexcept;
+    cxx::expected<bool, SemaphoreError> tryWaitUnsafe() noexcept;
+
+  protected:
+    SemaphoreInterface() noexcept = default;
+
+  private:
+    iox_sem_t* getHandle() noexcept;
+};
+} // namespace internal
+} // namespace posix
+} // namespace iox
+
+#endif

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -26,12 +26,17 @@ namespace posix
 {
 namespace internal
 {
+/// @brief Represent the state of a semaphore
 struct SemaphoreState
 {
+    /// @brief current value of the semaphore
     uint32_t value = 0U;
+
+    /// @brief states the number of threads waiting in wait, or timedWait
     uint32_t numberOfBlockedWait = 0U;
 };
 
+/// @brief Defines the interface of a named and unnamed semaphore.
 template <typename SemaphoreChild>
 class SemaphoreInterface
 {
@@ -42,10 +47,30 @@ class SemaphoreInterface
     SemaphoreInterface& operator=(SemaphoreInterface&&) noexcept = delete;
     ~SemaphoreInterface() noexcept = default;
 
+    /// @brief Increments the semaphore by one
+    /// @return Fails when the value of the semaphore overflows or when the
+    ///         semaphore was removed from outside the process
     cxx::expected<SemaphoreError> post() noexcept;
+
+    /// @brief Returns the state of the semaphore
+    /// @return Fails when semaphore was removed from outside the process
     cxx::expected<SemaphoreState, SemaphoreError> getState() noexcept;
+
+    /// @brief Decrements the semaphore by one. When the semaphore value is zero
+    ///        it blocks until the semaphore value is greater zero
+    /// @return Fails when semaphore was removed from outside the process
     cxx::expected<SemaphoreError> wait() noexcept;
+
+    /// @brief Tries to decrement the semaphore by one. When the semaphore value is zero
+    ///        it returns false otherwise it returns true and decrement the value by one.
+    /// @return Fails when semaphore was removed from outside the process
     cxx::expected<bool, SemaphoreError> tryWait() noexcept;
+
+    /// @brief Tries to decrement the semaphore by one. When the semaphore value is zero
+    ///        it waits until the timeout has passed.
+    /// @return If during the timeout time the semaphore value increases to non zero
+    ///         it returns SemaphoreWaitState::NO_TIMEOUT and decreases the semaphore by one
+    ///         otherwise returns SemaphoreWaitState::TIMEOUT
     cxx::expected<SemaphoreWaitState, SemaphoreError> timedWait(const units::Duration& timeout) noexcept;
 
   protected:

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -18,6 +18,7 @@
 
 #include "iceoryx_hoofs/cxx/expected.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"
+#include "iceoryx_hoofs/platform/semaphore.hpp"
 #include "iceoryx_hoofs/posix_wrapper/semaphore.hpp"
 
 namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -25,7 +25,7 @@ namespace iox
 {
 namespace posix
 {
-class UnnamedSemaphore final : internal::SemaphoreInterface<UnnamedSemaphore>
+class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaphore>
 {
   public:
     UnnamedSemaphore(const UnnamedSemaphore&) noexcept = delete;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -38,7 +38,7 @@ class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaph
   private:
     friend class UnnamedSemaphoreBuilder;
     friend class iox::cxx::optional<UnnamedSemaphore>;
-    friend class SemaphoreInterface<UnnamedSemaphore>;
+    friend class internal::SemaphoreInterface<UnnamedSemaphore>;
 
     UnnamedSemaphore() noexcept = default;
     iox_sem_t* getHandle() noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_HOOFS_POSIX_WRAPPER_UNNAMED_SEMAPHORE_HPP
+#define IOX_HOOFS_POSIX_WRAPPER_UNNAMED_SEMAPHORE_HPP
+
+#include "iceoryx_hoofs/cxx/expected.hpp"
+#include "iceoryx_hoofs/cxx/optional.hpp"
+#include "iceoryx_hoofs/design_pattern/builder.hpp"
+#include "iceoryx_hoofs/posix_wrapper/semaphore.hpp"
+
+namespace iox
+{
+namespace posix
+{
+template <typename SemaphoreChild>
+class SemaphoreInterface
+{
+  public:
+    SemaphoreInterface(const SemaphoreInterface&) noexcept = delete;
+    SemaphoreInterface(SemaphoreInterface&&) noexcept = delete;
+    SemaphoreInterface& operator=(const SemaphoreInterface&) noexcept = delete;
+    SemaphoreInterface& operator=(SemaphoreInterface&&) noexcept = delete;
+    ~SemaphoreInterface() noexcept = default;
+
+    void post() noexcept;
+    cxx::expected<SemaphoreError> postUnsafe() noexcept;
+
+    uint32_t getValue() const noexcept;
+    cxx::expected<uint32_t, SemaphoreError> getValueUnsafe() const noexcept;
+
+    void timedWait() noexcept;
+    cxx::expected<SemaphoreError> timedWaitUnsafe() noexcept;
+
+    void tryWait() noexcept;
+    cxx::expected<SemaphoreError> tryWaitUnsafe() noexcept;
+
+  protected:
+    SemaphoreInterface() noexcept = default;
+};
+
+class UnnamedSemaphore : SemaphoreInterface<UnnamedSemaphore>
+{
+  public:
+    UnnamedSemaphore(const UnnamedSemaphore&) noexcept = delete;
+    UnnamedSemaphore(UnnamedSemaphore&&) noexcept = delete;
+    UnnamedSemaphore& operator=(const UnnamedSemaphore&) noexcept = delete;
+    UnnamedSemaphore& operator=(UnnamedSemaphore&&) noexcept = delete;
+    ~UnnamedSemaphore() noexcept;
+
+    friend class UnnamedSemaphoreBuilder;
+    friend class iox::cxx::optional<UnnamedSemaphore>;
+    friend class SemaphoreInterface<UnnamedSemaphore>;
+
+  private:
+    UnnamedSemaphore() noexcept = default;
+    iox_sem_t* getHandle() noexcept;
+    const iox_sem_t* getHandle() const noexcept;
+
+    iox_sem_t m_handle;
+    bool m_destroyHandle = true;
+};
+
+class UnnamedSemaphoreBuilder
+{
+    IOX_BUILDER_PARAMETER(uint32_t, initialValue, 0U)
+    IOX_BUILDER_PARAMETER(bool, isInterProcessCapable, true)
+
+  public:
+    cxx::expected<SemaphoreError> create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) noexcept;
+};
+} // namespace posix
+} // namespace iox
+
+#endif

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -34,11 +34,11 @@ class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaph
     UnnamedSemaphore& operator=(UnnamedSemaphore&&) noexcept = delete;
     ~UnnamedSemaphore() noexcept;
 
+  private:
     friend class UnnamedSemaphoreBuilder;
     friend class iox::cxx::optional<UnnamedSemaphore>;
     friend class SemaphoreInterface<UnnamedSemaphore>;
 
-  private:
     UnnamedSemaphore() noexcept = default;
     iox_sem_t* getHandle() noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -19,39 +19,13 @@
 #include "iceoryx_hoofs/cxx/expected.hpp"
 #include "iceoryx_hoofs/cxx/optional.hpp"
 #include "iceoryx_hoofs/design_pattern/builder.hpp"
-#include "iceoryx_hoofs/posix_wrapper/semaphore.hpp"
+#include "iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp"
 
 namespace iox
 {
 namespace posix
 {
-template <typename SemaphoreChild>
-class SemaphoreInterface
-{
-  public:
-    SemaphoreInterface(const SemaphoreInterface&) noexcept = delete;
-    SemaphoreInterface(SemaphoreInterface&&) noexcept = delete;
-    SemaphoreInterface& operator=(const SemaphoreInterface&) noexcept = delete;
-    SemaphoreInterface& operator=(SemaphoreInterface&&) noexcept = delete;
-    ~SemaphoreInterface() noexcept = default;
-
-    void post() noexcept;
-    cxx::expected<SemaphoreError> postUnsafe() noexcept;
-
-    uint32_t getValue() const noexcept;
-    cxx::expected<uint32_t, SemaphoreError> getValueUnsafe() const noexcept;
-
-    void timedWait() noexcept;
-    cxx::expected<SemaphoreError> timedWaitUnsafe() noexcept;
-
-    void tryWait() noexcept;
-    cxx::expected<SemaphoreError> tryWaitUnsafe() noexcept;
-
-  protected:
-    SemaphoreInterface() noexcept = default;
-};
-
-class UnnamedSemaphore : SemaphoreInterface<UnnamedSemaphore>
+class UnnamedSemaphore final : internal::SemaphoreInterface<UnnamedSemaphore>
 {
   public:
     UnnamedSemaphore(const UnnamedSemaphore&) noexcept = delete;
@@ -67,7 +41,6 @@ class UnnamedSemaphore : SemaphoreInterface<UnnamedSemaphore>
   private:
     UnnamedSemaphore() noexcept = default;
     iox_sem_t* getHandle() noexcept;
-    const iox_sem_t* getHandle() const noexcept;
 
     iox_sem_t m_handle;
     bool m_destroyHandle = true;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -25,6 +25,7 @@ namespace iox
 {
 namespace posix
 {
+/// @brief A unnamed posix semaphore.
 class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaphore>
 {
   public:
@@ -48,7 +49,11 @@ class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaph
 
 class UnnamedSemaphoreBuilder
 {
+    /// @brief Set the initial value of the unnamed posix semaphore
     IOX_BUILDER_PARAMETER(uint32_t, initialValue, 0U)
+
+    /// @brief Set if the unnamed semaphore can be stored in the shared memory
+    ///        for inter process usage
     IOX_BUILDER_PARAMETER(bool, isInterProcessCapable, true)
 
   public:

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/semaphore.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/semaphore.hpp
@@ -33,8 +33,8 @@
 
 #define SEM_FAILED 0
 // win32 API page talks about maximum allowed value without defining it or how to obtain.
-// We use the SEM_VALUE_MAX from linux which is 2^31 - 1
-#define SEM_VALUE_MAX 2147483647
+// We use the SEM_VALUE_MAX from linux which is INT_MAX
+#define SEM_VALUE_MAX INT_MAX
 
 struct iox_sem_t
 {

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/semaphore.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/semaphore.hpp
@@ -32,6 +32,9 @@
 #include <type_traits>
 
 #define SEM_FAILED 0
+// win32 API page talks about maximum allowed value without defining it or how to obtain.
+// We use the SEM_VALUE_MAX from linux which is 2^31 - 1
+#define SEM_VALUE_MAX 2147483647
 
 struct iox_sem_t
 {

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -77,7 +77,7 @@ cxx::expected<uint32_t, SemaphoreError> SemaphoreInterface<SemaphoreChild>::getV
         return createErrorFromErrno(result.get_error().errnum);
     }
 
-    return cxx::success<uint32_t>(std::max(0, value));
+    return cxx::success<uint32_t>(static_cast<uint32_t>(std::max(0, value)));
 }
 
 template <typename SemaphoreChild>

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -1,0 +1,172 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp"
+#include "iceoryx_hoofs/internal/log/hoofs_logging.hpp"
+#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
+
+namespace iox
+{
+namespace posix
+{
+namespace internal
+{
+
+template <typename SemaphoreChild>
+iox_sem_t* SemaphoreInterface<SemaphoreChild>::getHandle() noexcept
+{
+    return static_cast<SemaphoreChild*>(this)->getHandle();
+}
+
+template <typename SemaphoreChild>
+void SemaphoreInterface<SemaphoreChild>::post() noexcept
+{
+    postUnsafe().expect("Fatal semaphore failure occurred.");
+}
+
+template <typename SemaphoreChild>
+cxx::expected<SemaphoreError> SemaphoreInterface<SemaphoreChild>::postUnsafe() noexcept
+{
+    auto result = posixCall(iox_sem_post)(getHandle()).failureReturnValue(-1).evaluate();
+
+    if (result.has_error())
+    {
+        switch (result.get_error().errnum)
+        {
+        case EINVAL:
+            LogError() << "The semaphore handle is no longer valid. This can indicate a corrupted system.";
+            return cxx::error<SemaphoreError>(SemaphoreError::INVALID_SEMAPHORE_HANDLE);
+        case EOVERFLOW:
+            LogError() << "Semaphore overflow.";
+            return cxx::error<SemaphoreError>(SemaphoreError::SEMAPHORE_OVERFLOW);
+        default:
+            LogError() << "This should never happen. An unknown error occurred.";
+            break;
+        }
+        return cxx::error<SemaphoreError>(SemaphoreError::UNDEFINED);
+    }
+
+    return cxx::success<>();
+}
+
+template <typename SemaphoreChild>
+SemaphoreState SemaphoreInterface<SemaphoreChild>::getState() noexcept
+{
+    return getStateUnsafe().expect("Fatal semaphore failure occurred.");
+}
+
+template <typename SemaphoreChild>
+cxx::expected<SemaphoreState, SemaphoreError> SemaphoreInterface<SemaphoreChild>::getStateUnsafe() noexcept
+{
+    int value = 0;
+    auto result = posixCall(iox_sem_getvalue)(getHandle(), &value).failureReturnValue(-1).evaluate();
+    if (result.has_error())
+    {
+        switch (result.get_error().errnum)
+        {
+        case EINVAL:
+            LogError() << "The semaphore handle is no longer valid. This can indicate a corrupted system.";
+            return cxx::error<SemaphoreError>(SemaphoreError::INVALID_SEMAPHORE_HANDLE);
+        default:
+            LogError() << "This should never happen. An unknown error occurred.";
+            break;
+        }
+        return cxx::error<SemaphoreError>(SemaphoreError::UNDEFINED);
+    }
+
+    SemaphoreState state;
+    state.value = (value > 0) ? static_cast<uint32_t>(value) : 0U;
+    state.numberOfBlockedWait = (value < 0) ? static_cast<uint32_t>(-value) : 0U;
+
+    return cxx::success<SemaphoreState>(state);
+}
+
+template <typename SemaphoreChild>
+SemaphoreWaitState SemaphoreInterface<SemaphoreChild>::timedWait(const units::Duration& timeout) noexcept
+{
+    return timedWaitUnsafe(timeout).expect("Fatal semaphore failure occurred.");
+}
+
+template <typename SemaphoreChild>
+cxx::expected<SemaphoreWaitState, SemaphoreError>
+SemaphoreInterface<SemaphoreChild>::timedWaitUnsafe(const units::Duration& timeout) noexcept
+{
+    const timespec timeoutAsTimespec = timeout.timespec(units::TimeSpecReference::Epoch);
+    auto result = posixCall(iox_sem_timedwait)(getHandle(), &timeoutAsTimespec)
+                      .failureReturnValue(-1)
+                      .ignoreErrnos(ETIMEDOUT)
+                      .evaluate();
+
+    if (result.has_error())
+    {
+        switch (result.get_error().errnum)
+        {
+        case ETIMEDOUT:
+            return cxx::success<SemaphoreWaitState>(SemaphoreWaitState::TIMEOUT);
+        case EINVAL:
+            LogError() << "The semaphore handle is no longer valid. This can indicate a corrupted system.";
+            return cxx::error<SemaphoreError>(SemaphoreError::INVALID_SEMAPHORE_HANDLE);
+        case EINTR:
+            LogError() << "The sem_timedwait was interrupted multiple times by the operating system. Abort operation!";
+            return cxx::error<SemaphoreError>(SemaphoreError::INTERRUPTED_BY_SIGNAL_HANDLER);
+        default:
+            LogError() << "This should never happen. An unknown error occurred.";
+            break;
+        }
+        return cxx::error<SemaphoreError>(SemaphoreError::UNDEFINED);
+    }
+
+    return cxx::success<SemaphoreWaitState>(SemaphoreWaitState::NO_TIMEOUT);
+}
+
+template <typename SemaphoreChild>
+bool SemaphoreInterface<SemaphoreChild>::tryWait() noexcept
+{
+    return tryWaitUnsafe().expect("Fatal semaphore failure occurred.");
+}
+
+template <typename SemaphoreChild>
+cxx::expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWaitUnsafe() noexcept
+{
+    auto result = posixCall(iox_sem_trywait)(getHandle()).failureReturnValue(-1).ignoreErrnos(EAGAIN).evaluate();
+
+    if (result.has_error())
+    {
+        switch (result.get_error().errnum)
+        {
+        case EAGAIN:
+            return cxx::success<bool>(false);
+        case EINVAL:
+            LogError() << "The semaphore handle is no longer valid. This can indicate a corrupted system.";
+            return cxx::error<SemaphoreError>(SemaphoreError::INVALID_SEMAPHORE_HANDLE);
+        case EINTR:
+            LogError() << "The sem_trywait was interrupted multiple times by the operating system. Abort operation!";
+            return cxx::error<SemaphoreError>(SemaphoreError::INTERRUPTED_BY_SIGNAL_HANDLER);
+        default:
+            LogError() << "This should never happen. An unknown error occurred.";
+            break;
+        }
+        return cxx::error<SemaphoreError>(SemaphoreError::UNDEFINED);
+    }
+
+    return cxx::success<bool>(true);
+}
+
+template class SemaphoreInterface<UnnamedSemaphore>;
+} // namespace internal
+} // namespace posix
+} // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -25,7 +25,6 @@ namespace posix
 {
 namespace internal
 {
-
 template <typename SemaphoreChild>
 iox_sem_t* SemaphoreInterface<SemaphoreChild>::getHandle() noexcept
 {
@@ -163,7 +162,6 @@ cxx::expected<SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexcep
 
     return cxx::success<>();
 }
-
 
 template class SemaphoreInterface<UnnamedSemaphore>;
 } // namespace internal

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -81,12 +81,5 @@ iox_sem_t* UnnamedSemaphore::getHandle() noexcept
 {
     return &m_handle;
 }
-
-const iox_sem_t* UnnamedSemaphore::getHandle() const noexcept
-{
-    return &m_handle;
-}
-
-
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
+#include "iceoryx_hoofs/internal/log/hoofs_logging.hpp"
+#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+
+#include <climits>
+
+namespace iox
+{
+namespace posix
+{
+cxx::expected<SemaphoreError>
+UnnamedSemaphoreBuilder::create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) noexcept
+{
+    uninitializedSemaphore.emplace();
+
+    auto result = posixCall(iox_sem_init)(&uninitializedSemaphore.value().m_handle,
+                                          (m_isInterProcessCapable) ? 0 : 1,
+                                          static_cast<unsigned int>(m_initialValue))
+                      .failureReturnValue(-1)
+                      .evaluate();
+
+    if (result.has_error())
+    {
+        uninitializedSemaphore.value().m_destroyHandle = false;
+        uninitializedSemaphore.reset();
+
+        switch (result.get_error().errnum)
+        {
+        case EINVAL:
+            LogError() << "The initial value of " << m_initialValue << " exceeds " << SEM_VALUE_MAX;
+            break;
+        case ENOSYS:
+            LogError() << "The system does not support process-shared semaphores";
+            break;
+        default:
+            LogError() << "This should never happen. An unknown error occurred.";
+            break;
+        }
+    }
+
+    return cxx::success<>();
+}
+
+UnnamedSemaphore::~UnnamedSemaphore() noexcept
+{
+    if (m_destroyHandle)
+    {
+        auto result = posixCall(iox_sem_destroy)(getHandle()).failureReturnValue(-1).evaluate();
+        if (result.has_error())
+        {
+            switch (result.get_error().errnum)
+            {
+            case EINVAL:
+                LogError() << "The semaphore handle was no longer valid. This can indicate a corrupted system.";
+                break;
+            default:
+                LogError() << "This should never happen. An unknown error occurred.";
+                break;
+            }
+        }
+    }
+}
+
+iox_sem_t* UnnamedSemaphore::getHandle() noexcept
+{
+    return &m_handle;
+}
+
+const iox_sem_t* UnnamedSemaphore::getHandle() const noexcept
+{
+    return &m_handle;
+}
+
+
+} // namespace posix
+} // namespace iox

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
@@ -217,13 +217,13 @@ TYPED_TEST(FunctionalInterface_test, AndThenDoesNotCrashWithNullFunction_ConstLV
 
 TYPED_TEST(FunctionalInterface_test, AndThenDoesNotCrashWithNullFunction_RValueCase)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "38ee906c-1314-440a-9328-976362555db0");
+    ::testing::Test::RecordProperty("TEST_ID", "d121b82a-de11-4ef4-a182-14c075066688");
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenDoesNotCrashWithNullFunction, std::move(sut));
 }
 
 TYPED_TEST(FunctionalInterface_test, AndThenDoesNotCrashWithNullFunction_ConstRValueCase)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "38ee906c-1314-440a-9328-976362555db0");
+    ::testing::Test::RecordProperty("TEST_ID", "42061fc8-963b-4b41-9016-1a3bde8706e7");
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenDoesNotCrashWithNullFunction_Const,
                                   std::move(const_cast<const SutType&>(sut)));
 }

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
@@ -200,13 +200,13 @@ struct OrElseDoesNotCrashWithNullFunction_Const<TYPE_HAS_GET_ERROR_METHOD>
 
 TYPED_TEST(FunctionalInterface_test, OrElseDoesNotCrashWithNullFunction_LValueCase)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "661a087d-90ee-4b27-9af4-b4d4b211adeb");
+    ::testing::Test::RecordProperty("TEST_ID", "d61adb35-0324-4e8e-9a36-0ee6f0cb0436");
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseDoesNotCrashWithNullFunction, sut);
 }
 
 TYPED_TEST(FunctionalInterface_test, OrElseDoesNotCrashWithNullFunction_ConstLValueCase)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "5913ed24-cb6e-47e6-a0af-c0650cc642a0");
+    ::testing::Test::RecordProperty("TEST_ID", "814fa9d6-d1d6-4bbf-a3a4-ee5665a3eb3f");
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseDoesNotCrashWithNullFunction_Const, const_cast<const SutType&>(sut));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -295,7 +295,10 @@ TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedUntilTriggeredAn
     auto start = std::chrono::steady_clock::now();
     counter = 2;
 
-    auto result = this->sut->timedWait(iox::units::Duration::max());
+    /// As time units::Duration::max() would be a better fit but this causes an overflow
+    /// in the internal MacOS semaphore platform implementation. This is a good compromise
+    /// for a long wait time which will be interrupted by sut->post in thread t1
+    auto result = this->sut->timedWait(this->TIMING_TEST_WAIT_TIME * 100);
     auto end = std::chrono::steady_clock::now();
 
     ASSERT_FALSE(result.has_error());

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -95,9 +95,9 @@ TYPED_TEST(SemaphoreInterfaceTest, PostIncreasesSemaphoreValue)
         ASSERT_FALSE(this->sut->post().has_error());
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS));
+    EXPECT_THAT(*result, Eq(NUMBER_OF_INCREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, WaitDecreasesSemaphoreValue)
@@ -115,9 +115,9 @@ TYPED_TEST(SemaphoreInterfaceTest, WaitDecreasesSemaphoreValue)
         ASSERT_FALSE(this->sut->wait().has_error());
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
+    EXPECT_THAT(*result, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTryWaitDecreasesSemaphoreValue)
@@ -137,9 +137,9 @@ TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTryWaitDecreasesSemaphoreValue)
         ASSERT_THAT(*call, Eq(true));
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
+    EXPECT_THAT(*result, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
@@ -154,9 +154,9 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
         ASSERT_THAT(*call, Eq(false));
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(0));
+    EXPECT_THAT(*result, Eq(0));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
@@ -178,9 +178,9 @@ TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
         ASSERT_TRUE(call.value() == iox::posix::SemaphoreWaitState::NO_TIMEOUT);
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
+    EXPECT_THAT(*result, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
@@ -196,9 +196,9 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
         ASSERT_TRUE(call.value() == iox::posix::SemaphoreWaitState::TIMEOUT);
     }
 
-    auto result = this->sut->getState();
+    auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(0));
+    EXPECT_THAT(*result, Eq(0));
 }
 
 
@@ -243,9 +243,8 @@ TYPED_TEST(SemaphoreInterfaceTest, WaitBlocksAtLeastDefinedSleepTime)
     ASSERT_FALSE(this->sut->wait().has_error());
     auto end = std::chrono::steady_clock::now();
 
-    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
-
     t1.join();
+    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedSleepTimeAndSignalsTimeout)

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -156,7 +156,7 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
 
     auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(*result, Eq(0));
+    EXPECT_THAT(*result, Eq(0U));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
@@ -198,7 +198,7 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
 
     auto result = this->sut->getValue();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(*result, Eq(0));
+    EXPECT_THAT(*result, Eq(0U));
 }
 
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -1,0 +1,309 @@
+// Copyright (c) 2019, 2021 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp"
+#include "iceoryx_hoofs/internal/units/duration.hpp"
+#include "iceoryx_hoofs/platform/time.hpp"
+#include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
+#include "iceoryx_hoofs/testing/test.hpp"
+#include "iceoryx_hoofs/testing/timing_test.hpp"
+#include "iceoryx_hoofs/testing/watch_dog.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace
+{
+using namespace ::testing;
+using namespace iox::units::duration_literals;
+
+template <typename T>
+class SemaphoreInterfaceTest : public Test
+{
+  public:
+    using SutFactory = T;
+    using SutType = typename SutFactory::SutType;
+
+    SemaphoreInterfaceTest()
+    {
+    }
+
+    ~SemaphoreInterfaceTest()
+    {
+    }
+
+    void SetUp()
+    {
+        deadlockWatchdog.watchAndActOnFailure([] { std::terminate(); });
+        ASSERT_TRUE(SutFactory::create(sut));
+    }
+
+    void TearDown()
+    {
+    }
+
+    SutType sut;
+
+    static constexpr iox::units::Duration WATCHDOG_TIMEOUT = 5_s;
+    static constexpr iox::units::Duration TIMING_TEST_WAIT_TIME = 100_ms;
+    Watchdog deadlockWatchdog{WATCHDOG_TIMEOUT};
+};
+template <typename T>
+constexpr iox::units::Duration SemaphoreInterfaceTest<T>::WATCHDOG_TIMEOUT;
+
+template <typename T>
+constexpr iox::units::Duration SemaphoreInterfaceTest<T>::TIMING_TEST_WAIT_TIME;
+
+struct UnnamedSemaphoreTest
+{
+    using SutType = iox::cxx::optional<iox::posix::UnnamedSemaphore>;
+    static bool create(SutType& sut)
+    {
+        return !iox::posix::UnnamedSemaphoreBuilder()
+                    .initialValue(0U)
+                    .isInterProcessCapable(false)
+                    .create(sut)
+                    .has_error();
+    }
+};
+
+using Implementations = Types<UnnamedSemaphoreTest>;
+TYPED_TEST_SUITE(SemaphoreInterfaceTest, Implementations);
+
+TYPED_TEST(SemaphoreInterfaceTest, PostIncreasesSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "af3013ef-683e-4ad4-874f-5c7e1a3f41fd");
+    for (int i = 0; i < 12; ++i)
+    {
+        ASSERT_FALSE(this->sut->post().has_error());
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(12));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, WaitDecreasesSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "29a63157-caee-4d28-a477-c4fa7048911c");
+    for (int i = 0; i < 18; ++i)
+    {
+        ASSERT_FALSE(this->sut->post().has_error());
+    }
+    for (int i = 0; i < 7; ++i)
+    {
+        ASSERT_FALSE(this->sut->wait().has_error());
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(11));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTryWaitDecreasesSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a98d1c45-d538-4abc-9633-f4868163785d");
+    for (int i = 0; i < 15; ++i)
+    {
+        ASSERT_FALSE(this->sut->post().has_error());
+    }
+    for (int i = 0; i < 9; ++i)
+    {
+        auto call = this->sut->tryWait();
+        ASSERT_THAT(call.has_error(), Eq(false));
+        ASSERT_THAT(*call, Eq(true));
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(6));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8bad3784-888b-44cd-ad5d-1c4662b26b17");
+    for (int i = 0; i < 4; ++i)
+    {
+        auto call = this->sut->tryWait();
+        ASSERT_THAT(call.has_error(), Eq(false));
+        ASSERT_THAT(*call, Eq(false));
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(0));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "e3bd3f5d-967c-4a5b-9f22-a8f92f73b3c3");
+    const iox::units::Duration timeToWait = 2_ms;
+    for (int i = 0; i < 19; ++i)
+    {
+        ASSERT_FALSE(this->sut->post().has_error());
+    }
+
+    for (int i = 0; i < 12; ++i)
+    {
+        auto call = this->sut->timedWait(timeToWait);
+        ASSERT_FALSE(call.has_error());
+        ASSERT_TRUE(call.value() == iox::posix::SemaphoreWaitState::NO_TIMEOUT);
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(7));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5a630be5-aef6-493e-a8ee-4dfabe642258");
+    const iox::units::Duration timeToWait = 2_us;
+    for (int i = 0; i < 4; ++i)
+    {
+        auto call = this->sut->timedWait(timeToWait);
+        ASSERT_FALSE(call.has_error());
+        ASSERT_TRUE(call.value() == iox::posix::SemaphoreWaitState::TIMEOUT);
+    }
+
+    auto result = this->sut->getState();
+    ASSERT_THAT(result.has_error(), Eq(false));
+    EXPECT_THAT(result->value, Eq(0));
+}
+
+
+TYPED_TEST(SemaphoreInterfaceTest, TryWaitAfterPostIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "22354447-c44d-443c-97a5-f5fdffb09748");
+    ASSERT_FALSE(this->sut->post().has_error());
+    auto call = this->sut->tryWait();
+    ASSERT_THAT(call.has_error(), Eq(false));
+    ASSERT_THAT(*call, Eq(true));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, TryWaitWithNoPostIsNotSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "0e5d6817-88a9-4fca-889e-4dbfe2c30e48");
+    ASSERT_FALSE(this->sut->post().has_error());
+    auto call = this->sut->tryWait();
+    ASSERT_THAT(call.has_error(), Eq(false));
+    ASSERT_THAT(*call, Eq(true));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, WaitValidAfterPostIsNonBlocking)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d4b1de28-89c4-4dfa-a465-8c7cfc652d67");
+    ASSERT_FALSE(this->sut->post().has_error());
+    // this call should not block and should be successful
+    EXPECT_THAT(this->sut->wait().has_error(), Eq(false));
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, WaitBlocksAtLeastDefinedSleepTime)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
+    std::atomic<int> counter{0};
+
+    std::thread t1([&] {
+        counter = 1;
+        while (counter.load() != 2)
+        {
+        }
+        std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
+        ASSERT_FALSE(this->sut->post().has_error());
+    });
+
+    while (counter.load() != 1)
+    {
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    counter = 2;
+
+    ASSERT_FALSE(this->sut->wait().has_error());
+    auto end = std::chrono::steady_clock::now();
+
+    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
+
+    t1.join();
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedSleepTimeAndSignalsTimeout)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
+    std::atomic<int> counter{0};
+
+    std::thread t1([&] {
+        counter = 1;
+        while (counter.load() != 2)
+        {
+        }
+        std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds() * 2));
+        ASSERT_FALSE(this->sut->post().has_error());
+    });
+
+    while (counter.load() != 1)
+    {
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    counter = 2;
+
+    auto result = this->sut->timedWait(this->TIMING_TEST_WAIT_TIME);
+    auto end = std::chrono::steady_clock::now();
+
+    ASSERT_FALSE(result.has_error());
+    EXPECT_THAT(*result, Eq(iox::posix::SemaphoreWaitState::TIMEOUT));
+
+    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
+
+    t1.join();
+}
+
+TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedUntilTriggeredAndSignalsNoTimeout)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
+    std::atomic<int> counter{0};
+
+    std::thread t1([&] {
+        counter = 1;
+        while (counter.load() != 2)
+        {
+        }
+        std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
+        ASSERT_FALSE(this->sut->post().has_error());
+    });
+
+    while (counter.load() != 1)
+    {
+    }
+
+    auto start = std::chrono::steady_clock::now();
+    counter = 2;
+
+    auto result = this->sut->timedWait(iox::units::Duration::max());
+    auto end = std::chrono::steady_clock::now();
+
+    ASSERT_FALSE(result.has_error());
+    EXPECT_THAT(*result, Eq(iox::posix::SemaphoreWaitState::NO_TIMEOUT));
+
+    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
+
+    t1.join();
+}
+
+} // namespace

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -244,25 +244,9 @@ TYPED_TEST(SemaphoreInterfaceTest, WaitBlocksAtLeastDefinedSleepTime)
 
 TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedSleepTimeAndSignalsTimeout)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
-    std::atomic<int> counter{0};
-
-    std::thread t1([&] {
-        counter = 1;
-        while (counter.load() != 2)
-        {
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds() * 2));
-        ASSERT_FALSE(this->sut->post().has_error());
-    });
-
-    while (counter.load() != 1)
-    {
-    }
+    ::testing::Test::RecordProperty("TEST_ID", "71ca9773-f724-4625-8550-6c56ef135ad7");
 
     auto start = std::chrono::steady_clock::now();
-    counter = 2;
-
     auto result = this->sut->timedWait(this->TIMING_TEST_WAIT_TIME);
     auto end = std::chrono::steady_clock::now();
 
@@ -270,43 +254,5 @@ TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedSleepTimeAndSign
     EXPECT_THAT(*result, Eq(iox::posix::SemaphoreWaitState::TIMEOUT));
 
     EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
-
-    t1.join();
 }
-
-TYPED_TEST(SemaphoreInterfaceTest, TimedWaitBlocksAtLeastDefinedUntilTriggeredAndSignalsNoTimeout)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
-    std::atomic<int> counter{0};
-
-    std::thread t1([&] {
-        counter = 1;
-        while (counter.load() != 2)
-        {
-        }
-        std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
-        ASSERT_FALSE(this->sut->post().has_error());
-    });
-
-    while (counter.load() != 1)
-    {
-    }
-
-    auto start = std::chrono::steady_clock::now();
-    counter = 2;
-
-    /// As time units::Duration::max() would be a better fit but this causes an overflow
-    /// in the internal MacOS semaphore platform implementation. This is a good compromise
-    /// for a long wait time which will be interrupted by sut->post in thread t1
-    auto result = this->sut->timedWait(this->TIMING_TEST_WAIT_TIME * 100);
-    auto end = std::chrono::steady_clock::now();
-
-    ASSERT_FALSE(result.has_error());
-    EXPECT_THAT(*result, Eq(iox::posix::SemaphoreWaitState::NO_TIMEOUT));
-
-    EXPECT_THAT(std::chrono::nanoseconds(end - start).count(), Ge(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
-
-    t1.join();
-}
-
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -87,42 +87,50 @@ TYPED_TEST_SUITE(SemaphoreInterfaceTest, Implementations);
 
 TYPED_TEST(SemaphoreInterfaceTest, PostIncreasesSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "af3013ef-683e-4ad4-874f-5c7e1a3f41fd");
-    for (int i = 0; i < 12; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "728c70a7-dca3-4f09-a7bf-c347106dab0c");
+    constexpr uint64_t NUMBER_OF_INCREMENTS = 12U;
+
+    for (uint64_t i = 0U; i < NUMBER_OF_INCREMENTS; ++i)
     {
         ASSERT_FALSE(this->sut->post().has_error());
     }
 
     auto result = this->sut->getState();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(12));
+    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, WaitDecreasesSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "29a63157-caee-4d28-a477-c4fa7048911c");
-    for (int i = 0; i < 18; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "ae40f4b2-1997-41ab-afe1-7927d5269a36");
+    constexpr uint64_t NUMBER_OF_INCREMENTS = 18U;
+    constexpr uint64_t NUMBER_OF_DECREMENTS = 7U;
+
+    for (uint64_t i = 0; i < NUMBER_OF_INCREMENTS; ++i)
     {
         ASSERT_FALSE(this->sut->post().has_error());
     }
-    for (int i = 0; i < 7; ++i)
+    for (uint64_t i = 0; i < NUMBER_OF_DECREMENTS; ++i)
     {
         ASSERT_FALSE(this->sut->wait().has_error());
     }
 
     auto result = this->sut->getState();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(11));
+    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTryWaitDecreasesSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "a98d1c45-d538-4abc-9633-f4868163785d");
-    for (int i = 0; i < 15; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "977ee162-a233-4e42-9abd-8faa996b6a5c");
+    constexpr uint64_t NUMBER_OF_INCREMENTS = 15U;
+    constexpr uint64_t NUMBER_OF_DECREMENTS = 9U;
+
+    for (uint64_t i = 0; i < NUMBER_OF_INCREMENTS; ++i)
     {
         ASSERT_FALSE(this->sut->post().has_error());
     }
-    for (int i = 0; i < 9; ++i)
+    for (uint64_t i = 0; i < NUMBER_OF_DECREMENTS; ++i)
     {
         auto call = this->sut->tryWait();
         ASSERT_THAT(call.has_error(), Eq(false));
@@ -131,13 +139,15 @@ TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTryWaitDecreasesSemaphoreValue)
 
     auto result = this->sut->getState();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(6));
+    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "8bad3784-888b-44cd-ad5d-1c4662b26b17");
-    for (int i = 0; i < 4; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "c5eff306-7b73-425a-a4d8-9d1af4d5d345");
+    constexpr uint64_t NUMBER_OF_DECREMENTS = 4U;
+
+    for (uint64_t i = 0; i < NUMBER_OF_DECREMENTS; ++i)
     {
         auto call = this->sut->tryWait();
         ASSERT_THAT(call.has_error(), Eq(false));
@@ -151,14 +161,17 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTryWaitDoesNotChangeSemaphoreValue)
 
 TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "e3bd3f5d-967c-4a5b-9f22-a8f92f73b3c3");
-    const iox::units::Duration timeToWait = 2_ms;
-    for (int i = 0; i < 19; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "6bee4652-4eac-4d70-908a-f3be954185de");
+    constexpr uint64_t NUMBER_OF_INCREMENTS = 19U;
+    constexpr uint64_t NUMBER_OF_DECREMENTS = 12U;
+    constexpr iox::units::Duration timeToWait = 2_ms;
+
+    for (uint64_t i = 0; i < NUMBER_OF_INCREMENTS; ++i)
     {
         ASSERT_FALSE(this->sut->post().has_error());
     }
 
-    for (int i = 0; i < 12; ++i)
+    for (uint64_t i = 0; i < NUMBER_OF_DECREMENTS; ++i)
     {
         auto call = this->sut->timedWait(timeToWait);
         ASSERT_FALSE(call.has_error());
@@ -167,14 +180,16 @@ TYPED_TEST(SemaphoreInterfaceTest, SuccessfulTimedWaitDecreasesSemaphoreValue)
 
     auto result = this->sut->getState();
     ASSERT_THAT(result.has_error(), Eq(false));
-    EXPECT_THAT(result->value, Eq(7));
+    EXPECT_THAT(result->value, Eq(NUMBER_OF_INCREMENTS - NUMBER_OF_DECREMENTS));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "5a630be5-aef6-493e-a8ee-4dfabe642258");
-    const iox::units::Duration timeToWait = 2_us;
-    for (int i = 0; i < 4; ++i)
+    ::testing::Test::RecordProperty("TEST_ID", "cb2f5ded-7c04-4e2d-ab41-bbe231a520c7");
+    constexpr uint64_t NUMBER_OF_DECREMENTS = 4U;
+    constexpr iox::units::Duration timeToWait = 2_us;
+
+    for (uint64_t i = 0; i < NUMBER_OF_DECREMENTS; ++i)
     {
         auto call = this->sut->timedWait(timeToWait);
         ASSERT_FALSE(call.has_error());
@@ -189,7 +204,7 @@ TYPED_TEST(SemaphoreInterfaceTest, FailingTimedWaitDoesNotChangeSemaphoreValue)
 
 TYPED_TEST(SemaphoreInterfaceTest, TryWaitAfterPostIsSuccessful)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "22354447-c44d-443c-97a5-f5fdffb09748");
+    ::testing::Test::RecordProperty("TEST_ID", "df5d32f5-9417-419e-b36e-93a0502ed6e7");
     ASSERT_FALSE(this->sut->post().has_error());
     auto call = this->sut->tryWait();
     ASSERT_THAT(call.has_error(), Eq(false));
@@ -198,7 +213,7 @@ TYPED_TEST(SemaphoreInterfaceTest, TryWaitAfterPostIsSuccessful)
 
 TYPED_TEST(SemaphoreInterfaceTest, TryWaitWithNoPostIsNotSuccessful)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "0e5d6817-88a9-4fca-889e-4dbfe2c30e48");
+    ::testing::Test::RecordProperty("TEST_ID", "8d0eebcd-11e3-456f-8d19-3fdb6fc70241");
     ASSERT_FALSE(this->sut->post().has_error());
     auto call = this->sut->tryWait();
     ASSERT_THAT(call.has_error(), Eq(false));
@@ -207,7 +222,7 @@ TYPED_TEST(SemaphoreInterfaceTest, TryWaitWithNoPostIsNotSuccessful)
 
 TYPED_TEST(SemaphoreInterfaceTest, WaitValidAfterPostIsNonBlocking)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "d4b1de28-89c4-4dfa-a465-8c7cfc652d67");
+    ::testing::Test::RecordProperty("TEST_ID", "c08220e3-c368-43d5-85d2-cbf7e1659017");
     ASSERT_FALSE(this->sut->post().has_error());
     // this call should not block and should be successful
     EXPECT_THAT(this->sut->wait().has_error(), Eq(false));
@@ -215,24 +230,15 @@ TYPED_TEST(SemaphoreInterfaceTest, WaitValidAfterPostIsNonBlocking)
 
 TYPED_TEST(SemaphoreInterfaceTest, WaitBlocksAtLeastDefinedSleepTime)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "5869a475-6be3-4b55-aa58-2ebf11d46081");
-    std::atomic<int> counter{0};
+    ::testing::Test::RecordProperty("TEST_ID", "9fb454db-2d1d-43a5-b0a5-d9de7f1886e0");
 
+    std::chrono::steady_clock::time_point start;
     std::thread t1([&] {
-        counter = 1;
-        while (counter.load() != 2)
-        {
-        }
+        start = std::chrono::steady_clock::now();
         std::this_thread::sleep_for(std::chrono::nanoseconds(this->TIMING_TEST_WAIT_TIME.toNanoseconds()));
         ASSERT_FALSE(this->sut->post().has_error());
     });
 
-    while (counter.load() != 1)
-    {
-    }
-
-    auto start = std::chrono::steady_clock::now();
-    counter = 2;
 
     ASSERT_FALSE(this->sut->wait().has_error());
     auto end = std::chrono::steady_clock::now();

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -40,16 +40,18 @@ class UnnamedSemaphoreTest : public Test
 
 TEST_F(UnnamedSemaphoreTest, DefaultInitialValueIsZero)
 {
+    ::testing::Test::RecordProperty("TEST_ID", "33b6c6b9-ef33-4c62-a03b-f4405cfa2414");
     ASSERT_FALSE(UnnamedSemaphoreBuilder().create(sut).has_error());
-    EXPECT_THAT(0U, sut->getState().expect("Failed to access semaphore").value);
+    EXPECT_THAT(sut->getState().expect("Failed to access semaphore").value, Eq(0U));
 }
 
 TEST_F(UnnamedSemaphoreTest, InitialValueIsSetOnCreation)
 {
-    for (uint32_t initialValue = 313; initialValue < 10000; initialValue *= 3)
+    ::testing::Test::RecordProperty("TEST_ID", "33e6a780-f115-4477-b78d-34cdfc89a824");
+    for (uint32_t initialValue = 313U; initialValue < 10000U; initialValue *= 3U)
     {
         ASSERT_FALSE(UnnamedSemaphoreBuilder().initialValue(initialValue).create(sut).has_error());
-        EXPECT_THAT(initialValue, sut->getState().expect("Failed to access semaphore").value);
+        EXPECT_THAT(sut->getState().expect("Failed to access semaphore").value, Eq(initialValue));
     }
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
+#include "test.hpp"
+
+
+namespace
+{
+using namespace ::testing;
+using namespace iox::posix;
+using namespace iox::cxx;
+
+class UnnamedSemaphoreTest : public Test
+{
+  public:
+    void SetUp() override
+    {
+    }
+
+    void TearDown() override
+    {
+    }
+
+    optional<UnnamedSemaphore> sut;
+};
+
+TEST_F(UnnamedSemaphoreTest, asd)
+{
+}
+} // namespace
+

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -42,7 +42,7 @@ TEST_F(UnnamedSemaphoreTest, DefaultInitialValueIsZero)
 {
     ::testing::Test::RecordProperty("TEST_ID", "33b6c6b9-ef33-4c62-a03b-f4405cfa2414");
     ASSERT_FALSE(UnnamedSemaphoreBuilder().create(sut).has_error());
-    EXPECT_THAT(sut->getState().expect("Failed to access semaphore").value, Eq(0U));
+    EXPECT_THAT(sut->getValue().expect("Failed to access semaphore"), Eq(0U));
 }
 
 TEST_F(UnnamedSemaphoreTest, InitialValueIsSetOnCreation)
@@ -51,7 +51,7 @@ TEST_F(UnnamedSemaphoreTest, InitialValueIsSetOnCreation)
     for (uint32_t initialValue = 313U; initialValue < 10000U; initialValue *= 3U)
     {
         ASSERT_FALSE(UnnamedSemaphoreBuilder().initialValue(initialValue).create(sut).has_error());
-        EXPECT_THAT(sut->getState().expect("Failed to access semaphore").value, Eq(initialValue));
+        EXPECT_THAT(sut->getValue().expect("Failed to access semaphore"), Eq(initialValue));
     }
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -38,8 +38,19 @@ class UnnamedSemaphoreTest : public Test
     optional<UnnamedSemaphore> sut;
 };
 
-TEST_F(UnnamedSemaphoreTest, asd)
+TEST_F(UnnamedSemaphoreTest, DefaultInitialValueIsZero)
 {
+    ASSERT_FALSE(UnnamedSemaphoreBuilder().create(sut).has_error());
+    EXPECT_THAT(0U, sut->getState().expect("Failed to access semaphore").value);
+}
+
+TEST_F(UnnamedSemaphoreTest, InitialValueIsSetOnCreation)
+{
+    for (uint32_t initialValue = 313; initialValue < 10000; initialValue *= 3)
+    {
+        ASSERT_FALSE(UnnamedSemaphoreBuilder().initialValue(initialValue).create(sut).has_error());
+        EXPECT_THAT(initialValue, sut->getState().expect("Failed to access semaphore").value);
+    }
 }
 } // namespace
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -53,4 +53,3 @@ TEST_F(UnnamedSemaphoreTest, InitialValueIsSetOnCreation)
     }
 }
 } // namespace
-


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/advanced/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
At the moment our semaphore wrapper has the following issues:
* is moveable but it shouldn't be
* combines unnamed semaphore & named semaphore in one class - wastes resources, has increased unnecessary complexity
* uses the creation pattern

This PR lays the foundation for two classes `UnnamedSemaphore` and `NamedSemaphore` which will both inherit from `SemaphoreInterface` which provides methods like `post`, `wait`, `timedWait` etc.
They won't be moveable anymore and use the builder pattern for creation.

`test_posix_semaphore_interface.cpp` were taken by copy from `test_semaphore_module.cpp` and cleaned up a bit.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- closes a todo in #751
