### PR TITLE
Iox #1196 fix functional interface warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
@@ -58,6 +58,11 @@ struct HasGetErrorMethod<Derived, cxx::void_t<decltype(std::declval<Derived>().g
 void print_expect_message(const char* message) noexcept;
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct Expect
 {
     /// @brief Expects that the object is valid, otherwise the method prints the
@@ -72,6 +77,11 @@ struct Expect
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ExpectWithValue
 {
     /// @brief Expects that the object is valid and returns the contained value, otherwise
@@ -111,6 +121,11 @@ struct ExpectWithValue
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ValueOr
 {
     /// @brief When the object contains a value a copy will be returned otherwise
@@ -136,6 +151,11 @@ struct ValueOr
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AndThenWithValue
 {
     using and_then_callback_t = cxx::function_ref<void(ValueType&)>;
@@ -183,6 +203,11 @@ struct AndThenWithValue
 };
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AndThen
 {
     using and_then_callback_t = cxx::function_ref<void()>;
@@ -216,6 +241,11 @@ struct AndThen
 };
 
 template <typename Derived, typename ErrorType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct OrElseWithValue
 {
     using or_else_callback_t = cxx::function_ref<void(ErrorType&)>;
@@ -263,6 +293,11 @@ struct OrElseWithValue
 };
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct OrElse
 {
     using or_else_callback_t = cxx::function_ref<void()>;
@@ -296,6 +331,11 @@ struct OrElse
 };
 
 template <typename Derived, typename ValueType, typename ErrorType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl : public ExpectWithValue<Derived, ValueType>,
                                  public ValueOr<Derived, ValueType>,
                                  public AndThenWithValue<Derived, ValueType>,
@@ -306,6 +346,11 @@ struct FunctionalInterfaceImpl : public ExpectWithValue<Derived, ValueType>,
 };
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, void, void>
     : public Expect<Derived>, public AndThen<Derived>, public OrElse<Derived>
 {
@@ -314,6 +359,11 @@ struct FunctionalInterfaceImpl<Derived, void, void>
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, ValueType, void> : public ExpectWithValue<Derived, ValueType>,
                                                            public ValueOr<Derived, ValueType>,
                                                            public AndThenWithValue<Derived, ValueType>,
@@ -324,6 +374,11 @@ struct FunctionalInterfaceImpl<Derived, ValueType, void> : public ExpectWithValu
 };
 
 template <typename Derived, typename ErrorType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, void, ErrorType>
     : public Expect<Derived>, public AndThen<Derived>, public OrElseWithValue<Derived, ErrorType>
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/functional_interface.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/functional_interface.inl
@@ -49,7 +49,7 @@ inline ValueType& ExpectWithValue<Derived, ValueType>::expect(const StringType& 
     static_assert(is_char_array<StringType>::value || is_cxx_string<StringType>::value,
                   "Only char arrays and iox::cxx::strings are allowed as message type.");
 
-    Derived* derivedThis = static_cast<Derived*>(this);
+    auto* derivedThis = static_cast<Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -65,6 +65,8 @@ template <typename StringType>
 inline const ValueType& ExpectWithValue<Derived, ValueType>::expect(const StringType& msg) const& noexcept
 {
     using Self = ExpectWithValue<Derived, ValueType>;
+    // const_cast avoids code duplication, is safe since the constness of the return value is restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<const ValueType&>(const_cast<Self*>(this)->expect(msg));
 }
 
@@ -80,6 +82,8 @@ template <typename StringType>
 inline const ValueType&& ExpectWithValue<Derived, ValueType>::expect(const StringType& msg) const&& noexcept
 {
     using Self = ExpectWithValue<Derived, ValueType>;
+    // const_cast avoids code duplication, is safe since the constness of the return value is restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<const ValueType&&>(std::move(const_cast<Self*>(this)->expect(msg)));
 }
 // END expect
@@ -91,7 +95,7 @@ template <typename Derived, typename ValueType>
 template <typename U>
 inline ValueType ValueOr<Derived, ValueType>::value_or(U&& alternative) const& noexcept
 {
-    const Derived* derivedThis = static_cast<const Derived*>(this);
+    const auto* derivedThis = static_cast<const Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -105,7 +109,7 @@ template <typename Derived, typename ValueType>
 template <typename U>
 inline ValueType ValueOr<Derived, ValueType>::value_or(U&& alternative) && noexcept
 {
-    const Derived* derivedThis = static_cast<const Derived*>(this);
+    const auto* derivedThis = static_cast<const Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -126,7 +130,7 @@ inline Derived& AndThenWithValue<Derived, ValueType>::and_then(const Functor& ca
     static_assert(cxx::is_invocable<Functor, ValueType&>::value,
                   "Only callables with a signature of void(ValueType&) are allowed!");
 
-    Derived* derivedThis = static_cast<Derived*>(this);
+    auto* derivedThis = static_cast<Derived*>(this);
 
     if (*derivedThis)
     {
@@ -151,7 +155,7 @@ inline const Derived& AndThenWithValue<Derived, ValueType>::and_then(const Funct
     static_assert(cxx::is_invocable<Functor, const ValueType&>::value,
                   "Only callables with a signature of void(const ValueType&) are allowed!");
 
-    const Derived* derivedThis = static_cast<const Derived*>(this);
+    const auto* derivedThis = static_cast<const Derived*>(this);
 
     if (*derivedThis)
     {
@@ -172,7 +176,7 @@ inline const Derived&& AndThenWithValue<Derived, ValueType>::and_then(const Func
 template <typename Derived>
 inline Derived& AndThen<Derived>::and_then(const and_then_callback_t& callable) & noexcept
 {
-    Derived* derivedThis = static_cast<Derived*>(this);
+    auto* derivedThis = static_cast<Derived*>(this);
 
     if (*derivedThis)
     {
@@ -186,6 +190,8 @@ template <typename Derived>
 inline const Derived& AndThen<Derived>::and_then(const and_then_callback_t& callable) const& noexcept
 {
     using Self = AndThen<Derived>;
+    // const_cast avoids code duplication, is safe since the constness of the return value is restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<const Derived&>(const_cast<Self*>(this)->and_then(callable));
 }
 
@@ -199,6 +205,8 @@ template <typename Derived>
 inline const Derived&& AndThen<Derived>::and_then(const and_then_callback_t& callable) const&& noexcept
 {
     using Self = AndThen<Derived>;
+    // const_cast avoids code duplication, is safe since the constness of the return value is restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return std::move(const_cast<const Derived&>(const_cast<Self*>(this)->and_then(callable)));
 }
 // END and_then
@@ -213,7 +221,7 @@ inline Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor& call
     static_assert(cxx::is_invocable<Functor, ErrorType&>::value,
                   "Only callables with a signature of void(ErrorType&) are allowed!");
 
-    Derived* derivedThis = static_cast<Derived*>(this);
+    auto* derivedThis = static_cast<Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -238,7 +246,7 @@ inline const Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor
     static_assert(cxx::is_invocable<Functor, ErrorType&>::value,
                   "Only callables with a signature of void(const ErrorType&) are allowed!");
 
-    const Derived* derivedThis = static_cast<const Derived*>(this);
+    const auto* derivedThis = static_cast<const Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -259,7 +267,7 @@ inline const Derived&& OrElseWithValue<Derived, ErrorType>::or_else(const Functo
 template <typename Derived>
 inline Derived& OrElse<Derived>::or_else(const or_else_callback_t& callable) & noexcept
 {
-    Derived* derivedThis = static_cast<Derived*>(this);
+    auto* derivedThis = static_cast<Derived*>(this);
 
     if (!(*derivedThis))
     {
@@ -279,6 +287,8 @@ template <typename Derived>
 inline const Derived& OrElse<Derived>::or_else(const or_else_callback_t& callable) const& noexcept
 {
     using Self = OrElse<Derived>;
+    // const_cast avoids code duplication, is safe since the constness of the return value is restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<const Derived&>(const_cast<Self*>(this)->or_else(callable));
 }
 

--- a/iceoryx_hoofs/test/.clang-tidy
+++ b/iceoryx_hoofs/test/.clang-tidy
@@ -5,11 +5,13 @@ InheritParentConfig:  true
 
 Checks: '
 -cert-err58-cpp,
+-cppcoreguidelines-avoid-magic-numbers,
 -cppcoreguidelines-avoid-non-const-global-variables,
 -cppcoreguidelines-owning-memory,
 -cppcoreguidelines-special-member-functions,
 -hicpp-special-member-functions,
 -readability-identifier-naming,
+-readability-magic-numbers,
 '
 
 ## Justifications for rule deactivation ##
@@ -43,3 +45,12 @@ CheckOptions:
 # EXPECT_*, ASSERT_* and TEST_F, TYPED_TEST macros introduce additional
 # branches and increase the code complexity without affecting the user. Therefore,
 # those metrics are hardly applicable in tests.
+#
+# * rule: cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers
+#   justification: too many false positives and it enforces a less readable code style
+#   example:
+#     bad:
+#       constexpr uint64_t STRING_CAPACITY = 100U;
+#       cxx::string<STRING_CAPACITY> myString; // the 100 is already part of the type name so why not allow it
+#     good:
+#       cxx::string<100> myString; // this leads to a warning but we want it

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
@@ -31,7 +31,7 @@ TYPED_TEST(FunctionalInterface_test, AndThenHasCorrectSignature)
 }
 
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_and_then.cpp
@@ -30,11 +30,16 @@ TYPED_TEST(FunctionalInterface_test, AndThenHasCorrectSignature)
     EXPECT_THAT(DOES_AND_THEN_HAVE_A_VALUE, Eq(Factory::EXPECT_AND_THEN_WITH_VALUE));
 }
 
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_VALUE_METHOD = iox::cxx::internal::HasValueMethod<SutType>::value;                              \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) prevents clang-tidy parsing failures */                              \
     TestName<HAS_VALUE_METHOD>::template performTest<typename TestFixture::TestFactoryType>(                           \
-        [](auto& sut, auto callback) { variationPoint.and_then(callback); })
+        [](auto& sut, auto callback) { (variationPoint).and_then(callback); })
 
 constexpr bool TYPE_HAS_VALUE_METHOD = true;
 constexpr bool TYPE_HAS_NO_VALUE_METHOD = false;
@@ -82,6 +87,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenIsCalledCorrectlyWhenValid_LValueCas
 TYPED_TEST(FunctionalInterface_test, AndThenIsCalledCorrectlyWhenValid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "80724fcd-78a4-4f52-82fe-1613069823f0");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenIsCalledCorrectlyWhenValid, const_cast<const SutType&>(sut));
 }
 
@@ -94,6 +101,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenIsCalledCorrectlyWhenValid_RValueCas
 TYPED_TEST(FunctionalInterface_test, AndThenIsCalledCorrectlyWhenValid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "225f1e86-6b37-47db-9e1f-f44040040e8a");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenIsCalledCorrectlyWhenValid, std::move(const_cast<const SutType&>(sut)));
 }
 
@@ -137,6 +146,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenIsNotCalledWhenInvalid_LValueCase)
 TYPED_TEST(FunctionalInterface_test, AndThenIsNotCalledWhenInvalid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1fcd75d8-ce17-49c3-8a0a-d676d649b985");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenIsNotCalledWhenInvalid, const_cast<const SutType&>(sut));
 }
 
@@ -149,6 +160,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenIsNotCalledWhenInvalid_RValueCase)
 TYPED_TEST(FunctionalInterface_test, AndThenIsNotCalledWhenInvalid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d4162bb7-c2b3-4c82-bb78-bc63acf4b3b9");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenIsNotCalledWhenInvalid, std::move(const_cast<const SutType&>(sut)));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_common.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_common.cpp
@@ -18,6 +18,7 @@
 
 namespace test_cxx_functional_interface
 {
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) only for testing purposes
 GenericValueError::GenericValueError(const value_t value, const error_t error) noexcept
     : m_value{value}
     , m_error{error}
@@ -41,11 +42,17 @@ const GenericValueError::value_t& GenericValueError::value() const& noexcept
 
 GenericValueError::value_t&& GenericValueError::value() && noexcept
 {
+    // we must use std::move otherwise m_value is not converted into a rvalue
+    // which would lead to a compile failure
+    // NOLINTNEXTLINE(hicpp-move-const-arg, performance-move-const-arg)
     return std::move(m_value);
 }
 
 const GenericValueError::value_t&& GenericValueError::value() const&& noexcept
 {
+    // we must use std::move otherwise m_value is not converted into a rvalue
+    // which would lead to a compile failure
+    // NOLINTNEXTLINE(hicpp-move-const-arg, performance-move-const-arg)
     return std::move(m_value);
 }
 
@@ -61,17 +68,25 @@ const GenericValueError::error_t& GenericValueError::get_error() const& noexcept
 
 GenericValueError::error_t&& GenericValueError::get_error() && noexcept
 {
+    // we must use std::move otherwise m_value is not converted into a rvalue
+    // which would lead to a compile failure
+    // NOLINTNEXTLINE(hicpp-move-const-arg, performance-move-const-arg)
     return std::move(m_error);
 }
 
 const GenericValueError::error_t&& GenericValueError::get_error() const&& noexcept
 {
+    // we must use std::move otherwise m_value is not converted into a rvalue
+    // which would lead to a compile failure
+    // NOLINTNEXTLINE(hicpp-move-const-arg, performance-move-const-arg)
     return std::move(m_error);
 }
 
-GenericPlain::GenericPlain(const int value, const int)
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) only for testing purposes
+GenericPlain::GenericPlain(const int value, const int error)
     : m_isValid{value != INVALID_VALUE}
 {
+    IOX_DISCARD_RESULT(error);
 }
 
 GenericPlain::operator bool() const noexcept

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_concat_multiple_calls.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_concat_multiple_calls.cpp
@@ -21,7 +21,7 @@ using namespace test_cxx_functional_interface;
 using namespace ::testing;
 
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_concat_multiple_calls.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_concat_multiple_calls.cpp
@@ -20,13 +20,18 @@ namespace
 using namespace test_cxx_functional_interface;
 using namespace ::testing;
 
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_VALUE_METHOD = iox::cxx::internal::HasValueMethod<SutType>::value;                              \
     constexpr bool HAS_GET_ERROR_METHOD = iox::cxx::internal::HasGetErrorMethod<SutType>::value;                       \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) prevents clang-tidy parsing failures */                              \
     TestName<HAS_VALUE_METHOD, HAS_GET_ERROR_METHOD>::template performTest<typename TestFixture::TestFactoryType>(     \
         [](auto& sut, auto andThenCallback, auto orElseCallback) {                                                     \
-            variationPoint.and_then(andThenCallback).or_else(orElseCallback);                                          \
+            (variationPoint).and_then(andThenCallback).or_else(orElseCallback);                                        \
         })
 
 constexpr bool TYPE_HAS_VALUE_METHOD = true;
@@ -124,6 +129,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorksWhenInvalid_L
 TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorksWhenInvalid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7810e0de-ac7f-4247-9adc-4177294bb60f");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenOrElseConcatenatedWorksWhenInvalid, const_cast<const SutType&>(sut));
 }
 
@@ -137,6 +144,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorksWhenInvalid_C
 {
     ::testing::Test::RecordProperty("TEST_ID", "4ca6c6d0-fa72-45ff-a2ae-9b7a9574c450");
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenOrElseConcatenatedWorksWhenInvalid,
+                                  // const_cast avoids code duplication
+                                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                                   std::move(const_cast<const SutType&>(sut)));
 }
 
@@ -230,6 +239,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorkWhenValid_LVal
 TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorkWhenValid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d70fd26a-f8bb-4976-b119-409651301e1b");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenOrElseConcatenatedWorkWhenValid, const_cast<SutType&>(sut));
 }
 
@@ -242,6 +253,8 @@ TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorkWhenValid_RVal
 TYPED_TEST(FunctionalInterface_test, AndThenOrElseConcatenatedWorkWhenValid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "96b3f8d5-07e0-407e-8e7e-5c7ae258a623");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(AndThenOrElseConcatenatedWorkWhenValid, std::move(const_cast<SutType&>(sut)));
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_expect.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_expect.cpp
@@ -24,7 +24,7 @@ using namespace test_cxx_functional_interface;
 using namespace ::testing;
 
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
@@ -130,9 +130,8 @@ template <>
 struct ExpectReturnsValueWhenValid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ExpectCall>
-    static void performTest(const ExpectCall& callExpect)
+    static void performTest(const ExpectCall& callExpect IOX_MAYBE_UNUSED)
     {
-        IOX_DISCARD_RESULT(callExpect);
     }
 };
 
@@ -149,7 +148,7 @@ struct ExpectReturnsValueWhenValid<TYPE_HAS_VALUE_METHOD>
 
 #undef IOX_TEST_FUNCTIONAL_INTERFACE
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_expect.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_expect.cpp
@@ -23,11 +23,16 @@ namespace
 using namespace test_cxx_functional_interface;
 using namespace ::testing;
 
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) prevents clang-tidy parsing failures */                              \
     TestName<typename TestFixture::TestFactoryType, SutType>([](auto& sut) {                                           \
-        variationPoint.expect(                                                                                         \
-            "hypnotoad eats unicorns for breakfast - just kidding, hypnotoad would never harm another being");         \
+        (variationPoint)                                                                                               \
+            .expect("hypnotoad eats unicorns for breakfast - just kidding, hypnotoad would never harm another being"); \
     })
 
 template <typename FactoryType, typename SutType, typename ExpectCall>
