### PR TITLE
Iox #1196 fix list warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
@@ -271,6 +271,9 @@ class list
 
         /// @brief construct a const_iterator from an iterator
         /// @param[in] iter is the iterator which will deliver list and index info for the const_iterator
+        /// @NOLINTJUSTIFICATION conversion from non const iterator to const iterator follows the
+        ///                      STL behavior and should be allowed
+        /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
         IteratorBase(const IteratorBase<false>& iter) noexcept;
 
         /// @brief assigns a const_iterator from an iterator; needs to be implemented because the copy c'tor is also
@@ -379,9 +382,14 @@ class list
     // to the beginning and end of the list. This additional element (index position 'capacity' aka
     // BEGIN_END_LINK_INDEX) 'previous' will point to the last valid element (end()) and 'next' will point to the
     // first used list element (begin())
+
+    /// @NOLINTJUSTIFICATION the c arrays are the base of the list and completely wrapped inside
+    ///                      the list. the list ensures a safe access to it.
+    /// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     NodeLink m_links[NODE_LINK_COUNT];
     using element_t = uint8_t[sizeof(T)];
     alignas(T) element_t m_data[Capacity];
+    /// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 
     size_type m_size{0U};
 }; // list

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
@@ -383,7 +383,7 @@ class list
     // BEGIN_END_LINK_INDEX) 'previous' will point to the last valid element (end()) and 'next' will point to the
     // first used list element (begin())
 
-    /// @NOLINTJUSTIFICATION will be replaced by uninitialized array
+    /// @NOLINTJUSTIFICATION todo #1196 will be replaced by uninitialized array
     /// @NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     NodeLink m_links[NODE_LINK_COUNT];
     using element_t = uint8_t[sizeof(T)];

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
@@ -383,13 +383,12 @@ class list
     // BEGIN_END_LINK_INDEX) 'previous' will point to the last valid element (end()) and 'next' will point to the
     // first used list element (begin())
 
-    /// @NOLINTJUSTIFICATION the c arrays are the base of the list and completely wrapped inside
-    ///                      the list. the list ensures a safe access to it.
-    /// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    /// @NOLINTJUSTIFICATION will be replaced by uninitialized array
+    /// @NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     NodeLink m_links[NODE_LINK_COUNT];
     using element_t = uint8_t[sizeof(T)];
     alignas(T) element_t m_data[Capacity];
-    /// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    /// @NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 
     size_type m_size{0U};
 }; // list

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
@@ -26,7 +26,7 @@ namespace iox
 {
 namespace cxx
 {
-/// m_data fields are explicitly initialized whenever a new element is inserted
+/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
 /// into the list
 /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
@@ -35,7 +35,7 @@ inline list<T, Capacity>::list() noexcept
     init();
 }
 
-/// m_data fields are explicitly initialized whenever a new element is inserted
+/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
 /// into the list
 /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
@@ -45,7 +45,7 @@ inline list<T, Capacity>::list(const list& rhs) noexcept
     *this = rhs;
 }
 
-/// m_data fields are explicitly initialized whenever a new element is inserted
+/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
 /// into the list
 /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
