### PR TITLE
iox-#1196 Fix warnings in types

### DIFF
--- a/iceoryx_hoofs/source/posix_wrapper/types.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/types.cpp
@@ -45,8 +45,10 @@ int convertToOflags(const OpenMode openMode) noexcept
     case OpenMode::OPEN_OR_CREATE:
         return O_CREAT;
     case OpenMode::EXCLUSIVE_CREATE:
-        return O_CREAT | O_EXCL;
     case OpenMode::PURGE_AND_CREATE:
+        // wrapped inside function so that the user does not have to use bitwise operations; operands have positive
+        // values and result is within integer range
+        // NOLINTNEXTLINE(hicpp-signed-bitwise)
         return O_CREAT | O_EXCL;
     }
 
@@ -56,6 +58,9 @@ int convertToOflags(const OpenMode openMode) noexcept
 
 int convertToOflags(const AccessMode accessMode, const OpenMode openMode) noexcept
 {
+    // wrapped inside function so that the user does not have to use bitwise operations; operands have positive
+    // values and result is within integer range
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
     return convertToOflags(accessMode) | convertToOflags((openMode));
 }
 } // namespace posix

--- a/iceoryx_hoofs/test/moduletests/test_posix_types.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_types.cpp
@@ -37,8 +37,11 @@ TEST(TypesTest, ConvertToOflagFromAccessModeWorks)
 TEST(TypesTest, ConvertToOflagFromOpenModeWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "95fa55c9-2d64-4296-8bbb-41ff3c9dac3f");
+    // used for test purposes; operands have positive values and result is within integer range
+    // NOLINTBEGIN(hicpp-signed-bitwise)
     EXPECT_THAT(convertToOflags(OpenMode::EXCLUSIVE_CREATE), Eq(O_CREAT | O_EXCL));
     EXPECT_THAT(convertToOflags(OpenMode::PURGE_AND_CREATE), Eq(O_CREAT | O_EXCL));
+    // NOLINTEND(hicpp-signed-bitwise)
     EXPECT_THAT(convertToOflags(OpenMode::OPEN_OR_CREATE), Eq(O_CREAT));
     EXPECT_THAT(convertToOflags(OpenMode::OPEN_EXISTING), Eq(0));
     EXPECT_THAT(convertToOflags(INVALID_OPEN_MODE), Eq(0));
@@ -47,6 +50,8 @@ TEST(TypesTest, ConvertToOflagFromOpenModeWorks)
 TEST(TypesTest, ConvertToOflagFromAccessAndOpenModeWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4ea6823c-2ecd-48a5-bcea-0ea0585bee72");
+    // used for test purposes; operands have positive values and result is within integer range
+    // NOLINTBEGIN(hicpp-signed-bitwise)
     EXPECT_THAT(convertToOflags(AccessMode::READ_ONLY, OpenMode::EXCLUSIVE_CREATE), Eq(O_RDONLY | O_CREAT | O_EXCL));
     EXPECT_THAT(convertToOflags(AccessMode::READ_ONLY, OpenMode::PURGE_AND_CREATE), Eq(O_RDONLY | O_CREAT | O_EXCL));
     EXPECT_THAT(convertToOflags(AccessMode::READ_ONLY, OpenMode::OPEN_OR_CREATE), Eq(O_RDONLY | O_CREAT));
@@ -61,6 +66,7 @@ TEST(TypesTest, ConvertToOflagFromAccessAndOpenModeWorks)
 
     EXPECT_THAT(convertToOflags(INVALID_ACCESS_MODE, OpenMode::EXCLUSIVE_CREATE), Eq(O_CREAT | O_EXCL));
     EXPECT_THAT(convertToOflags(INVALID_ACCESS_MODE, OpenMode::PURGE_AND_CREATE), Eq(O_CREAT | O_EXCL));
+    // NOLINTEND(hicpp-signed-bitwise)
     EXPECT_THAT(convertToOflags(INVALID_ACCESS_MODE, OpenMode::OPEN_OR_CREATE), Eq(O_CREAT));
     EXPECT_THAT(convertToOflags(INVALID_ACCESS_MODE, OpenMode::OPEN_EXISTING), Eq(0));
     EXPECT_THAT(convertToOflags(INVALID_ACCESS_MODE, INVALID_OPEN_MODE), Eq(0));


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