@@ -53,6 +58,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectDoesNotCallTerminateWhenObjectIsValid
 TYPED_TEST(FunctionalInterface_test, ExpectDoesNotCallTerminateWhenObjectIsValid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "252fe5e0-eb3e-4e9b-a03d-36c4e2344d39");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectDoesNotCallTerminateWhenObjectIsValid, const_cast<const SutType&>(sut));
 }
 
@@ -66,6 +73,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectDoesNotCallTerminateWhenObjectIsValid
 {
     ::testing::Test::RecordProperty("TEST_ID", "86bd8ee1-7b05-4e64-88c6-b4359f87d346");
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectDoesNotCallTerminateWhenObjectIsValid,
+                                  // const_cast avoids code duplication
+                                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                                   std::move(const_cast<const SutType&>(sut)));
 }
 
@@ -76,6 +85,8 @@ void ExpectDoesCallTerminateWhenObjectIsInvalid(const ExpectCall& callExpect)
     {
         auto handle =
             iox::ErrorHandlerMock::setTemporaryErrorHandler<iox::HoofsError>([&](auto, auto) { std::terminate(); });
+        // todo #1196 remove EXPECT_DEATH
+        // NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
         EXPECT_DEATH(callExpect(sut), ".*");
     }
 }
@@ -89,6 +100,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectDoesCallTerminateWhenObjectIsInvalid_
 TYPED_TEST(FunctionalInterface_test, ExpectDoesCallTerminateWhenObjectIsInvalid_constLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "52e66941-416a-45d6-bb33-e6a1c3824692");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectDoesCallTerminateWhenObjectIsInvalid, const_cast<const SutType&>(sut));
 }
 