@@ -26,12 +26,18 @@ namespace iox
 {
 namespace cxx
 {
+/// m_data fields are explicitly initialized whenever a new element is inserted
+/// into the list
+/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list() noexcept
 {
     init();
 }
 
+/// m_data fields are explicitly initialized whenever a new element is inserted
+/// into the list
+/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list(const list& rhs) noexcept
 {
@@ -39,6 +45,9 @@ inline list<T, Capacity>::list(const list& rhs) noexcept
     *this = rhs;
 }
 
+/// m_data fields are explicitly initialized whenever a new element is inserted
+/// into the list
+/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list(list&& rhs) noexcept
 {
@@ -459,6 +468,9 @@ template <bool IsConstIterator>
 inline typename list<T, Capacity>::template IteratorBase<IsConstIterator>&
 list<T, Capacity>::IteratorBase<IsConstIterator>::operator=(const IteratorBase<false>& rhs) noexcept
 {
+    /// @NOLINTJUSTIFICATION ensure that this and rhs are not the same object without taking the type into account
+    ///                      required since it is possible to assign a non const iterator to a const iterator
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     if (reinterpret_cast<const void*>(this) != reinterpret_cast<const void*>(&rhs))
     {
         m_list = rhs.m_list;
@@ -584,7 +596,10 @@ inline const typename list<T, Capacity>::size_type& list<T, Capacity>::getPrevId
 template <typename T, uint64_t Capacity>
 inline typename list<T, Capacity>::size_type& list<T, Capacity>::getPrevIdx(const size_type idx) noexcept
 {
-    return const_cast<size_type&>(static_cast<const list<T, Capacity>*>(this)->getPrevIdx(idx));
+    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    /// restored
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<size_type&>(const_cast<const list<T, Capacity>*>(this)->getPrevIdx(idx));
 }
 
 template <typename T, uint64_t Capacity>
@@ -595,7 +610,10 @@ inline const typename list<T, Capacity>::size_type& list<T, Capacity>::getNextId
 template <typename T, uint64_t Capacity>
 inline typename list<T, Capacity>::size_type& list<T, Capacity>::getNextIdx(const size_type idx) noexcept
 {
-    return const_cast<size_type&>(static_cast<const list<T, Capacity>*>(this)->getNextIdx(idx));
+    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    /// restored
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<size_type&>(const_cast<const list<T, Capacity>*>(this)->getNextIdx(idx));
 }
 
 template <typename T, uint64_t Capacity>
@@ -640,13 +658,18 @@ inline const T* list<T, Capacity>::getDataPtrFromIdx(const size_type idx) const 
 {
     cxx::Expects(isValidElementIdx(idx) && "invalid list element");
 
+    /// @NOLINTJUSTIFICATION provide type safe access to the encapsulated untyped m_data array
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return &(reinterpret_cast<const T*>(&m_data)[idx]);
 }
 
 template <typename T, uint64_t Capacity>
 inline T* list<T, Capacity>::getDataPtrFromIdx(const size_type idx) noexcept
 {
-    return const_cast<T*>(static_cast<const list<T, Capacity>*>(this)->getDataPtrFromIdx(idx));
+    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    /// restored
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<T*>(const_cast<const list<T, Capacity>*>(this)->getDataPtrFromIdx(idx));
 }
 
 /*************************/

--- a/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
@@ -49,6 +49,7 @@ class list_test : public Test
             classValue = m_value;
         }
 
+        /// @NOLINTJUSTIFICATION only used in tests
         /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
         TestListElement(const int64_t value)
             : m_value(value)
@@ -2441,7 +2442,7 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
             sut1.emplace_front(static_cast<int64_t>(j));
         }
 
-        /// @NOLINTJUSTIFICATION actually the list is trivially copyable and this test verifies this with memcpy
+        /// @NOLINTJUSTIFICATION the list is trivially copyable and this test verifies this with memcpy
         /// @NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         memcpy(otherSutPtr, &sut1, sizeof(sut1));
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
@@ -25,8 +25,8 @@ namespace
 using namespace ::testing;
 using namespace iox::cxx;
 
-static constexpr uint64_t TESTLISTCAPACITY{10U};
-static constexpr int64_t TEST_LIST_ELEMENT_DEFAULT_VALUE{-99L};
+constexpr uint64_t TESTLISTCAPACITY{10U};
+constexpr int64_t TEST_LIST_ELEMENT_DEFAULT_VALUE{-99L};
 
 class list_test : public Test
 {
@@ -49,6 +49,7 @@ class list_test : public Test
             classValue = m_value;
         }
 
+        /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
         TestListElement(const int64_t value)
             : m_value(value)
         {
@@ -57,32 +58,38 @@ class list_test : public Test
         }
 
         TestListElement(const TestListElement& rhs)
+            : m_value{rhs.m_value}
         {
             copyCTor++;
-            m_value = rhs.m_value;
             classValue = m_value;
         }
 
-        TestListElement(TestListElement&& rhs)
+        TestListElement(TestListElement&& rhs) noexcept
+            : m_value{rhs.m_value}
         {
             moveCTor++;
-            m_value = rhs.m_value;
             classValue = m_value;
         }
 
         TestListElement& operator=(const TestListElement& rhs)
         {
-            copyAssignment++;
-            m_value = rhs.m_value;
-            classValue = m_value;
+            if (this != &rhs)
+            {
+                copyAssignment++;
+                m_value = rhs.m_value;
+                classValue = m_value;
+            }
             return *this;
         }
 
-        TestListElement& operator=(TestListElement&& rhs)
+        TestListElement& operator=(TestListElement&& rhs) noexcept
         {
-            moveAssignment++;
-            m_value = rhs.m_value;
-            classValue = m_value;
+            if (this != &rhs)
+            {
+                moveAssignment++;
+                m_value = rhs.m_value;
+                classValue = m_value;
+            }
             return *this;
         }
 
@@ -101,7 +108,7 @@ class list_test : public Test
     };
 
 
-    void SetUp()
+    void SetUp() override
     {
         cTor = 0U;
         customCTor = 0U;
@@ -113,17 +120,10 @@ class list_test : public Test
         classValue = 0U;
     }
 
-    bool isSetupState()
+    static bool isSetupState()
     {
-        if (cTor == 0U && customCTor == 0U && copyCTor == 0U && moveCTor == 0U && moveAssignment == 0U
-            && copyAssignment == 0U && dTor == 0U && classValue == 0U)
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return (cTor == 0U && customCTor == 0U && copyCTor == 0U && moveCTor == 0U && moveAssignment == 0U
+                && copyAssignment == 0U && dTor == 0U && classValue == 0U);
     }
 
     list<TestListElement, TESTLISTCAPACITY> sut;
@@ -276,6 +276,8 @@ TEST_F(list_test, FullWhenFilledWithMoreThanCapacityElements)
     }
 
     EXPECT_THAT(sut.full(), Eq(true));
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(sut.emplace_front(), "");
 }
 TEST_F(list_test, NotFullWhenFilledWithCapacityAndEraseOneElements)
