### PR TITLE
iox-#1566 Replace QAC++ suppressions with Axivion AUTOSAR suppressions

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -478,37 +478,37 @@ inline constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept
 
 namespace duration_literals
 {
-inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept
 {
     return Duration::fromNanoseconds(value);
 }
 
-inline constexpr Duration operator"" _us(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _us(unsigned long long int value) noexcept
 {
     return Duration::fromMicroseconds(value);
 }
 
-inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept
 {
     return Duration::fromMilliseconds(value);
 }
 
-inline constexpr Duration operator"" _s(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _s(unsigned long long int value) noexcept
 {
     return Duration::fromSeconds(value);
 }
 
-inline constexpr Duration operator"" _m(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _m(unsigned long long int value) noexcept
 {
     return Duration::fromMinutes(value);
 }
 
-inline constexpr Duration operator"" _h(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _h(unsigned long long int value) noexcept
 {
     return Duration::fromHours(value);
 }
 
-inline constexpr Duration operator"" _d(unsigned long long int value) noexcept // PRQA S 48
+inline constexpr Duration operator"" _d(unsigned long long int value) noexcept
 {
     return Duration::fromDays(value);
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -38,8 +38,7 @@ cxx::expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
         l_memoryProtection = PROT_READ | PROT_WRITE;
         break;
     }
-    // PRQA S 3066 1 # incompatibility with POSIX definition of mmap
-
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3, CertC++-EXP55 : Incompatibility with POSIX definition of mmap
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) low-level memory management
     auto result = posixCall(mmap)(const_cast<void*>(m_baseAddressHint),
                                   m_length,

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -61,7 +61,8 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(cxx::not_null<ChunkQueue
     {
         if (getMembers()->m_queues.size() < getMembers()->m_queues.capacity())
         {
-            // PRQA S 3804 1 # we checked the capacity, so pushing will be fine
+            // AXIVION Next Construct AutosarC++19_03-A0.1.2, AutosarC++19_03-M0-3-2 : we checked the capacity, so
+            // pushing will be fine
             getMembers()->m_queues.push_back(rp::RelativePointer<ChunkQueueData_t>(queueToAdd));
 
             const auto currChunkHistorySize = getMembers()->m_history.size();
@@ -105,7 +106,7 @@ inline cxx::expected<ChunkDistributorError> ChunkDistributor<ChunkDistributorDat
     const auto iter = std::find(getMembers()->m_queues.begin(), getMembers()->m_queues.end(), queueToRemove);
     if (iter != getMembers()->m_queues.end())
     {
-        // PRQA S 3804 1 # we don't use iter any longer so return value can be ignored
+        // AXIVION Next Construct AutosarC++19_03-A0.1.2 : we don't use iter any longer so return value can be ignored
         getMembers()->m_queues.erase(iter);
 
         return cxx::success<void>();
@@ -300,11 +301,12 @@ inline void ChunkDistributor<ChunkDistributorDataType>::addToHistoryWithoutDeliv
         {
             auto chunkToRemove = getMembers()->m_history.begin();
             chunkToRemove->releaseToSharedChunk();
-            // PRQA S 3804 1 # we are not iterating here, so return value can be ignored
+            // AXIVION Next Construct AutosarC++19_03-A0.1.2 : we are not iterating here, so return value can be ignored
             getMembers()->m_history.erase(chunkToRemove);
         }
-        // PRQA S 3804 1 # we ensured that there is space in the history, so return value can be ignored
-        getMembers()->m_history.push_back(chunk); // PRQA S 3804
+        // AXIVION Next Construct AutosarC++19_03-A0.1.2, AutosarC++19_03-M0-3-2 : we ensured that there is space in the
+        // history, so return value can be ignored
+        getMembers()->m_history.push_back(chunk);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
@@ -118,7 +118,8 @@ inline void ChunkQueuePopper<ChunkQueueDataType>::clear() noexcept
 {
     while (auto maybeUnmanagedChunk = getMembers()->m_queue.pop())
     {
-        // PRQA S 4117 4 # d'tor of SharedChunk will release the memory, so RAII has the side effect here
+        // AXIVION Next Construct AutosarC++19_03-A0.1.2 : d'tor of SharedChunk will release the memory, so RAII has the
+        // side effect here and return value does not need to be evaluated
         maybeUnmanagedChunk.value().releaseToSharedChunk();
     }
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
@@ -101,8 +101,8 @@ template <typename ChunkReceiverDataType>
 inline void ChunkReceiver<ChunkReceiverDataType>::release(const mepoo::ChunkHeader* const chunkHeader) noexcept
 {
     mepoo::SharedChunk chunk(nullptr);
-    // PRQA S 4127 1 # d'tor of SharedChunk will release the memory, we do not have to touch the returned chunk
-    if (!getMembers()->m_chunksInUse.remove(chunkHeader, chunk)) // PRQA S 4127
+    // d'tor of SharedChunk will release the memory, we do not have to touch the returned chunk
+    if (!getMembers()->m_chunksInUse.remove(chunkHeader, chunk))
     {
         errorHandler(PoshError::POPO__CHUNK_RECEIVER_INVALID_CHUNK_TO_RELEASE_FROM_USER, ErrorLevel::SEVERE);
     }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
@@ -171,7 +171,7 @@ template <typename ChunkSenderDataType>
 inline void ChunkSender<ChunkSenderDataType>::release(const mepoo::ChunkHeader* const chunkHeader) noexcept
 {
     mepoo::SharedChunk chunk(nullptr);
-    // PRQA S 4127 1 # d'tor of SharedChunk will release the memory, we do not have to touch the returned chunk
+    // d'tor of SharedChunk will release the memory, we do not have to touch the returned chunk
     if (!getMembers()->m_chunksInUse.remove(chunkHeader, chunk))
     {
         errorHandler(PoshError::POPO__CHUNK_SENDER_INVALID_CHUNK_TO_FREE_FROM_USER, ErrorLevel::SEVERE);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Replace QAC++ suppressions with AUTOSAR suppressions using Axivion

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1566 