@@ -102,6 +115,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectDoesCallTerminateWhenObjectIsInvalid_
 {
     ::testing::Test::RecordProperty("TEST_ID", "cbdf0b40-d4bb-41a6-b811-dcafc96c86de");
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectDoesCallTerminateWhenObjectIsInvalid,
+                                  // const_cast avoids code duplication
+                                  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
                                   std::move(const_cast<const SutType&>(sut)));
 }
 
@@ -115,8 +130,9 @@ template <>
 struct ExpectReturnsValueWhenValid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ExpectCall>
-    static void performTest(const ExpectCall&)
+    static void performTest(const ExpectCall& callExpect)
     {
+        IOX_DISCARD_RESULT(callExpect);
     }
 };
 
@@ -132,12 +148,17 @@ struct ExpectReturnsValueWhenValid<TYPE_HAS_VALUE_METHOD>
 };
 
 #undef IOX_TEST_FUNCTIONAL_INTERFACE
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_VALUE_METHOD = iox::cxx::internal::HasValueMethod<SutType>::value;                              \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) prevents clang-tidy parsing failures */                              \
     TestName<HAS_VALUE_METHOD>::template performTest<typename TestFixture::TestFactoryType>([](auto& sut) {            \
-        return variationPoint.expect(                                                                                  \
-            "hypnotoad eats unicorns for breakfast - just kidding, hypnotoad would never harm another being");         \
+        return (variationPoint)                                                                                        \
+            .expect("hypnotoad eats unicorns for breakfast - just kidding, hypnotoad would never harm another being"); \
     })
 
 