@@ -723,6 +725,8 @@ TEST_F(list_test, EmplaceBackWithMoreThanCapacityElements)
         }
         else
         {
+            /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+            /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
             EXPECT_DEATH(sut1.emplace_back(cnt), "");
         }
         ++cnt;
@@ -745,7 +749,8 @@ TEST_F(list_test, EmplaceWithWrongListIterator)
     ::testing::Test::RecordProperty("TEST_ID", "54b1d551-30d8-4738-a46b-b4c886e9ea50");
     constexpr uint64_t CAPACITY{42U};
     constexpr uint64_t ELEMENT_COUNT{13U};
-    list<TestListElement, CAPACITY> sut11, sut12;
+    list<TestListElement, CAPACITY> sut11;
+    list<TestListElement, CAPACITY> sut12;
     auto iterOfSut1 = sut11.begin();
     auto iterOfSut2 = sut12.begin();
     int64_t cnt = 0;
@@ -756,6 +761,8 @@ TEST_F(list_test, EmplaceWithWrongListIterator)
         ++cnt;
     }
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(sut11.emplace(iterOfSut2, cnt), "");
 }
 
@@ -1477,7 +1484,8 @@ TEST_F(list_test, IteratorDecrementOperatorBeyondBeginWithFullList)
 TEST_F(list_test, IteratorComparisonOfDifferentLists)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0be4cfdd-1abb-4a34-93b1-490b0cf07b9c");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(15842);
     sut11.emplace_front(1584122);
     sut11.emplace_front(158432);
@@ -1489,26 +1497,38 @@ TEST_F(list_test, IteratorComparisonOfDifferentLists)
 
     auto iterSut1 = sut11.begin();
     auto iterSut2 = sut12.begin();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 == iterSut2), "");
 
     iterSut1 = sut11.begin();
     iterSut2 = sut12.begin();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 == iterSut2), "");
 
     iterSut1 = sut11.end();
     iterSut2 = sut12.end();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 == iterSut2), "");
 
     iterSut1 = sut11.begin();
     iterSut2 = sut12.begin();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 != iterSut2), "");
 
     iterSut1 = sut11.begin();
     iterSut2 = sut12.begin();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 != iterSut2), "");
 
     iterSut1 = sut11.end();
     iterSut2 = sut12.end();
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iterSut1 != iterSut2), "");
 }
 
