### PR TITLE
iox-#1196 fix smart lock warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/smart_lock.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/smart_lock.hpp
@@ -63,6 +63,11 @@ class smart_lock
         Proxy(T& base, MutexType& lock) noexcept;
         ~Proxy() noexcept;
 
+        Proxy(const Proxy&) noexcept = default;
+        Proxy(Proxy&&) noexcept = default;
+        Proxy& operator=(const Proxy&) noexcept = default;
+        Proxy& operator=(Proxy&&) noexcept = default;
+
         T* operator->() noexcept;
         const T* operator->() const noexcept;
 
@@ -72,12 +77,16 @@ class smart_lock
     };
 
   public:
-    ///@brief c'tor creating empty smart_lock
-    smart_lock() noexcept;
+    /// @brief c'tor creating empty smart_lock
+    smart_lock() noexcept = default;
 
-    ///@brief c'tor forwarding all args to the underlying object
+    /// @brief c'tor forwarding all args to the underlying object
+    /// @param[in] ForwardArgsToCTor is a compile time constant to indicate that this constructor forwards all arguments
+    /// to the underlying object
+    /// @param[in] args are the arguments that are forwarded to the underlying object
     template <typename... ArgTypes>
-    smart_lock(ForwardArgsToCTor_t, ArgTypes&&... args) noexcept;
+    // NOLINTNEXTLINE(readability-named-parameter, hicpp-named-parameter) justification in Doxygen documentation
+    explicit smart_lock(ForwardArgsToCTor_t, ArgTypes&&... args) noexcept;
 
     smart_lock(const smart_lock& rhs) noexcept;
     smart_lock(smart_lock&& rhs) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/smart_lock.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/smart_lock.inl
@@ -30,12 +30,8 @@ smart_lock<T, MutexType> make_smart_lock(Targs&&... args) noexcept
 }
 
 template <typename T, typename MutexType>
-smart_lock<T, MutexType>::smart_lock() noexcept
-{
-}
-
-template <typename T, typename MutexType>
 template <typename... ArgTypes>
+// NOLINTNEXTLINE(readability-named-parameter, hicpp-named-parameter) justification in Doxygen documentation
 smart_lock<T, MutexType>::smart_lock(ForwardArgsToCTor_t, ArgTypes&&... args) noexcept
     : base(std::forward<ArgTypes>(args)...)
 {
@@ -93,8 +89,11 @@ typename smart_lock<T, MutexType>::Proxy smart_lock<T, MutexType>::operator->() 
 }
 
 template <typename T, typename MutexType>
+// const return type improves const correctness, operator-> can be chained with underlying operator->
+// NOLINTNEXTLINE(readability-const-return-type)
 const typename smart_lock<T, MutexType>::Proxy smart_lock<T, MutexType>::operator->() const noexcept
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) const_cast to avoid code duplication
     return const_cast<smart_lock<T, MutexType>*>(this)->operator->();
 }
 
@@ -105,8 +104,11 @@ typename smart_lock<T, MutexType>::Proxy smart_lock<T, MutexType>::getScopeGuard
 }
 
 template <typename T, typename MutexType>
+// const return type improves const correctness, operator-> can be chained with underlying operator->
+// NOLINTNEXTLINE(readability-const-return-type)
 const typename smart_lock<T, MutexType>::Proxy smart_lock<T, MutexType>::getScopeGuard() const noexcept
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) const_cast to avoid code duplication
     return const_cast<smart_lock<T, MutexType>*>(this)->getScopeGuard();
 }
 
@@ -142,6 +144,7 @@ T* smart_lock<T, MutexType>::Proxy::operator->() noexcept
 template <typename T, typename MutexType>
 const T* smart_lock<T, MutexType>::Proxy::operator->() const noexcept
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) const_cast to avoid code duplication
     return const_cast<smart_lock<T, MutexType>::Proxy*>(this)->operator->();
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_smart_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_smart_lock.cpp
@@ -35,54 +35,52 @@ class SmartLockTester
     // just for clarity, we could also write ++m_a but we want
     // to highlight the possible race condition here when we call this from
     // multiple threads, therefore m_a = m_a + 1
-    SmartLockTester()
-    {
-    }
+    SmartLockTester() noexcept = default;
 
-    SmartLockTester(const int32_t a)
+    explicit SmartLockTester(const int32_t a) noexcept
         : m_a(a)
     {
     }
 
