### PR TITLE
iox-#1196 fix warnings in named pipe

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_pipe.hpp
@@ -36,13 +36,16 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
   public:
     // no system restrictions at all, except available memory. MAX_MESSAGE_SIZE and MAX_NUMBER_OF_MESSAGES can be
     // increased as long as there is enough memory available
-    static constexpr uint64_t MAX_MESSAGE_SIZE = 4U * 1024U;
+    static constexpr uint64_t MAX_MESSAGE_SIZE = 4096U;
     static constexpr uint32_t MAX_NUMBER_OF_MESSAGES = 10U;
     static_assert(MAX_NUMBER_OF_MESSAGES < IOX_SEM_VALUE_MAX,
                   "The maximum number of supported messages must be less than the maximum allowed semaphore value");
 
     static constexpr uint64_t NULL_TERMINATOR_SIZE = 0U;
     static constexpr units::Duration CYCLE_TIME = units::Duration::fromMilliseconds(10);
+
+    /// NOLINTJUSTIFICATION used as safe compile time string literal
+    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static constexpr const char NAMED_PIPE_PREFIX[] = "iox_np_";
 
     using Message_t = cxx::string<MAX_MESSAGE_SIZE>;
@@ -131,6 +134,7 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
 
         NamedPipeData& operator=(const NamedPipeData&) = delete;
         NamedPipeData& operator=(NamedPipeData&& rhs) = delete;
+        ~NamedPipeData() = default;
 
         UnnamedSemaphore& sendSemaphore() noexcept;
         UnnamedSemaphore& receiveSemaphore() noexcept;
@@ -150,6 +154,8 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
         static constexpr units::Duration WAIT_FOR_INIT_SLEEP_TIME = units::Duration::fromMilliseconds(1);
 
         std::atomic<uint64_t> initializationGuard{INVALID_DATA};
+        /// NOLINTJUSTIFICATION todo iox-#1196 replace with cxx::array implementation
+        /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
         cxx::optional<UnnamedSemaphore> semaphores[2U];
     };
 

--- a/iceoryx_hoofs/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_pipe.cpp
@@ -25,6 +25,8 @@ namespace iox
 {
 namespace posix
 {
+/// NOLINTJUSTIFICATION see declaration in header
+/// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
 constexpr units::Duration NamedPipe::CYCLE_TIME;
 constexpr units::Duration NamedPipe::NamedPipeData::WAIT_FOR_INIT_SLEEP_TIME;
@@ -47,10 +49,10 @@ NamedPipe::NamedPipe(const IpcChannelName_t& name,
     // parameters MAX_MSG_SIZE and MAX_MSG_NUMBER from which the Message_t size and m_messages queue
     // size is obtained. Reducing the max message size / number of messages even further would not gain
     // reduced memory usage or decreased runtime. See issue #832.
-    if (name.size() + strlen(NAMED_PIPE_PREFIX) > MAX_MESSAGE_SIZE)
+    if (name.size() + strlen(&NAMED_PIPE_PREFIX[0]) > MAX_MESSAGE_SIZE)
     {
         std::cerr << "The named pipe name: \"" << name
-                  << "\" is too long. Maxium name length is: " << MAX_MESSAGE_SIZE - strlen(NAMED_PIPE_PREFIX)
+                  << "\" is too long. Maxium name length is: " << MAX_MESSAGE_SIZE - strlen(&NAMED_PIPE_PREFIX[0])
                   << std::endl;
         m_isInitialized = false;
         m_errorValue = IpcChannelError::INVALID_CHANNEL_NAME;
@@ -136,7 +138,7 @@ NamedPipe& NamedPipe::operator=(NamedPipe&& rhs) noexcept
         CreationPattern_t::operator=(std::move(rhs));
 
         m_sharedMemory = std::move(rhs.m_sharedMemory);
-        m_data = std::move(rhs.m_data);
+        m_data = rhs.m_data;
         rhs.m_data = nullptr;
     }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