@@ -150,6 +171,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectReturnsValueWhenValid_LValueCase)
 TYPED_TEST(FunctionalInterface_test, ExpectReturnsValueWhenValid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b699d117-ba1d-4806-86b3-0a92dc255cbb");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectReturnsValueWhenValid, const_cast<const SutType&>(sut));
 }
 
@@ -162,6 +185,8 @@ TYPED_TEST(FunctionalInterface_test, ExpectReturnsValueWhenValid_RValueCase)
 TYPED_TEST(FunctionalInterface_test, ExpectReturnsValueWhenValid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "49e22cde-eae3-4fb5-b078-7a5d53916171");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(ExpectReturnsValueWhenValid, std::move(const_cast<const SutType&>(sut)));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
@@ -30,11 +30,16 @@ TYPED_TEST(FunctionalInterface_test, OrElseHasCorrectSignature)
     EXPECT_THAT(DOES_OR_ELSE_HAVE_A_VALUE, Eq(Factory::EXPECT_OR_ELSE_WITH_VALUE));
 }
 
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_GET_ERROR_METHOD = iox::cxx::internal::HasGetErrorMethod<SutType>::value;                       \
+    /* NOLINTNEXTLINE(bugprone-macro-parentheses) prevents clang-tidy parsing failures */                              \
     TestName<HAS_GET_ERROR_METHOD>::template performTest<typename TestFixture::TestFactoryType>(                       \
-        [](auto& sut, auto callback) { variationPoint.or_else(callback); })
+        [](auto& sut, auto callback) { (variationPoint).or_else(callback); })
 
 constexpr bool TYPE_HAS_GET_ERROR_METHOD = true;
 constexpr bool TYPE_HAS_NO_GET_ERROR_METHOD = false;
