### PR TITLE
iox-#1196 Fix clang-tidy warnings in relocatable ptr

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -16,8 +16,6 @@
 ./iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
 ./iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
 ./iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
-./iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
-./iceoryx_hoofs/include/iceoryx_hoofs/test/moduletests/test_relocatable_ptr.cpp
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/*
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/*
@@ -28,6 +26,8 @@
 ./iceoryx_hoofs/source/posix_wrapper/*
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/test/moduletests/test_posix*
+
+./iceoryx_dust/include/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
 
 # IMPORTANT:
 #    after the first # everything is considered a comment, add new files and

--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -16,6 +16,8 @@
 ./iceoryx_hoofs/test/moduletests/test_concurrent_sofi.cpp
 ./iceoryx_hoofs/test/stresstests/test_stress_sofi.cpp
 ./iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+./iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
+./iceoryx_hoofs/include/iceoryx_hoofs/test/moduletests/test_relocatable_ptr.cpp
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/*
 ./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/*

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
@@ -55,13 +55,17 @@ class relocatable_ptr
     using ptr_t = T*;
 
     /// @brief Construct from raw pointer.
+    // NOLINTJUSTIFICATION implicit conversion from raw pointer is intentional in design of relocatable structures
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     relocatable_ptr(T* ptr = nullptr) noexcept;
 
     /// @brief Construct from other relocatable pointer.
     relocatable_ptr(const relocatable_ptr& other) noexcept;
 
     /// @brief Move construct from other relocatable pointer.
-    relocatable_ptr(relocatable_ptr&& other);
+    relocatable_ptr(relocatable_ptr&& other) noexcept;
+
+    ~relocatable_ptr() = default;
 
     /// @brief Assign from relocatable pointer rhs.
     relocatable_ptr& operator=(const relocatable_ptr& rhs) noexcept;
@@ -100,10 +104,14 @@ class relocatable_ptr
 
     /// @brief Convert to the corresponding raw pointer.
     /// @return corresponding raw pointer
+    // NOLINTJUSTIFICATION implicit conversion to raw pointer is intentional in design of relocatable structures
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     operator T*() noexcept;
 
     /// @brief Convert to the corresponding const raw pointer.
     /// @return corresponding const raw pointer
+    // NOLINTJUSTIFICATION implicit conversion to raw pointer is intentional in design of relocatable structures
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     operator const T*() const noexcept;
 
   private:

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
@@ -36,7 +36,7 @@ inline relocatable_ptr<T>::relocatable_ptr(const relocatable_ptr& other) noexcep
 }
 
 template <typename T>
-inline relocatable_ptr<T>::relocatable_ptr(relocatable_ptr&& other)
+inline relocatable_ptr<T>::relocatable_ptr(relocatable_ptr&& other) noexcept
     : m_offset(to_offset(other.get()))
 {
     other.m_offset = NULL_POINTER_OFFSET;
@@ -120,6 +120,7 @@ inline relocatable_ptr<T>::operator const T*() const noexcept
 template <typename T>
 inline typename relocatable_ptr<T>::offset_t relocatable_ptr<T>::self() const noexcept
 {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) cast required to obtain object address as offset
     return reinterpret_cast<offset_t>(this);
 }
 
@@ -130,6 +131,7 @@ inline typename relocatable_ptr<T>::offset_t relocatable_ptr<T>::to_offset(const
     {
         return NULL_POINTER_OFFSET;
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) cast required to obtain offset from ptr
     auto p = reinterpret_cast<offset_t>(ptr);
     return p - self();
 }
@@ -141,6 +143,7 @@ inline T* relocatable_ptr<T>::from_offset(offset_t offset) const noexcept
     {
         return nullptr;
     }
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) cast required to ptr from offset
     return reinterpret_cast<T*>(offset + self());
 }
 

--- a/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
+++ b/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
+++ b/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
@@ -105,7 +105,7 @@ constexpr auto dereferencingReturns()
 
 struct Data
 {
-    Data(uint32_t value = 0)
+    explicit Data(uint32_t value = 0)
         : value(value)
     {
     }
@@ -115,7 +115,7 @@ struct Data
 class RelocatableType
 {
   public:
-    RelocatableType(int value)
+    explicit RelocatableType(int value)
         : data(value)
         , rp(&this->data)
     {
@@ -479,10 +479,6 @@ TYPED_TEST(Relocatable_ptr_typed_test, positiveNullPointerCheckWithIfWorks)
     {
         GTEST_FAIL();
     }
-    else
-    {
-        GTEST_SUCCEED();
-    }
 }
 
 TEST_F(Relocatable_ptr_test, dereferencingWorks)
@@ -535,12 +531,16 @@ TEST_F(Relocatable_ptr_test, relocationWorks)
     ::testing::Test::RecordProperty("TEST_ID", "b1b85836-2a4f-4859-a8f9-796e20fbb735");
     using T = RelocatableType;
     using storage_t = std::aligned_storage<sizeof(T), alignof(T)>::type;
-    storage_t sourceStorage, destStorage;
+    storage_t sourceStorage;
+    storage_t destStorage;
 
     void* sourcePtr = new (&sourceStorage) T(37);
     void* destPtr = &destStorage;
+    // NOLINTJUSTIFICATION explicit cast to void* required for memcpy of relocatable type with copy ctor
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
     T* source = reinterpret_cast<T*>(sourcePtr);
     T* dest = reinterpret_cast<T*>(destPtr);
+    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
 
     EXPECT_EQ(source->data, 37);
     EXPECT_EQ(*source->rp, 37);

--- a/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
+++ b/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
@@ -484,9 +484,10 @@ TYPED_TEST(Relocatable_ptr_typed_test, positiveNullPointerCheckWithIfWorks)
 TEST_F(Relocatable_ptr_test, dereferencingWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ea67f218-6ff8-4a82-a81e-52ae988546dc");
-    int x = 666;
+    constexpr int VALUE = 666;
+    int x = VALUE;
     iox::rp::relocatable_ptr<int> rp(&x);
-    EXPECT_EQ(*rp, x);
+    EXPECT_EQ(*rp, VALUE);
 
     constexpr bool isNotConst = dereferencingReturns<decltype(rp), int&>();
     EXPECT_TRUE(isNotConst);
@@ -495,9 +496,10 @@ TEST_F(Relocatable_ptr_test, dereferencingWorks)
 TEST_F(Relocatable_ptr_test, dereferencingConstWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "64a7e44e-b9eb-428a-bd50-3bd9e14400bc");
-    int x = 314;
+    constexpr int VALUE = 314;
+    int x = VALUE;
     const iox::rp::relocatable_ptr<int> rp(&x);
-    EXPECT_EQ(*rp, x);
+    EXPECT_EQ(*rp, VALUE);
 
     constexpr bool isConst = dereferencingReturns<decltype(rp), const int&>();
     EXPECT_TRUE(isConst);
@@ -506,7 +508,8 @@ TEST_F(Relocatable_ptr_test, dereferencingConstWorks)
 TEST_F(Relocatable_ptr_test, dereferencingComplexTypeWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e4a2bda1-c3f2-424e-b6dd-a4da6703b699");
-    Data x(69);
+    constexpr int VALUE = 69;
+    Data x(VALUE);
     iox::rp::relocatable_ptr<Data> rp(&x);
     EXPECT_EQ((*rp).value, x.value);
     EXPECT_EQ(rp->value, x.value);
@@ -515,7 +518,8 @@ TEST_F(Relocatable_ptr_test, dereferencingComplexTypeWorks)
 TEST_F(Relocatable_ptr_test, dereferencingConstComplexTypeWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b60f0fd5-ff9b-40a5-ad0d-d13965eff578");
-    Data x(42);
+    constexpr int VALUE = 69;
+    Data x(VALUE);
     const iox::rp::relocatable_ptr<Data> rp(&x);
     EXPECT_EQ((*rp).value, x.value);
     EXPECT_EQ(rp->value, x.value);
@@ -534,7 +538,10 @@ TEST_F(Relocatable_ptr_test, relocationWorks)
     storage_t sourceStorage;
     storage_t destStorage;
 
-    void* sourcePtr = new (&sourceStorage) T(37);
+    constexpr uint32_t SOURCE_VALUE{37};
+    constexpr uint32_t NEW_VALUE{73};
+
+    void* sourcePtr = new (&sourceStorage) T(SOURCE_VALUE);
     void* destPtr = &destStorage;
     // NOLINTJUSTIFICATION explicit cast to void* required for memcpy of relocatable type with copy ctor
     // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -542,22 +549,22 @@ TEST_F(Relocatable_ptr_test, relocationWorks)
     T* dest = reinterpret_cast<T*>(destPtr);
     // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
 
-    EXPECT_EQ(source->data, 37);
-    EXPECT_EQ(*source->rp, 37);
+    EXPECT_EQ(source->data, SOURCE_VALUE);
+    EXPECT_EQ(*source->rp, SOURCE_VALUE);
 
     // structure is relocated by memcopy
     std::memcpy(destPtr, sourcePtr, sizeof(T));
     source->clear();
 
     EXPECT_EQ(source->data, 0);
-    EXPECT_EQ(dest->data, 37);
+    EXPECT_EQ(dest->data, SOURCE_VALUE);
 
     // points to relocated data automatically
-    EXPECT_EQ(*dest->rp, 37);
-    dest->data = 73;
+    EXPECT_EQ(*dest->rp, SOURCE_VALUE);
+    dest->data = NEW_VALUE;
 
     EXPECT_EQ(source->data, 0);
-    EXPECT_EQ(*dest->rp, 73);
+    EXPECT_EQ(*dest->rp, NEW_VALUE);
 
     source->~T();
     dest->~T();


### PR DESCRIPTION
Signed-off-by: Matthias Killat <matthias.killat@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1196(partly)
