### PR TITLE
iox-#1196 activate clang-tidy check on design_pattern

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -19,8 +19,8 @@
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/*
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/*
-./iceoryx_hoofs/include/iceoryx_hoofs/design_pattern*
-./iceoryx_hoofs/include/iceoryx_hoofs/internal/design_pattern/*
+
+./iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/builder.hpp
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/source/posix_wrapper/*
@@ -30,7 +30,7 @@
 ./iceoryx_hoofs/test/moduletests/test_shared_memory.cpp
 ./iceoryx_hoofs/test/moduletests/test_shared_memory_object.cpp
 # Will be activated with #1521
-# ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp 
+# ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp
 # ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
 

--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -19,6 +19,9 @@
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/*
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/*
+./iceoryx_hoofs/include/iceoryx_hoofs/design_pattern*
+./iceoryx_hoofs/include/iceoryx_hoofs/internal/design_pattern/*
+
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/source/posix_wrapper/*
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*

--- a/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/builder.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/builder.hpp
@@ -43,6 +43,10 @@
 ///     // END
 ///   };
 /// @endcode
+// NOLINTJUSTIFICATION brackets around macro parameter would lead in this case to compile time failures
+// NOLINTBEGIN(bugprone-macro-parentheses)
+// NOLINTJUSTIFICATION cannot be realized with templates or constexpr functions
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_BUILDER_PARAMETER(type, name, defaultValue)                                                                \
   public:                                                                                                              \
     decltype(auto) name(type const& value)&&                                                                           \
@@ -59,5 +63,6 @@
                                                                                                                        \
   private:                                                                                                             \
     type m_##name{defaultValue};
+// NOLINTEND(bugprone-macro-parentheses)
 
 #endif

--- a/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/creation.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/creation.hpp
@@ -17,6 +17,8 @@
 #ifndef IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP
 #define IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP
 
+// NOLINTJUSTIFICATION iox-#1036 will be replaced by builder pattern
+// NOLINTBEGIN
 #include "iceoryx_hoofs/cxx/expected.hpp"
 
 #include <utility>
@@ -145,5 +147,6 @@ class Creation
 } // namespace DesignPattern
 
 #include "iceoryx_hoofs/internal/design_pattern/creation.inl"
+// NOLINTEND
 
 #endif // IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1196 
