### PR TITLE
iox-#1196 fix warnings in semaphore

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_semaphore.hpp
@@ -75,7 +75,7 @@ class NamedSemaphoreBuilder
     /// @param[in] uninitializedSemaphore since the semaphore is not movable the user has to provide
     ///            memory to store the semaphore into - packed in an optional
     /// @return an error describing the failure or success
-    cxx::expected<SemaphoreError> create(cxx::optional<NamedSemaphore>& uninitializedSemaphore) noexcept;
+    cxx::expected<SemaphoreError> create(cxx::optional<NamedSemaphore>& uninitializedSemaphore) const noexcept;
 };
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -26,6 +26,10 @@ namespace iox
 namespace posix
 {
 /// @brief A unnamed posix semaphore.
+/// NOLINTJUSTIFICATION m_handle is always initialized during create in the UnnamedSemaphoreBuilder
+///                     hence it is impossible to create a UnnamedSemaphore without an initialized
+///                     m_handle
+/// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 class UnnamedSemaphore final : public internal::SemaphoreInterface<UnnamedSemaphore>
 {
   public:
@@ -61,7 +65,7 @@ class UnnamedSemaphoreBuilder
     /// @param[in] uninitializedSemaphore since the semaphore is not movable the user has to provide
     ///            memory to store the semaphore into - packed in an optional
     /// @return an error describing the failure or success
-    cxx::expected<SemaphoreError> create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) noexcept;
+    cxx::expected<SemaphoreError> create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) const noexcept;
 };
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
@@ -96,6 +96,11 @@ tryOpenExistingSemaphore(cxx::optional<NamedSemaphore>& uninitializedSemaphore,
     return cxx::success<bool>(false);
 }
 
+/// NOLINTJUSTIFICATION used only internally in this file. Furthermore the problem cannot be avoided since
+///                     those arguments are required by the posix function sem_open. One could call it
+///                     before this function and provide the result but this would increase code complexity
+///                     even further
+/// NOLINTNEXTLINE(readability-function-size)
 static cxx::expected<SemaphoreError> createSemaphore(cxx::optional<NamedSemaphore>& uninitializedSemaphore,
                                                      const NamedSemaphore::Name_t& name,
                                                      const OpenMode openMode,
@@ -146,7 +151,7 @@ static cxx::expected<SemaphoreError> createSemaphore(cxx::optional<NamedSemaphor
 }
 
 cxx::expected<SemaphoreError>
-NamedSemaphoreBuilder::create(cxx::optional<NamedSemaphore>& uninitializedSemaphore) noexcept
+NamedSemaphoreBuilder::create(cxx::optional<NamedSemaphore>& uninitializedSemaphore) const noexcept
 {
     if (!cxx::isValidFileName(m_name))
     {
@@ -176,7 +181,8 @@ NamedSemaphoreBuilder::create(cxx::optional<NamedSemaphore>& uninitializedSemaph
         }
         return cxx::success<>();
     }
-    else if (m_openMode == OpenMode::OPEN_OR_CREATE)
+
+    if (m_openMode == OpenMode::OPEN_OR_CREATE)
     {
         auto result = tryOpenExistingSemaphore(uninitializedSemaphore, m_name);
         if (result.has_error())
@@ -191,7 +197,8 @@ NamedSemaphoreBuilder::create(cxx::optional<NamedSemaphore>& uninitializedSemaph
 
         return createSemaphore(uninitializedSemaphore, m_name, m_openMode, m_permissions, m_initialValue);
     }
-    else if (m_openMode == OpenMode::EXCLUSIVE_CREATE)
+
+    if (m_openMode == OpenMode::EXCLUSIVE_CREATE)
     {
         return createSemaphore(uninitializedSemaphore, m_name, m_openMode, m_permissions, m_initialValue);
     }

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -25,7 +25,7 @@ namespace iox
 namespace posix
 {
 cxx::expected<SemaphoreError>
-UnnamedSemaphoreBuilder::create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) noexcept
+UnnamedSemaphoreBuilder::create(cxx::optional<UnnamedSemaphore>& uninitializedSemaphore) const noexcept
 {
     if (m_initialValue > IOX_SEM_VALUE_MAX)
     {

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_common.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_common.hpp
@@ -31,7 +31,7 @@ inline bool setSemaphoreToZeroAndVerifyValue(SemaphoreType& semaphore, const uin
         {
             return false;
         }
-        if (*result == false)
+        if (!*result)
         {
             return (count == expectedValue);
         }

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -45,15 +45,7 @@ class SemaphoreInterfaceTest : public Test
     using SutFactory = T;
     using SutType = typename SutFactory::SutType;
 
-    SemaphoreInterfaceTest()
-    {
-    }
-
-    ~SemaphoreInterfaceTest()
-    {
-    }
-
-    void SetUp()
+    void SetUp() override
     {
         deadlockWatchdog.watchAndActOnFailure([] { std::terminate(); });
         ASSERT_TRUE(SutFactory::create(sut, 0U));
@@ -65,7 +57,7 @@ class SemaphoreInterfaceTest : public Test
         return SutFactory::create(sut, value);
     }
 
-    void TearDown()
+    void TearDown() override
     {
     }
 
@@ -148,7 +140,7 @@ TYPED_TEST(SemaphoreInterfaceTest, PostWithMaxSemaphoreValueLeadsToOverflow)
         return;
     }
 
-    uint32_t INITIAL_VALUE = static_cast<uint32_t>(IOX_SEM_VALUE_MAX);
+    auto INITIAL_VALUE = static_cast<uint32_t>(IOX_SEM_VALUE_MAX);
 
     ASSERT_FALSE(this->createSutWithInitialValue(INITIAL_VALUE).has_error());
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
