### PR TITLE
iox-#1394 Mention Axivion syntax in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -273,6 +273,9 @@ If you want to report a vulnerability, please use the [Eclipse process](https://
 
 #### Static code analysis
 
+The iceoryx maintainers have a partnership with [Axivion](https://www.axivion.com/en/) and use their
+[Axivion Suite](https://www.axivion.com/en/products/static-code-analysis/) to run a static code analysis.
+
 Github [labels](https://github.com/eclipse-iceoryx/iceoryx/labels) are used to group issues into the rulesets:
 
 | Ruleset name | Github issue label | Priority |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,14 +289,27 @@ If one of the rules is not followed, a rationale is added in the following manne
 Either with a comment in the same line:
 
 ```cpp
-*mynullptr = foo; // PRQA S 4242 # Short description why
+*mynullptr = foo; // AXIVION Same Line Ruleset-A1.2.3 : Short description why
 ```
 
-Or with a comment one line above (the number after the warning number indicates that next ’n’ lines are inclusive)
+Or with a comment one line above:
 
 ```cpp
-// PRQA S 4242 1 # Short description why
+// AXIVION Next Line Ruleset-A1.2.3 : Short description why
 *mynullptr = foo;
+```
+
+It is also possible to suppress a rule for a complete construct:
+
+```cpp
+// AXIVION Construct Ruleset-A1.2.3 : Short description why
+class Foo
+{
+  void doSomething()
+  {
+    // Do something useful
+  }
+};
 ```
 
 ### Header


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Replace QAC with Axivion syntax in our docs

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394
