### PR TITLE
iox-#1196 Fix clang tidy warnings in `cxx::unique_ptr`

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
@@ -39,7 +39,7 @@ class unique_ptr
     ///
     /// @brief unique_ptr Creates an empty unique ptr that owns nothing. Can be passed ownership later via reset.
     ///
-    unique_ptr(const function<void(T*)>& deleter) noexcept;
+    explicit unique_ptr(const function<void(T*)>& deleter) noexcept;
 
     ///
     /// @brief unique_ptr Creates a unique pointer that takes ownership of an object.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -76,13 +76,15 @@ T* unique_ptr<T>::operator->() noexcept
 template <typename T>
 const T* unique_ptr<T>::operator->() const noexcept
 {
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     return const_cast<const T*>(get());
 }
 
 template <typename T>
 unique_ptr<T>::operator bool() const noexcept
 {
-    return get() != nullptr ? true : false;
+    return get();
 }
 
 template <typename T>
@@ -94,6 +96,8 @@ T* unique_ptr<T>::get() noexcept
 template <typename T>
 const T* unique_ptr<T>::get() const noexcept
 {
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     return const_cast<const T*>(m_ptr);
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -84,7 +84,7 @@ const T* unique_ptr<T>::operator->() const noexcept
 template <typename T>
 unique_ptr<T>::operator bool() const noexcept
 {
-    return get();
+    return get() != nullptr;
 }
 
 template <typename T>

--- a/iceoryx_hoofs/test/moduletests/test_cxx_unique_ptr.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_unique_ptr.cpp
@@ -107,6 +107,9 @@ TEST_F(UniquePtrTest, CtorUsingMoveWithObjectPtrAndDeleterSetsPtrToObjectAndCall
 
             // no deleter called during move
             EXPECT_FALSE(m_deleterCalled);
+            // check if move is invalidating the object
+            // NOLINTNEXTLINE (bugprone-use-after-move)
+            EXPECT_FALSE(sut);
             EXPECT_EQ(anotherSut.get(), object);
         }
         // anotherSUT is out of scope and should have called deleter
@@ -130,6 +133,9 @@ TEST_F(UniquePtrTest, MoveAssignmentUniquePtrsSetsPtrToObjectAndCallsDeleter)
 
             // no deleter called during move
             EXPECT_FALSE(m_deleterCalled);
+            // check if move is invalidating the object
+            // NOLINTNEXTLINE (bugprone-use-after-move)
+            EXPECT_FALSE(sut);
             EXPECT_EQ(anotherSut.get(), object);
         }
         // anotherSUT is out of scope and should have called deleter

