### PR TITLE
iox-#1575 Properly initialize `ServiceRegistry` in shared memory

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -43,6 +43,7 @@
 - The testing libs are broken for in source tree usage [\#1528](https://github.com/eclipse-iceoryx/iceoryx/issues/1528)
   - This bug was not part of a release but introduce during the v3 development
 - Add "inline" keyword to smart_lock method implementation [\#1551](https://github.com/eclipse-iceoryx/iceoryx/issues/1551)
+- Fix RouDi crash due to uninitialized `ServiceRegistry` chunk [\#1575](https://github.com/eclipse-iceoryx/iceoryx/issues/1575)
 
 **Refactoring:**
 

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -1051,10 +1051,8 @@ void PortManager::publishServiceRegistry() const noexcept
                           CHUNK_NO_USER_HEADER_SIZE,
                           CHUNK_NO_USER_HEADER_ALIGNMENT)
         .and_then([&](auto& chunk) {
-            auto sample = static_cast<ServiceRegistry*>(chunk->userPayload());
-
             // It's ok to copy as the modifications happen in the same thread and not concurrently
-            *sample = m_serviceRegistry;
+            new (chunk->userPayload()) ServiceRegistry(m_serviceRegistry);
 
             publisher.sendChunk(chunk);
         })


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] ~~All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`~~ not done for posh
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Fixes a bug, that would call `vector::operator=(const vector&)` on uninitialized data
  * No test was added as the false behavior relies on shared memory not being initialized, which can not be always reproduced (see below)


```
// Call stack before the bugfix

ServiceRegistry::operator=(const ServiceRegistry& rhs) (implicitly defined)
  |
   -- >  vector::operator=(const vector& rhs)
         |
         --> With certain compiler/compiler settings: vector::size() != 0, leading to false execution of copy assignment branch (at(i) = rhs.at(i))

// Call stack after the bugfix

ServiceRegistry::ServiceRegistry(const ServiceRegistry& rhs) (implicitly defined, ensures that all member variables are properly initialized)
  |
   -- >  vector::vector(const vector& rhs)
         |
         --> vector::operator=(const vector& rhs)
               |
               --> vector::size() == 0 is ensured, leading to correct execution of copy c'tor branch (emplace_back(rhs.at(i)))
```

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- ~~[ ] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`~~
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1575 
