### PR TITLE
iox-#1394 fix axivion violation for type traits hpp types hpp

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
@@ -76,8 +76,6 @@ struct is_invocable
     // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     // This is chosen if Callable(ArgTypes) does not resolve to a valid type.
     template <typename C, typename... As>
-    /// @NOLINTJUSTIFICATION we require a SFINEA failure case where all parameter types (non invokable ones) are
-    ///                      allowed, this can be achieved with variadic arguments
     /// @NOLINTNEXTLINE(cert-dcl50-cpp)
     static constexpr std::false_type test(...) noexcept
     {
@@ -107,8 +105,6 @@ struct is_invocable_r
     // AXIVION Next Construct AutosarC++19_03-A8.4.1 : we require a SFINEA failure case where all
     // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     template <typename C, typename... As>
-    /// @NOLINTJUSTIFICATION we require a SFINEA failure case where all parameter types (non invokable ones) are
-    ///                      allowed, this can be achieved with variadic arguments
     /// @NOLINTNEXTLINE(cert-dcl50-cpp)
     static constexpr std::false_type test(...) noexcept
     {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
@@ -55,17 +55,17 @@ using add_const_conditionally_t = typename add_const_conditionally<T, C>::type;
 /// @endcode
 ///
 template <typename>
-constexpr bool always_false_v = false;
-
+constexpr bool always_false_v{false};
 // windows defines __cplusplus as 199711L
-#if __cplusplus < 201703L && !defined(_WIN32)
+// AXIVION DISABLE STYLE AutosarC++19_03-A16.0.1: TODO
+#if (__cplusplus < 201703L) && !defined(_WIN32)
 template <typename C, typename... Cargs>
 using invoke_result = std::result_of<C(Cargs...)>;
-#elif __cplusplus >= 201703L || defined(_WIN32)
+#elif (__cplusplus >= 201703L) || defined(_WIN32)
 template <typename C, typename... Cargs>
 using invoke_result = std::invoke_result<C, Cargs...>;
 #endif
-
+// AXIVION ENABLE STYLE AutosarC++19_03-A16.0.1:
 ///
 /// @brief Verifies whether the passed Callable type is in fact invocable with the given arguments
 ///
@@ -80,6 +80,8 @@ struct is_invocable
         return {};
     }
 
+    // AXIVION Next Construct AutosarC++19_03-A8.4.1 : we require a SFINEA failure case where all
+    // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     // This is chosen if Callable(ArgTypes) does not resolve to a valid type.
     template <typename C, typename... As>
     /// @NOLINTJUSTIFICATION we require a SFINEA failure case where all parameter types (non invokable ones) are
@@ -91,7 +93,7 @@ struct is_invocable
     }
 
     // Test with nullptr as this can stand in for a pointer to any type.
-    static constexpr bool value = decltype(test<Callable, ArgTypes...>(nullptr))::value;
+    static constexpr bool value{decltype(test<Callable, ArgTypes...>(nullptr))::value};
 };
 
 ///
@@ -110,7 +112,8 @@ struct is_invocable_r
     {
         return {};
     }
-
+    // AXIVION Next Construct AutosarC++19_03-A8.4.1 : we require a SFINEA failure case where all
+    // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     template <typename C, typename... As>
     /// @NOLINTJUSTIFICATION we require a SFINEA failure case where all parameter types (non invokable ones) are
     ///                      allowed, this can be achieved with variadic arguments
@@ -121,7 +124,7 @@ struct is_invocable_r
     }
 
     // Test with nullptr as this can stand in for a pointer to any type.
