### PR TITLE
iox-#1571 Add check for `nullptr` in `unique_ptr::get()`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -44,6 +44,7 @@
   - This bug was not part of a release but introduce during the v3 development
 - Add "inline" keyword to smart_lock method implementation [\#1551](https://github.com/eclipse-iceoryx/iceoryx/issues/1551)
 - Fix RouDi crash due to uninitialized `ServiceRegistry` chunk [\#1575](https://github.com/eclipse-iceoryx/iceoryx/issues/1575)
+- Add check in `cxx::unique_ptr::get` to avoid `nullptr` dereferencing [\#1571](https://github.com/eclipse-iceoryx/iceoryx/issues/1571)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
@@ -37,11 +37,6 @@ class unique_ptr
     unique_ptr() = delete;
 
     ///
-    /// @brief unique_ptr Creates an empty unique ptr that owns nothing. Can be passed ownership later via reset.
-    ///
-    explicit unique_ptr(const function<void(T*)>& deleter) noexcept;
-
-    ///
     /// @brief unique_ptr Creates a unique pointer that takes ownership of an object.
     /// @details A deleter must always be provided as no default can be provided given that no heap is used.
     /// The unique_ptr must know how to delete the managed object when the pointer goes out of scope.
@@ -56,7 +51,7 @@ class unique_ptr
     unique_ptr& operator=(unique_ptr&& rhs) noexcept;
 
     ///
-    /// Automatically deletes the managed object on destruction.
+    /// @brief Automatically deletes the managed object on destruction.
     ///
     ~unique_ptr() noexcept;
 
@@ -65,13 +60,13 @@ class unique_ptr
 
     ///
     /// @brief operator -> Transparent access to the managed object.
-    /// @return
+    /// @return Pointer to the stored object
     ///
     T* operator->() noexcept;
 
     ///
     /// @brief operator -> Transparent access to the managed object.
-    /// @return
+    /// @return Const pointer to the stored object
     ///
     const T* operator->() const noexcept;
 
@@ -83,14 +78,14 @@ class unique_ptr
     ///
     /// @brief get Retrieve the underlying raw pointer.
     /// @details The unique_ptr retains ownership, therefore the "borrowed" pointer must not be deleted.
-    /// @return Pointer to managed object or nullptr if none owned.
+    /// @return Pointer to managed object or errorHandler call if none owned.
     ///
     T* get() noexcept;
 
     ///
     /// @brief get Retrieve the underlying raw pointer.
     /// @details The unique_ptr retains ownership, therefore the "borrowed" pointer must not be deleted.
-    /// @return Pointer to managed object or nullptr if none owned.
+    /// @return Const pointer to managed object or errorHandler call if none owned.
     ///
     const T* get() const noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -32,12 +32,6 @@ unique_ptr<T>::unique_ptr(T* const ptr, const function<void(T*)>& deleter) noexc
 }
 
 template <typename T>
-unique_ptr<T>::unique_ptr(const function<void(T*)>& deleter) noexcept
-    : unique_ptr(nullptr, std::move(deleter))
-{
-}
-
-template <typename T>
 unique_ptr<T>& unique_ptr<T>::operator=(std::nullptr_t) noexcept
 {
     reset();
@@ -84,12 +78,13 @@ const T* unique_ptr<T>::operator->() const noexcept
 template <typename T>
 unique_ptr<T>::operator bool() const noexcept
 {
-    return get() != nullptr;
+    return m_ptr != nullptr;
 }
 
 template <typename T>
 T* unique_ptr<T>::get() noexcept
 {
+    cxx::Expects(m_ptr != nullptr);
     return m_ptr;
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/smart_chunk.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/smart_chunk.inl
@@ -84,7 +84,7 @@ inline const T& SmartChunk<TransmissionInterface, T, H>::operator*() const noexc
 template <typename TransmissionInterface, typename T, typename H>
 inline SmartChunk<TransmissionInterface, T, H>::operator bool() const noexcept
 {
-    return get() != nullptr;
+    return m_members.smartChunkUniquePtr.operator bool();
 }
 
 template <typename TransmissionInterface, typename T, typename H>

--- a/iceoryx_posh/test/moduletests/test_popo_request.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_request.cpp
@@ -39,7 +39,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithSuccessResult)
     auto sendResult = sutProducer.send();
 
     EXPECT_FALSE(sendResult.has_error());
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Request_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
@@ -51,7 +51,7 @@ TEST_F(Request_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
     auto sendResult = movedSut.send();
 
     EXPECT_FALSE(sendResult.has_error());
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Request_test, SendCallsInterfaceMockWithErrorResult)
@@ -65,7 +65,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithErrorResult)
 
     ASSERT_TRUE(sendResult.has_error());
     EXPECT_THAT(sendResult.get_error(), Eq(CLIENT_SEND_ERROR));
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Request_test, SendingAlreadySentRequestCallsErrorHandler)

--- a/iceoryx_posh/test/moduletests/test_popo_response.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_response.cpp
@@ -39,7 +39,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithSuccessResult)
     auto sendResult = sutProducer.send();
 
     EXPECT_FALSE(sendResult.has_error());
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Response_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
@@ -51,7 +51,7 @@ TEST_F(Response_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
     auto sendResult = movedSut.send();
 
     EXPECT_FALSE(sendResult.has_error());
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Response_test, SendCallsInterfaceMockWithErrorResult)
@@ -65,7 +65,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithErrorResult)
 
     ASSERT_TRUE(sendResult.has_error());
     EXPECT_THAT(sendResult.get_error(), Eq(SERVER_SEND_ERROR));
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Response_test, SendingAlreadySentResponseCallsErrorHandler)

