### PR TITLE
iox-#1196 Fix clang-tidy warning in storable_function

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -65,9 +65,17 @@ class storable_function<StorageType, signature<ReturnType, Args...>>
               typename = typename std::enable_if<std::is_class<Functor>::value
                                                      && is_invocable_r<ReturnType, Functor, Args...>::value,
                                                  void>::type>
+    /// @NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
+    ///                      explicit would require a static_cast. Furthermore, the storable_functor stores a copy
+    ///                      which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
+    /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
     storable_function(const Functor& functor) noexcept;
 
     /// @brief construct from function pointer (including static functions)
+    /// @NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
+    ///                      explicit would require a static_cast. Furthermore, the storable_functor stores a copy
+    ///                      which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
+    /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
     storable_function(ReturnType (*function)(Args...)) noexcept;
 
     /// @brief construct from object reference and member function
@@ -154,6 +162,7 @@ class storable_function<StorageType, signature<ReturnType, Args...>>
         operations& operator=(const operations& other) noexcept = default;
         operations(operations&& other) noexcept = default;
         operations& operator=(operations&& other) noexcept = default;
+        ~operations() = default;
 
         void copy(const storable_function& src, storable_function& dest) noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -37,6 +37,9 @@ storable_function<S, signature<ReturnType, Args...>>::storable_function(ReturnTy
     if (function)
     {
         m_invoker = invokeFreeFunction;
+        /// @NOLINTJUSTIFICATION we use type erasure in combination with compile time template arguments to restore
+        ///                      the correct type whenever the callable is used
+        /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         m_callable = reinterpret_cast<void*>(function);
         m_operations.copyFunction = copyFreeFunction;
         m_operations.moveFunction = moveFreeFunction;
@@ -162,6 +165,8 @@ void storable_function<S, signature<ReturnType, Args...>>::storeFunctor(const Fu
     if (ptr)
     {
         // functor will fit, copy it
+        /// @NOLINTJUSTIFICATION ownership is encapsulated in storable_function and will be released in destroy
+        /// @NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         ptr = new (ptr) StoredType(functor);
 
         // erase the functor type and store as reference to the call in storage
@@ -197,6 +202,8 @@ void storable_function<S, signature<ReturnType, Args...>>::copy(const storable_f
     if (ptr)
     {
         auto obj = static_cast<CallableType*>(src.m_callable);
+        /// @NOLINTJUSTIFICATION ownership is encapsulated in storable_function and will be released in destroy
+        /// @NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         ptr = new (ptr) CallableType(*obj);
         dest.m_callable = ptr;
         dest.m_invoker = src.m_invoker;
@@ -227,6 +234,8 @@ void storable_function<S, signature<ReturnType, Args...>>::move(storable_functio
     if (ptr)
     {
         auto obj = static_cast<CallableType*>(src.m_callable);
+        /// @NOLINTJUSTIFICATION ownership is encapsulated in storable_function and will be released in destroy
+        /// @NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
         ptr = new (ptr) CallableType(std::move(*obj));
         dest.m_callable = ptr;
         dest.m_invoker = src.m_invoker;
@@ -284,6 +293,9 @@ ReturnType storable_function<S, signature<ReturnType, Args...>>::invoke(void* ca
 template <typename S, typename ReturnType, typename... Args>
 ReturnType storable_function<S, signature<ReturnType, Args...>>::invokeFreeFunction(void* callable, Args&&... args)
 {
+    /// @NOLINTJUSTIFICATION we use type erasure in combination with compile time template arguments to restore
+    ///                      the correct type whenever the callable is used
+    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return (reinterpret_cast<ReturnType (*)(Args...)>(callable))(std::forward<Args>(args)...);
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -53,13 +53,13 @@ class Counter
         ++numCreated;
     }
 
-    Counter(const Counter&)
+    Counter(const Counter& rhs IOX_MAYBE_UNUSED)
     {
         ++numCreated;
         ++numCopied;
     }
 
-    Counter(Counter&&)
+    Counter(Counter&& rhs IOX_MAYBE_UNUSED) noexcept
     {
         ++numMoved;
     }
@@ -69,14 +69,22 @@ class Counter
         ++numDestroyed;
     }
 
-    Counter& operator=(const Counter&)
+    Counter& operator=(const Counter& rhs)
     {
-        ++numCopied;
+        if (this != &rhs)
+        {
+            ++numCopied;
+        }
+        return *this;
     }
 
-    Counter& operator=(Counter&&)
+    Counter& operator=(Counter&& rhs) noexcept
     {
-        ++numMoved;
+        if (this != &rhs)
+        {
+            ++numMoved;
+        }
+        return *this;
     }
 
     static void resetCounts()
@@ -104,9 +112,8 @@ uint64_t Counter<T>::numDestroyed = 0U;
 class Functor : public Counter<Functor>
 {
   public:
-    Functor(int32_t state)
-        : Counter<Functor>()
-        , m_state(state)
+    explicit Functor(int32_t state)
+        : m_state(state)
     {
     }
 
@@ -133,7 +140,7 @@ int32_t freeFunction(int32_t n)
 struct Arg : Counter<Arg>
 {
     Arg() = default;
-    Arg(int32_t value)
+    explicit Arg(int32_t value)
         : value(value){};
     Arg(const Arg&) = default;
     Arg& operator=(const Arg&) = default;
@@ -145,10 +152,10 @@ struct Arg : Counter<Arg>
     // Note that this is mainly an issue if the argument is passed by value.
     // The std::function also fails to compile in this case (gcc implementation).
 
-    int32_t value;
+    int32_t value{0};
 };
 
-int32_t freeFunctionWithCopyableArg(Arg arg)
+int32_t freeFunctionWithCopyableArg(const Arg& arg)
 {
     return arg.value;
 }
@@ -273,7 +280,7 @@ TEST_F(function_test, FunctionStateIsIndependentOfSource)
     ::testing::Test::RecordProperty("TEST_ID", "8302046f-cd6a-4527-aca6-3e6408f87a6b");
     constexpr uint32_t INITIAL_STATE = 73U;
     static_storage<1024U> storage;
-    auto p = storage.allocate<Functor>();
+    auto* p = storage.allocate<Functor>();
     p = new (p) Functor(INITIAL_STATE);
 
     // call the dtor in any case (even if the test fails due to ASSERT)
@@ -319,6 +326,8 @@ TEST_F(function_test, CopyCtorCopiesStoredFunctor)
     test_function f(functor);
     Functor::resetCounts();
 
+    /// @NOLINTJUSTIFICATION the copy constructor is tested here
+    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     test_function sut(f);
 
     EXPECT_EQ(Functor::numCopied, 1U);
@@ -382,6 +391,8 @@ TEST_F(function_test, CopyCtorCopiesStoredFreeFunction)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8f95a82a-c879-48b1-aa56-316bf15b983a");
     test_function f(freeFunction);
+    /// @NOLINTJUSTIFICATION the copy constructor is tested here
+    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     test_function sut(f);
 
     ASSERT_TRUE(sut.operator bool());
@@ -440,6 +451,8 @@ TEST_F(function_test, CopiedNonCallableFunctionIsNotCallable)
     test_function f;
     Functor::resetCounts();
 
+    /// @NOLINTJUSTIFICATION the copy constructor is tested here
+    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     test_function sut(f);
 
     EXPECT_EQ(Functor::numCopied, 0U);
@@ -567,8 +580,8 @@ TEST_F(function_test, IsNotStorableDueToSignature)
 TEST_F(function_test, CallWithCopyConstructibleArgument)
 {
     ::testing::Test::RecordProperty("TEST_ID", "20018d76-6255-407a-b3d3-77b6b480067d");
-    iox::cxx::function<int32_t(Arg), 1024> sut(freeFunctionWithCopyableArg);
-    std::function<int32_t(Arg)> func(freeFunctionWithCopyableArg);
+    iox::cxx::function<int32_t(const Arg&), 1024> sut(freeFunctionWithCopyableArg);
+    std::function<int32_t(const Arg&)> func(freeFunctionWithCopyableArg);
     Arg::resetCounts();
 
     Arg arg(73);
@@ -631,7 +644,9 @@ TEST_F(function_test, CallWithValueArgumentsWorks)
     const int32_t initial = 73;
     Arg arg(initial);
 
-    auto lambda = [](Arg a) { return a.value + 1; };
+    /// @NOLINTJUSTIFICATION value argument is tested here
+    /// @NOLINTNEXTLINE(performance-unnecessary-value-param)
+    auto lambda = [](const Arg a) { return a.value + 1; };
     iox::cxx::function<int32_t(Arg&), 128> sut(lambda);
 
     ASSERT_TRUE(sut.operator bool());
@@ -665,6 +680,8 @@ TEST_F(function_test, CallWithMixedArgumentsWorks)
 
     constexpr int32_t sum = 10;
 
+    /// @NOLINTJUSTIFICATION value argument is tested here
+    /// @NOLINTNEXTLINE(performance-unnecessary-value-param)
     auto lambda = [](Arg& a1, const Arg& a2, Arg&& a3, Arg a4) { return a1.value + a2.value + a3.value + a4.value; };
     iox::cxx::function<int32_t(Arg&, const Arg&, Arg&&, Arg), 128> sut(lambda);
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196 
