### PR TITLE
iox-#1196 Fix clang tidy warnings in `RelativePointerData`

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -6,12 +6,16 @@
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/units/*
 ./iceoryx_hoofs/test/moduletests/test_unit*
 ./iceoryx_hoofs/source/units/*
-./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/pointer_repository.inl
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.hpp
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/sofi.inl
 ./iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
 ./iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
+./iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+./iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/pointer_repository.inl
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp
@@ -68,8 +68,12 @@ class RelativePointerData
     static constexpr offset_t NULL_POINTER_OFFSET{OFFSET_RANGE};
     /// @note the maximum offset which can be represented
     static constexpr offset_t MAX_VALID_OFFSET{OFFSET_RANGE - 1U};
+    /// @note the maximum allowed size of RelativePointerData
+    static constexpr uint64_t MAX_ALLOWED_SIZE_OF_RELATIVE_POINTER_DATA{8U};
+    /// @note offset in bits for storing and reading the id
+    static constexpr uint64_t ID_BIT_SIZE{16U};
     /// @note internal representation of a nullptr
-    static constexpr offset_t LOGICAL_NULLPTR{NULL_POINTER_OFFSET << 16 | NULL_POINTER_ID};
+    static constexpr offset_t LOGICAL_NULLPTR{NULL_POINTER_OFFSET << ID_BIT_SIZE | NULL_POINTER_ID};
 
   private:
     uint64_t m_idAndOffset{LOGICAL_NULLPTR};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl
@@ -17,12 +17,14 @@
 #ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
 #define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
 
+#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp"
+
 namespace iox
 {
 namespace rp
 {
 constexpr RelativePointerData::RelativePointerData(id_t id, offset_t offset) noexcept
-    : m_idAndOffset(static_cast<uint64_t>(id) | (offset << 16U))
+    : m_idAndOffset(static_cast<uint64_t>(id) | (offset << ID_BIT_SIZE))
 {
     if (id > MAX_VALID_ID || offset > MAX_VALID_OFFSET)
     {

--- a/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+++ b/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
@@ -24,8 +24,8 @@ namespace rp
 // This is necessary if an supervising application needs to do a cleanup of resources hold by a crashed application. If
 // the size is larger than 8 bytes on a 64 bit system, torn writes happens and if the application crashes at the wrong
 // time, the supervisor reads corrupt data.
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-static_assert(sizeof(RelativePointerData) <= 8U, "The RelativePointerData size must not exceed 64 bit!");
+static_assert(sizeof(RelativePointerData) <= RelativePointerData::MAX_ALLOWED_SIZE_OF_RELATIVE_POINTER_DATA,
+              "The RelativePointerData size must not exceed 64 bit!");
 // This ensures that the address of the RelativePointerData object is appropriately aligned to be accessed within one
 // CPU cycle, i.e. if the size is 8 and the alignment is 4 it could be placed at an address with modulo 4 which would
 // also result in torn writes.
@@ -42,6 +42,8 @@ constexpr RelativePointerData::id_t RelativePointerData::MAX_VALID_ID;
 constexpr RelativePointerData::offset_t RelativePointerData::OFFSET_RANGE;
 constexpr RelativePointerData::offset_t RelativePointerData::NULL_POINTER_OFFSET;
 constexpr RelativePointerData::offset_t RelativePointerData::MAX_VALID_OFFSET;
+constexpr uint64_t RelativePointerData::MAX_ALLOWED_SIZE_OF_RELATIVE_POINTER_DATA;
+constexpr uint64_t RelativePointerData::ID_BIT_SIZE;
 constexpr uint64_t RelativePointerData::LOGICAL_NULLPTR;
 
 RelativePointerData::id_t RelativePointerData::id() const noexcept
@@ -52,8 +54,7 @@ RelativePointerData::id_t RelativePointerData::id() const noexcept
 RelativePointerData::offset_t RelativePointerData::offset() const noexcept
 {
     // extract offset by removing id (first 16 bits)
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    return (m_idAndOffset >> 16) & OFFSET_RANGE;
+    return (m_idAndOffset >> ID_BIT_SIZE) & OFFSET_RANGE;
 }
 
 void RelativePointerData::reset() noexcept


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Fix `clang-tidy` warnings in `RelativePointerData`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196 (partly)