@@ -80,6 +85,8 @@ TYPED_TEST(FunctionalInterface_test, OrElseIsCalledCorrectlyWhenInvalid_LValueCa
 TYPED_TEST(FunctionalInterface_test, OrElseIsCalledCorrectlyWhenInvalid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "851ca90c-4433-4a6d-9a7b-08cdca78b3c4");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseIsCalledCorrectlyWhenInvalid, const_cast<const SutType&>(sut));
 }
 
@@ -92,6 +99,8 @@ TYPED_TEST(FunctionalInterface_test, OrElseIsCalledCorrectlyWhenInvalid_RValueCa
 TYPED_TEST(FunctionalInterface_test, OrElseIsCalledCorrectlyWhenInvalid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1c85d1bb-7934-43ad-b08e-87cafa5dce26");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseIsCalledCorrectlyWhenInvalid, std::move(const_cast<const SutType&>(sut)));
 }
 
@@ -133,6 +142,8 @@ TYPED_TEST(FunctionalInterface_test, OrElseIsNotCalledWhenValid_LValueCase)
 TYPED_TEST(FunctionalInterface_test, OrElseIsNotCalledWhenValid_ConstLValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4a061c42-eb93-4fc4-ad30-a117f8703659");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseIsNotCalledWhenValid, const_cast<const SutType&>(sut));
 }
 
@@ -145,6 +156,8 @@ TYPED_TEST(FunctionalInterface_test, OrElseIsNotCalledWhenValid_RValueCase)
 TYPED_TEST(FunctionalInterface_test, OrElseIsNotCalledWhenValid_ConstRValueCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6e58eee9-9c99-4ade-b144-d83821a25170");
+    // const_cast avoids code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     IOX_TEST_FUNCTIONAL_INTERFACE(OrElseIsNotCalledWhenValid, std::move(const_cast<const SutType&>(sut)));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_or_else.cpp
@@ -31,7 +31,7 @@ TYPED_TEST(FunctionalInterface_test, OrElseHasCorrectSignature)
 }
 
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_types.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_types.cpp
@@ -31,10 +31,11 @@ void GenericValueErrorFactory::configureNextTestCase() noexcept
     // we increment all the values with an arbitrary value (23) int every test case
     // so that we have some variation with every test and reduce the false positives
     // probability due to memory corruptions
-    usedTestValue += 23;
-    anotherTestValue += 23;
-    usedErrorValue += 23;
-    anotherErrorValue += 23;
+    constexpr value_t NEXT_CASE_INCREMENT_VALUE = 23;
+    usedTestValue += NEXT_CASE_INCREMENT_VALUE;
+    anotherTestValue += NEXT_CASE_INCREMENT_VALUE;
+    usedErrorValue += NEXT_CASE_INCREMENT_VALUE;
+    anotherErrorValue += NEXT_CASE_INCREMENT_VALUE;
 }
 
 GenericValueErrorFactory::Type GenericValueErrorFactory::createValidObject() noexcept
