### PR TITLE
iox-#1394 Fix Axivion warnings for builder.hpp

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/builder.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/design_pattern/builder.hpp
@@ -43,19 +43,23 @@
 ///     // END
 ///   };
 /// @endcode
-// NOLINTJUSTIFICATION brackets around macro parameter would lead in this case to compile time failures
+// AXIVION Next Construct AutosarC++19_03-M16.0.1 this macro is used to prevent a large amount of boilerplate code
+// which cannot be realized with templates or constexpr functions
+// AXIVION Next Construct AutosarC++19_03-M16.0.6 brackets around macro parameter would lead in this case to compile
+// time failures
+// AXIVION Next Construct AutosarC++19_03-M16.3.1 multiple '##' operators are required to declare and use a variable
+// AXIVION Next Construct AutosarC++19_03-M16.3.2 the '##' operator is required to be able to reduce boilerplate code
 // NOLINTBEGIN(bugprone-macro-parentheses)
-// NOLINTJUSTIFICATION cannot be realized with templates or constexpr functions
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_BUILDER_PARAMETER(type, name, defaultValue)                                                                \
   public:                                                                                                              \
-    decltype(auto) name(type const& value)&&                                                                           \
+    decltype(auto) name(type const& value)&& noexcept                                                                  \
     {                                                                                                                  \
         m_##name = value;                                                                                              \
         return std::move(*this);                                                                                       \
     }                                                                                                                  \
                                                                                                                        \
-    decltype(auto) name(type&& value)&&                                                                                \
+    decltype(auto) name(type&& value)&& noexcept                                                                       \
     {                                                                                                                  \
         m_##name = std::move(value);                                                                                   \
         return std::move(*this);                                                                                       \


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes the Axivion warnings for `builder.hpp` and makes the methods `noexcept`/`const noexcept`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1394