@@ -1516,7 +1536,8 @@ TEST_F(list_test, IteratorComparisonOfDifferentLists)
 TEST_F(list_test, ComparingConstIteratorAndIterator)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0ab56e3f-c22b-4544-806e-04dfda4ce449");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(15842U);
     sut11.emplace_front(1584122U);
     sut11.emplace_front(158432U);
@@ -1603,6 +1624,8 @@ TEST_F(list_test, CopyConstructorWithEmptyList)
 {
     ::testing::Test::RecordProperty("TEST_ID", "65409af0-bd13-4011-bdd7-e1b6aa0d4703");
     list<TestListElement, TESTLISTCAPACITY> sut11;
+    /// @NOLINTJUSTIFICATION the test should explicitly test the copy constructor
+    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     list<TestListElement, TESTLISTCAPACITY> sut12(sut11);
     EXPECT_THAT(copyCTor, Eq(0U));
     EXPECT_THAT(sut12.size(), Eq(0U));
@@ -1661,7 +1684,7 @@ TEST_F(list_test, MoveConstructorWithEmptyList)
 {
     ::testing::Test::RecordProperty("TEST_ID", "42991766-c8dd-4261-814f-837ae99f6647");
     list<TestListElement, TESTLISTCAPACITY> sut11;
-    list<TestListElement, TESTLISTCAPACITY> sut12(sut11);
+    list<TestListElement, TESTLISTCAPACITY> sut12(std::move(sut11));
     EXPECT_THAT(moveCTor, Eq(0U));
     EXPECT_THAT(cTor, Eq(0U));
     EXPECT_THAT(customCTor, Eq(0U));
@@ -1730,7 +1753,8 @@ TEST_F(list_test, DestructorWithFullList)
 TEST_F(list_test, CopyAssignmentWithEmptySource)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d4f0c079-d7bb-4c46-8221-dd0a616537bb");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(812U);
     sut11.emplace_front(81122U);
     sut11.emplace_front(8132U);
@@ -1748,7 +1772,8 @@ TEST_F(list_test, CopyAssignmentWithEmptySource)
 TEST_F(list_test, CopyAssignmentWithEmptyDestination)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9202d629-f0db-482e-9363-456a83410d54");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(5812U);
     sut11.emplace_front(581122U);
     sut11.emplace_front(58132U);
@@ -1770,7 +1795,8 @@ TEST_F(list_test, CopyAssignmentWithEmptyDestination)
 TEST_F(list_test, CopyAssignmentWithLargerDestination)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f16524d0-1493-4f57-8590-211a96fb9849");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(5842U);
     sut11.emplace_front(584122U);
     sut11.emplace_front(58432U);
@@ -1795,7 +1821,8 @@ TEST_F(list_test, CopyAssignmentWithLargerDestination)
 TEST_F(list_test, CopyAssignmentWithLargerSource)
 {
     ::testing::Test::RecordProperty("TEST_ID", "876a0d55-1047-4ec7-8b97-7a90b928fea1");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(15842U);
     sut11.emplace_front(1584122U);
     sut11.emplace_front(158432U);
@@ -1823,7 +1850,8 @@ TEST_F(list_test, CopyAssignmentWithLargerSource)
 TEST_F(list_test, MoveAssignmentWithEmptySource)
 {
     ::testing::Test::RecordProperty("TEST_ID", "135d1210-1434-40f8-b169-ef742622ec41");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(812U);
     sut11.emplace_front(81122U);
     sut11.emplace_front(8132U);
@@ -1840,7 +1868,8 @@ TEST_F(list_test, MoveAssignmentWithEmptySource)
 TEST_F(list_test, MoveAssignmentWithEmptyDestination)
 {
     ::testing::Test::RecordProperty("TEST_ID", "457b17f5-2bea-429c-b836-d30b4006c8be");
-    list<TestListElement, TESTLISTCAPACITY> sut11, sut12;
+    list<TestListElement, TESTLISTCAPACITY> sut11;
+    list<TestListElement, TESTLISTCAPACITY> sut12;
     sut11.emplace_front(5812U);
     sut11.emplace_front(581122U);
     sut11.emplace_front(58132U);
@@ -1867,7 +1896,8 @@ TEST_F(list_test, MoveAssignmentWithEmptyDestination)
 TEST_F(list_test, MoveAssignmentWithLargerDestination)
 {
     ::testing::Test::RecordProperty("TEST_ID", "66e0e3b9-be1d-4e00-a56a-41902255b43c");
-    list<TestListElement, 10U> sut11, sut12;
+    list<TestListElement, 10U> sut11;
+    list<TestListElement, 10U> sut12;
     sut11.emplace_front(5842U);
     sut11.emplace_front(584122U);
     sut11.emplace_front(58432U);
@@ -1892,7 +1922,8 @@ TEST_F(list_test, MoveAssignmentWithLargerDestination)
 TEST_F(list_test, MoveAssignmentWithLargerSource)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c190218d-f3dc-4f44-b4b4-2e8f5b161a65");
-    list<TestListElement, 10U> sut11, sut12;
+    list<TestListElement, 10U> sut11;
+    list<TestListElement, 10U> sut12;
     sut11.emplace_front(15842U);
     sut11.emplace_front(1584122U);
     sut11.emplace_front(158432U);
@@ -2278,6 +2309,8 @@ TEST_F(list_test, invalidIteratorErase)
     ++iter;
     sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(sut.erase(iter), "");
 }
 
@@ -2294,6 +2327,8 @@ TEST_F(list_test, invalidIteratorIncrement)
     ++iter;
     sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(++iter, "");
 }
 
@@ -2310,6 +2345,8 @@ TEST_F(list_test, invalidIteratorDecrement)
     ++iter;
     sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(--iter, "");
 }
 
@@ -2326,6 +2363,8 @@ TEST_F(list_test, invalidIteratorComparison)
     ++iter;
     auto iter2 IOX_MAYBE_UNUSED = sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(sut.cbegin() == iter), "");
 }
 
@@ -2342,6 +2381,8 @@ TEST_F(list_test, invalidIteratorComparisonUnequal)
     ++iter;
     auto iter2 = sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iter2 != iter), "");
 }
 
