### PR TITLE
iox-#1196 Fix clang tidy warnings in `cxx::variant`

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -123,7 +123,7 @@ class variant
     /// @param[in] args variadic list of arguments which will be forwarded to the constructor to
     ///                 the type at index
     template <uint64_t N, typename... CTorArguments>
-    constexpr variant(const in_place_index<N>& index, CTorArguments&&... args) noexcept;
+    constexpr explicit variant(const in_place_index<N>& index, CTorArguments&&... args) noexcept;
 
     /// @brief creates a variant and perform an in place construction of the type T.
     ///         If T is not part of the variant you get a compiler error.
@@ -133,7 +133,7 @@ class variant
     /// @param[in] args variadic list of arguments which will be forwarded to the constructor to
     ///                 the type
     template <typename T, typename... CTorArguments>
-    constexpr variant(const in_place_type<T>& type, CTorArguments&&... args) noexcept;
+    constexpr explicit variant(const in_place_type<T>& type, CTorArguments&&... args) noexcept;
 
     /// @brief creates a variant from a user supplied value
     /// @tparam[in] T type of the value to be stored in the variant
@@ -142,7 +142,7 @@ class variant
               typename = std::enable_if_t<!std::is_same<std::decay_t<T>, variant>::value>,
               typename std::enable_if_t<!internal::is_in_place_index<std::decay_t<T>>::value, bool> = false,
               typename std::enable_if_t<!internal::is_in_place_type<std::decay_t<T>>::value, bool> = false>
-    constexpr variant(T&& arg) noexcept;
+    constexpr explicit variant(T&& arg) noexcept;
 
     /// @brief if the variant contains an element the elements copy constructor is called
     ///     otherwise an empty variant is copied
@@ -177,6 +177,8 @@ class variant
     /// @param[in] rhs source object for the underlying move assignment
     /// @return reference to the variant itself
     template <typename T>
+    // Correct return type is used through enable_if
+    // NOLINTNEXTLINE (cppcoreguidelines-c-copy-assignment-signature)
     typename std::enable_if<!std::is_same<T, variant<Types...>&>::value, variant<Types...>>::type&
     operator=(T&& rhs) noexcept;
 
@@ -259,8 +261,11 @@ class variant
     constexpr uint64_t index() const noexcept;
 
   private:
-    alignas(algorithm::max(alignof(Types)...)) internal::byte_t m_storage[TYPE_SIZE]{0u};
-    uint64_t m_type_index = INVALID_VARIANT_INDEX;
+    /// @todo #1196 Replace with UninitializedArray
+    // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays)
+    alignas(algorithm::max(alignof(Types)...)) internal::byte_t m_storage[TYPE_SIZE]{0U};
+    // NOLINTEND(cppcoreguidelines-avoid-c-arrays)
+    uint64_t m_type_index{INVALID_VARIANT_INDEX};
 
   private:
     template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -76,7 +76,7 @@ T* unique_ptr<T>::operator->() noexcept
 template <typename T>
 const T* unique_ptr<T>::operator->() const noexcept
 {
-    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // Avoid code duplication
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     return const_cast<const T*>(get());
 }
@@ -96,9 +96,9 @@ T* unique_ptr<T>::get() noexcept
 template <typename T>
 const T* unique_ptr<T>::get() const noexcept
 {
-    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : Avoid code duplication
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
-    return const_cast<const T*>(m_ptr);
+    return const_cast<unique_ptr<T>*>(this)->get();
 }
 
 template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
@@ -30,13 +30,14 @@ inline constexpr variant<Types...>::variant(const variant& rhs) noexcept
 {
     if (m_type_index != INVALID_VARIANT_INDEX)
     {
-        internal::call_at_index<0, Types...>::copyConstructor(
-            m_type_index, const_cast<internal::byte_t*>(rhs.m_storage), m_storage);
+        internal::call_at_index<0, Types...>::copyConstructor(m_type_index, rhs.m_storage, m_storage);
     }
 }
 
 template <typename... Types>
 template <uint64_t N, typename... CTorArguments>
