### PR TITLE
iox-#1196 fix sofi warnings

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -7,6 +7,11 @@
 ./iceoryx_hoofs/test/moduletests/test_unit*
 ./iceoryx_hoofs/source/units/*
 
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
+./iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
+./iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
+
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/test/moduletests/test_allocator.cpp

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
@@ -65,9 +65,9 @@ class SoFi
 
     /// @brief pushs an element into sofi. if sofi is full the oldest data will be
     ///         returned and the pushed element is stored in its place instead.
-    /// @param[in] valueOut value which should be stored
-    /// @param[out] f_paramOut_r if sofi is overflowing  the value of the overridden value
-    ///                            is stored here
+    /// @param[in] valueIn value which should be stored
+    /// @param[out] valueOut if sofi is overflowing  the value of the overridden value
+    ///                      is stored here
     /// @concurrent restricted thread safe: single pop, single push no
     ///             push calls from multiple contexts
     /// @return return true if push was sucessfull else false.
@@ -84,7 +84,7 @@ class SoFi
     ///                        |-----A-------|
     ///                                      |-----B-------|
     ///                                                    |-----C-------|
-    ///                                     (’D’ is returned as value_out)
+    ///                                     (’D’ is returned as valueOut)
     ///
     /// ###################################################################
     ///
@@ -98,7 +98,7 @@ class SoFi
     ///                                                     |-------------|
     ///                                                      (New Data)
     /// @endcode
-    bool push(const ValueType& valueOut, ValueType& f_paramOut_r) noexcept;
+    bool push(const ValueType& valueIn, ValueType& valueOut) noexcept;
 
     /// @brief pop the oldest element
     /// @param[out] valueOut storage of the pop'ed value

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
@@ -61,7 +61,7 @@ class SoFi
 
   public:
     /// @brief default constructor which constructs an empty sofi
-    SoFi() noexcept;
+    SoFi() noexcept = default;
 
     /// @brief pushs an element into sofi. if sofi is full the oldest data will be
     ///         returned and the pushed element is stored in its place instead.
@@ -86,7 +86,7 @@ class SoFi
     ///                                                    |-----C-------|
     ///                                     (’D’ is returned as value_out)
     ///
-    ///###################################################################
+    /// ###################################################################
     ///
     /// (if SOFI is not FULL , calling push() add new data)
     ///     Start|-------------|
@@ -151,13 +151,15 @@ class SoFi
     uint64_t size() const noexcept;
 
   private:
+    // safe access is guaranteed since the array is wrapped inside the SoFi
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     ValueType m_data[INTERNAL_SOFI_SIZE];
     uint64_t m_size = INTERNAL_SOFI_SIZE;
 
     /// @brief the write/read pointers are "atomic pointers" so that they are not
     /// reordered (read or written too late)
-    std::atomic<uint64_t> m_readPosition{0u};
-    std::atomic<uint64_t> m_writePosition{0u};
+    std::atomic<uint64_t> m_readPosition{0};
+    std::atomic<uint64_t> m_writePosition{0};
 };
 
 } // namespace concurrent

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
@@ -151,6 +151,7 @@ class SoFi
     uint64_t size() const noexcept;
 
   private:
+    // @todo iox-#1196 Replace with UninitializedArray
     // safe access is guaranteed since the array is wrapped inside the SoFi
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     ValueType m_data[INTERNAL_SOFI_SIZE];

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
@@ -139,14 +139,14 @@ inline bool SoFi<ValueType, CapacityValue>::popIf(ValueType& valueOut, const Ver
 }
 
 template <class ValueType, uint64_t CapacityValue>
-bool SoFi<ValueType, CapacityValue>::push(const ValueType& valueOut, ValueType& f_paramOut_r) noexcept
+bool SoFi<ValueType, CapacityValue>::push(const ValueType& valueIn, ValueType& valueOut) noexcept
 {
     constexpr bool SOFI_OVERFLOW{false};
 
     uint64_t currentWritePosition = m_writePosition.load(std::memory_order_relaxed);
     uint64_t nextWritePosition = currentWritePosition + 1U;
 
-    m_data[currentWritePosition % m_size] = valueOut;
+    m_data[currentWritePosition % m_size] = valueIn;
     m_writePosition.store(nextWritePosition, std::memory_order_release);
 
     uint64_t currentReadPosition = m_readPosition.load(std::memory_order_acquire);
@@ -179,7 +179,7 @@ bool SoFi<ValueType, CapacityValue>::push(const ValueType& valueOut, ValueType& 
     if (m_readPosition.compare_exchange_strong(
             currentReadPosition, nextReadPosition, std::memory_order_acq_rel, std::memory_order_relaxed))
     {
-        std::memcpy(&f_paramOut_r, &m_data[currentReadPosition % m_size], sizeof(ValueType));
+        std::memcpy(&valueOut, &m_data[currentReadPosition % m_size], sizeof(ValueType));
         return SOFI_OVERFLOW;
     }
 

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
@@ -17,25 +17,25 @@
 
 #include "iceoryx_hoofs/internal/concurrent/sofi.hpp"
 
+#include <cstdlib>
 #include <gtest/gtest.h>
-#include <stdlib.h>
 
 namespace
 {
 class CUnitTestContainerSoFi : public ::testing::Test
 {
   protected:
-    virtual void SetUp()
+    void SetUp() override
     {
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 
     /// @brief returns the ID of the current test in the format "TestCaseName.TestName"
     /// @return std::string: the id of the test
-    std::string testId();
+    static std::string testId();
 
     /// @brief pushes some serial numbers to the SoFi with the expectation to not overflow
     /// @param[in] serNumStart is the offset for the serial numbers to push into the SoFi
@@ -74,6 +74,7 @@ class CUnitTestContainerSoFi : public ::testing::Test
     void checkMultiOverflow(const std::string& scope, int serNumStart);
 
     static constexpr uint64_t TEST_SOFI_CAPACITY = 10;
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes) only used in test file
     iox::concurrent::SoFi<int, TEST_SOFI_CAPACITY> m_sofi;
 };
 
@@ -83,10 +84,11 @@ std::string CUnitTestContainerSoFi::testId()
            + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name());
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) used only for test purposes
 int CUnitTestContainerSoFi::pushSome(int serNumStart, uint32_t numberOfItems)
 {
     int valIn = serNumStart;
-    int valOut;
+    int valOut{-1};
 
     // fill the SoFi; SoFi has an internal capacity with two more items than specified the ones
     // the write position must always point to an empty position
@@ -101,9 +103,10 @@ int CUnitTestContainerSoFi::pushSome(int serNumStart, uint32_t numberOfItems)
     return valIn;
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) used only for test purposes
 void CUnitTestContainerSoFi::popSome(int serNumOldest, uint32_t numberOfItems)
 {
-    int valOut;
+    int valOut{-2};
     for (uint32_t i = 0; i < numberOfItems; i++)
     {
         valOut = -2; // set valOut to a value not present in the SoFi
@@ -269,7 +272,7 @@ TEST_F(CUnitTestContainerSoFi, SoFiSizeEqualsNumberOfPushes)
     // check if a new instace of the SoFi is empty
     EXPECT_TRUE(m_sofi.empty());
 
-    int ret;
+    int ret{-1};
 
     // Push 10 items till SoFi is full and check size
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY; i++)
@@ -288,7 +291,7 @@ TEST_F(CUnitTestContainerSoFi, SoFiSizeEqualsNumberOfPushesOverflow)
     // check if a new instace of the SoFi is empty
     EXPECT_TRUE(m_sofi.empty());
 
-    int ret;
+    int ret{-1};
 
     // Push 11 items to provoke overflow and check size
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY; i++)
@@ -328,7 +331,7 @@ TEST_F(CUnitTestContainerSoFi, MultiOverflow)
 TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingASingleElement)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9c7c43d8-939c-4fa8-b1b9-b379515931e9");
-    int ret;
+    int ret{-1};
     m_sofi.push(123, ret);
     EXPECT_EQ(m_sofi.setCapacity(4), false);
 }
@@ -336,7 +339,7 @@ TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingASingleElement)
 TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingAMultipleElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a98bd656-7d39-4274-a77f-bc918a2c1301");
-    int ret;
+    int ret{-1};
     m_sofi.push(123, ret);
     m_sofi.push(13, ret);
     m_sofi.push(23, ret);
@@ -346,7 +349,7 @@ TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingAMultipleElements)
 TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenFull)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6f58b6dd-20ab-42c7-9006-fbbcadb04f42");
-    for (int ret; !m_sofi.push(123, ret);)
+    for (int ret{-1}; !m_sofi.push(123, ret);)
     {
     }
     EXPECT_EQ(m_sofi.setCapacity(4), false);
@@ -388,12 +391,12 @@ TEST_F(CUnitTestContainerSoFi, ResizeAndSizeFillUp)
         EXPECT_EQ(m_sofi.setCapacity(i), true);
         for (uint32_t k = 0; k < i; ++k)
         {
-            int temp;
+            int temp{-1};
             EXPECT_EQ(m_sofi.push(static_cast<int>(k), temp), true);
         }
         for (uint32_t k = 0; k < i; ++k)
         {
-            int temp;
+            int temp{-1};
             EXPECT_EQ(m_sofi.pop(temp), true);
             EXPECT_EQ(temp, static_cast<int>(k));
         }
@@ -403,12 +406,12 @@ TEST_F(CUnitTestContainerSoFi, ResizeAndSizeFillUp)
 TEST_F(CUnitTestContainerSoFi, PopIfWithValidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f149035c-21cc-4f7d-ba4d-564a645e933b");
-    int returnValue;
+    int returnValue{-1};
     m_sofi.push(10, returnValue);
     m_sofi.push(11, returnValue);
     m_sofi.push(12, returnValue);
 
-    int output;
+    int output{-1};
     bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 20; });
 
     EXPECT_EQ(result, true);
@@ -418,12 +421,12 @@ TEST_F(CUnitTestContainerSoFi, PopIfWithValidCondition)
 TEST_F(CUnitTestContainerSoFi, PopIfWithInvalidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1a494c28-928f-48f4-8b01-e68dfbd7563e");
-    int returnValue;
+    int returnValue{-1};
     m_sofi.push(15, returnValue);
     m_sofi.push(16, returnValue);
     m_sofi.push(17, returnValue);
 
-    int output;
+    int output{-1};
     bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 5; });
 
     EXPECT_EQ(result, false);
@@ -432,7 +435,7 @@ TEST_F(CUnitTestContainerSoFi, PopIfWithInvalidCondition)
 TEST_F(CUnitTestContainerSoFi, PopIfOnEmpty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "960ad78f-cb9b-4c34-a077-6adb343a841c");
-    int output;
+    int output{-1};
     bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 7; });
 
     EXPECT_EQ(result, false);
@@ -441,11 +444,13 @@ TEST_F(CUnitTestContainerSoFi, PopIfOnEmpty)
 TEST_F(CUnitTestContainerSoFi, PopIfFullWithValidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "167f2f01-f926-4442-bc4f-ff5e7cfe9fe0");
-    int output;
+    int output{-1};
     constexpr int INITIAL_VALUE = 100;
     constexpr int OFFSET = 2;
     for (int i = 0; i < static_cast<int>(m_sofi.capacity()) + OFFSET; i++)
+    {
         m_sofi.push(i + INITIAL_VALUE, output);
+    }
 
     bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 150; });
 
@@ -456,9 +461,11 @@ TEST_F(CUnitTestContainerSoFi, PopIfFullWithValidCondition)
 TEST_F(CUnitTestContainerSoFi, PopIfFullWithInvalidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "672881b9-eebd-471d-9d62-e792a8b8013f");
-    int output;
+    int output{-1};
     for (int i = 0; i < static_cast<int>(m_sofi.capacity()) + 2; i++)
+    {
         m_sofi.push(i + 100, output);
+    }
 
     bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
 
@@ -468,7 +475,7 @@ TEST_F(CUnitTestContainerSoFi, PopIfFullWithInvalidCondition)
 TEST_F(CUnitTestContainerSoFi, PopIfValidEmptyAfter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "19444dcd-7746-4e6b-a3b3-398c9d62317d");
-    int output;
+    int output{-1};
     m_sofi.push(2, output);
 
     m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
@@ -479,13 +486,11 @@ TEST_F(CUnitTestContainerSoFi, PopIfValidEmptyAfter)
 TEST_F(CUnitTestContainerSoFi, PopIfInvalidNotEmptyAfter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cadd7f02-6fe5-49a5-bd5d-837f5fcb2a71");
-    int output;
+    int output{-1};
     m_sofi.push(200, output);
 
     m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
 
     EXPECT_EQ(m_sofi.empty(), false);
 }
-
-/// @todo popif empty test
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
@@ -22,9 +22,8 @@
 
 namespace
 {
-class CUnitTestContainerSoFi : public ::testing::Test
+struct SoFiTest : public ::testing::Test
 {
-  protected:
     void SetUp() override
     {
     }
@@ -74,18 +73,18 @@ class CUnitTestContainerSoFi : public ::testing::Test
     void checkMultiOverflow(const std::string& scope, int serNumStart);
 
     static constexpr uint64_t TEST_SOFI_CAPACITY = 10;
-    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes) only used in test file
-    iox::concurrent::SoFi<int, TEST_SOFI_CAPACITY> m_sofi;
+    iox::concurrent::SoFi<int, TEST_SOFI_CAPACITY> sofi;
+    int returnVal{-1}; // set to a value that should not be present in the SoFi
 };
 
-std::string CUnitTestContainerSoFi::testId()
+std::string SoFiTest::testId()
 {
     return std::string(::testing::UnitTest::GetInstance()->current_test_info()->test_case_name()) + "."
            + std::string(::testing::UnitTest::GetInstance()->current_test_info()->name());
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) used only for test purposes
-int CUnitTestContainerSoFi::pushSome(int serNumStart, uint32_t numberOfItems)
+int SoFiTest::pushSome(int serNumStart, uint32_t numberOfItems)
 {
     int valIn = serNumStart;
     int valOut{-1};
@@ -96,7 +95,7 @@ int CUnitTestContainerSoFi::pushSome(int serNumStart, uint32_t numberOfItems)
     for (uint32_t i = 0; i < numberOfItems; i++, valIn++)
     {
         valOut = -1; // we push only positive values, so this is a value we shouldn't get from the SoFi
-        EXPECT_TRUE(this->m_sofi.push(valIn, valOut)) << "There shouldn't be an overflow here!";
+        EXPECT_TRUE(this->sofi.push(valIn, valOut)) << "There shouldn't be an overflow here!";
         EXPECT_EQ(-1, valOut); // valOut should not be changed if there was no overflow
     }
 
@@ -104,22 +103,22 @@ int CUnitTestContainerSoFi::pushSome(int serNumStart, uint32_t numberOfItems)
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) used only for test purposes
-void CUnitTestContainerSoFi::popSome(int serNumOldest, uint32_t numberOfItems)
+void SoFiTest::popSome(int serNumOldest, uint32_t numberOfItems)
 {
     int valOut{-2};
     for (uint32_t i = 0; i < numberOfItems; i++)
     {
         valOut = -2; // set valOut to a value not present in the SoFi
-        EXPECT_TRUE(m_sofi.pop(valOut)) << "SoFi shouldn't be empty here!";
+        EXPECT_TRUE(sofi.pop(valOut)) << "SoFi shouldn't be empty here!";
         EXPECT_EQ(serNumOldest + static_cast<int>(i), valOut); // check if the serial numbers are really consecutive
     }
 }
 
-void CUnitTestContainerSoFi::popAll(int serNumOldest)
+void SoFiTest::popAll(int serNumOldest)
 {
     int valOut{-2}; // set valOut to a value not present in the SoFi
     int serNum = serNumOldest;
-    while (m_sofi.pop(valOut))
+    while (sofi.pop(valOut))
     {
         EXPECT_EQ(serNum, valOut); // check if we have valid data
         serNum++;
@@ -127,31 +126,31 @@ void CUnitTestContainerSoFi::popAll(int serNumOldest)
     }
 }
 
-void CUnitTestContainerSoFi::checkEmpty(const std::string& scope, int serNumStart)
+void SoFiTest::checkEmpty(const std::string& scope, int serNumStart)
 {
     SCOPED_TRACE(scope); // just a helper to trace the failure when subroutines are used
 
     int valOut{-1}; // set valOut to a value not present in the SoFi
 
-    EXPECT_TRUE(m_sofi.empty()) << "SoFi should be empty!";
+    EXPECT_TRUE(sofi.empty()) << "SoFi should be empty!";
 
-    EXPECT_FALSE(m_sofi.pop(valOut)) << "It shouldn't be possible to pop from empty SoFi!";
+    EXPECT_FALSE(sofi.pop(valOut)) << "It shouldn't be possible to pop from empty SoFi!";
 
     // push an item
-    valOut = -1;                                   // set valOut to a value not present in the SoFi
-    EXPECT_TRUE(m_sofi.push(serNumStart, valOut)); // if empty, it should be possible to push
-    EXPECT_EQ(-1, valOut);                         // if push successful, valOut should not change
+    valOut = -1;                                 // set valOut to a value not present in the SoFi
+    EXPECT_TRUE(sofi.push(serNumStart, valOut)); // if empty, it should be possible to push
+    EXPECT_EQ(-1, valOut);                       // if push successful, valOut should not change
 
-    EXPECT_FALSE(m_sofi.empty()) << "SoFi shouldn't be empty anymore!";
+    EXPECT_FALSE(sofi.empty()) << "SoFi shouldn't be empty anymore!";
 
-    valOut = -1;                     // set valOut to a value not present in the SoFi
-    EXPECT_TRUE(m_sofi.pop(valOut)); // if not empty, pop should be successful
-    EXPECT_EQ(serNumStart, valOut);  // if pop successful, valOut should be serNumStart
+    valOut = -1;                    // set valOut to a value not present in the SoFi
+    EXPECT_TRUE(sofi.pop(valOut));  // if not empty, pop should be successful
+    EXPECT_EQ(serNumStart, valOut); // if pop successful, valOut should be serNumStart
 
-    EXPECT_TRUE(m_sofi.empty()) << "SoFi should be empty again!";
+    EXPECT_TRUE(sofi.empty()) << "SoFi should be empty again!";
 }
 
-void CUnitTestContainerSoFi::checkCapacity(const std::string& scope, int serNumStart)
+void SoFiTest::checkCapacity(const std::string& scope, int serNumStart)
 {
     SCOPED_TRACE(scope); // just a helper to trace the failure when subroutines are used
 
@@ -159,14 +158,14 @@ void CUnitTestContainerSoFi::checkCapacity(const std::string& scope, int serNumS
     int valIn = pushSome(serNumStart, TEST_SOFI_CAPACITY);
     // one more element should cause an overflow, which means the SoFi was already full
     int valOut{-1}; // set valOut to a value not present in the SoFi
-    EXPECT_FALSE(m_sofi.push(valIn, valOut)) << "No overflow occured! SoFi is not full yet!";
+    EXPECT_FALSE(sofi.push(valIn, valOut)) << "No overflow occured! SoFi is not full yet!";
     EXPECT_EQ(serNumStart, valOut); // in the case of an overflow, the oldest item is returned
 
     // empty the SoFi
     popAll(valOut + 1);
 }
 
-void CUnitTestContainerSoFi::checkOverflow(const std::string& scope, int serNumStart)
+void SoFiTest::checkOverflow(const std::string& scope, int serNumStart)
 {
     SCOPED_TRACE(scope); // just a helper to trace the failure when subroutines are used
 
@@ -176,7 +175,7 @@ void CUnitTestContainerSoFi::checkOverflow(const std::string& scope, int serNumS
     // fill the SoFi and return the first not pushed serial number
     valIn = pushSome(serNumStart, TEST_SOFI_CAPACITY);
     // pushing another item, should cause an overflow and returning the oldest pushed item
-    EXPECT_FALSE(m_sofi.push(valIn, valOut)) << "Expected overflow didn't occur";
+    EXPECT_FALSE(sofi.push(valIn, valOut)) << "Expected overflow didn't occur";
     EXPECT_EQ(serNumStart, valOut);
 
     // popping should return the remaining item
@@ -184,11 +183,11 @@ void CUnitTestContainerSoFi::checkOverflow(const std::string& scope, int serNumS
 
     // SoFi should now be empty
     valOut = -2; // set valOut to a value not present in the SoFi
-    EXPECT_FALSE(m_sofi.pop(valOut)) << "SoFi is not empty as expected!";
+    EXPECT_FALSE(sofi.pop(valOut)) << "SoFi is not empty as expected!";
     EXPECT_EQ(-2, valOut); // valOut not changed if empty
 }
 
-void CUnitTestContainerSoFi::checkMultiOverflow(const std::string& scope, int serNumStart)
+void SoFiTest::checkMultiOverflow(const std::string& scope, int serNumStart)
 {
     SCOPED_TRACE(scope); // just a helper to trace the failure when subroutines are used
 
@@ -203,7 +202,7 @@ void CUnitTestContainerSoFi::checkMultiOverflow(const std::string& scope, int se
     for (uint32_t i = 0; i < 3 * TEST_SOFI_CAPACITY; i++)
     {
         valOut = -2; // set valOut to a value not present in the SoFi
-        EXPECT_FALSE(m_sofi.push(valIn, valOut)) << "Expected overflow didn't occur at iteration " << i << "!";
+        EXPECT_FALSE(sofi.push(valIn, valOut)) << "Expected overflow didn't occur at iteration " << i << "!";
         EXPECT_EQ(serNumExp, valOut); // in case of an overflow, we should get the oldest item out of the SoFi
         valIn++;
         serNumExp++;
@@ -214,17 +213,17 @@ void CUnitTestContainerSoFi::checkMultiOverflow(const std::string& scope, int se
 
     // SoFi should now be empty
     valOut = -2; // set valOut to a value not present in the SoFi
-    EXPECT_FALSE(m_sofi.pop(valOut)) << "SoFi is not empty as expected!";
+    EXPECT_FALSE(sofi.pop(valOut)) << "SoFi is not empty as expected!";
     EXPECT_EQ(-2, valOut); // valOut not changed if empty
 }
 
-TEST_F(CUnitTestContainerSoFi, Empty)
+TEST_F(SoFiTest, Empty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "557d4e60-b214-4170-a07a-bf7ccbc38ba6");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
 
     // check if a new instace of the SoFi is empty
-    EXPECT_TRUE(m_sofi.empty());
+    EXPECT_TRUE(sofi.empty());
 
     // test with an initial SoFi read and write position of zero
     int serNumStart{1000};
@@ -234,13 +233,13 @@ TEST_F(CUnitTestContainerSoFi, Empty)
     checkEmpty("second", serNumStart);
 }
 
-TEST_F(CUnitTestContainerSoFi, Capacity)
+TEST_F(SoFiTest, Capacity)
 {
     ::testing::Test::RecordProperty("TEST_ID", "693ea584-72b2-401a-8a52-b5159eecdb53");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
 
     // check if SoFi sets the right capacity
-    EXPECT_EQ(static_cast<uint32_t>(TEST_SOFI_CAPACITY), m_sofi.capacity());
+    EXPECT_EQ(static_cast<uint32_t>(TEST_SOFI_CAPACITY), sofi.capacity());
 
     // check if SoFi doesn't lie to us
 
@@ -252,57 +251,53 @@ TEST_F(CUnitTestContainerSoFi, Capacity)
     checkCapacity("second", serNumStart);
 }
 
-TEST_F(CUnitTestContainerSoFi, NewlyCreatedSoFiIsEmpty)
+TEST_F(SoFiTest, NewlyCreatedSoFiIsEmpty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1e29ee14-c592-4d60-b7c0-c38bd390e518");
-    EXPECT_TRUE(m_sofi.empty());
+    EXPECT_TRUE(sofi.empty());
 }
 
-TEST_F(CUnitTestContainerSoFi, NewlyCreatedSoFiHasSizeZero)
+TEST_F(SoFiTest, NewlyCreatedSoFiHasSizeZero)
 {
     ::testing::Test::RecordProperty("TEST_ID", "89f0ccea-2e96-4a8c-9279-d33aec95b4c9");
-    EXPECT_EQ(m_sofi.size(), 0);
+    EXPECT_EQ(sofi.size(), 0);
 }
 
-TEST_F(CUnitTestContainerSoFi, SoFiSizeEqualsNumberOfPushes)
+TEST_F(SoFiTest, SoFiSizeEqualsNumberOfPushes)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cf415600-d1f5-45bb-8e23-7d72a8212efe");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
 
     // check if a new instace of the SoFi is empty
-    EXPECT_TRUE(m_sofi.empty());
-
-    int ret{-1};
+    EXPECT_TRUE(sofi.empty());
 
     // Push 10 items till SoFi is full and check size
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY; i++)
     {
-        EXPECT_EQ(m_sofi.size(), i);
-        m_sofi.push(static_cast<int>(i), ret);
-        EXPECT_EQ(m_sofi.size(), i + 1);
+        EXPECT_EQ(sofi.size(), i);
+        sofi.push(static_cast<int>(i), returnVal);
+        EXPECT_EQ(sofi.size(), i + 1);
     }
 }
 
-TEST_F(CUnitTestContainerSoFi, SoFiSizeEqualsNumberOfPushesOverflow)
+TEST_F(SoFiTest, SoFiSizeEqualsNumberOfPushesOverflow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "be946957-dddc-4038-8b34-cea6f8931e5e");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
 
     // check if a new instace of the SoFi is empty
-    EXPECT_TRUE(m_sofi.empty());
-
-    int ret{-1};
+    EXPECT_TRUE(sofi.empty());
 
     // Push 11 items to provoke overflow and check size
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY; i++)
     {
-        EXPECT_EQ(m_sofi.size(), i);
-        m_sofi.push(static_cast<int>(i), ret);
-        EXPECT_EQ(m_sofi.size(), i + 1);
+        EXPECT_EQ(sofi.size(), i);
+        sofi.push(static_cast<int>(i), returnVal);
+        EXPECT_EQ(sofi.size(), i + 1);
     }
 }
 
-TEST_F(CUnitTestContainerSoFi, Overflow)
+TEST_F(SoFiTest, Overflow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "47548956-f8f6-4649-9a04-eb766a014171");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
@@ -315,7 +310,7 @@ TEST_F(CUnitTestContainerSoFi, Overflow)
     checkOverflow("second", serNumStart);
 }
 
-TEST_F(CUnitTestContainerSoFi, MultiOverflow)
+TEST_F(SoFiTest, MultiOverflow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1b229258-250a-4cf6-b73f-ab5235a10624");
     SCOPED_TRACE(testId()); // just a helper to trace the failure when subroutines are used
@@ -328,169 +323,159 @@ TEST_F(CUnitTestContainerSoFi, MultiOverflow)
     checkMultiOverflow("second", serNumStart);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingASingleElement)
+TEST_F(SoFiTest, ResizeFailsWhenContainingASingleElement)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9c7c43d8-939c-4fa8-b1b9-b379515931e9");
-    int ret{-1};
-    m_sofi.push(123, ret);
-    EXPECT_EQ(m_sofi.setCapacity(4), false);
+    sofi.push(123, returnVal);
+    EXPECT_EQ(sofi.setCapacity(4), false);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenContainingAMultipleElements)
+TEST_F(SoFiTest, ResizeFailsWhenContainingAMultipleElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a98bd656-7d39-4274-a77f-bc918a2c1301");
-    int ret{-1};
-    m_sofi.push(123, ret);
-    m_sofi.push(13, ret);
-    m_sofi.push(23, ret);
-    EXPECT_EQ(m_sofi.setCapacity(4), false);
+    sofi.push(123, returnVal);
+    sofi.push(13, returnVal);
+    sofi.push(23, returnVal);
+    EXPECT_EQ(sofi.setCapacity(4), false);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizeFailsWhenFull)
+TEST_F(SoFiTest, ResizeFailsWhenFull)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6f58b6dd-20ab-42c7-9006-fbbcadb04f42");
-    for (int ret{-1}; !m_sofi.push(123, ret);)
+    while (!sofi.push(123, returnVal))
     {
     }
-    EXPECT_EQ(m_sofi.setCapacity(4), false);
+    EXPECT_EQ(sofi.setCapacity(4), false);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizingLargeThanCapacityFails)
+TEST_F(SoFiTest, ResizingLargeThanCapacityFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "609918f3-56aa-4e7e-8f7c-d171f2ca4602");
-    EXPECT_EQ(m_sofi.setCapacity(TEST_SOFI_CAPACITY + 1), false);
+    EXPECT_EQ(sofi.setCapacity(TEST_SOFI_CAPACITY + 1), false);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizingToZeroIsValid)
+TEST_F(SoFiTest, ResizingToZeroIsValid)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6675b4c4-7866-43d3-b3b2-aa1bff6b3053");
-    EXPECT_EQ(m_sofi.setCapacity(0), true);
+    EXPECT_EQ(sofi.setCapacity(0), true);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizingDefault)
+TEST_F(SoFiTest, ResizingDefault)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f2371e2a-56f2-4ab1-a168-a53fa2440f0b");
-    EXPECT_EQ(m_sofi.setCapacity(TEST_SOFI_CAPACITY - 1), true);
+    EXPECT_EQ(sofi.setCapacity(TEST_SOFI_CAPACITY - 1), true);
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizeAndSizeCheck)
+TEST_F(SoFiTest, ResizeAndSizeCheck)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b916cb44-303c-4dc3-8900-aea244482ef6");
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY; ++i)
     {
-        EXPECT_EQ(m_sofi.setCapacity(i), true);
-        EXPECT_EQ(m_sofi.capacity(), i);
+        EXPECT_EQ(sofi.setCapacity(i), true);
+        EXPECT_EQ(sofi.capacity(), i);
     }
 }
 
-TEST_F(CUnitTestContainerSoFi, ResizeAndSizeFillUp)
+TEST_F(SoFiTest, ResizeAndSizeFillUp)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3db02cd3-68ac-4507-8437-6bdbe423babf");
     for (uint32_t i = 0; i < TEST_SOFI_CAPACITY - 1; ++i)
     {
-        EXPECT_EQ(m_sofi.setCapacity(i), true);
+        EXPECT_EQ(sofi.setCapacity(i), true);
         for (uint32_t k = 0; k < i; ++k)
         {
-            int temp{-1};
-            EXPECT_EQ(m_sofi.push(static_cast<int>(k), temp), true);
+            returnVal = -1;
+            EXPECT_EQ(sofi.push(static_cast<int>(k), returnVal), true);
         }
         for (uint32_t k = 0; k < i; ++k)
         {
-            int temp{-1};
-            EXPECT_EQ(m_sofi.pop(temp), true);
-            EXPECT_EQ(temp, static_cast<int>(k));
+            returnVal = -1;
+            EXPECT_EQ(sofi.pop(returnVal), true);
+            EXPECT_EQ(returnVal, static_cast<int>(k));
         }
     }
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfWithValidCondition)
+TEST_F(SoFiTest, PopIfWithValidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f149035c-21cc-4f7d-ba4d-564a645e933b");
-    int returnValue{-1};
-    m_sofi.push(10, returnValue);
-    m_sofi.push(11, returnValue);
-    m_sofi.push(12, returnValue);
+    sofi.push(10, returnVal);
+    sofi.push(11, returnVal);
+    sofi.push(12, returnVal);
 
     int output{-1};
-    bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 20; });
+    bool result = sofi.popIf(output, [](const int& peek) { return peek < 20; });
 
     EXPECT_EQ(result, true);
     EXPECT_EQ(output, 10);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfWithInvalidCondition)
+TEST_F(SoFiTest, PopIfWithInvalidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1a494c28-928f-48f4-8b01-e68dfbd7563e");
-    int returnValue{-1};
-    m_sofi.push(15, returnValue);
-    m_sofi.push(16, returnValue);
-    m_sofi.push(17, returnValue);
+    sofi.push(15, returnVal);
+    sofi.push(16, returnVal);
+    sofi.push(17, returnVal);
 
-    int output{-1};
-    bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 5; });
+    bool result = sofi.popIf(returnVal, [](const int& peek) { return peek < 5; });
 
     EXPECT_EQ(result, false);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfOnEmpty)
+TEST_F(SoFiTest, PopIfOnEmpty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "960ad78f-cb9b-4c34-a077-6adb343a841c");
-    int output{-1};
-    bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 7; });
+    bool result = sofi.popIf(returnVal, [](const int& peek) { return peek < 7; });
 
     EXPECT_EQ(result, false);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfFullWithValidCondition)
+TEST_F(SoFiTest, PopIfFullWithValidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "167f2f01-f926-4442-bc4f-ff5e7cfe9fe0");
-    int output{-1};
     constexpr int INITIAL_VALUE = 100;
     constexpr int OFFSET = 2;
-    for (int i = 0; i < static_cast<int>(m_sofi.capacity()) + OFFSET; i++)
+    for (int i = 0; i < static_cast<int>(sofi.capacity()) + OFFSET; i++)
     {
-        m_sofi.push(i + INITIAL_VALUE, output);
+        sofi.push(i + INITIAL_VALUE, returnVal);
     }
 
-    bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 150; });
+    bool result = sofi.popIf(returnVal, [](const int& peek) { return peek < 150; });
 
     EXPECT_EQ(result, true);
-    EXPECT_EQ(output, INITIAL_VALUE + OFFSET);
+    EXPECT_EQ(returnVal, INITIAL_VALUE + OFFSET);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfFullWithInvalidCondition)
+TEST_F(SoFiTest, PopIfFullWithInvalidCondition)
 {
     ::testing::Test::RecordProperty("TEST_ID", "672881b9-eebd-471d-9d62-e792a8b8013f");
-    int output{-1};
-    for (int i = 0; i < static_cast<int>(m_sofi.capacity()) + 2; i++)
+    for (int i = 0; i < static_cast<int>(sofi.capacity()) + 2; i++)
     {
-        m_sofi.push(i + 100, output);
+        sofi.push(i + 100, returnVal);
     }
 
-    bool result = m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
+    bool result = sofi.popIf(returnVal, [](const int& peek) { return peek < 50; });
 
     EXPECT_EQ(result, false);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfValidEmptyAfter)
+TEST_F(SoFiTest, PopIfValidEmptyAfter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "19444dcd-7746-4e6b-a3b3-398c9d62317d");
-    int output{-1};
-    m_sofi.push(2, output);
+    sofi.push(2, returnVal);
 
-    m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
+    sofi.popIf(returnVal, [](const int& peek) { return peek < 50; });
 
-    EXPECT_EQ(m_sofi.empty(), true);
+    EXPECT_EQ(sofi.empty(), true);
 }
 
-TEST_F(CUnitTestContainerSoFi, PopIfInvalidNotEmptyAfter)
+TEST_F(SoFiTest, PopIfInvalidNotEmptyAfter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cadd7f02-6fe5-49a5-bd5d-837f5fcb2a71");
-    int output{-1};
-    m_sofi.push(200, output);
+    sofi.push(200, returnVal);
 
-    m_sofi.popIf(output, [](const int& peek) { return peek < 50; });
+    sofi.popIf(returnVal, [](const int& peek) { return peek < 50; });
 
-    EXPECT_EQ(m_sofi.empty(), false);
+    EXPECT_EQ(sofi.empty(), false);
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,14 +24,6 @@ namespace
 {
 struct SoFiTest : public ::testing::Test
 {
-    void SetUp() override
-    {
-    }
-
-    void TearDown() override
-    {
-    }
-
     /// @brief returns the ID of the current test in the format "TestCaseName.TestName"
     /// @return std::string: the id of the test
     static std::string testId();

--- a/iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
+++ b/iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,15 +39,6 @@ constexpr std::chrono::milliseconds STRESS_TIME{
 class SoFiStress : public Test
 {
   protected:
-    void SetUp() override
-    {
-    }
-
-    void TearDown() override
-    {
-    }
-
-
     /// @brief Sets the CPU affinity for a thread
     ///
     /// @param cpu is the CPU the thread shall use

--- a/iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
+++ b/iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
@@ -20,9 +20,9 @@
 #include "iceoryx_hoofs/testing/test.hpp"
 
 #include <cstdint>
+#include <cstdlib>
 #include <mutex>
 #include <queue>
-#include <stdlib.h>
 #include <thread>
 
 using namespace testing;
@@ -38,13 +38,12 @@ constexpr std::chrono::milliseconds STRESS_TIME{
 
 class SoFiStress : public Test
 {
-  public:
   protected:
-    virtual void SetUp()
+    void SetUp() override
     {
     }
 
-    virtual void TearDown()
+    void TearDown() override
     {
     }
 
@@ -54,12 +53,14 @@ class SoFiStress : public Test
     /// @param cpu is the CPU the thread shall use
     /// @param nativeHandle is the native handle of the c++11 std::thread
     /// @return bool: if true, setting the affinity was successfull
-    bool setCpuAffinity(unsigned int cpu, std::thread::native_handle_type nativeHandle)
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) used only for test purposes
+    static bool setCpuAffinity(unsigned int cpu, std::thread::native_handle_type nativeHandle)
     {
 #ifdef __linux__
         // Create a cpu_set_t object representing a set of CPUs. Clear it and mark only cpu as set.
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic) used only for test purposes
         CPU_SET(cpu, &cpuset);
         auto retVal = pthread_setaffinity_np(nativeHandle, sizeof(cpu_set_t), &cpuset);
         if (retVal != 0)
@@ -157,7 +158,7 @@ TEST_F(SoFiStress, SimultaneouslyPushAndPopOnEmptySoFi)
             isPushing = false;
 
             // if we do not get an expected value, perform the test for logging and stop the threads
-            if (pushResult == false || valOut >= 0)
+            if (!pushResult || valOut >= 0)
             {
                 EXPECT_THAT(pushResult, Eq(true)) << "Pushing is slower than popping! No overflow should occur!";
                 EXPECT_THAT(valOut, Lt(0)) << "Pushing is slower than popping! No value should be returned!";
@@ -244,14 +245,14 @@ TEST_F(SoFiStress, PopFromContinuouslyOverflowingSoFi)
             pushCounter++;
 
             // if we do not get an expected value, perform the test for logging and stop the threads
-            if (pushResult == true && valOut >= 0)
+            if (pushResult && valOut >= 0)
             {
                 EXPECT_THAT(valOut, Lt(0)) << "There was no overflow, but we still got data!";
                 stopPushThread = true;
                 stopPopThread = true;
             }
 
-            if (pushResult == false && valOut < 0)
+            if (!pushResult && valOut < 0)
             {
                 EXPECT_THAT(valOut, Gt(INVALID_SOFI_DATA)) << "There was an overflow, but we did not get data!";
                 stopPushThread = true;
@@ -262,7 +263,7 @@ TEST_F(SoFiStress, PopFromContinuouslyOverflowingSoFi)
             // if "pushResult == true" and "valOut < 0" -> no error, we are pushing into an non-full SoFi
 
             // this is what we want, an overflowing SoFi
-            if (pushResult == false && valOut >= 0)
+            if (!pushResult && valOut >= 0)
             {
                 // we had our first overflow -> allow popping
                 if (dataCounter == 0)
@@ -324,7 +325,7 @@ TEST_F(SoFiStress, PopFromContinuouslyOverflowingSoFi)
 
             // SoFi should never be empty
             auto emptyResult = sofi.empty();
-            if (emptyResult == true)
+            if (emptyResult)
             {
                 EXPECT_THAT(emptyResult, Eq(false)) << "SoFi is continuously overflowing and shouldn't be empty!";
                 stopPushThread = true;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