@@ -81,8 +82,10 @@ void OptionalFactory::configureNextTestCase() noexcept
     // we increment all the values with an arbitrary value every test case
     // so that we have some variation with every test and reduce the false positives
     // probability due to memory corruptions
-    usedTestValue += 67;
-    anotherTestValue += 69;
+    constexpr value_t NEXT_CASE_VALUE_INCREMENT = 67;
+    constexpr value_t NEXT_CASE_VALUE_2_INCREMENT = 69;
+    usedTestValue += NEXT_CASE_VALUE_INCREMENT;
+    anotherTestValue += NEXT_CASE_VALUE_2_INCREMENT;
 }
 
 OptionalFactory::Type OptionalFactory::createValidObject() noexcept
@@ -111,10 +114,12 @@ void ExpectedValueErrorFactory::configureNextTestCase() noexcept
     // we increment all the values with an static arbitrary value in every test case
     // so that we have some variation with every test and reduce the false positives
     // probability due to memory corruptions
-    usedTestValue += 189;
-    anotherTestValue += 189;
-    usedErrorValue += 191;
-    anotherErrorValue += 191;
+    constexpr value_t NEXT_CASE_VALUE_INCREMENT = 189;
+    constexpr error_t NEXT_CASE_ERROR_INCREMENT = 191;
+    usedTestValue += NEXT_CASE_VALUE_INCREMENT;
+    anotherTestValue += NEXT_CASE_VALUE_INCREMENT;
+    usedErrorValue += NEXT_CASE_ERROR_INCREMENT;
+    anotherErrorValue += NEXT_CASE_ERROR_INCREMENT;
 }
 
 ExpectedValueErrorFactory::Type ExpectedValueErrorFactory::createValidObject() noexcept