@@ -2358,6 +2399,8 @@ TEST_F(list_test, invalidIteratorDereferencing)
     ++iter;
     auto iter2 IOX_MAYBE_UNUSED = sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc((*iter).m_value), "");
 }
 
@@ -2374,6 +2417,8 @@ TEST_F(list_test, invalidIteratorAddressOfOperator)
     ++iter;
     auto iter2 IOX_MAYBE_UNUSED = sut.erase(iter);
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(dummyFunc(iter->m_value == 12U), "");
 }
 
@@ -2382,8 +2427,10 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
     ::testing::Test::RecordProperty("TEST_ID", "ce16f50e-8da5-497c-abd5-a3af4ebd78d2");
     uint64_t i = 0U;
     using TestFwdList = list<TestListElement, TESTLISTCAPACITY>;
+    /// @NOLINTJUSTIFICATION required temporary memory buffer for the memcpy test
+    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     alignas(TestFwdList) uint8_t otherSutBuffer[sizeof(TestFwdList)];
-    uint8_t* otherSutPtr = otherSutBuffer;
+    uint8_t* otherSutPtr = &otherSutBuffer[0];
 
     {
         TestFwdList sut1;
@@ -2394,7 +2441,9 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
             sut1.emplace_front(static_cast<int64_t>(j));
         }
 
-        memcpy(reinterpret_cast<void*>(otherSutPtr), reinterpret_cast<const void*>(&sut1), sizeof(sut1));
+        /// @NOLINTJUSTIFICATION actually the list is trivially copyable and this test verifies this with memcpy
+        /// @NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
+        memcpy(otherSutPtr, &sut1, sizeof(sut1));
 
         // overwrite copied-from list before it's being destroyed
         sut1.clear();
@@ -2405,6 +2454,9 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
         }
     }
 
+    /// @NOLINTJUSTIFICATION we need to verify that list is in fact trivially copyable and stored in otherSubBuffer
+    /// therefore we need to cast it
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     for (auto& listElement : *reinterpret_cast<TestFwdList*>(otherSutPtr))
     {
         --i;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
