### PR TITLE
iox-#1394 iox-#1196 Address Axivion and clang-tidy findings for `cxx::function_ref`

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
@@ -15,15 +15,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// AXIVION DISABLE STYLE AutosarC++19_03-A16.2.3 : <type_traits> is included
+
 #ifndef IOX_HOOFS_CXX_FUNCTION_REF_HPP
 #define IOX_HOOFS_CXX_FUNCTION_REF_HPP
 
+// AXIVION Next Line AutosarC++19_03-A16.2.2 : Needed for Expects and Ensures macros
 #include "iceoryx_hoofs/cxx/requires.hpp"
 #include "iceoryx_hoofs/cxx/type_traits.hpp"
 
-#include <cstddef>
-#include <iostream>
-#include <memory>
 #include <type_traits>
 
 namespace iox
@@ -33,6 +33,12 @@ namespace cxx
 template <typename SignatureType>
 class function_ref;
 
+/// @brief Type trait which checks for the same decayed type
+/// @tparam[in] T1 first type
+/// @tparam[in] T2 second type
+template <typename T1, typename T2>
+using has_same_decayed_type = typename std::
+    integral_constant<bool, bool(std::is_same<typename std::decay<T1>::type, typename std::decay<T2>::type>::value)>;
 
 /// @brief cxx::function_ref is a non-owning reference to a callable.
 ///
@@ -61,28 +67,22 @@ class function_ref;
 ///         callback();
 /// @endcode
 template <class ReturnType, class... ArgTypes>
-class function_ref<ReturnType(ArgTypes...)>
+class function_ref<ReturnType(ArgTypes...)> final
 {
-    using SignatureType = ReturnType(ArgTypes...);
-
-    template <typename T1, typename T2>
-    using has_same_decayed_type = typename std::integral_constant<
-        bool,
-        bool(std::is_same<typename std::decay<T1>::type, typename std::decay<T2>::type>::value)>;
-
   public:
     ~function_ref() noexcept = default;
 
     function_ref(const function_ref&) noexcept = default;
 
-    function_ref& operator=(const function_ref&) noexcept = default;
+    function_ref& operator=(const function_ref&) & noexcept = default;
 
     /// @brief Creates a function_ref with a callable whose lifetime has to be longer than function_ref
     /// @param[in] callable that is not a function_ref
     template <typename CallableType,
-              typename = std::enable_if_t<!is_function_pointer<CallableType>::value
-                                          && !has_same_decayed_type<CallableType, function_ref>::value
-                                          && is_invocable<CallableType, ArgTypes...>::value>>
+              typename = std::enable_if_t<(!is_function_pointer<CallableType>::value)
+                                          && (!has_same_decayed_type<CallableType, function_ref>::value)
+                                          && (is_invocable<CallableType, ArgTypes...>::value)>>
+    // AXIVION Next Line AutosarC++19_03-A12.1.4 : Implicit conversion is needed for lambdas
     function_ref(CallableType&& callable) noexcept;
 
     /// @brief Creates a function_ref from a function pointer
@@ -95,7 +95,7 @@ class function_ref<ReturnType(ArgTypes...)>
 
     function_ref(function_ref&& rhs) noexcept;
 
-    function_ref& operator=(function_ref&& rhs) noexcept;
+    function_ref& operator=(function_ref&& rhs) & noexcept;
 
     /// @brief Calls the provided callable
     /// @param[in] Arguments are forwarded to the underlying function pointer
@@ -115,6 +115,7 @@ class function_ref<ReturnType(ArgTypes...)>
 } // namespace cxx
 } // namespace iox
 
+// AXIVION Next Line AutosarC++19_03-M16.0.1 : Include needed to split template declaration and definition
 #include "iceoryx_hoofs/internal/cxx/function_ref.inl"
 