@@ -141,8 +146,9 @@ void ExpectedErrorFactory::configureNextTestCase() noexcept
     // we increment all the values with an static arbitrary value in every test case
     // so that we have some variation with every test and reduce the false positives
     // probability due to memory corruptions
-    usedErrorValue += 191;
-    anotherErrorValue += 191;
+    constexpr error_t NEXT_CASE_INCREMENT_VALUE = 191;
+    usedErrorValue += NEXT_CASE_INCREMENT_VALUE;
+    anotherErrorValue += NEXT_CASE_INCREMENT_VALUE;
 }
 
 ExpectedErrorFactory::Type ExpectedErrorFactory::createValidObject() noexcept

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_value_or.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_value_or.cpp
@@ -25,10 +25,10 @@ constexpr bool TYPE_HAS_VALUE_METHOD = true;
 constexpr bool TYPE_HAS_NO_VALUE_METHOD = false;
 
 // the macro is used as code generator to make the tests more readable. because of the
-// template nature of those tests this is cannot be implemented in the same readable fashion
+// template nature of those tests this cannot be implemented in the same readable fashion
 // as with macros
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
+#define IOX_TEST_FUNCTIONAL_INTERFACE(variationPoint)                                                                  \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_VALUE_METHOD = iox::cxx::internal::HasValueMethod<SutType>::value;                              \
     ValueOrReturnsValueWhenValid<HAS_VALUE_METHOD>::template performTest<typename TestFixture::TestFactoryType>(       \
@@ -42,9 +42,8 @@ template <>
 struct ValueOrReturnsValueWhenValid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ValueOrCall>
-    static void performTest(const ValueOrCall& callValueOr)
+    static void performTest(const ValueOrCall& callValueOr IOX_MAYBE_UNUSED)
     {
-        IOX_DISCARD_RESULT(callValueOr);
     }
 };
 
