### PR TITLE
iox-#1196 Fix warnings in file lock

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/file_lock.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/file_lock.hpp
@@ -60,6 +60,8 @@ class FileLock
 {
   public:
     static constexpr int32_t INVALID_FD = -1;
+    /// NOLINTJUSTIFICATION Required as a safe and null terminated compile time string literal
+    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static constexpr const char LOCK_FILE_SUFFIX[] = ".lock";
     static constexpr uint64_t PATH_SEPARATOR_LENGTH = 1U;
     static constexpr uint64_t LOCK_FILE_SUFFIX_LENGTH = sizeof(LOCK_FILE_SUFFIX) / sizeof(char);
@@ -88,6 +90,8 @@ class FileLock
   private:
     enum class LockOperation : int32_t
     {
+        /// NOLINTJUSTIFICATION abstracted in enum as value so that the user does not have to use bit operations
+        /// NOLINTNEXTLINE(hicpp-signed-bitwise)
         LOCK = LOCK_EX | LOCK_NB,
         UNLOCK = LOCK_UN
     };

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -30,6 +30,8 @@ namespace iox
 {
 namespace posix
 {
+/// NOLINTJUSTIFICATION see declaration
+/// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char FileLock::LOCK_FILE_SUFFIX[];
 
 cxx::expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
@@ -112,7 +114,7 @@ FileLock& FileLock::operator=(FileLock&& rhs) noexcept
         }
 
         m_fileLockPath = std::move(rhs.m_fileLockPath);
-        m_fd = std::move(rhs.m_fd);
+        m_fd = rhs.m_fd;
 
         rhs.invalidate();
     }
@@ -217,7 +219,7 @@ FileLockError FileLock::convertErrnoToFileLockError(const int32_t errnum, const 
     }
     case ENOENT:
     {
-        LogError() << "directory \"" << platform::IOX_LOCK_FILE_PATH_PREFIX << "\""
+        LogError() << "directory \"" << &platform::IOX_LOCK_FILE_PATH_PREFIX[0] << "\""
                    << " does not exist.";
         return FileLockError::NO_SUCH_DIRECTORY;
     }

--- a/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
@@ -25,8 +25,12 @@ using namespace ::testing;
 using namespace iox::posix;
 using namespace iox::cxx;
 
+/// NOLINTJUSTIFICATION compile time string literal used only in tests
+/// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr char TEST_NAME[] = "TestProcess";
 constexpr char ANOTHER_TEST_NAME[] = "AnotherTestProcess";
+/// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+
 
 /// @req
 /// @brief This test suite verifies the RAII behaviour of FileLock
@@ -36,11 +40,7 @@ constexpr char ANOTHER_TEST_NAME[] = "AnotherTestProcess";
 class FileLock_test : public Test
 {
   public:
-    FileLock_test()
-    {
-    }
-
-    void SetUp()
+    void SetUp() override
     {
         auto maybeFileLock =
             iox::posix::FileLockBuilder().name(TEST_NAME).permission(iox::cxx::perms::owner_all).create();
@@ -49,14 +49,11 @@ class FileLock_test : public Test
         ASSERT_TRUE(m_sut.has_value());
     }
 
-    void TearDown()
+    void TearDown() override
     {
         m_sut.reset();
     }
 
-    ~FileLock_test()
-    {
-    }
     optional<FileLock> m_sut;
 };
 
@@ -91,7 +88,7 @@ TEST_F(FileLock_test, MaxStringWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1cf3418d-51d1-4ead-9001-e0d8e61617f0");
     const FileLock::FileName_t maxString(iox::cxx::TruncateToCapacity,
-                                         std::string(FileLock::FileName_t().capacity(), 'x'));
+                                         std::string(FileLock::FileName_t::capacity(), 'x'));
     auto sut2 = iox::posix::FileLockBuilder().name(maxString).create();
     ASSERT_FALSE(sut2.has_error());
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