-#endif
+#endif // IOX_HOOFS_CXX_FUNCTION_REF_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
@@ -83,7 +83,7 @@ class function_ref<ReturnType(ArgTypes...)> final
                                           && (!has_same_decayed_type<CallableType, function_ref>::value)
                                           && (is_invocable<CallableType, ArgTypes...>::value)>>
     // AXIVION Next Line AutosarC++19_03-A12.1.4 : Implicit conversion is needed for lambdas
-    function_ref(CallableType&& callable) noexcept;
+    function_ref(CallableType&& callable) noexcept; // NOLINT(hicpp-explicit-conversions)
 
     /// @brief Creates a function_ref from a function pointer
     /// @param[in] function function reference to function we want to reference
@@ -91,6 +91,8 @@ class function_ref<ReturnType(ArgTypes...)> final
     /// @note This overload is needed, as the general implementation
     /// will not work properly for function pointers.
     /// This ctor is not needed anymore once we can use user-defined-deduction guides (C++17)
+    // For justification see c'tor above
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     function_ref(ReturnType (&function)(ArgTypes...)) noexcept;
 
     function_ref(function_ref&& rhs) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
@@ -91,7 +91,7 @@ class function_ref<ReturnType(ArgTypes...)> final
     /// @note This overload is needed, as the general implementation
     /// will not work properly for function pointers.
     /// This ctor is not needed anymore once we can use user-defined-deduction guides (C++17)
-    // For justification see c'tor above
+    // Implicit conversion needed for method pointers
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     function_ref(ReturnType (&function)(ArgTypes...)) noexcept;
 
@@ -113,6 +113,9 @@ class function_ref<ReturnType(ArgTypes...)> final
     void* m_pointerToCallable{nullptr};
     ReturnType (*m_functionPointer)(void*, ArgTypes...){nullptr};
 };
+
+template <class ReturnType, class... ArgTypes>
+void swap(function_ref<ReturnType(ArgTypes...)>& lhs, function_ref<ReturnType(ArgTypes...)>& rhs) noexcept;
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// AXIVION DISABLE STYLE AutosarC++19_03-A16.2.3 : <type_traits> is included
+// AXIVION DISABLE STYLE AutosarC++19_03-A16.2.3 : <type_traits> is included through "type_traits.hpp"
 
 #ifndef IOX_HOOFS_CXX_FUNCTION_REF_HPP
 #define IOX_HOOFS_CXX_FUNCTION_REF_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
@@ -33,13 +33,16 @@ template <typename CallableType, typename>
 // explicit
 // AXIVION Next Line AutosarC++19_03-A8.4.6 : Only ArgTypes needs to be forwarded
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callable) noexcept
-    // AXIVION Next Line AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.3, CertC++-EXP55 : Type-safety ensured by casting
-    // back on call
+    // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.3, CertC++-EXP55 : Type-safety ensured by
+    // casting back on call
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-type-const-cast)
     : m_pointerToCallable(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(callable))))
     // AXIVION Next Line AutosarC++19_03-A15.4.4 : Lambda not 'noexcept' as callable might throw
     , m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
-        // AXIVION Next Line AutosarC++19_03-A5.2.4, CertC++-EXP36 : Type-safety ensured by casting from type
-        // AXIVION Next Line AutosarC++19_03-A5.3.2, AutosarC++19_03-M5.2.8 : Check for 'nullptr' is performed on call
+        // AXIVION Next Construct AutosarC++19_03-A5.2.4, CertC++-EXP36 : Type-safety ensured by casting from type
+        // AXIVION Next Construct AutosarC++19_03-A5.3.2, AutosarC++19_03-M5.2.8 : Check for 'nullptr' is performed on
+        // call
+        // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
         return (*reinterpret_cast<typename std::add_pointer<CallableType>::type>(target))(
             std::forward<ArgTypes>(args)...);
     })
