### PR TITLE
iox-#1196 fix warnings in mutex

### DIFF
--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -47,6 +47,8 @@ mutex::mutex(bool f_isRecursive) noexcept
     isInitialized &= !posixCall(pthread_mutex_init)(&m_handle, &attr).returnValueMatchesErrno().evaluate().has_error();
     isInitialized &= !posixCall(pthread_mutexattr_destroy)(&attr).returnValueMatchesErrno().evaluate().has_error();
 
+    /// NOLINTJUSTIFICATION is fixed in the PR iox-#1443
+    /// NOLINTNEXTLINE(hicpp-no-array-decay,cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Ensures(isInitialized && "Unable to create mutex");
 }
 
@@ -54,6 +56,8 @@ mutex::~mutex() noexcept
 {
     auto destroyCall = posixCall(pthread_mutex_destroy)(&m_handle).returnValueMatchesErrno().evaluate();
 
+    /// NOLINTJUSTIFICATION is fixed in the PR iox-#1443
+    /// NOLINTNEXTLINE(hicpp-no-array-decay,cppcoreguidelines-pro-bounds-array-to-pointer-decay)
     cxx::Ensures(!destroyCall.has_error() && "Could not destroy mutex");
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
@@ -51,7 +51,7 @@ class Mutex_test : public Test
         doWaitForThread.store(false, std::memory_order_relaxed);
     }
 
-    void waitForThread()
+    void waitForThread() const
     {
         while (doWaitForThread.load(std::memory_order_relaxed))
         {
@@ -114,6 +114,8 @@ TEST_F(Mutex_test, CallingDestructorOnLockedMutexLeadsToTermination)
     std::string output = internal::GetCapturedStderr();
     std::set_terminate([]() { std::cout << "", std::abort(); });
 
+    /// @NOLINTJUSTIFICATION todo #1196 remove EXPECT_DEATH
+    /// @NOLINTNEXTLINE (cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
     EXPECT_DEATH(
         {
             iox::posix::mutex mtx{false};


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
