### PR TITLE
iox-#1396 Fix data race in concurrent::FIFO push

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -25,6 +25,7 @@
 - High CPU load in blocked publisher is reduced by introducing smart busy loop waiting (adaptive_wait) [\#1347](https://github.com/eclipse-iceoryx/iceoryx/issues/1347)
 - Compile Error : iceoryx_dds/Mempool.hpp: No such file or directory [\#1364](https://github.com/eclipse-iceoryx/iceoryx/issues/1364)
 - RPATH is correctly set up for all libraries and binaries. [\#1287](https://github.com/eclipse-iceoryx/iceoryx/issues/1287)
+- Wrong memory order in concurrent::FIFO [\#1396](https://github.com/eclipse-iceoryx/iceoryx/issues/1396)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/fifo.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/fifo.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/fifo.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/fifo.inl
@@ -71,7 +71,7 @@ inline bool FiFo<ValueType, Capacity>::empty() const noexcept
 template <class ValueType, uint64_t Capacity>
 inline cxx::optional<ValueType> FiFo<ValueType, Capacity>::pop() noexcept
 {
-    auto currentReadPos = m_read_pos.load(std::memory_order_relaxed);
+    auto currentReadPos = m_read_pos.load(std::memory_order_acquire);
     bool isEmpty = (currentReadPos ==
                     // we are not allowed to use the empty method since we have to sync with
                     // the producer pop - this is done here
@@ -87,7 +87,7 @@ inline cxx::optional<ValueType> FiFo<ValueType, Capacity>::pop() noexcept
         // m_read_pos must be increased after reading the pop'ed value otherwise
         // it is possible that the pop'ed value is overwritten by push while it is read.
         // Implementing a single consumer fifo here allows us to use store.
-        m_read_pos.store(currentReadPos + 1, std::memory_order_relaxed);
+        m_read_pos.store(currentReadPos + 1, std::memory_order_release);
         return out;
     }
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This bug fixes a data race due to a wrong memory order in the push method of `concurrent::FIFO`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1396
