### PR TITLE
iox-#1196 Fix compiler warnings in binding c tests

### DIFF
--- a/iceoryx_binding_c/test/CMakeLists.txt
+++ b/iceoryx_binding_c/test/CMakeLists.txt
@@ -46,13 +46,3 @@ iox_add_executable( TARGET                  ${PROJECT_PREFIX}_moduletests
                     LIBS_APPLE              dl
                     LIBS_LINUX              acl dl pthread rt
 )
-
-## TODO: iox-#1287 remove those compiler warning exceptions
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set(TEST_CXX_FLAGS PRIVATE ${ICEORYX_WARNINGS} /bigobj)
-else()
-    set(TEST_CXX_FLAGS PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS} -Wno-pedantic -Wno-conversion)
-endif()
-
-target_compile_options(${PROJECT_PREFIX}_moduletests PRIVATE ${TEST_CXX_FLAGS})
-## TODO: END iox-#1287 remove those compiler warning exceptions

--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -355,7 +355,7 @@ TIMING_TEST_F(iox_listener_test, UserTriggerCallbackIsCalledWhenTriggered, Repea
     iox_user_trigger_trigger(m_userTrigger[0U]);
     std::this_thread::sleep_for(TIMEOUT);
     EXPECT_THAT(g_userTriggerCallbackArgument, Eq(m_userTrigger[0U]));
-});
+})
 
 TIMING_TEST_F(iox_listener_test, UserTriggerCallbackWithContextDataIsCalledWhenTriggered, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "55c61dc2-4aa3-4c26-b14a-5c137ad1f20e");
@@ -367,7 +367,7 @@ TIMING_TEST_F(iox_listener_test, UserTriggerCallbackWithContextDataIsCalledWhenT
     std::this_thread::sleep_for(TIMEOUT);
     EXPECT_THAT(g_userTriggerCallbackArgument, Eq(m_userTrigger[0U]));
     EXPECT_THAT(g_contextData, Eq(static_cast<void*>(&someContextData)));
-});
+})
 
 TIMING_TEST_F(iox_listener_test, SubscriberCallbackIsCalledSampleIsReceived, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "541b118b-4a7a-4ea5-aa5f-8e922dfd4aa0");
@@ -388,7 +388,7 @@ TIMING_TEST_F(iox_listener_test, SubscriberCallbackIsCalledSampleIsReceived, Rep
 
     std::this_thread::sleep_for(TIMEOUT);
     EXPECT_THAT(g_subscriberCallbackArgument, Eq(&m_subscriber[0U]));
-});
+})
 
 TIMING_TEST_F(iox_listener_test, SubscriberCallbackWithContextDataIsCalledSampleIsReceived, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "a51ff99b-f1df-458d-b3c0-a97ddfacf4ec");
@@ -415,7 +415,7 @@ TIMING_TEST_F(iox_listener_test, SubscriberCallbackWithContextDataIsCalledSample
     std::this_thread::sleep_for(TIMEOUT);
     EXPECT_THAT(g_subscriberCallbackArgument, Eq(&m_subscriber[0U]));
     EXPECT_THAT(g_contextData, Eq(static_cast<void*>(&someContextData)));
-});
+})
 
 TEST_F(iox_listener_test, AttachingClientWorks)
 {
@@ -460,7 +460,7 @@ TIMING_TEST_F(iox_listener_test, NotifyingClientEventWorks, Repeat(5), [&] {
     iox_listener_detach_client_event(&m_sut, client, ClientEvent_RESPONSE_RECEIVED);
 
     iox_client_deinit(client);
-});
+})
 
 TIMING_TEST_F(iox_listener_test, NotifyingClientEventWithContextDataWorks, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "64178bc6-ec8f-4504-aceb-6a32ee568ab8");
@@ -481,7 +481,7 @@ TIMING_TEST_F(iox_listener_test, NotifyingClientEventWithContextDataWorks, Repea
     iox_listener_detach_client_event(&m_sut, client, ClientEvent_RESPONSE_RECEIVED);
 
     iox_client_deinit(client);
-});
+})
 
 //////////////////////
 /// BEGIN server tests
@@ -548,7 +548,7 @@ TIMING_TEST_F(iox_listener_test, NotifyingServerEventWorks, Repeat(5), [&] {
     iox_listener_detach_server_event(&m_sut, server, ServerEvent_REQUEST_RECEIVED);
 
     iox_server_deinit(server);
-});
+})
 
 TIMING_TEST_F(iox_listener_test, NotifyingServerEventWithContextDataWorks, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "ae71bd2c-474b-4f39-b2d8-7959d26e7d90");
@@ -569,7 +569,7 @@ TIMING_TEST_F(iox_listener_test, NotifyingServerEventWithContextDataWorks, Repea
     iox_listener_detach_server_event(&m_sut, server, ServerEvent_REQUEST_RECEIVED);
 
     iox_server_deinit(server);
-});
+})
 
 //////////////////////
 /// END server tests
