### PR TITLE
Iox #1440 fix file lock leak in release 2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,9 @@ jobs:
         usesh: true
         mem: 2048
         prepare: pkg install -y cmake git ncurses bash wget bison
-        run: ./tools/ci/build-test-freebsd.sh
+        run: |
+         git config --global --add safe.directory /Users/runner/work/iceoryx/iceoryx
+         ./tools/ci/build-test-freebsd.sh
 
   build-test-windows:
     runs-on: windows-2019

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -8,7 +8,7 @@
 
 **Bugfixes:**
 
-- Foo Bar [\#000](https://github.com/eclipse-iceoryx/iceoryx/issues/000)
+- Fix FileLock leak when lock failed [\#1440](https://github.com/eclipse-iceoryx/iceoryx/issues/1440)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -60,6 +60,8 @@ cxx::expected<FileLockError> FileLock::initializeFileLock() noexcept
         return cxx::error<FileLockError>(convertErrnoToFileLockError(openCall.get_error().errnum));
     }
 
+    m_isInitialized = true;
+
     auto lockCall = posixCall(iox_flock)(m_fd, LOCK_EX | LOCK_NB)
                         .failureReturnValue(ERROR_CODE)
                         .suppressErrorMessagesForErrnos(EWOULDBLOCK)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
This bug occurs only in 2.0.x . On master the `FileLock` was refactored and with that the bug is already solved.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1440 and backports #1338 to 2.0
