### PR TITLE
iox-#1394 Prevent destruction of FunctionalInterface derived classes by base class pointer

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
@@ -280,12 +280,16 @@ struct FunctionalInterfaceImpl : public ExpectWithValue<Derived, ValueType>,
                                  public AndThenWithValue<Derived, ValueType>,
                                  public OrElseWithValue<Derived, ErrorType>
 {
+  protected:
+    ~FunctionalInterfaceImpl() = default;
 };
 
 template <typename Derived>
 struct FunctionalInterfaceImpl<Derived, void, void>
     : public Expect<Derived>, public AndThen<Derived>, public OrElse<Derived>
 {
+  protected:
+    ~FunctionalInterfaceImpl() = default;
 };
 
 template <typename Derived, typename ValueType>
@@ -294,12 +298,16 @@ struct FunctionalInterfaceImpl<Derived, ValueType, void> : public ExpectWithValu
                                                            public AndThenWithValue<Derived, ValueType>,
                                                            public OrElse<Derived>
 {
+  protected:
+    ~FunctionalInterfaceImpl() = default;
 };
 
 template <typename Derived, typename ErrorType>
 struct FunctionalInterfaceImpl<Derived, void, ErrorType>
     : public Expect<Derived>, public AndThen<Derived>, public OrElseWithValue<Derived, ErrorType>
 {
+  protected:
+    ~FunctionalInterfaceImpl() = default;
 };
 } // namespace internal
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

See also https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The `optional` and `expected` derive from `FunctionalInterface` to gain functionality like `and_then`, `or_else`, etc.
This leads to the possibility to destruct the derived classes via an pointer to the `FunctionalInterface`. Since the `FunctionalInterface` cannot have a virtual destructor (due to usage in shared memory) this must be prevented by making the destructor of  `FunctionalInterface` protected.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1394