+// First param is helper struct only
+// NOLINTNEXTLINE (hicpp-named-parameter)
 inline constexpr variant<Types...>::variant(const in_place_index<N>&, CTorArguments&&... args) noexcept
 {
     emplace_at_index<N>(std::forward<CTorArguments>(args)...);
@@ -44,6 +45,8 @@ inline constexpr variant<Types...>::variant(const in_place_index<N>&, CTorArgume
 
 template <typename... Types>
 template <typename T, typename... CTorArguments>
+// First param is helper struct only
+// NOLINTNEXTLINE (hicpp-named-parameter)
 inline constexpr variant<Types...>::variant(const in_place_type<T>&, CTorArguments&&... args) noexcept
 {
     emplace<T>(std::forward<CTorArguments>(args)...);
@@ -71,16 +74,14 @@ inline constexpr variant<Types...>& variant<Types...>::operator=(const variant& 
 
             if (m_type_index != INVALID_VARIANT_INDEX)
             {
-                internal::call_at_index<0, Types...>::copyConstructor(
-                    m_type_index, const_cast<internal::byte_t*>(rhs.m_storage), m_storage);
+                internal::call_at_index<0, Types...>::copyConstructor(m_type_index, rhs.m_storage, m_storage);
             }
         }
         else
         {
             if (m_type_index != INVALID_VARIANT_INDEX)
             {
-                internal::call_at_index<0, Types...>::copy(
-                    m_type_index, const_cast<internal::byte_t*>(rhs.m_storage), m_storage);
+                internal::call_at_index<0, Types...>::copy(m_type_index, rhs.m_storage, m_storage);
             }
         }
     }
@@ -137,6 +138,8 @@ inline void variant<Types...>::call_element_destructor() noexcept
     }
 }
 
+// Correct return type is used through enable_if
+// NOLINTNEXTLINE (cppcoreguidelines-c-copy-assignment-signature)
 template <typename... Types>
 template <typename T>
 inline typename std::enable_if<!std::is_same<T, variant<Types...>&>::value, variant<Types...>>::type&
@@ -220,6 +223,8 @@ inline const typename internal::get_type_at_index<0, TypeIndex, Types...>::type*
 variant<Types...>::get_at_index() const noexcept
 {
     using T = typename internal::get_type_at_index<0, TypeIndex, Types...>::type;
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     return const_cast<const T*>(const_cast<variant*>(this)->template get_at_index<TypeIndex>());
 }
 
@@ -231,33 +236,36 @@ inline const T* variant<Types...>::get() const noexcept
     {
         return nullptr;
     }
-    else
-    {
-        return static_cast<const T*>(static_cast<const void*>(m_storage));
-    }
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
+    return static_cast<const T*>(static_cast<const void*>(m_storage));
 }
 
 template <typename... Types>
 template <typename T>
 inline T* variant<Types...>::get() noexcept
 {
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     return const_cast<T*>(const_cast<const variant*>(this)->get<T>());
 }
 
 template <typename... Types>
 template <typename T>
-inline T* variant<Types...>::get_if(T* default_value) noexcept
+inline T* variant<Types...>::get_if(T* defaultValue) noexcept
 {
-    return const_cast<T*>(const_cast<const variant*>(this)->get_if<T>(const_cast<const T*>(default_value)));
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
+    return const_cast<T*>(const_cast<const variant*>(this)->get_if<T>(const_cast<const T*>(defaultValue)));
 }
 
 template <typename... Types>
 template <typename T>
-inline const T* variant<Types...>::get_if(const T* default_value) const noexcept
+inline const T* variant<Types...>::get_if(const T* defaultValue) const noexcept
 {
     if (has_bad_variant_element_access<T>())
     {
-        return default_value;
+        return defaultValue;
     }
 
     return this->get<T>();

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
@@ -98,6 +98,8 @@ struct call_at_index
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<T*>(ptr)->~T();
         }
         else
@@ -110,6 +112,8 @@ struct call_at_index
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             *reinterpret_cast<T*>(destination) = std::move(*reinterpret_cast<T*>(source));
         }
         else
