### PR TITLE
Iox #1196 fix clang tidy warnings shared memory object

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,8 +31,6 @@ hicpp-*,
 -readability-use-anyofallof,
 -readability-named-parameter,
 
-- bugprone-easily-swappable-parameters
-
 '
 
 ### Temporarily disabled because massive API changes:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,8 @@ hicpp-*,
 -readability-use-anyofallof,
 -readability-named-parameter,
 
+- bugprone-easily-swappable-parameters
+
 '
 
 ### Temporarily disabled because massive API changes:

--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -2,8 +2,11 @@
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/*
 ./iceoryx_hoofs/test/moduletests/test_cxx*
 ./iceoryx_hoofs/source/cxx/*
-
-
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
+./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
+./iceoryx_hoofs/test/moduletests/test_allocator.cpp
+./iceoryx_hoofs/test/moduletests/test_shared_memory.cpp
+./iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
 
 # IMPORTANT:
 #    after the first # everything is considered a comment, add new files and

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp
@@ -54,8 +54,8 @@ class Allocator
 
   private:
     byte_t* m_startAddress{nullptr};
-    uint64_t m_length{0u};
-    uint64_t m_currentPosition = 0u;
+    uint64_t m_length{0U};
+    uint64_t m_currentPosition = 0U;
     bool m_allocationFinalized = false;
 };
 } // namespace posix

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp
@@ -57,9 +57,11 @@ enum class MemoryMapFlags : int32_t
     PRIVATE_CHANGES = MAP_PRIVATE,
 
     /// @brief SHARED and enforce the base address hint
+    // NOLINTNEXTLINE(hicpp-signed-bitwise) enum type is defined by POSIX, no logical fault
     SHARE_CHANGES_AND_FORCE_BASE_ADDRESS_HINT = MAP_SHARED | MAP_FIXED,
 
     /// @brief PRIVATE and enforce the base address hint
+    // NOLINTNEXTLINE(hicpp-signed-bitwise) enum type is defined POSIX, no logical fault
     PRIVATE_CHANGES_AND_FORCE_BASE_ADDRESS_HINT = MAP_PRIVATE | MAP_FIXED,
 };
 

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -35,12 +35,8 @@ Allocator::Allocator(void* const startAddress, const uint64_t length) noexcept
 
 void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
 {
-    /// @todo replace Expects with IOX_ASSERT
-    // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Expects(size > 0);
 
-    /// @todo replace Expects with IOX_ASSERT
-    // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Expects(
         !m_allocationFinalized
         && "allocate() call after finalizeAllocation()! You are not allowed to acquire shared memory chunks anymore");

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -33,6 +33,8 @@ Allocator::Allocator(void* const startAddress, const uint64_t length) noexcept
     /// @todo memset to set memory and to avoid the usage of unavailable memory
 }
 
+// NOLINTJUSTIFICATION allocation interface requires size and alignment as integral types
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
 {
     cxx::Expects(size > 0);

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -35,14 +35,21 @@ Allocator::Allocator(void* const startAddress, const uint64_t length) noexcept
 
 void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
 {
+    /// @todo replace Expects with IOX_ASSERT
+    // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Expects(size > 0);
 
+    /// @todo replace Expects with IOX_ASSERT
+    // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Expects(
         !m_allocationFinalized
         && "allocate() call after finalizeAllocation()! You are not allowed to acquire shared memory chunks anymore");
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     uint64_t currentAddress = reinterpret_cast<uint64_t>(m_startAddress) + m_currentPosition;
     uint64_t alignedPosition = cxx::align(currentAddress, static_cast<uint64_t>(alignment));
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     alignedPosition -= reinterpret_cast<uint64_t>(m_startAddress);
 
     byte_t* l_returnValue = nullptr;
@@ -59,6 +66,8 @@ void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcep
                   << " when there are already " << alignedPosition << " aligned bytes in use." << std::endl;
         std::cerr << "Only " << m_length - alignedPosition << " bytes left." << std::endl;
 
+        /// @todo replace Expects with IOX_ASSERT
+        // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         cxx::Expects(false && "Not enough space left in shared memory");
     }
 

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -64,8 +64,6 @@ void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcep
                   << " when there are already " << alignedPosition << " aligned bytes in use." << std::endl;
         std::cerr << "Only " << m_length - alignedPosition << " bytes left." << std::endl;
 
-        /// @todo replace Expects with IOX_ASSERT
-        // NOLINTNEXTLINE(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         cxx::Expects(false && "Not enough space left in shared memory");
     }
 

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -49,11 +49,9 @@ cxx::expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
                                   m_offset)
 
                       // NOLINTJUSTIFICATION cast required, type of error MAP_FAILED defined by POSIX to be void*
-                      // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr,
-                      // cppcoreguidelines-pro-type-reinterpret-cast)
-                      .failureReturnValue(reinterpret_cast<void*>(MAP_FAILED))
-                      // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr,
-                      // cppcoreguidelines-pro-type-reinterpret-cast)
+                      // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr)
+                      .failureReturnValue(MAP_FAILED)
+                      // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr)
                       .evaluate();
 
     if (result)

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -34,6 +34,7 @@ cxx::expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
         l_memoryProtection = PROT_READ;
         break;
     case AccessMode::READ_WRITE:
+        // NOLINTNEXTLINE(hicpp-signed-bitwise) enum type is defined by POSIX, no logical fault
         l_memoryProtection = PROT_READ | PROT_WRITE;
         break;
     }
@@ -46,8 +47,11 @@ cxx::expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
                                   static_cast<int32_t>(m_flags),
                                   m_fileDescriptor,
                                   m_offset)
-                      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr)
-                      .failureReturnValue(MAP_FAILED)
+                      // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr,
+                      // cppcoreguidelines-pro-type-reinterpret-cast)
+                      // cast required, type of error MAP_FAILED defined by POSIX to be void*
+                      .failureReturnValue(reinterpret_cast<void*>(MAP_FAILED))
+                      // NOLINTEND
                       .evaluate();
 
     if (result)
@@ -148,8 +152,8 @@ MemoryMap& MemoryMap::operator=(MemoryMap&& rhs) noexcept
             std::cerr << "move assignment failed to unmap mapped memory" << std::endl;
         }
 
-        m_baseAddress = std::move(rhs.m_baseAddress);
-        m_length = std::move(rhs.m_length);
+        m_baseAddress = rhs.m_baseAddress;
+        m_length = rhs.m_length;
 
         rhs.m_baseAddress = nullptr;
         rhs.m_length = 0U;

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -47,11 +47,13 @@ cxx::expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
                                   static_cast<int32_t>(m_flags),
                                   m_fileDescriptor,
                                   m_offset)
+
+                      // NOLINTJUSTIFICATION cast required, type of error MAP_FAILED defined by POSIX to be void*
                       // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr,
                       // cppcoreguidelines-pro-type-reinterpret-cast)
-                      // cast required, type of error MAP_FAILED defined by POSIX to be void*
                       .failureReturnValue(reinterpret_cast<void*>(MAP_FAILED))
-                      // NOLINTEND
+                      // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr,
+                      // cppcoreguidelines-pro-type-reinterpret-cast)
                       .evaluate();
 
     if (result)

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -187,8 +187,8 @@ SharedMemory& SharedMemory::operator=(SharedMemory&& rhs) noexcept
         destroy();
 
         m_name = rhs.m_name;
-        m_hasOwnership = std::move(rhs.m_hasOwnership);
-        m_handle = std::move(rhs.m_handle);
+        m_hasOwnership = rhs.m_hasOwnership;
+        m_handle = rhs.m_handle;
 
         rhs.reset();
     }

--- a/iceoryx_hoofs/test/moduletests/test_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_allocator.cpp
@@ -78,10 +78,12 @@ TEST_F(Allocator_Test, allocateTooMuchSingleElement)
     ::testing::Test::RecordProperty("TEST_ID", "9deed5c0-19d8-4469-a5c3-f185d4d881f1");
     iox::posix::Allocator sut(memory, memorySize);
     std::set_terminate([]() { std::cout << "", std::abort(); });
+    // todo #1196 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg) death test
+    // hiccpp-vararg)
     EXPECT_DEATH({ sut.allocate(memorySize + 1, MEMORY_ALIGNMENT); }, ".*");
-    // NOLINTEND
+    // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg)
 }
 
 TEST_F(Allocator_Test, allocateTooMuchMultipleElement)
@@ -95,10 +97,12 @@ TEST_F(Allocator_Test, allocateTooMuchMultipleElement)
 
     std::set_terminate([]() { std::cout << "", std::abort(); });
 
+    // todo #1196 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg) death test
+    // hiccpp-vararg)
     EXPECT_DEATH({ sut.allocate(1, MEMORY_ALIGNMENT); }, ".*");
-    // NOLINTEND
+    // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg)
 }
 
 TEST_F(Allocator_Test, allocateAndAlignment)
@@ -115,10 +119,12 @@ TEST_F(Allocator_Test, allocateElementOfSizeZero)
     ::testing::Test::RecordProperty("TEST_ID", "17caa50c-94bf-4a1d-a1ec-dfda563caa0b");
     iox::posix::Allocator sut(memory, memorySize);
 
+    // todo #1196 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg) death test
+    // hiccpp-vararg)
     EXPECT_DEATH(sut.allocate(0, MEMORY_ALIGNMENT), ".*");
-    // NOLINTEND
+    // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg)
 }
 
 TEST_F(Allocator_Test, allocateAfterFinalizeAllocation)
@@ -140,9 +146,11 @@ TEST_F(Allocator_Test, allocateAfterFinalizeAllocation)
 
     std::set_terminate([]() { std::cout << "", std::abort(); });
 
+    // todo #1196 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg) death test
+    // hiccpp-vararg)
     EXPECT_DEATH({ sut.allocate(5, MEMORY_ALIGNMENT); }, ".*");
-    // NOLINTEND
+    // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg)
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_allocator.cpp
@@ -27,17 +27,19 @@ class Allocator_Test : public Test
   public:
     void SetUp() override
     {
+        // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) required to test allocation
         memory = malloc(memorySize);
     }
 
     void TearDown() override
     {
+        // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) required to test allocation
         free(memory);
     }
 
     static constexpr uint64_t MEMORY_ALIGNMENT{iox::posix::Allocator::MEMORY_ALIGNMENT};
 
-    void* memory;
+    void* memory{nullptr};
     size_t memorySize = 10016;
 };
 
@@ -65,7 +67,7 @@ TEST_F(Allocator_Test, allocateEverythingWithMultipleElements)
     iox::posix::Allocator sut(memory, memorySize);
     for (size_t i = 0; i < memorySize; i += 32)
     {
-        size_t* bla = static_cast<size_t*>(sut.allocate(32, 1));
+        auto* bla = static_cast<size_t*>(sut.allocate(32, 1));
         *bla = i;
         EXPECT_THAT(*bla, Eq(i));
     }
@@ -76,7 +78,10 @@ TEST_F(Allocator_Test, allocateTooMuchSingleElement)
     ::testing::Test::RecordProperty("TEST_ID", "9deed5c0-19d8-4469-a5c3-f185d4d881f1");
     iox::posix::Allocator sut(memory, memorySize);
     std::set_terminate([]() { std::cout << "", std::abort(); });
+    // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg) death test
     EXPECT_DEATH({ sut.allocate(memorySize + 1, MEMORY_ALIGNMENT); }, ".*");
+    // NOLINTEND
 }
 
 TEST_F(Allocator_Test, allocateTooMuchMultipleElement)
@@ -89,15 +94,19 @@ TEST_F(Allocator_Test, allocateTooMuchMultipleElement)
     }
 
     std::set_terminate([]() { std::cout << "", std::abort(); });
+
+    // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg) death test
     EXPECT_DEATH({ sut.allocate(1, MEMORY_ALIGNMENT); }, ".*");
+    // NOLINTEND
 }
 
 TEST_F(Allocator_Test, allocateAndAlignment)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4252ddcc-05d4-499f-ad7c-30bffb420e08");
     iox::posix::Allocator sut(memory, memorySize);
-    auto bla = static_cast<uint8_t*>(sut.allocate(5, MEMORY_ALIGNMENT));
-    auto bla2 = static_cast<uint8_t*>(sut.allocate(5, MEMORY_ALIGNMENT));
+    auto* bla = static_cast<uint8_t*>(sut.allocate(5, MEMORY_ALIGNMENT));
+    auto* bla2 = static_cast<uint8_t*>(sut.allocate(5, MEMORY_ALIGNMENT));
     EXPECT_THAT(bla2 - bla, Eq(8U));
 }
 
@@ -105,7 +114,11 @@ TEST_F(Allocator_Test, allocateElementOfSizeZero)
 {
     ::testing::Test::RecordProperty("TEST_ID", "17caa50c-94bf-4a1d-a1ec-dfda563caa0b");
     iox::posix::Allocator sut(memory, memorySize);
+
+    // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg) death test
     EXPECT_DEATH(sut.allocate(0, MEMORY_ALIGNMENT), ".*");
+    // NOLINTEND
 }
 
 TEST_F(Allocator_Test, allocateAfterFinalizeAllocation)
@@ -126,6 +139,10 @@ TEST_F(Allocator_Test, allocateAfterFinalizeAllocation)
     sut.finalizeAllocation();
 
     std::set_terminate([]() { std::cout << "", std::abort(); });
+
+    // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+    // hiccpp-vararg) death test
     EXPECT_DEATH({ sut.allocate(5, MEMORY_ALIGNMENT); }, ".*");
+    // NOLINTEND
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_shared_memory.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_shared_memory.cpp
@@ -127,12 +127,9 @@ TEST_F(SharedMemory_Test, MoveCTorWithValidValues)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2844c9c5-856e-4b51-890d-1418f79f1a80");
 
-    // NOLINTNEXTLINE(cppcoreguidelines-init-variables) initialized before read
-    int handle;
-
     auto sut = createSut(SUT_SHM_NAME, iox::posix::OpenMode::PURGE_AND_CREATE);
     ASSERT_FALSE(sut.has_error());
-    handle = sut->getHandle();
+    int handle = sut->getHandle();
     {
         iox::posix::SharedMemory sut2(std::move(*sut));
         EXPECT_THAT(handle, Eq(sut2.getHandle()));

--- a/iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
@@ -46,10 +46,12 @@ class SharedMemoryObject_Test : public Test
         std::set_terminate([]() { std::cout << "", std::abort(); });
 
         internal::GetCapturedStderr();
+        // todo #1196 remove EXPECT_DEATH
         // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-        // hiccpp-vararg) death test
+        // hiccpp-vararg)
         EXPECT_DEATH({ deathTest(); }, ".*");
-        // NOLINTEND
+        // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+        // hiccpp-vararg)
         internal::CaptureStderr();
     }
 };

--- a/iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
@@ -41,12 +41,15 @@ class SharedMemoryObject_Test : public Test
         }
     }
 
-    void PerformDeathTest(const std::function<void()>& deathTest)
+    static void PerformDeathTest(const std::function<void()>& deathTest)
     {
         std::set_terminate([]() { std::cout << "", std::abort(); });
 
         internal::GetCapturedStderr();
+        // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
+        // hiccpp-vararg) death test
         EXPECT_DEATH({ deathTest(); }, ".*");
+        // NOLINTEND
         internal::CaptureStderr();
     }
 };
@@ -134,7 +137,7 @@ TEST_F(SharedMemoryObject_Test, AllocateWholeSharedMemoryWithMultipleChunks)
 TEST_F(SharedMemoryObject_Test, AllocateTooMuchMemoryInSharedMemoryWithOneChunk)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4b054aac-1d49-4260-afc0-908b184e0b12");
-    uint64_t memorySize{8u};
+    uint64_t memorySize{8U};
 
     auto sut = iox::posix::SharedMemoryObjectBuilder()
                    .name("shmAllocate")
@@ -152,7 +155,7 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchMemoryInSharedMemoryWithOneChunk)
 TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5bb3c7fc-0f15-4487-8479-b27d1d4a17d3");
-    uint64_t memorySize{8u};
+    uint64_t memorySize{8U};
     auto sut = iox::posix::SharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(memorySize)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes
