### PR TITLE
Iox #1196 fix stack warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
@@ -23,11 +23,13 @@ namespace iox
 {
 namespace cxx
 {
+// AXIVION Construct Ruleset-A12.1.1 : it is guaranteed that the array elements are initialized on access
 /// @brief stack implementation with a simple push pop interface
 /// @tparam T type which the stack contains
 /// @tparam Capacity the capacity of the stack
+/// @NOLINTJUSTIFICATION same as AXIVION comment
 template <typename T, uint64_t Capacity>
-class stack
+class stack // NOLINT (cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 {
   public:
     /// @brief returns the last pushed element when the stack contains elements
@@ -48,7 +50,13 @@ class stack
     static constexpr uint64_t capacity() noexcept;
 
   private:
+    // AXIVION Next Line Ruleset-A18.1.1 : safe access is guaranteed since the char array is wrapped inside the stack
+    // class
+    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     using element_t = uint8_t[sizeof(T)];
+    // AXIVION Next Line Ruleset-A18.1.1 : safe access is guaranteed since the char array is wrapped inside the stack
+    // class
+    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     alignas(T) element_t m_data[Capacity];
     uint64_t m_size = 0U;
 };

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -16,6 +16,8 @@
 #ifndef IOX_HOOFS_CXX_STACK_INL
 #define IOX_HOOFS_CXX_STACK_INL
 
+#include "iceoryx_hoofs/cxx/stack.hpp"
+
 namespace iox
 {
 namespace cxx
@@ -28,6 +30,9 @@ inline cxx::optional<T> stack<T, Capacity>::pop() noexcept
         return cxx::nullopt;
     }
 
+    // low level memory management with access to the topmost element on the untyped buffer;
+    // type safety is ensured by the template parameter
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return *reinterpret_cast<T*>(m_data[--m_size]);
 }
 
@@ -40,6 +45,9 @@ inline bool stack<T, Capacity>::push(Targs&&... args) noexcept
         return false;
     }
 
+    // low level memory management with access to the topmost element on the untyped buffer;
+    // type safety is ensured by the template parameter
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     new (reinterpret_cast<T*>(m_data[m_size++])) T(std::forward<Targs>(args)...);
     return true;
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