@@ -62,13 +61,13 @@ struct ValueOrReturnsValueWhenValid<TYPE_HAS_VALUE_METHOD>
 TYPED_TEST(FunctionalInterface_test, ValueOrReturnsValueWhenValid_LValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "88a8f419-6df9-4d8c-9e60-039100d67efa");
-    IOX_TEST_FUNCTIONAL_INTERFACE(ValueOrReturnsValueWhenValid, sut);
+    IOX_TEST_FUNCTIONAL_INTERFACE(sut);
 }
 
 TYPED_TEST(FunctionalInterface_test, ValueOrReturnsValueWhenValid_RValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2783061c-e746-4413-88e9-6b10065dd06a");
-    IOX_TEST_FUNCTIONAL_INTERFACE(ValueOrReturnsValueWhenValid, std::move(sut));
+    IOX_TEST_FUNCTIONAL_INTERFACE(std::move(sut));
 }
 
 template <bool HasValue>
@@ -78,9 +77,8 @@ template <>
 struct ValueOrReturnsArgumentWhenInalid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ValueOrCall>
-    static void performTest(const ValueOrCall& callValueOr)
+    static void performTest(const ValueOrCall& callValueOr IOX_MAYBE_UNUSED)
     {
-        IOX_DISCARD_RESULT(callValueOr);
     }
 };
 
@@ -98,13 +96,13 @@ struct ValueOrReturnsArgumentWhenInalid<TYPE_HAS_VALUE_METHOD>
 TYPED_TEST(FunctionalInterface_test, ValueOrReturnsArgumentWhenInalid_LValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b1398860-a440-4857-9a25-7e5bb9dc2fc9");
-    IOX_TEST_FUNCTIONAL_INTERFACE(ValueOrReturnsArgumentWhenInalid, sut);
+    IOX_TEST_FUNCTIONAL_INTERFACE(sut);
 }
 
 TYPED_TEST(FunctionalInterface_test, ValueOrReturnsArgumentWhenInalid_RValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f85dcc3d-684d-4b32-9f1d-e7ac5ee45c0f");
-    IOX_TEST_FUNCTIONAL_INTERFACE(ValueOrReturnsArgumentWhenInalid, std::move(sut));
+    IOX_TEST_FUNCTIONAL_INTERFACE(std::move(sut));
 }
 
 #undef IOX_TEST_FUNCTIONAL_INTERFACE

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_value_or.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_value_or.cpp
@@ -24,11 +24,15 @@ using namespace ::testing;
 constexpr bool TYPE_HAS_VALUE_METHOD = true;
 constexpr bool TYPE_HAS_NO_VALUE_METHOD = false;
 
+// the macro is used as code generator to make the tests more readable. because of the
+// template nature of those tests this is cannot be implemented in the same readable fashion
+// as with macros
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_TEST_FUNCTIONAL_INTERFACE(TestName, variationPoint)                                                        \
     using SutType = typename TestFixture::TestFactoryType::Type;                                                       \
     constexpr bool HAS_VALUE_METHOD = iox::cxx::internal::HasValueMethod<SutType>::value;                              \
     ValueOrReturnsValueWhenValid<HAS_VALUE_METHOD>::template performTest<typename TestFixture::TestFactoryType>(       \
-        [](auto& sut, auto alternativeValue) { return variationPoint.value_or(alternativeValue); });
+        [](auto& sut, auto alternativeValue) { return (variationPoint).value_or(alternativeValue); });
 
 
 template <bool HasValue>
@@ -38,8 +42,9 @@ template <>
 struct ValueOrReturnsValueWhenValid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ValueOrCall>
-    static void performTest(const ValueOrCall&)
+    static void performTest(const ValueOrCall& callValueOr)
     {
+        IOX_DISCARD_RESULT(callValueOr);
     }
 };
 
@@ -73,8 +78,9 @@ template <>
 struct ValueOrReturnsArgumentWhenInalid<TYPE_HAS_NO_VALUE_METHOD>
 {
     template <typename TestFactory, typename ValueOrCall>
-    static void performTest(const ValueOrCall&)
+    static void performTest(const ValueOrCall& callValueOr)
     {
+        IOX_DISCARD_RESULT(callValueOr);
     }
 };
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
