### PR TITLE
iox-#1365 set thread name in start routine

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/optional.hpp
@@ -230,10 +230,22 @@ class optional : public FunctionalInterface<optional<T>, T, void>
     const T&& value() const&& noexcept;
 
   private:
+    // the hasValue member should be first member in the memory layout to reveal casting
+    // bugs early.
+    //
+    // See the following problem:
+    //   void initHandle(void * ptr) {
+    //     Handle * handle = static_cast<Handle>(ptr);
+    //   }
+    //   void doStuff(cxx::optional<Handle> & handle) {
+    //     // uses optional<Handle> instead of handle, if the bool is the second parameter such
+    //     // mistakes can be introduced quickly in low level c abstraction classes
+    //     initHandle(&handle);
+    //   }
+    bool m_hasValue{false};
     // safe access is guaranteed since the array is wrapped inside the optional
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     alignas(T) byte_t m_data[sizeof(T)];
-    bool m_hasValue{false};
 
   private:
     template <typename... Targs>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
@@ -84,9 +84,12 @@ class Thread
 
     static void* startRoutine(void* callable);
 
+    // iox_pthread_t m_threadHandle;
+    //  callable_t m_callable;
+    bool m_isThreadConstructed{false};
     iox_pthread_t m_threadHandle;
     callable_t m_callable;
-    bool m_isThreadConstructed{false};
+    ThreadName_t m_threadName;
 };
 
 class ThreadBuilder

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
@@ -84,11 +84,9 @@ class Thread
 
     static void* startRoutine(void* callable);
 
-    // iox_pthread_t m_threadHandle;
-    //  callable_t m_callable;
-    bool m_isThreadConstructed{false};
     iox_pthread_t m_threadHandle;
     callable_t m_callable;
+    bool m_isThreadConstructed{false};
     ThreadName_t m_threadName;
 };
 

--- a/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/pthread.hpp
@@ -43,4 +43,9 @@ inline int iox_pthread_join(iox_pthread_t thread, void** retval)
     return pthread_join(thread, retval);
 }
 
+inline iox_pthread_t iox_pthread_self()
+{
+    return pthread_self();
+}
+
 #endif // IOX_HOOFS_LINUX_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/linux/include/iceoryx_hoofs/platform/pthread.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/pthread.hpp
@@ -30,4 +30,7 @@ int iox_pthread_create(iox_pthread_t* thread, const iox_pthread_attr_t* attr, vo
 
 int iox_pthread_join(iox_pthread_t thread, void** retval);
 
+iox_pthread_t iox_pthread_self();
+
+
 #endif // IOX_HOOFS_MAC_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/mac/include/iceoryx_hoofs/platform/pthread.hpp
@@ -32,5 +32,4 @@ int iox_pthread_join(iox_pthread_t thread, void** retval);
 
 iox_pthread_t iox_pthread_self();
 
-
 #endif // IOX_HOOFS_MAC_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/mac/source/pthread.cpp
+++ b/iceoryx_hoofs/platform/mac/source/pthread.cpp
@@ -65,3 +65,8 @@ int iox_pthread_join(iox_pthread_t thread, void** retval)
     }
     return pthread_join(thread, retval);
 }
+
+int iox_pthread_self()
+{
+    return pthread_self();
+}

--- a/iceoryx_hoofs/platform/mac/source/pthread.cpp
+++ b/iceoryx_hoofs/platform/mac/source/pthread.cpp
@@ -66,7 +66,7 @@ int iox_pthread_join(iox_pthread_t thread, void** retval)
     return pthread_join(thread, retval);
 }
 
-int iox_pthread_self()
+iox_pthread_t iox_pthread_self()
 {
     return pthread_self();
 }

--- a/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/pthread.hpp
@@ -43,4 +43,9 @@ inline int iox_pthread_join(iox_pthread_t thread, void** retval)
     return pthread_join(thread, retval);
 }
 
+inline iox_pthread_t iox_pthread_self()
+{
+    return pthread_self();
+}
+
 #endif // IOX_HOOFS_QNX_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/qnx/include/iceoryx_hoofs/platform/pthread.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/pthread.hpp
@@ -46,4 +46,9 @@ inline int iox_pthread_join(iox_pthread_t thread, void** retval)
     return pthread_join(thread, retval);
 }
 
+inline iox_pthread_t iox_pthread_self()
+{
+    return pthread_self();
+}
+
 #endif // IOX_HOOFS_UNIX_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/unix/include/iceoryx_hoofs/platform/pthread.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/pthread.hpp
+++ b/iceoryx_hoofs/platform/win/include/iceoryx_hoofs/platform/pthread.hpp
@@ -62,5 +62,6 @@ int iox_pthread_setname_np(iox_pthread_t thread, const char* name);
 int iox_pthread_getname_np(iox_pthread_t thread, char* name, size_t len);
 int iox_pthread_create(iox_pthread_t* thread, const iox_pthread_attr_t* attr, void* (*start_routine)(void*), void* arg);
 int iox_pthread_join(iox_pthread_t thread, void** retval);
+iox_pthread_t iox_pthread_self();
 
 #endif // IOX_HOOFS_WIN_PLATFORM_PTHREAD_HPP

--- a/iceoryx_hoofs/platform/win/source/pthread.cpp
+++ b/iceoryx_hoofs/platform/win/source/pthread.cpp
@@ -78,12 +78,18 @@ int iox_pthread_create(iox_pthread_t* thread, const iox_pthread_attr_t* attr, vo
     }
 
     *thread = result.value;
+
     return result.error;
 }
 
 int iox_pthread_join(iox_pthread_t thread, void**)
 {
     return Win32Call(WaitForSingleObject, thread, INFINITE).error;
+}
+
+iox_pthread_t iox_pthread_self()
+{
+    return GetCurrentThread();
 }
 
 int pthread_mutexattr_destroy(pthread_mutexattr_t* attr)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
The thread name is now a member of the `Thread` class so that the name can be set within the start routine. This also simplifies the `getName` method.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partially closes #1365 