-    SmartLockTester(const SmartLockTester& rhs)
+    SmartLockTester(const SmartLockTester& rhs) noexcept
         : m_a(rhs.m_a)
     {
+        // NOLINTNEXTLINE(cert-oop58-cpp) used to test thread safety of smart_lock
         rhs.m_b = rhs.m_b + 1;
     }
 
-    SmartLockTester(SmartLockTester&& rhs)
+    SmartLockTester(SmartLockTester&& rhs) noexcept
         : m_a(rhs.m_a)
     {
-        rhs.isMoved = true;
+        rhs.m_isMoved = true;
         rhs.m_a = 0;
         rhs.m_b = rhs.m_b + 1;
     }
 
-    SmartLockTester& operator=(const SmartLockTester& rhs)
+    SmartLockTester& operator=(const SmartLockTester& rhs) noexcept
     {
         if (this != &rhs)
         {
+            // NOLINTNEXTLINE(cert-oop58-cpp) used to test thread safety of smart_lock
             rhs.m_b = rhs.m_b + 1;
             m_a = rhs.m_a;
         }
         return *this;
     }
 
-    SmartLockTester& operator=(SmartLockTester&& rhs)
+    SmartLockTester& operator=(SmartLockTester&& rhs) noexcept
     {
         if (this != &rhs)
         {
             rhs.m_b = rhs.m_b + 1;
             m_a = rhs.m_a;
             rhs.m_a = 0;
-            rhs.isMoved = true;
+            rhs.m_isMoved = true;
         }
         return *this;
     }
 
-    ~SmartLockTester()
-    {
-    }
+    ~SmartLockTester() noexcept = default;
 
     int32_t getA() const
     {
@@ -104,11 +102,15 @@ class SmartLockTester
         m_a = m_a + 1;
     }
 
-    bool isMoved = false;
+    bool isMoved() const
+    {
+        return m_isMoved;
+    }
 
   private:
     mutable int32_t m_a = 0;
     mutable int32_t m_b = 0;
+    bool m_isMoved = false;
 };
 
 class smart_lock_test : public Test
@@ -176,7 +178,7 @@ TEST_F(smart_lock_test, MoveConstructionOfUnderlyinObjectWorks)
     SmartLockTester tester(CTOR_VALUE);
     m_sut.emplace(ForwardArgsToCTor, std::move(tester));
     EXPECT_THAT((*m_sut)->getA(), Eq(CTOR_VALUE));
-    EXPECT_TRUE(tester.isMoved);
+    EXPECT_TRUE(tester.isMoved());
 }
 
 TEST_F(smart_lock_test, CopyConstructorWorks)
@@ -212,7 +214,7 @@ TEST_F(smart_lock_test, MoveConstructorWorks)
 
     SutType_t sut2(std::move(*m_sut));
 
-    EXPECT_TRUE((*m_sut)->isMoved);
+    EXPECT_TRUE((*m_sut)->isMoved());
     EXPECT_THAT(sut2->getA(), Eq(CTOR_VALUE));
 }
 
@@ -225,7 +227,7 @@ TEST_F(smart_lock_test, MoveAssignmentWorks)
     SutType_t sut2;
     sut2 = std::move(m_sut.value());
 
-    EXPECT_TRUE((*m_sut)->isMoved);
+    EXPECT_TRUE((*m_sut)->isMoved());
     EXPECT_THAT(sut2->getA(), Eq(CTOR_VALUE));
 }
 
@@ -316,6 +318,7 @@ TEST_F(smart_lock_test, ThreadSafeAccessThroughArrowOperator)
 TEST_F(smart_lock_test, ThreadSafeAccessThroughConstArrowOperator)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c0dedded-cf07-47dc-9032-e5de3db859d2");
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) used to explitly test const arrow operator
     threadSafeOperationTest(this, [=] { (const_cast<const SutType_t&>(*m_sut))->constIncrementA(); });
     EXPECT_THAT((*m_sut)->getA(), Eq(NUMBER_OF_RUNS_PER_THREAD * NUMBER_OF_THREADS));
 }
@@ -334,6 +337,7 @@ TEST_F(smart_lock_test, ThreadSafeAccessThroughConstScopedGuard)
 {
     ::testing::Test::RecordProperty("TEST_ID", "dc2efd41-4c0a-4ac0-93ed-f8e9195e0dfd");
     threadSafeOperationTest(this, [=] {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) used to explitly test const getScopeGuard()
         auto guard = const_cast<const SutType_t&>(*m_sut).getScopeGuard();
         guard->incrementA();
     });


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