@@ -122,6 +126,8 @@ struct call_at_index
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             new (destination) T(std::move(*reinterpret_cast<T*>(source)));
         }
         else
@@ -130,11 +136,13 @@ struct call_at_index
         }
     }
 
-    static void copy(const uint64_t index, byte_t* source, byte_t* destination) noexcept
+    static void copy(const uint64_t index, const byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
-            *reinterpret_cast<T*>(destination) = *reinterpret_cast<T*>(source);
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<T*>(destination) = *reinterpret_cast<const T*>(source);
         }
         else
         {
@@ -142,11 +150,13 @@ struct call_at_index
         }
     }
 
-    static void copyConstructor(const uint64_t index, byte_t* source, byte_t* destination) noexcept
+    static void copyConstructor(const uint64_t index, const byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
-            new (destination) T(*reinterpret_cast<T*>(source));
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+            new (destination) T(*reinterpret_cast<const T*>(source));
         }
         else
         {
@@ -158,10 +168,14 @@ struct call_at_index
 template <uint64_t N, typename T>
 struct call_at_index<N, T>
 {
+    // d'tor changes the data to which source is pointing to
+    // NOLINTNEXTLINE (readability-non-const-parameter)
     static void destructor(const uint64_t index, byte_t* ptr) noexcept
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<T*>(ptr)->~T();
         }
         else
@@ -170,10 +184,14 @@ struct call_at_index<N, T>
         }
     }
 
+    // move c'tor changes the data to which source is pointing to
+    // NOLINTNEXTLINE (readability-non-const-parameter)
     static void move(const uint64_t index, byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             *reinterpret_cast<T*>(destination) = std::move(*reinterpret_cast<T*>(source));
         }
         else
@@ -182,10 +200,14 @@ struct call_at_index<N, T>
         }
     }
 
+    // Both 'source' and 'destination' will be changed and can't be const
+    // NOLINTNEXTLINE (readability-non-const-parameter)
     static void moveConstructor(const uint64_t index, byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
             new (destination) T(std::move(*reinterpret_cast<T*>(source)));
         }
         else
@@ -194,11 +216,13 @@ struct call_at_index<N, T>
         }
     }
 
-    static void copy(const uint64_t index, byte_t* source, byte_t* destination) noexcept
+    static void copy(const uint64_t index, const byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
-            *reinterpret_cast<T*>(destination) = *reinterpret_cast<T*>(source);
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+            *reinterpret_cast<T*>(destination) = *reinterpret_cast<const T*>(source);
         }
         else
         {
@@ -206,11 +230,15 @@ struct call_at_index<N, T>
         }
     }
 