@@ -642,7 +642,7 @@ TIMING_TEST_F(iox_listener_test, NotifyingServiceDiscoveryEventWorks, Repeat(5),
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);
 
     iox_service_discovery_deinit(serviceDiscovery);
-});
+})
 
 TIMING_TEST_F(iox_listener_test, NotifyingServiceDiscoveryEventWithContextDataWorks, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "257c27a5-95c6-489d-919f-125471b399e8");
@@ -667,6 +667,6 @@ TIMING_TEST_F(iox_listener_test, NotifyingServiceDiscoveryEventWithContextDataWo
         &m_sut, serviceDiscovery, ServiceDiscoveryEvent_SERVICE_REGISTRY_CHANGED);
 
     iox_service_discovery_deinit(serviceDiscovery);
-});
+})
 
 } // namespace

--- a/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
@@ -564,7 +564,7 @@ TIMING_TEST_F(iox_ws_test, WaitIsBlockingTillTriggered, Repeat(5), [&] {
 
     t.join();
     TIMING_TEST_EXPECT_TRUE(waitWasCalled.load());
-});
+})
 
 TIMING_TEST_F(iox_ws_test, WaitIsNonBlockingAfterMarkForDestruction, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "4e576665-fda1-4f3c-8588-e9d2cffcb3f4");
@@ -583,7 +583,7 @@ TIMING_TEST_F(iox_ws_test, WaitIsNonBlockingAfterMarkForDestruction, Repeat(5), 
 
     t.join();
     TIMING_TEST_EXPECT_TRUE(waitWasCalled.load());
-});
+})
 
 
 TIMING_TEST_F(iox_ws_test, TimedWaitIsBlockingTillTriggered, Repeat(5), [&] {
@@ -603,7 +603,7 @@ TIMING_TEST_F(iox_ws_test, TimedWaitIsBlockingTillTriggered, Repeat(5), [&] {
 
     t.join();
     TIMING_TEST_EXPECT_TRUE(waitWasCalled.load());
-});
+})
 
 TIMING_TEST_F(iox_ws_test, TimedWaitIsNonBlockingAfterMarkForDestruction, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "a6da4f49-b162-4c70-b0fa-c4ef1f988c57");
@@ -622,7 +622,7 @@ TIMING_TEST_F(iox_ws_test, TimedWaitIsNonBlockingAfterMarkForDestruction, Repeat
 
     t.join();
     TIMING_TEST_EXPECT_TRUE(waitWasCalled.load());
-});
+})
 
 TIMING_TEST_F(iox_ws_test, TimedWaitBlocksTillTimeout, Repeat(5), [&] {
     ::testing::Test::RecordProperty("TEST_ID", "12fbbbc8-80b2-4e7e-af41-1376b2e48f4a");
@@ -641,7 +641,7 @@ TIMING_TEST_F(iox_ws_test, TimedWaitBlocksTillTimeout, Repeat(5), [&] {
     TIMING_TEST_EXPECT_TRUE(waitWasCalled.load());
 
     t.join();
-});
+})
 
 TEST_F(iox_ws_test, SubscriberEventCallbackIsCalled)
 {

--- a/iceoryx_binding_c/test/test.hpp
+++ b/iceoryx_binding_c/test/test.hpp
@@ -34,7 +34,7 @@ T maxUnderlyingCEnumValue()
 #pragma GCC diagnostic ignored "-Wconversion"
     return static_cast<T>(std::numeric_limits<std::underlying_type_t<T>>::max());
 #pragma GCC diagnostic pop
-};
-}; // namespace iox_test_binding_c
+}
+} // namespace iox_test_binding_c
 
 #endif // IOX_BINDING_C_TEST_HPP

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
@@ -45,8 +45,10 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
         mockRuntime().reset();
     }
 
+#ifdef __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
     MOCK_METHOD(iox::PublisherPortUserType::MemberType_t*,
                 getMiddlewarePublisher,
                 (const iox::capro::ServiceDescription&,
@@ -81,7 +83,9 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
                 sendRequestToRouDi,
                 (const iox::runtime::IpcMessage&, iox::runtime::IpcMessage&),
                 (noexcept, override));
+#ifdef __clang__
 #pragma GCC diagnostic pop
+#endif
 
   private:
     PoshRuntimeMock(const iox::RuntimeName_t& name)

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
@@ -45,6 +45,8 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
         mockRuntime().reset();
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
     MOCK_METHOD(iox::PublisherPortUserType::MemberType_t*,
                 getMiddlewarePublisher,
                 (const iox::capro::ServiceDescription&,
@@ -79,6 +81,7 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
                 sendRequestToRouDi,
                 (const iox::runtime::IpcMessage&, iox::runtime::IpcMessage&),
                 (noexcept, override));
+#pragma GCC diagnostic pop
 
   private:
     PoshRuntimeMock(const iox::RuntimeName_t& name)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Part of #1196 