### PR TITLE
iox-#1196 fix warnings in message queue and ipc channel test

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/message_queue.hpp
@@ -90,7 +90,7 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
     /// @brief try to send a message to the queue for a given timeout duration using std::string
     cxx::expected<IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
 
-    cxx::expected<bool, IpcChannelError> isOutdated() noexcept;
+    static cxx::expected<bool, IpcChannelError> isOutdated() noexcept;
 
   private:
     MessageQueue(const IpcChannelName_t& name,
@@ -120,6 +120,9 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
     static constexpr int TIMEOUT_ERRNO = ETIMEDOUT;
 #endif
     // read/write permissions
+    /// NOLINTJUSTIFICATION used inside the wrapper so that the user does not have to use this
+    ///                     construct from outside
+    /// NOLINTNEXTLINE(hicpp-signed-bitwise)
     static constexpr mode_t m_filemode{S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH};
 };
 } // namespace posix

--- a/iceoryx_hoofs/test/moduletests/test_ipc_channel.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_ipc_channel.cpp
@@ -40,10 +40,13 @@ using IpcChannelTypes = Types<UnixDomainSocket, NamedPipe>;
 using IpcChannelTypes = Types<MessageQueue, UnixDomainSocket, NamedPipe>;
 #endif
 
+/// NOLINTJUSTIFICATION only used in testing
+/// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr char goodName[] = "channel_test";
 constexpr char anotherGoodName[] = "horst";
 constexpr char theUnknown[] = "WhoeverYouAre";
 constexpr char slashName[] = "/miau";
+/// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 
 /// @req
 /// @brief This test suite verifies that the abstract interface IpcChannelType is fulfilled by both the UnixDomainSocket
@@ -58,7 +61,7 @@ class IpcChannel_test : public Test
   public:
     using IpcChannelType = T;
 
-    void SetUp()
+    void SetUp() override
     {
         IOX_DISCARD_RESULT(IpcChannelType::unlinkIfExists(goodName));
 
@@ -72,17 +75,13 @@ class IpcChannel_test : public Test
         client = std::move(clientResult.value());
     }
 
-    void TearDown()
+    void TearDown() override
     {
         std::string output = ::testing::internal::GetCapturedStderr();
         if (Test::HasFailure())
         {
             std::cout << output << std::endl;
         }
-    }
-
-    ~IpcChannel_test()
-    {
     }
 
     static const size_t MaxMsgSize;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
