### PR TITLE
iox-#1394 Address AUTOSAR warnings in `RelativePointerData`

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp
@@ -30,7 +30,7 @@ namespace rp
 class RelativePointerData
 {
   public:
-    using id_t = uint16_t;
+    using identifier_t = uint16_t;
     using offset_t = uint64_t;
 
     /// @brief Default constructed RelativePointerData which is logically equal to a nullptr
@@ -39,11 +39,11 @@ class RelativePointerData
     /// @brief constructs a RelativePointerData from a given offset and segment id
     /// @param[in] id is the unique id of the segment
     /// @param[in] offset is the offset within the segment
-    constexpr RelativePointerData(id_t id, offset_t offset) noexcept;
+    constexpr RelativePointerData(identifier_t id, offset_t offset) noexcept;
 
     /// @brief Getter for the id which identifies the segment
     /// @return the id which identifies the segment
-    id_t id() const noexcept;
+    identifier_t id() const noexcept;
 
     /// @brief Getter for the offset within the segment
     /// @return the offset
@@ -57,12 +57,12 @@ class RelativePointerData
     bool isLogicalNullptr() const noexcept;
 
     /// @note the maximum number of available ids
-    static constexpr id_t ID_RANGE{std::numeric_limits<id_t>::max()};
+    static constexpr identifier_t ID_RANGE{std::numeric_limits<identifier_t>::max()};
     /// @note this represents the id of a logically nullptr
-    static constexpr id_t NULL_POINTER_ID{ID_RANGE};
+    static constexpr identifier_t NULL_POINTER_ID{ID_RANGE};
     /// @note the maximum number of valid ids
-    static constexpr id_t MAX_VALID_ID{ID_RANGE - 1U};
-    /// id_t is 16 bit and the offset consumes the remaining 48 bits -> offset range is 2^48 - 1
+    static constexpr identifier_t MAX_VALID_ID{ID_RANGE - 1U};
+    /// identifier_t is 16 bit and the offset consumes the remaining 48 bits -> offset range is 2^48 - 1
     static constexpr offset_t OFFSET_RANGE{(1ULL << 48U) - 1U};
     /// @note this represents the offset of a logically nullptr;
     static constexpr offset_t NULL_POINTER_OFFSET{OFFSET_RANGE};
@@ -70,12 +70,12 @@ class RelativePointerData
     static constexpr offset_t MAX_VALID_OFFSET{OFFSET_RANGE - 1U};
     /// @note the maximum allowed size of RelativePointerData
     static constexpr uint64_t MAX_ALLOWED_SIZE_OF_RELATIVE_POINTER_DATA{8U};
+
+  private:
     /// @note offset in bits for storing and reading the id
     static constexpr uint64_t ID_BIT_SIZE{16U};
     /// @note internal representation of a nullptr
     static constexpr offset_t LOGICAL_NULLPTR{NULL_POINTER_OFFSET << ID_BIT_SIZE | NULL_POINTER_ID};
-
-  private:
     uint64_t m_idAndOffset{LOGICAL_NULLPTR};
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl
@@ -23,10 +23,11 @@ namespace iox
 {
 namespace rp
 {
-constexpr RelativePointerData::RelativePointerData(id_t id, offset_t offset) noexcept
+// AXIVION Next Construct AutosarC++19_03-A12.1.2 : NSDMI with null value is more explicit
+constexpr RelativePointerData::RelativePointerData(identifier_t id, offset_t offset) noexcept
     : m_idAndOffset(static_cast<uint64_t>(id) | (offset << ID_BIT_SIZE))
 {
-    if (id > MAX_VALID_ID || offset > MAX_VALID_OFFSET)
+    if ((id > MAX_VALID_ID) || (offset > MAX_VALID_OFFSET))
     {
         m_idAndOffset = LOGICAL_NULLPTR;
     }

--- a/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+++ b/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
@@ -29,26 +29,26 @@ static_assert(sizeof(RelativePointerData) <= RelativePointerData::MAX_ALLOWED_SI
 // This ensures that the address of the RelativePointerData object is appropriately aligned to be accessed within one
 // CPU cycle, i.e. if the size is 8 and the alignment is 4 it could be placed at an address with modulo 4 which would
 // also result in torn writes.
-static_assert(sizeof(RelativePointerData) == alignof(RelativePointerData),
+static_assert((sizeof(RelativePointerData)) == (alignof(RelativePointerData)),
               "A RelativePointerData must be placed on an address which does not cross the native alignment!");
 // This is important for the use in the SOFI where under some conditions the copy operation could work on partially
 // obsolet data and therefore non-trivial copy ctor/assignment operator or dtor would work on corrupted data.
 static_assert(std::is_trivially_copyable<RelativePointerData>::value,
               "The RelativePointerData must be trivially copyable!");
 
-constexpr RelativePointerData::id_t RelativePointerData::ID_RANGE;
-constexpr RelativePointerData::id_t RelativePointerData::NULL_POINTER_ID;
-constexpr RelativePointerData::id_t RelativePointerData::MAX_VALID_ID;
+constexpr RelativePointerData::identifier_t RelativePointerData::ID_RANGE;
+constexpr RelativePointerData::identifier_t RelativePointerData::NULL_POINTER_ID;
+constexpr RelativePointerData::identifier_t RelativePointerData::MAX_VALID_ID;
 constexpr RelativePointerData::offset_t RelativePointerData::OFFSET_RANGE;
 constexpr RelativePointerData::offset_t RelativePointerData::NULL_POINTER_OFFSET;
 constexpr RelativePointerData::offset_t RelativePointerData::MAX_VALID_OFFSET;
 constexpr uint64_t RelativePointerData::MAX_ALLOWED_SIZE_OF_RELATIVE_POINTER_DATA;
 constexpr uint64_t RelativePointerData::ID_BIT_SIZE;
-constexpr uint64_t RelativePointerData::LOGICAL_NULLPTR;
+constexpr RelativePointerData::offset_t RelativePointerData::LOGICAL_NULLPTR;
 
-RelativePointerData::id_t RelativePointerData::id() const noexcept
+RelativePointerData::identifier_t RelativePointerData::id() const noexcept
 {
-    return static_cast<id_t>(m_idAndOffset & ID_RANGE);
+    return static_cast<identifier_t>(m_idAndOffset & ID_RANGE);
 }
 
 RelativePointerData::offset_t RelativePointerData::offset() const noexcept

--- a/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
@@ -47,7 +47,7 @@ ShmSafeUnmanagedChunk::ShmSafeUnmanagedChunk(mepoo::SharedChunk chunk) noexcept
         cxx::Ensures(id <= rp::RelativePointerData::ID_RANGE && "RelativePointer id must fit into id type!");
         cxx::Ensures(offset <= rp::RelativePointerData::OFFSET_RANGE
                      && "RelativePointer offset must fit into offset type!");
-        m_chunkManagement = rp::RelativePointerData(static_cast<rp::RelativePointerData::id_t>(id), offset);
+        m_chunkManagement = rp::RelativePointerData(static_cast<rp::RelativePointerData::identifier_t>(id), offset);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Simon Hoinkis <simon.hoinkis@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Address AUTOSAR warnings in `RelativePointerData`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
    - [x] Each unit test case has a unique UUID
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partly)
