### PR TITLE
iox-#1196 fix periodic task warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -151,4 +151,4 @@ CheckOptions:
   - { key: readability-function-size.LineThreshold,               value: 200 }
   - { key: readability-function-size.StatementThreshold,          value: 200 }
   - { key: readability-function-size.BranchThreshold,             value: 10 }
-  - { key: readability-function-size.ParameterThreshold,          value: 3 }
+  - { key: readability-function-size.ParameterThreshold,          value: 4 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
@@ -72,7 +72,9 @@ class PeriodicTask
     /// @param[in] taskName will be set as thread name
     /// @param[in] args are forwarded to the underlying callable object
     template <typename... Args>
-    PeriodicTask(const PeriodicTaskManualStart_t, const posix::ThreadName_t taskName, Args&&... args) noexcept;
+    // PeriodicTaskManualStart_t is a compile time constant to indicate that this constructor does not start the task
+    // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
+    PeriodicTask(const PeriodicTaskManualStart_t, const posix::ThreadName_t& taskName, Args&&... args) noexcept;
 
     /// @brief Creates a periodic task by spawning a thread. The specified callable is executed immediately on creation
     /// and then periodically after the interval duration.
@@ -83,6 +85,8 @@ class PeriodicTask
     /// @param[in] taskName will be set as thread name
     /// @param[in] args are forwarded to the underlying callable object
     template <typename... Args>
+    // PeriodicTaskAutoStart_t is a compile time constant to indicate that this constructor starts the task
+    // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
     PeriodicTask(const PeriodicTaskAutoStart_t,
                  const units::Duration interval,
                  const posix::ThreadName_t taskName,

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
@@ -89,7 +89,7 @@ class PeriodicTask
     // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
     PeriodicTask(const PeriodicTaskAutoStart_t,
                  const units::Duration interval,
-                 const posix::ThreadName_t taskName,
+                 const posix::ThreadName_t& taskName,
                  Args&&... args) noexcept;
 
     /// @brief Stops and joins the thread spawned by the constructor.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.inl
@@ -25,8 +25,9 @@ namespace concurrent
 {
 template <typename T>
 template <typename... Args>
+// NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter) justification in header
 inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskManualStart_t,
-                                     const posix::ThreadName_t taskName,
+                                     const posix::ThreadName_t& taskName,
                                      Args&&... args) noexcept
     : m_callable(std::forward<Args>(args)...)
     , m_taskName(taskName)
@@ -37,6 +38,7 @@ inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskManualStart_t,
 
 template <typename T>
 template <typename... Args>
+// NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter) justification in header
 inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskAutoStart_t,
                                      const units::Duration interval,
                                      const posix::ThreadName_t taskName,

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.inl
@@ -41,7 +41,7 @@ template <typename... Args>
 // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter) justification in header
 inline PeriodicTask<T>::PeriodicTask(const PeriodicTaskAutoStart_t,
                                      const units::Duration interval,
-                                     const posix::ThreadName_t taskName,
+                                     const posix::ThreadName_t& taskName,
                                      Args&&... args) noexcept
     : PeriodicTask(PeriodicTaskManualStart, taskName, std::forward<Args>(args)...)
 {

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_periodic_task.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_periodic_task.cpp
@@ -46,17 +46,12 @@ struct PeriodicTaskTestType
   public:
     PeriodicTaskTestType() = default;
 
-    PeriodicTaskTestType(uint64_t callCounterOffset)
+    explicit PeriodicTaskTestType(uint64_t callCounterOffset)
     {
         callCounter = callCounterOffset;
     }
 
     void operator()()
-    {
-        increment();
-    }
-
-    void incrementMethod()
     {
         increment();
     }
@@ -74,12 +69,12 @@ uint64_t PeriodicTaskTestType::callCounter{0};
 class PeriodicTask_test : public Test
 {
   public:
-    virtual void SetUp()
+    void SetUp() override
     {
         PeriodicTaskTestType::callCounter = 0;
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 };


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