--- a/iceoryx_posh/test/moduletests/test_popo_sample.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_sample.cpp
@@ -38,7 +38,7 @@ TEST_F(Sample_test, SendCallsInterfaceMockWithSuccessResult)
 
     sutProducer.publish();
 
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Sample_test, SendOnMoveDestinationCallsInterfaceMock)
@@ -49,7 +49,7 @@ TEST_F(Sample_test, SendOnMoveDestinationCallsInterfaceMock)
     auto movedSut = std::move(sutProducer);
     movedSut.publish();
 
-    EXPECT_THAT(sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(sutProducer);
 }
 
 TEST_F(Sample_test, PublishingAlreadyPublishedSampleCallsErrorHandler)

--- a/iceoryx_posh/test/moduletests/test_popo_smart_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_smart_chunk.cpp
@@ -58,11 +58,11 @@ TYPED_TEST(SmartChunkTest, SmartChunkIsInvalidatedAfterMoveConstruction)
     ::testing::Test::RecordProperty("TEST_ID", "90c8db15-6cf2-4dfc-a9ca-cb1333081fe3");
 
     typename TestFixture::SutProducerType producer(std::move(this->variation.sutProducer));
-    EXPECT_THAT(this->variation.sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(this->variation.sutProducer);
     EXPECT_THAT(producer.get(), Eq(this->variation.chunkMock.sample()));
 
     typename TestFixture::SutConsumerType consumer(std::move(this->variation.sutConsumer));
-    EXPECT_THAT(this->variation.sutConsumer.get(), Eq(nullptr));
+    EXPECT_FALSE(this->variation.sutConsumer);
     EXPECT_THAT(consumer.get(), Eq(this->variation.chunkMock.sample()));
 }
 
@@ -73,13 +73,13 @@ TYPED_TEST(SmartChunkTest, SmartChunkIsInvalidatedAfterMoveAssignment)
     this->variation.sutProducerForMove = std::move(this->variation.sutProducer);
     EXPECT_FALSE(this->variation.sutProducer);
     EXPECT_TRUE(this->variation.sutProducerForMove);
-    EXPECT_THAT(this->variation.sutProducer.get(), Eq(nullptr));
+    EXPECT_FALSE(this->variation.sutProducer);
     EXPECT_THAT(this->variation.sutProducerForMove.get(), Eq(this->variation.chunkMock.sample()));
 
     this->variation.sutConsumerForMove = std::move(this->variation.sutConsumer);
     EXPECT_FALSE(this->variation.sutConsumer);
     EXPECT_TRUE(this->variation.sutConsumerForMove);
-    EXPECT_THAT(this->variation.sutConsumer.get(), Eq(nullptr));
+    EXPECT_FALSE(this->variation.sutConsumer);
     EXPECT_THAT(this->variation.sutConsumerForMove.get(), Eq(this->variation.chunkMock.sample()));
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Remove unused c'tor
* Check for `nullptr` when accessing via `get()`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1571 
