### PR TITLE
iox-#1580 Disable monitoring feature in RouDi by default

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -73,6 +73,7 @@
 - Cleanup helplets [\#1560](https://github.com/eclipse-iceoryx/iceoryx/issues/1560)
 - Moved package `iceoryx_dds` to [separate repository](https://github.com/eclipse-iceoryx/iceoryx-gateway-dds) [\#1564](https://github.com/eclipse-iceoryx/iceoryx/issues/1564)
 - Set `SOVERSION` with project major version for shared libraries in CMake [\#1308](https://github.com/eclipse-iceoryx/iceoryx/issues/1308)
+- Monitoring feature of RouDi is now disabled by default [\#1580](https://github.com/eclipse-iceoryx/iceoryx/issues/1580)
 
 **Workflow:**
 

--- a/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
@@ -28,7 +28,7 @@ namespace config
 {
 struct CmdLineArgs_t
 {
-    roudi::MonitoringMode monitoringMode{roudi::MonitoringMode::ON};
+    roudi::MonitoringMode monitoringMode{roudi::MonitoringMode::OFF};
     iox::log::LogLevel logLevel{iox::log::LogLevel::kWarn};
     version::CompatibilityCheckLevel compatibilityCheckLevel{version::CompatibilityCheckLevel::PATCH};
     units::Duration processKillDelay{roudi::PROCESS_DEFAULT_KILL_DELAY};

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_cmd_line_parser.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_cmd_line_parser.hpp
@@ -65,7 +65,7 @@ class CmdLineParser
   protected:
     bool m_run{true};
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::kWarn};
-    roudi::MonitoringMode m_monitoringMode{roudi::MonitoringMode::ON};
+    roudi::MonitoringMode m_monitoringMode{roudi::MonitoringMode::OFF};
     version::CompatibilityCheckLevel m_compatibilityCheckLevel{version::CompatibilityCheckLevel::PATCH};
     cxx::optional<uint16_t> m_uniqueRouDiId;
     units::Duration m_processKillDelay{roudi::PROCESS_DEFAULT_KILL_DELAY};

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -54,7 +54,7 @@ CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cm
             std::cout << "-u, --unique-roudi-id <INT>       Set the unique RouDi id." << std::endl;
             std::cout << "-m, --monitoring-mode <MODE>      Set process alive monitoring mode." << std::endl;
             std::cout << "                                  <MODE> {on, off}" << std::endl;
-            std::cout << "                                  default = 'on'" << std::endl;
+            std::cout << "                                  default = 'off'" << std::endl;
             std::cout << "                                  on: enables monitoring for all processes" << std::endl;
             std::cout << "                                  off: disables monitoring for all processes" << std::endl;
             std::cout << "-l, --log-level <LEVEL>           Set log level." << std::endl;

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
@@ -133,7 +133,7 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorIsSuccessful)
 
     EXPECT_TRUE(roudi.getVariableRun());
     EXPECT_EQ(roudi.getLogLevel(), iox::log::LogLevel::kWarn);
-    EXPECT_EQ(roudi.getMonitoringMode(), roudi::MonitoringMode::ON);
+    EXPECT_EQ(roudi.getMonitoringMode(), roudi::MonitoringMode::OFF);
 }
 
 TEST_F(IceoryxRoudiApp_test, CreateTwoRoudiAppIsSuccessful)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] ~~All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`~~ not done for posh
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Disable monitoring feature in RouDi by default

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- ~~[ ] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`~~
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1580 
