### PR TITLE
Iox 1556 remove posix rights struct

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -65,6 +65,7 @@
 - Remove implicit conversion from `cxx::expected` to `cxx::optional` [\#1196](https://github.com/eclipse-iceoryx/iceoryx/issues/1196)
 - Remove AtomicRelocatablePointer [\#1512](https://github.com/eclipse-iceoryx/iceoryx/issues/1512)
 - `SignalHandler` returns an `expected` in `registerSignalHandler` [\#1196](https://github.com/eclipse-iceoryx/iceoryx/issues/1196)
+- Remove the unused `PosixRights` struct [\#1556](https://github.com/eclipse-iceoryx/iceoryx/issues/1556)
 
 **Workflow:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp
@@ -30,14 +30,6 @@ namespace posix
 {
 static constexpr int MaxNumberOfGroups = 888;
 
-struct PosixRights
-{
-    PosixRights(bool read, bool write, bool execute) noexcept;
-    bool m_read;
-    bool m_write;
-    bool m_execute;
-};
-
 class PosixGroup
 {
   public:

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -30,13 +30,6 @@ namespace iox
 {
 namespace posix
 {
-PosixRights::PosixRights(bool read, bool write, bool execute) noexcept
-    : m_read(read)
-    , m_write(write)
-    , m_execute(execute)
-{
-}
-
 PosixGroup::PosixGroup(gid_t id) noexcept
     : m_id(id)
     , m_doesExist(getGroupName(id).has_value())


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The `PosixRights` struct was not used and is therefore removed.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1556
