### PR TITLE
iox-#1196 Remove conversion operator in `RelativePointer`

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -23,6 +23,15 @@
 ./iceoryx_hoofs/source/posix_wrapper/*
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/test/moduletests/test_posix*
+./iceoryx_hoofs/test/moduletests/test_allocator.cpp
+./iceoryx_hoofs/test/moduletests/test_shared_memory.cpp
+./iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
+# Will be activated with #1521
+# ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp 
+# ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
+
+
 
 # IMPORTANT:
 #    after the first # everything is considered a comment, add new files and

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -174,6 +174,8 @@ class BaseRelativePointer
     static constexpr offset_t NULL_POINTER_OFFSET = std::numeric_limits<offset_t>::max();
 
   protected:
+    ~BaseRelativePointer() noexcept = default;
+
     id_t m_id{NULL_POINTER_ID};
     offset_t m_offset{NULL_POINTER_OFFSET};
 };

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp
@@ -82,9 +82,9 @@ class RelativePointer : public BaseRelativePointer
     /// @return a pointer to the underlying object
     T* get() const noexcept;
 
-    /// @brief converts the RelativePointer to a pointer of the type of the underlying object
-    /// @return a pointer of type T pointing to the underlying object
-    operator T*() const noexcept;
+    /// @brief converts the RelativePointer to bool
+    /// @return bool which contains true if the RelativePointer contains a pointer
+    explicit operator bool() const noexcept;
 
     /// @brief checks if this and ptr point to the same pointee
     /// @param[in] ptr is the pointer whose pointee is compared with this' pointee

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
@@ -84,9 +84,9 @@ inline T* RelativePointer<T>::get() const noexcept
 }
 
 template <typename T>
-inline RelativePointer<T>::operator T*() const noexcept
+inline RelativePointer<T>::operator bool() const noexcept
 {
-    return get();
+    return get() != nullptr;
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
@@ -145,7 +145,7 @@ inline void ChunkQueuePopper<ChunkQueueDataType>::unsetConditionVariable() noexc
 template <typename ChunkQueueDataType>
 inline bool ChunkQueuePopper<ChunkQueueDataType>::isConditionVariableSet() const noexcept
 {
-    return getMembers()->m_conditionVariableDataPtr;
+    return getMembers()->m_conditionVariableDataPtr != nullptr;
 }
 
 } // namespace popo

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,15 +90,15 @@ void* MemPool::getChunk() noexcept
     m_usedChunks.fetch_add(1U, std::memory_order_relaxed);
     adjustMinFree();
 
-    return m_rawMemory + l_index * m_chunkSize;
+    return m_rawMemory.get() + l_index * m_chunkSize;
 }
 
 void MemPool::freeChunk(const void* chunk) noexcept
 {
-    cxx::Expects(m_rawMemory <= chunk
-                 && chunk <= m_rawMemory + (static_cast<uint64_t>(m_chunkSize) * (m_numberOfChunks - 1U)));
+    cxx::Expects(m_rawMemory.get() <= chunk
+                 && chunk <= m_rawMemory.get() + (static_cast<uint64_t>(m_chunkSize) * (m_numberOfChunks - 1U)));
 
-    auto offset = static_cast<const uint8_t*>(chunk) - m_rawMemory;
+    auto offset = static_cast<const uint8_t*>(chunk) - m_rawMemory.get();
     cxx::Expects(offset % m_chunkSize == 0);
 
     uint32_t index = static_cast<uint32_t>(offset / m_chunkSize);

--- a/iceoryx_posh/source/mepoo/shared_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shared_chunk.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ void SharedChunk::decrementReferenceCounter() noexcept
 
 void SharedChunk::freeChunk() noexcept
 {
-    m_chunkManagement->m_mempool->freeChunk(m_chunkManagement->m_chunkHeader);
+    m_chunkManagement->m_mempool->freeChunk(static_cast<void*>(m_chunkManagement->m_chunkHeader.get()));
     m_chunkManagement->m_chunkManagementPool->freeChunk(m_chunkManagement);
     m_chunkManagement = nullptr;
 }
@@ -129,7 +129,7 @@ ChunkHeader* SharedChunk::getChunkHeader() const noexcept
 {
     if (m_chunkManagement != nullptr)
     {
-        return m_chunkManagement->m_chunkHeader;
+        return m_chunkManagement->m_chunkHeader.get();
     }
     else
     {

--- a/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ SharedChunk ShmSafeUnmanagedChunk::releaseToSharedChunk() noexcept
     }
     auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(), m_chunkManagement.id());
     m_chunkManagement.reset();
-    return SharedChunk(chunkMgmt);
+    return SharedChunk(chunkMgmt.get());
 }
 
 SharedChunk ShmSafeUnmanagedChunk::cloneToSharedChunk() noexcept
@@ -70,7 +70,7 @@ SharedChunk ShmSafeUnmanagedChunk::cloneToSharedChunk() noexcept
     }
     auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(), m_chunkManagement.id());
     chunkMgmt->m_referenceCounter.fetch_add(1U, std::memory_order_relaxed);
-    return SharedChunk(chunkMgmt);
+    return SharedChunk(chunkMgmt.get());
 }
 
 bool ShmSafeUnmanagedChunk::isLogicalNullptr() const noexcept
@@ -85,7 +85,7 @@ ChunkHeader* ShmSafeUnmanagedChunk::getChunkHeader() noexcept
         return nullptr;
     }
     auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(), m_chunkManagement.id());
-    return chunkMgmt->m_chunkHeader;
+    return chunkMgmt->m_chunkHeader.get();
 }
 
 const ChunkHeader* ShmSafeUnmanagedChunk::getChunkHeader() const noexcept


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Instead of making the conversion operator `explicit` remove it and use `get()`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196 (partly)