@@ -48,21 +51,22 @@ inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callab
 
 template <class ReturnType, class... ArgTypes>
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(ReturnType (&function)(ArgTypes...)) noexcept
-{
     // the cast is required to work on POSIX systems
-    // AXIVION Next Line AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.4-M5.2.6 : Type-safety ensured by casting back on
-    // call
-    m_pointerToCallable = reinterpret_cast<void*>(function);
-
+    // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.4-M5.2.6 : Type-safety ensured by casting
+    // back on call NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+    : m_pointerToCallable(reinterpret_cast<void*>(function))
+    ,
     // the lambda does not capture and is thus convertible to a function pointer
     // (required by the C++ standard)
-    m_functionPointer = [](void* target, ArgTypes... args) -> ReturnType {
+    m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
         using PointerType = ReturnType (*)(ArgTypes...);
-        // AXIVION Next Line AutosarC++19_03-A5.2.4 : Type-safety ensured by casting from type
-        PointerType f{reinterpret_cast<PointerType>(target)};
+        // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type-safety ensured by casting from type
+        // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+        PointerType f = reinterpret_cast<PointerType>(target);
         // AXIVION Next Line AutosarC++19_03-A5.3.2 : Check for 'nullptr' is performed on call
         return f(args...);
-    };
+    })
+{
 }
 
 template <class ReturnType, class... ArgTypes>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
@@ -39,10 +39,10 @@ inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callab
     : m_pointerToCallable(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(callable))))
     // AXIVION Next Line AutosarC++19_03-A15.4.4 : Lambda not 'noexcept' as callable might throw
     , m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
-        // AXIVION Next Construct AutosarC++19_03-A5.2.4, CertC++-EXP36 : Type-safety ensured by casting from type
-        // AXIVION Next Construct AutosarC++19_03-A5.3.2, AutosarC++19_03-M5.2.8 : Check for 'nullptr' is performed on
-        // call
-        // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+        // AXIVION Next Construct AutosarC++19_03-A5.2.4, CertC++-EXP36 : The class design ensures a cast to the actual
+        // type of target
+        // AXIVION Next Construct AutosarC++19_03-A5.3.2, AutosarC++19_03-M5.2.8 : Check for 'nullptr' is
+        // performed on call NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
         return (*reinterpret_cast<typename std::add_pointer<CallableType>::type>(target))(
             std::forward<ArgTypes>(args)...);
     })
@@ -53,7 +53,7 @@ template <class ReturnType, class... ArgTypes>
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(ReturnType (&function)(ArgTypes...)) noexcept
     // the cast is required to work on POSIX systems
     // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.4-M5.2.6 : Type-safety ensured by casting
-    // back on call
+    // back function pointer on call
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
     : m_pointerToCallable(reinterpret_cast<void*>(function))
     ,
