### PR TITLE
iox-#1196 fix warnings in posix call

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -102,6 +102,9 @@ struct PosixCallDetails
 ///        // when your posix call signals failure by returning the errno value instead of setting the errno use
 ///        // .returnValueMatchesErrno() instead of .successReturnValue(_)
 /// @endcode
+/// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
+///                     name
+/// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define posixCall(f)                                                                                                   \
     internal::createPosixCallBuilder(                                                                                  \
         f,                                                                                                             \

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/platform_correction.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/platform_correction.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 // Usage Instructions: This header has to be ALWAYS the last header which
 // is included otherwise some windows header pops up and defines some macros
 
+#include <cstring>
+
 #ifndef __PRETTY_FUNCTION__
 #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
@@ -38,3 +40,7 @@
 #undef CreateSemaphore
 #undef NO_ERROR
 #undef OPEN_EXISTING
+
+/// todo iox-#1196 required by posix but defined in libc header string.h
+///      move it into the upcoming libc layer in platform
+#define strerror_r(errnum, buf, buflen) strerror_s(buf, buflen, errnum)

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -21,6 +21,8 @@ using namespace ::testing;
 
 namespace
 {
+/// NOLINTJUSTIFICATION only used in testing
+/// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int testFunction(int returnValue, int errnoValue)
 {
     errno = errnoValue;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Part of #1196 