-    static constexpr bool value = decltype(test<Callable, ArgTypes...>(nullptr))::value;
+    static constexpr bool value{decltype(test<Callable, ArgTypes...>(nullptr))::value};
 };
 
 ///

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/type_traits.hpp
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "iceoryx_hoofs/cxx/attributes.hpp"
+#include "iceoryx_hoofs/platform/platform_settings.hpp"
 
 namespace iox
 {
@@ -56,16 +57,7 @@ using add_const_conditionally_t = typename add_const_conditionally<T, C>::type;
 ///
 template <typename>
 constexpr bool always_false_v{false};
-// windows defines __cplusplus as 199711L
-// AXIVION DISABLE STYLE AutosarC++19_03-A16.0.1: TODO
-#if (__cplusplus < 201703L) && !defined(_WIN32)
-template <typename C, typename... Cargs>
-using invoke_result = std::result_of<C(Cargs...)>;
-#elif (__cplusplus >= 201703L) || defined(_WIN32)
-template <typename C, typename... Cargs>
-using invoke_result = std::invoke_result<C, Cargs...>;
-#endif
-// AXIVION ENABLE STYLE AutosarC++19_03-A16.0.1:
+
 ///
 /// @brief Verifies whether the passed Callable type is in fact invocable with the given arguments
 ///
@@ -75,7 +67,7 @@ struct is_invocable
     // This variant is chosen when Callable(ArgTypes) successfully resolves to a valid type, i.e. is invocable.
     /// @note result_of is deprecated, switch to invoke_result in C++17
     template <typename C, typename... As>
-    static constexpr std::true_type test(typename cxx::invoke_result<C, As...>::type* f IOX_MAYBE_UNUSED) noexcept
+    static constexpr std::true_type test(typename platform::invoke_result<C, As...>::type* f IOX_MAYBE_UNUSED) noexcept
     {
         return {};
     }
@@ -107,7 +99,7 @@ struct is_invocable_r
 {
     template <typename C, typename... As>
     static constexpr std::true_type
-    test(std::enable_if_t<std::is_convertible<typename cxx::invoke_result<C, As...>::type, ReturnType>::value>* f
+    test(std::enable_if_t<std::is_convertible<typename platform::invoke_result<C, As...>::type, ReturnType>::value>* f
              IOX_MAYBE_UNUSED) noexcept
     {
         return {};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/types.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/types.hpp
@@ -23,8 +23,9 @@ namespace iox
 {
 namespace cxx
 {
+// aliasing for unit8_t
 using byte_t = uint8_t;
-}
+} // namespace cxx
 } // namespace iox
 
 #endif // IOX_HOOFS_CXX_TYPES_HPP

--- a/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/platform_settings.hpp
+++ b/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/platform_settings.hpp
@@ -36,6 +36,9 @@ constexpr const char IOX_PATH_SEPARATORS[IOX_NUMBER_OF_PATH_SEPARATORS] = {'/'};
 constexpr uint64_t IOX_UDS_SOCKET_MAX_MESSAGE_SIZE = 4096;
 constexpr const char IOX_UDS_SOCKET_PATH_PREFIX[] = "/tmp/";
 constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
+
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/platform_settings.hpp
+++ b/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/platform_settings.hpp
@@ -37,6 +37,10 @@ constexpr const char IOX_PATH_SEPARATORS[IOX_NUMBER_OF_PATH_SEPARATORS] = {'/'};
 constexpr uint64_t IOX_UDS_SOCKET_MAX_MESSAGE_SIZE = 2048;
 constexpr const char IOX_UDS_SOCKET_PATH_PREFIX[] = "/tmp/";
 constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
+
+template <typename C, typename... Cargs>
+using invoke_result = std::invoke_result<C, Cargs...>;
+
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/platform_settings.hpp
+++ b/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/platform_settings.hpp
@@ -35,6 +35,9 @@ constexpr const char IOX_PATH_SEPARATORS[IOX_NUMBER_OF_PATH_SEPARATORS] = {'/'};
 constexpr uint64_t IOX_UDS_SOCKET_MAX_MESSAGE_SIZE = 2048;
 constexpr const char IOX_UDS_SOCKET_PATH_PREFIX[] = "/tmp/";
 constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/var/lock/";
+
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/platform_settings.hpp
+++ b/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/platform_settings.hpp
@@ -36,6 +36,10 @@ constexpr const char IOX_PATH_SEPARATORS[IOX_NUMBER_OF_PATH_SEPARATORS] = {'/'};
 constexpr uint64_t IOX_UDS_SOCKET_MAX_MESSAGE_SIZE = 1024;
 constexpr const char IOX_UDS_SOCKET_PATH_PREFIX[] = "/tmp/";
 constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
+
+template <typename C, typename... Cargs>
+using invoke_result = std::invoke_result<C, Cargs...>;
+
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/platform_settings.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/platform_settings.hpp
@@ -39,6 +39,9 @@ constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "C:\\Windows\\Temp\\";
 constexpr uint64_t IOX_MAX_FILENAME_LENGTH = 128U;
 constexpr uint64_t IOX_MAX_PATH_LENGTH = 255U;
 
+template <typename C, typename... Cargs>
+using invoke_result = std::invoke_result<C, Cargs...>;
+
 namespace win32
 {
 // just increase this number to increase the maximum shared memory size supported

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
@@ -142,7 +142,7 @@ TEST(ChunkHeader_test, ChunkHeaderBinaryCompatibilityCheck)
 TEST(ChunkHeader_test, ChunkHeaderUserPayloadSizeTypeIsLargeEnoughForMempoolChunk)
 {
     ::testing::Test::RecordProperty("TEST_ID", "540e2e95-0890-4522-ae7f-c6d867679e0b");
-    using ChunkSize_t = iox::cxx::invoke_result<decltype(&MemPool::getChunkSize), MemPool>::type;
+    using ChunkSize_t = iox::platform::invoke_result<decltype(&MemPool::getChunkSize), MemPool>::type;
 
     auto maxOfChunkSizeType = std::numeric_limits<ChunkSize_t>::max();
     auto maxOfUserPayloadSizeType = std::numeric_limits<decltype(std::declval<ChunkHeader>().userPayloadSize())>::max();


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partly)