@@ -61,7 +61,7 @@ inline function_ref<ReturnType(ArgTypes...)>::function_ref(ReturnType (&function
     // (required by the C++ standard)
     m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
         using PointerType = ReturnType (*)(ArgTypes...);
-        // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type-safety ensured by casting from type
+        // AXIVION Next Construct AutosarC++19_03-A5.2.4 : The class design ensures a cast to the actual type of target
         // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
         PointerType f = reinterpret_cast<PointerType>(target);
         // AXIVION Next Line AutosarC++19_03-A5.3.2 : Check for 'nullptr' is performed on call

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
@@ -29,9 +29,9 @@ namespace cxx
 {
 template <class ReturnType, class... ArgTypes>
 template <typename CallableType, typename>
-// AXIVION Next Line AutosarC++19_03-A12.1.2 : Members are initialized in the same manner, NSDMI with nullptr is
+// AXIVION Next Construct AutosarC++19_03-A12.1.2 : Members are initialized in the same manner, NSDMI with nullptr is
 // explicit
-// AXIVION Next Line AutosarC++19_03-A8.4.6 : Only ArgTypes needs to be forwarded
+// AXIVION Next Construct AutosarC++19_03-A8.4.6 : Only ArgTypes needs to be forwarded
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callable) noexcept
     // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.3, CertC++-EXP55 : Type-safety ensured by
     // casting back on call
@@ -53,7 +53,8 @@ template <class ReturnType, class... ArgTypes>
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(ReturnType (&function)(ArgTypes...)) noexcept
     // the cast is required to work on POSIX systems
     // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.4-M5.2.6 : Type-safety ensured by casting
-    // back on call NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+    // back on call
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
     : m_pointerToCallable(reinterpret_cast<void*>(function))
     ,
     // the lambda does not capture and is thus convertible to a function pointer

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function_ref.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function_ref.cpp
@@ -25,21 +25,21 @@ namespace
 using namespace ::testing;
 using namespace iox::cxx;
 
-constexpr int freeFuncTestValue = 42 + 42;
-constexpr int functorTestValue = 11;
-constexpr int memberFuncTestValue = 4273;
-constexpr int sameSignatureIntTestValue = 12345;
-constexpr int sameSignatureVoidTestValue = 12346;
-constexpr int sameSignatureIntIntTestValue = 12347;
+constexpr int FREE_FUNC_TEST_VALUE = 42 + 42;
+constexpr int FUNCTOR_TEST_VALUE = 11;
+constexpr int MEMBER_FUNC_TEST_VALUE = 4273;
+constexpr int SAME_SIGNATURE_INT_TEST_VALUE = 12345;
+constexpr int SAME_SIGNATURE_VOID_TEST_VALUE = 12346;
+constexpr int SAME_SIGNATURE_INT_INT_TEST_VALUE = 12347;
 
 int freeFunction()
 {
-    return freeFuncTestValue;
+    return FREE_FUNC_TEST_VALUE;
 }
 
 void freeVoidFunction(int& arg)
 {
-    arg = freeFuncTestValue;
+    arg = FREE_FUNC_TEST_VALUE;
 }
 
 class Functor
@@ -47,7 +47,7 @@ class Functor
   public:
     int operator()()
     {
-        return functorTestValue;
+        return FUNCTOR_TEST_VALUE;
     }
 };
 
@@ -59,14 +59,7 @@ struct ComplexType
 
     bool operator==(const ComplexType& rhs) const
     {
-        if (a == rhs.a && b == rhs.b && c == rhs.c)
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return (a == rhs.a && b == rhs.b && c == rhs.c);
     }
 };
 
@@ -77,7 +70,7 @@ ComplexType returnComplexType(ComplexType foo)
 
 int SameSignature(function_ref<int(int)> callback)
 {
-    return callback(sameSignatureIntTestValue);
+    return callback(SAME_SIGNATURE_INT_TEST_VALUE);
 }
 
 int SameSignature(function_ref<int(void)> callback)
@@ -87,7 +80,7 @@ int SameSignature(function_ref<int(void)> callback)
 
 int SameSignature(function_ref<int(int, int)> callback)
 {
-    return callback(sameSignatureIntIntTestValue, sameSignatureIntIntTestValue);
+    return callback(SAME_SIGNATURE_INT_INT_TEST_VALUE, SAME_SIGNATURE_INT_INT_TEST_VALUE);
 }
 
 class function_refTest : public Test
@@ -101,9 +94,9 @@ class function_refTest : public Test
     {
     }
 
-    int foobar()
+    static int foobar()
     {
-        return memberFuncTestValue;
+        return MEMBER_FUNC_TEST_VALUE;
     }
 
     uint8_t m_iter{0};
@@ -172,6 +165,8 @@ TEST_F(function_refDeathTest, CallMovedFromLeadsToTermination)
     auto lambda = []() -> int { return 7654; };
     function_ref<int()> sut1{lambda};
     function_ref<int()> sut2{std::move(sut1)};
+    // Use after move is tested here
+    // NOLINTNEXTLINE (bugprone-use-after-move)
     EXPECT_DEATH(sut1(), "Empty function_ref invoked");
 }
 
@@ -218,7 +213,7 @@ TEST_F(function_refTest, CreateValidWithFreeFunctionResultEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "aaf49b6b-054a-4f8f-b176-6d92bb2918da");
     function_ref<int()> sut(freeFunction);
