### PR TITLE
iox-#1287 Setup RPATH correctly

### DIFF
--- a/iceoryx_hoofs/cmake/IceoryxPackageHelper.cmake
+++ b/iceoryx_hoofs/cmake/IceoryxPackageHelper.cmake
@@ -209,9 +209,7 @@ Macro(iox_add_executable)
         target_link_libraries(${IOX_TARGET} ${IOX_LIBS_UNIX})
     endif()
 
-    # TODO iox-#1287 lasting fix for rpath without implicit posh dependencies
-    #                and auto lib detection
-    ### iox_set_rpath( IS_EXECUTABLE TARGET ${IOX_TARGET} )
+    iox_set_rpath( IS_EXECUTABLE TARGET ${IOX_TARGET} )
 
     if ( IOX_PLACE_IN_BUILD_ROOT )
         set_target_properties(${IOX_TARGET} PROPERTIES
@@ -342,9 +340,7 @@ Macro(iox_add_library)
         target_link_libraries(${IOX_TARGET} PUBLIC ${IOX_PUBLIC_LIBS_WIN32} PRIVATE ${IOX_PRIVATE_LIBS_WIN32})
     endif ( LINUX )
 
-    # TODO iox-#1287 lasting fix for rpath without implicit posh dependencies
-    #                and auto lib detection
-    ### iox_set_rpath( TARGET ${IOX_TARGET} )
+    iox_set_rpath( TARGET ${IOX_TARGET} )
 
     foreach(INTERFACE ${IOX_BUILD_INTERFACE})
         target_include_directories(${IOX_TARGET}


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Before merging this PR, please perform the following tasks:
- [ ] try to reproduce the RPATH failure on Mac OS from: https://github.com/eclipse-cyclonedds/cyclonedds/issues/1270
- [ ] Test if this PR solves the RPATH issue
- [ ] Check that colcon works with the updated RPATH setting

## Notes for Reviewer
The RPATH issue on MacOS still persists, see: https://github.com/eclipse-cyclonedds/cyclonedds/issues/1270 
The solution is actually simple, just uncomment the rpath setter function.

@mossmaurice I think we did not merge it previously since you intervened and stated that it is bad when we have somehow "posh" stated in the hoofs library. I agree with this but I think it is even worse when it is not working at all (on mac os). The issue is already documented and I suggest to merge this, make it work and later we solve the issue and go for a clean solution.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Part of #1287 