-    static void copyConstructor(const uint64_t index, byte_t* source, byte_t* destination) noexcept
+    // 'operator new()' needs non-const 'destination'
+    // NOLINTNEXTLINE (readability-non-const-parameter)
+    static void copyConstructor(const uint64_t index, const byte_t* source, byte_t* destination) noexcept
     {
         if (N == index)
         {
-            new (destination) T(*reinterpret_cast<T*>(source));
+            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
+            // NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+            new (destination) T(*reinterpret_cast<const T*>(source));
         }
         else
         {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
@@ -46,6 +46,8 @@ class variant_Test : public Test
     class ComplexClass
     {
       public:
+        // Ok-ish for tests
+        // NOLINTNEXTLINE (bugprone-easily-swappable-parameters)
         ComplexClass(int a, float b)
             : a(a)
             , b(b)
@@ -82,7 +84,7 @@ class variant_Test : public Test
         {
             *this = rhs;
         }
-        DoubleDelete(DoubleDelete&& rhs)
+        DoubleDelete(DoubleDelete&& rhs) noexcept
             : doDtorCall{false}
         {
             *this = std::move(rhs);
@@ -98,18 +100,18 @@ class variant_Test : public Test
             return *this;
         }
 
-        DoubleDelete& operator=(DoubleDelete&& rhs)
+        DoubleDelete& operator=(DoubleDelete&& rhs) noexcept
         {
             if (this != &rhs)
             {
                 Delete();
-                doDtorCall = std::move(rhs.doDtorCall);
+                doDtorCall = rhs.doDtorCall;
                 rhs.doDtorCall = false;
             }
             return *this;
         }
 
-        void Delete()
+        void Delete() const
         {
             if (doDtorCall)
             {
@@ -184,7 +186,7 @@ TEST_F(variant_Test, EmplaceValidElementWorks)
 TEST_F(variant_Test, EmplaceSecondValidElementWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb4ba160-dd0c-4255-9916-cc56d950e970");
-    sut.emplace<ComplexClass>(123, 456.789f);
+    sut.emplace<ComplexClass>(123, 456.789F);
     ASSERT_THAT(sut.emplace<ComplexClass>(912, 65.03F), Eq(true));
     ASSERT_THAT(sut.get<ComplexClass>(), Ne(nullptr));
     EXPECT_THAT(sut.get<ComplexClass>()->a, Eq(912));
@@ -229,6 +231,8 @@ TEST_F(variant_Test, GetVariantWithIncorrectValueFails)
 TEST_F(variant_Test, ConstGetOnUninitializedVariantFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "16b511c8-e56a-48c9-bbff-5a7d07e7a500");
+    // Re-use 'sut' and testing const methods
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     EXPECT_THAT(const_cast<const decltype(sut)*>(&sut)->get<float>(), Eq(nullptr));
 }
 
@@ -236,6 +240,8 @@ TEST_F(variant_Test, constGetVariantWithCorrectValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4419f569-0541-43ab-8448-9ba10556b459");
     sut.emplace<float>(123.12F);
+    // Re-use 'sut' and testing const methods
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     EXPECT_THAT(const_cast<const decltype(sut)*>(&sut)->get<float>(), Ne(nullptr));
 }
 
@@ -243,13 +249,15 @@ TEST_F(variant_Test, ConstGetVariantWithIncorrectValueFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "979e1131-e981-4f67-bef2-a1fe4770c5a6");
     sut.emplace<float>(123.12F);
+    // Re-use 'sut' and testing const methods
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     EXPECT_THAT(const_cast<const decltype(sut)*>(&sut)->get<int>(), Eq(nullptr));
 }
 
 TEST_F(variant_Test, Get_ifWhenUninitializedReturnsProvidedValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "64585111-3495-4c01-8900-af2e19223e62");
-    float bla;
+    float bla{0.0F};
     EXPECT_THAT(sut.get_if<float>(&bla), Eq(&bla));
 }
 
@@ -257,7 +265,7 @@ TEST_F(variant_Test, Get_ifInitializedWithCorrectValueWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "27b80822-0f32-46a6-83d9-595b35e23139");
     sut.emplace<float>(12.1F);
-    float bla;
+    float bla{0.0F};
     EXPECT_THAT(sut.get_if<float>(&bla), Ne(&bla));
 }
 
@@ -265,7 +273,7 @@ TEST_F(variant_Test, Get_ifInitializedWithIncorrectValueReturnsProvidedValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4126af94-d4ce-405a-bcc7-1b6d1fce6d0b");
     sut.emplace<float>(12.1F);
-    int bla;
+    int bla{0};
     EXPECT_THAT(sut.get_if<int>(&bla), Eq(&bla));
 }
 
@@ -305,6 +313,8 @@ TEST_F(variant_Test, CopyCTorWithoutValueResultsInInvalidVariant)
 {
     ::testing::Test::RecordProperty("TEST_ID", "31b12efc-4f2d-4b3c-ad72-c12ca8a0cfc3");
     iox::cxx::variant<int, char> schlomo;
+    // Copy c'tor shall be tested
+    // NOLINTNEXTLINE (performance-unnecessary-copy-initialization)
     iox::cxx::variant<int, char> ignatz(schlomo);
     ASSERT_THAT(ignatz.index(), Eq(iox::cxx::INVALID_VARIANT_INDEX));
 }
@@ -344,6 +354,8 @@ TEST_F(variant_Test, MoveCTorWithValueLeadsToSameValue)
     iox::cxx::variant<int, char> ignatz(std::move(schlomo));
     ASSERT_THAT(ignatz.get<int>(), Ne(nullptr));
     EXPECT_THAT(*ignatz.get<int>(), Eq(123));
+    // check if move is invalidating the object
+    // NOLINTNEXTLINE (bugprone-use-after-move)
     EXPECT_THAT(schlomo.index(), Eq(0U));
 }
 
@@ -390,6 +402,8 @@ TEST_F(variant_Test, CreatingSecondObjectViaCopyCTorResultsInTwoDTorCalls)
         ignatz.emplace<DTorTest>();
         DTorTest::dtorWasCalled = false;
         {
+            // Copy c'tor shall be tested
+            // NOLINTNEXTLINE (performance-unnecessary-copy-initialization)
             iox::cxx::variant<int, DTorTest> schlomo(ignatz);
             EXPECT_THAT(DTorTest::dtorWasCalled, Eq(false));
         }
@@ -428,6 +442,8 @@ TEST_F(variant_Test, CreatingSecondObjectViaMoveCTorResultsInTwoDTorCalls)
         {
             iox::cxx::variant<int, DTorTest> schlomo(std::move(ignatz));
             EXPECT_THAT(DTorTest::dtorWasCalled, Eq(false));
+            // check if move is invalidating the object
+            // NOLINTNEXTLINE (bugprone-use-after-move)
             EXPECT_THAT(ignatz.index(), Eq(1U));
         }
         EXPECT_THAT(DTorTest::dtorWasCalled, Eq(true));
@@ -447,6 +463,8 @@ TEST_F(variant_Test, CreatingSecondObjectViaMoveAssignmentResultsInTwoDTorCalls)
             iox::cxx::variant<int, DTorTest> schlomo;
             schlomo.emplace<int>(123);
             schlomo = std::move(ignatz);
+            // check if move is invalidating the object
+            // NOLINTNEXTLINE (bugprone-use-after-move)
             EXPECT_THAT(ignatz.index(), Eq(1U));
             EXPECT_THAT(DTorTest::dtorWasCalled, Eq(false));
         }