-    EXPECT_THAT(sut(), Eq(freeFuncTestValue));
+    EXPECT_THAT(sut(), Eq(FREE_FUNC_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CreateValidWithComplexTypeResultEqual)
@@ -234,15 +229,15 @@ TEST_F(function_refTest, CreateValidWithFunctorResultEqual)
     ::testing::Test::RecordProperty("TEST_ID", "6fd3609b-3254-429a-96ae-20f6dbe99b2a");
     Functor foo;
     function_ref<int()> sut(foo);
-    EXPECT_THAT(sut(), Eq(functorTestValue));
+    EXPECT_THAT(sut(), Eq(FUNCTOR_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CreateValidWithStdBindResultEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f5f82896-44db-4d2d-96d0-c1b0fbbe5508");
-    auto callable = std::bind(&function_refTest::foobar, this);
+    auto callable = std::bind(&function_refTest::foobar);
     function_ref<int()> sut(callable);
-    EXPECT_THAT(sut(), Eq(memberFuncTestValue));
+    EXPECT_THAT(sut(), Eq(MEMBER_FUNC_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CreateValidWithStdFunctionResultEqual)
@@ -268,21 +263,21 @@ TEST_F(function_refTest, CallOverloadedFunctionResultsInCallOfInt)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3910ee08-305a-4764-82b3-8b8aa7e7038e");
     auto value = SameSignature([](int value) -> int { return value; });
-    EXPECT_THAT(value, Eq(sameSignatureIntTestValue));
+    EXPECT_THAT(value, Eq(SAME_SIGNATURE_INT_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CallOverloadedFunctionResultsInCallOfVoid)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ca8e8384-0b20-4e4a-b372-698c4e6672b7");
-    auto value = SameSignature([](void) -> int { return sameSignatureVoidTestValue; });
-    EXPECT_THAT(value, Eq(sameSignatureVoidTestValue));
+    auto value = SameSignature([](void) -> int { return SAME_SIGNATURE_VOID_TEST_VALUE; });
+    EXPECT_THAT(value, Eq(SAME_SIGNATURE_VOID_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CallOverloadedFunctionResultsInCallOfIntInt)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b37158b6-8100-4f80-bd62-d2957a7d9c46");
     auto value = SameSignature([](int value1, int value2 IOX_MAYBE_UNUSED) -> int { return value1; });
-    EXPECT_THAT(value, Eq(sameSignatureIntIntTestValue));
+    EXPECT_THAT(value, Eq(SAME_SIGNATURE_INT_INT_TEST_VALUE));
 }
 
 TEST_F(function_refTest, CreationWithFunctionPointerWorks)
@@ -292,7 +287,7 @@ TEST_F(function_refTest, CreationWithFunctionPointerWorks)
     function_ref<int(void)> sut(fp);
 
     auto result = sut();
-    EXPECT_EQ(result, freeFuncTestValue);
+    EXPECT_EQ(result, FREE_FUNC_TEST_VALUE);
 }
 
 TEST_F(function_refTest, CreationWithFunctionPointerWithRefArgWorks)
@@ -303,7 +298,7 @@ TEST_F(function_refTest, CreationWithFunctionPointerWithRefArgWorks)
 
     int arg{0};
     sut(arg);
-    EXPECT_EQ(arg, freeFuncTestValue);
+    EXPECT_EQ(arg, FREE_FUNC_TEST_VALUE);
 }
 
 TEST_F(function_refTest, CreationWithFunctionPointerWithComplexTypeArgWorks)


### PR DESCRIPTION
Signed-off-by: Simon Hoinkis <simon.hoinkis@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
* Address `AUTOSAR` warnings with Axivion
* Fix clang-tidy warnings in `cxx::function_ref`
* Findings regardings `Expects` not considered will be addressed as part of #1032 by @MatthiasKillat 

### Todo
* [x] Some suppressions not considered by Axivion -> Fixed
* [x] ~~`M7-1-2`: Shall constness of 'target' be changed?~~
* [x] Discuss `A2-7-3` and `A14-5-2`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partly)
- Closes #1196 (partly)
