### PR TITLE
iox-#1196 fix loffli warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/requires.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/requires.hpp
@@ -33,8 +33,12 @@ void Require(
 // see:
 // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-expects
 /// @NOLINTJUSTIFICATION macro required to capture file, line, function origin of call implicitly
-/// @NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+/// @NOLINTBEGIN(cppcoreguidelines-macro-usage)
+/// @NOLINTJUSTIFICATION array decay: needed for source code location, safely wrapped in macro
+/// @NOLINTBEGIN(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 #define Expects(condition) internal::Require(condition, __FILE__, __LINE__, __PRETTY_FUNCTION__, #condition)
+/// @NOLINTEND(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+/// @NOLINTEND(cppcoreguidelines-macro-usage)
 
 // implementing C++ Core Guideline, I.8. Prefer Ensures
 // see:

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
@@ -27,19 +27,22 @@ namespace iox
 {
 namespace concurrent
 {
+constexpr uint32_t NODE_ALIGNMENT{8};
+constexpr uint32_t NODE_SIZE{8};
+
 class LoFFLi
 {
   public:
     using Index_t = uint32_t;
 
   private:
-    struct alignas(8) Node
+    struct alignas(NODE_ALIGNMENT) Node
     {
         Index_t indexToNextFreeIndex;
         uint32_t abaCounter;
     };
 
-    static_assert(sizeof(Node) <= 8U,
+    static_assert(sizeof(Node) <= NODE_SIZE,
                   "The size of 'Node' must not exceed 8 bytes in order to be lock-free on 64 bit systems!");
 
     /// @todo introduce typesafe indices with the properties listed below

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.inl
@@ -17,6 +17,8 @@
 #ifndef IOX_HOOFS_CONCURRENT_LOFFLI_INL
 #define IOX_HOOFS_CONCURRENT_LOFFLI_INL
 
+#include "iceoryx_hoofs/internal/concurrent/loffli.hpp"
+
 namespace iox
 {
 namespace concurrent

--- a/iceoryx_hoofs/source/concurrent/loffli.cpp
+++ b/iceoryx_hoofs/source/concurrent/loffli.cpp
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/concurrent/loffli.hpp"
+#include "iceoryx_hoofs/cxx/requires.hpp"
 #include "iceoryx_hoofs/platform/platform_correction.hpp"
 
 #include <cassert>

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_loffli.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_loffli.cpp
@@ -52,6 +52,7 @@ class LoFFLi_test : public Test
     }
 
     using LoFFLiIndex_t = typename LoFFLiType::Index_t;
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays) needed for LoFFLi::init
     LoFFLiIndex_t m_memoryLoFFLi[LoFFLiType::requiredIndexMemorySize(Size)];
     LoFFLiType m_loffli;
 };
@@ -60,22 +61,30 @@ TYPED_TEST(LoFFLi_test, Misuse_NullptrMemory)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ab877f29-cab0-48ae-a2c0-054633b6415a");
     decltype(this->m_loffli) loFFLi;
+    // todo #1196 remove EXPECT_DEATH
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(loFFLi.init(nullptr, 1), ".*");
 }
 
 TYPED_TEST(LoFFLi_test, Misuse_ZeroSize)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb9c797b-22b4-4572-a7a2-eaf13574dbac");
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays) needed to test LoFFLi::init
     uint32_t memoryLoFFLi[4];
     decltype(this->m_loffli) loFFLi;
+    // todo #1196 remove EXPECT_DEATH
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(loFFLi.init(memoryLoFFLi, 0), ".*");
 }
 
 TYPED_TEST(LoFFLi_test, Misuse_SizeToLarge)
 {
     ::testing::Test::RecordProperty("TEST_ID", "14b4b82c-ae2b-4bd2-97cf-93fcea87f050");
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays) needed to test LoFFLi::init
     uint32_t memoryLoFFLi[4];
     decltype(this->m_loffli) loFFLi;
+    // todo #1196 remove EXPECT_DEATH
+    // NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(loFFLi.init(memoryLoFFLi, UINT32_MAX - 1), ".*");
 }
 
@@ -126,7 +135,7 @@ TYPED_TEST(LoFFLi_test, SinglePush)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0b7bf346-056b-4b1c-a6e9-92b54233598e");
     constexpr uint32_t AFFE = 0xAFFE;
-    uint32_t index;
+    uint32_t index{0};
     this->m_loffli.pop(index);
 
     uint32_t indexPush = index;
@@ -140,7 +149,7 @@ TYPED_TEST(LoFFLi_test, PushTillFull)
 {
     ::testing::Test::RecordProperty("TEST_ID", "610e3e8f-1db9-4a92-a5e8-2d1bb0077123");
     std::vector<uint32_t> useList;
-    uint32_t index;
+    uint32_t index{0};
     while (this->m_loffli.pop(index))
     {
         useList.push_back(index);
@@ -157,7 +166,7 @@ TYPED_TEST(LoFFLi_test, PushRandomOrder)
     ::testing::Test::RecordProperty("TEST_ID", "73700ca3-3a37-48af-8485-91e0a7b4e3d0");
     std::vector<uint32_t> useListToPush;
     std::vector<uint32_t> useListPoped;
-    uint32_t index;
+    uint32_t index{0};
     while (this->m_loffli.pop(index))
     {
         useListToPush.push_back(index);
@@ -187,7 +196,7 @@ TYPED_TEST(LoFFLi_test, PushRandomOrder)
 TYPED_TEST(LoFFLi_test, PushWrongIndex)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9a3fabd1-17c0-4e40-8390-53ca4d656d91");
-    uint32_t index;
+    uint32_t index{0};
     this->m_loffli.pop(index);
 
     uint32_t indexPush = index + 1;
@@ -197,7 +206,7 @@ TYPED_TEST(LoFFLi_test, PushWrongIndex)
 TYPED_TEST(LoFFLi_test, PushOutOfBoundIndex)
 {
     ::testing::Test::RecordProperty("TEST_ID", "261ba489-1cec-44db-8c41-d9e71c761d91");
-    uint32_t index;
+    uint32_t index{0};
     this->m_loffli.pop(index);
 
     EXPECT_THAT(this->m_loffli.push(Size), Eq(false));


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