@@ -589,6 +607,8 @@ TEST_F(variant_Test, ComplexDTorWithCopyCTor)
     DoubleDelete::dtorCalls = 0;
     {
         iox::cxx::variant<int, DoubleDelete> schlomo{iox::cxx::in_place_type<DoubleDelete>()};
+        // Copy c'tor shall be tested
+        // NOLINTNEXTLINE (performance-unnecessary-copy-initialization)
         iox::cxx::variant<int, DoubleDelete> sut{schlomo};
     }
 
@@ -660,7 +680,8 @@ TEST_F(variant_Test, MoveVariantIntoVariantOfDifferentType)
     ::testing::Test::RecordProperty("TEST_ID", "1f292f13-8a88-4f73-8589-df4d5259c791");
     DoubleDelete::ctorCalls = 0;
     DoubleDelete::dtorCalls = 0;
-    iox::cxx::variant<DoubleDelete, ComplexClass> sut1, sut2;
+    iox::cxx::variant<DoubleDelete, ComplexClass> sut1;
+    iox::cxx::variant<DoubleDelete, ComplexClass> sut2;
     sut1.emplace<DoubleDelete>();
     sut2.emplace<ComplexClass>(12, 12.12F);
 
@@ -674,7 +695,8 @@ TEST_F(variant_Test, CopyVariantIntoVariantOfDifferentType)
     ::testing::Test::RecordProperty("TEST_ID", "d0ea4fed-7b18-4d0d-aa05-d76911fb29f7");
     DoubleDelete::ctorCalls = 0;
     DoubleDelete::dtorCalls = 0;
-    iox::cxx::variant<DoubleDelete, ComplexClass> sut1, sut2;
+    iox::cxx::variant<DoubleDelete, ComplexClass> sut1;
+    iox::cxx::variant<DoubleDelete, ComplexClass> sut2;
     sut1.emplace<DoubleDelete>();
     sut2.emplace<ComplexClass>(12, 12.12F);
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
* Address clang-tidy and one AUTOSAR rule in `cxx::variant`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196 (partly)