--- a/iceoryx_hoofs/test/moduletests/test_cxx_unique_ptr.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_unique_ptr.cpp
@@ -25,9 +25,9 @@ namespace
 {
 using namespace ::testing;
 
-static constexpr double_t X_POS = 0.0;
-static constexpr double_t Y_POS = 1.1;
-static constexpr double_t Z_POS = 2.2;
+constexpr double_t X_POS = 0.0;
+constexpr double_t Y_POS = 1.1;
+constexpr double_t Z_POS = 2.2;
 
 struct Position
 {
@@ -39,18 +39,14 @@ struct Position
 class UniquePtrTest : public Test
 {
   public:
-    void SetUp()
+    void SetUp() override
     {
         m_deleterCalled = false;
         m_anotherDeleterCalled = false;
     }
 
-    void TearDown()
-    {
-    }
-
-    bool m_deleterCalled;
-    bool m_anotherDeleterCalled;
+    bool m_deleterCalled{false};
+    bool m_anotherDeleterCalled{false};
 
     iox::cxx::function<void(Position* const)> deleter = [this](Position* const p) {
         m_deleterCalled = true;
@@ -79,7 +75,7 @@ TEST_F(UniquePtrTest, CtorWithObjectPtrAndDeleterSetsPtrToObjectAndCallsDeleter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "85a90fc3-e8b1-4c3d-a15c-ee7f64070b57");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         EXPECT_TRUE(sut);
         EXPECT_EQ(sut.get(), object);
@@ -104,14 +100,13 @@ TEST_F(UniquePtrTest, CtorUsingMoveWithObjectPtrAndDeleterSetsPtrToObjectAndCall
 {
     ::testing::Test::RecordProperty("TEST_ID", "88ae1d4c-d893-4633-9256-766d7e42bcc6");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         {
             auto anotherSut = iox::cxx::unique_ptr<Position>(std::move(sut));
 
             // no deleter called during move
             EXPECT_FALSE(m_deleterCalled);
-            EXPECT_FALSE(sut);
             EXPECT_EQ(anotherSut.get(), object);
         }
         // anotherSUT is out of scope and should have called deleter
@@ -128,14 +123,13 @@ TEST_F(UniquePtrTest, MoveAssignmentUniquePtrsSetsPtrToObjectAndCallsDeleter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b3b67548-bd69-4a6f-a867-f9aaa6d869b1");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         {
             auto anotherSut = std::move(sut);
 
             // no deleter called during move
             EXPECT_FALSE(m_deleterCalled);
-            EXPECT_FALSE(sut);
             EXPECT_EQ(anotherSut.get(), object);
         }
         // anotherSUT is out of scope and should have called deleter
@@ -152,10 +146,10 @@ TEST_F(UniquePtrTest, MoveAssignmentOverwriteAUniquePtrWithAnotherOneAndCallsAno
 {
     ::testing::Test::RecordProperty("TEST_ID", "75a853ef-fd0e-41bd-9ce7-af63e0f67fa9");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         {
-            auto anotherObject = new Position();
+            auto* anotherObject = new Position();
             auto anotherSut = iox::cxx::unique_ptr<Position>(anotherObject, anotherDeleter);
 
             anotherSut = std::move(sut);
@@ -164,6 +158,8 @@ TEST_F(UniquePtrTest, MoveAssignmentOverwriteAUniquePtrWithAnotherOneAndCallsAno
             EXPECT_TRUE(m_anotherDeleterCalled);
             // SUT deleter not called during move
             EXPECT_FALSE(m_deleterCalled);
+            // check if move is invalidating the object
+            // NOLINTNEXTLINE (bugprone-use-after-move)
             EXPECT_FALSE(sut);
             EXPECT_EQ(anotherSut.get(), object);
         }
@@ -180,7 +176,7 @@ TEST_F(UniquePtrTest, MoveAssignmentOverwriteAUniquePtrWithAnotherOneAndCallsAno
 TEST_F(UniquePtrTest, AccessUnderlyingObjectResultsInCorrectValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5a3cc8f1-0744-4e79-85cf-02eb6c5cab9b");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_EQ(sut->x, X_POS);
@@ -189,10 +185,10 @@ TEST_F(UniquePtrTest, AccessUnderlyingObjectResultsInCorrectValue)
 TEST_F(UniquePtrTest, AccessUnderlyingObjectViaGetResultsInCorrectValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b795fa9d-b980-4987-8b94-9ea752a4e71e");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
-    auto objectPtr = sut.get();
+    auto* objectPtr = sut.get();
 
     EXPECT_EQ(objectPtr->x, X_POS);
 }
@@ -200,7 +196,7 @@ TEST_F(UniquePtrTest, AccessUnderlyingObjectViaGetResultsInCorrectValue)
 TEST_F(UniquePtrTest, ReleaseAnObjectResultsInUniquePtrBeingInvalidAndReturnOfObjectPtr)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8a1413a5-15cd-42ff-a05e-9dff158aa047");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_EQ(sut.release(), object);
@@ -230,8 +226,8 @@ TEST_F(UniquePtrTest, ResetToAnExistingObjectPtrResultsInDeleterCalledTwice)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e5da7713-e71d-49b2-8bf6-d6108aab6366");
     {
-        auto object = new Position();
-        auto anotherObject = new Position();
+        auto* object = new Position();
+        auto* anotherObject = new Position();
 
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
@@ -252,10 +248,10 @@ TEST_F(UniquePtrTest, SwapTwoValidUniquePtrsWithDifferentDeletersSucceeds)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c4d5ed18-2d92-44f3-93d9-753bd09f5c1b");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         {
-            auto anotherObject = new Position();
+            auto* anotherObject = new Position();
             auto anotherSut = iox::cxx::unique_ptr<Position>(anotherObject, anotherDeleter);
 
             sut.swap(anotherSut);
@@ -277,7 +273,7 @@ TEST_F(UniquePtrTest, SwapUniquePtrWithADeleterOnlyUniquePtrLeadsToDeletedUnique
 {
     ::testing::Test::RecordProperty("TEST_ID", "9017ba22-ff18-41d4-8590-ccb0d7729435");
     {
-        auto object = new Position();
+        auto* object = new Position();
         auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
         {
             auto anotherSut = iox::cxx::unique_ptr<Position>(anotherDeleter);
@@ -300,7 +296,7 @@ TEST_F(UniquePtrTest, SwapADeleterOnlyUniquePtrWithUniquePtrLeadsToOneValidAndOn
 {
     ::testing::Test::RecordProperty("TEST_ID", "0e7f9cf8-c240-468e-accf-27415fa0fcb1");
     {
-        auto anotherObject = new Position();
+        auto* anotherObject = new Position();
         auto anotherSut = iox::cxx::unique_ptr<Position>(anotherObject, anotherDeleter);
         {
             auto sut = iox::cxx::unique_ptr<Position>(deleter);
@@ -322,7 +318,7 @@ TEST_F(UniquePtrTest, SwapADeleterOnlyUniquePtrWithUniquePtrLeadsToOneValidAndOn
 TEST_F(UniquePtrTest, CompareAUniquePtrWithItselfIsTrue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d12f8cf6-e37e-424a-9ed5-aea580b8bdc9");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_TRUE(sut == sut);
@@ -331,7 +327,7 @@ TEST_F(UniquePtrTest, CompareAUniquePtrWithItselfIsTrue)
 TEST_F(UniquePtrTest, CompareAUniquePtrWithNullIsFalse)
 {
     ::testing::Test::RecordProperty("TEST_ID", "45e6ca29-8164-414c-af01-dc2cbb38de57");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_FALSE(sut == nullptr);
@@ -341,8 +337,8 @@ TEST_F(UniquePtrTest, CompareAUniquePtrWithNullIsFalse)
 TEST_F(UniquePtrTest, CompareAUniquePtrWithAnotherOneOfAnotherObjectIsFalse)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6a6135d2-1a79-49fa-a142-7e19327b6a9f");
-    auto object = new Position;
-    auto anotherObject = new Position;
+    auto* object = new Position;
+    auto* anotherObject = new Position;
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     auto anotherSut = iox::cxx::unique_ptr<Position>(anotherObject, anotherDeleter);
 
@@ -353,7 +349,7 @@ TEST_F(UniquePtrTest, CompareAUniquePtrWithAnotherOneOfAnotherObjectIsFalse)
 TEST_F(UniquePtrTest, NotEqualCompareOfAUniquePtrWithItselfIsFalse)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6305a2d9-28d7-41a0-bb0b-866912a39205");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_FALSE(sut != sut);
@@ -362,8 +358,8 @@ TEST_F(UniquePtrTest, NotEqualCompareOfAUniquePtrWithItselfIsFalse)
 TEST_F(UniquePtrTest, NotEqualCompareOfAUniquePtrWithAnotherOneOfAnotherObjectIsTrue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "58b9cd12-82f9-4e3a-b033-8c57afbd31d7");
-    auto object = new Position;
-    auto anotherObject = new Position;
+    auto* object = new Position;
+    auto* anotherObject = new Position;
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     auto anotherSut = iox::cxx::unique_ptr<Position>(anotherObject, anotherDeleter);
 
@@ -374,7 +370,7 @@ TEST_F(UniquePtrTest, NotEqualCompareOfAUniquePtrWithAnotherOneOfAnotherObjectIs
 TEST_F(UniquePtrTest, NotEqualCompareAUniquePtrWithNullIsTrue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4fe92923-dd5b-4389-92fc-5f7987cdc5ee");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
 
     EXPECT_TRUE(sut != nullptr);
@@ -384,7 +380,7 @@ TEST_F(UniquePtrTest, NotEqualCompareAUniquePtrWithNullIsTrue)
 TEST_F(UniquePtrTest, CanGetUnderlyingPtrFromConstUniquePtr)
 {
     ::testing::Test::RecordProperty("TEST_ID", "75727c11-f721-4a52-816a-a9a3a61e2b43");
-    auto object = new Position();
+    auto* object = new Position();
     const auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     EXPECT_TRUE(sut.get() != nullptr);
 }
@@ -392,7 +388,7 @@ TEST_F(UniquePtrTest, CanGetUnderlyingPtrFromConstUniquePtr)
 TEST_F(UniquePtrTest, CanUseArrowOperatorToAccessObjectInConstUniquePtr)
 {
     ::testing::Test::RecordProperty("TEST_ID", "045a9026-74f5-41ad-9881-14c2502527c4");
-    auto object = new Position();
+    auto* object = new Position();
     const auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     EXPECT_EQ(X_POS, sut->x);
     EXPECT_EQ(Y_POS, sut->y);
@@ -402,7 +398,7 @@ TEST_F(UniquePtrTest, CanUseArrowOperatorToAccessObjectInConstUniquePtr)
 TEST_F(UniquePtrTest, AssigningUniquePtrToNullptrDeletesTheManagedObject)
 {
     ::testing::Test::RecordProperty("TEST_ID", "42821e13-c28c-4274-9f89-10ab342bf372");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     sut = nullptr;
     EXPECT_TRUE(m_deleterCalled);
@@ -411,7 +407,7 @@ TEST_F(UniquePtrTest, AssigningUniquePtrToNullptrDeletesTheManagedObject)
 TEST_F(UniquePtrTest, AssigningUniquePtrToNullptrSetsUnderlyingObjectToNullptr)
 {
     ::testing::Test::RecordProperty("TEST_ID", "eacf4bf4-0fa8-42dd-b0a7-c343a1959282");
-    auto object = new Position();
+    auto* object = new Position();
     auto sut = iox::cxx::unique_ptr<Position>(object, deleter);
     sut = nullptr;
     EXPECT_EQ(nullptr, sut.get());


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
* Address clang-tidy warnings and one AUTOSAR rule

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196 (partly)
