### PR TITLE
iox-#1596 Add check for `nullptr` in `RelativePointer`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -46,6 +46,7 @@
 - Fix RouDi crash due to uninitialized `ServiceRegistry` chunk [\#1575](https://github.com/eclipse-iceoryx/iceoryx/issues/1575)
 - Add check in `cxx::unique_ptr::get` to avoid `nullptr` dereferencing [\#1571](https://github.com/eclipse-iceoryx/iceoryx/issues/1571)
 - Pass `CleanupCapacity` to underlying `cxx::function` in `ScopeGuard` (formerly known as `cxx::GenericRAII`) [\#1594](https://github.com/eclipse-iceoryx/iceoryx/issues/1594)
+- Add check in `RelativePointer::get` to avoid `nullptr` dereferencing [\#1596](https://github.com/eclipse-iceoryx/iceoryx/issues/1596)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl
@@ -67,13 +67,15 @@ inline T* RelativePointer<T>::operator->() const noexcept
 template <typename T>
 inline T* RelativePointer<T>::get() const noexcept
 {
-    return static_cast<T*>(computeRawPtr());
+    auto ptr = static_cast<T*>(computeRawPtr());
+    cxx::Ensures(ptr != nullptr);
+    return ptr;
 }
 
 template <typename T>
 inline RelativePointer<T>::operator bool() const noexcept
 {
-    return get() != nullptr;
+    return computeRawPtr() != nullptr;
 }
 
 template <typename T>

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -27,19 +27,6 @@ namespace
 using namespace ::testing;
 using namespace iox::rp;
 
-struct Data
-{
-    // NOLINTJUSTIFICATION Used only for test purposes
-    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-    Data(uint32_t i, uint32_t j)
-        : Data1(i)
-        , Data2(j)
-    {
-    }
-    uint32_t Data1 = 27;
-    uint32_t Data2 = 72;
-};
-
 constexpr uint64_t SHARED_MEMORY_SIZE = 4096UL * 32UL;
 constexpr uint64_t NUMBER_OF_MEMORY_PARTITIONS = 2U;
 uint8_t memoryPatternValue = 1U;
@@ -185,7 +172,7 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
 
     {
         RelativePointer<TypeParam> rp(nullptr);
-        EXPECT_EQ(rp, nullptr);
+        EXPECT_FALSE(rp);
     }
 
     {
@@ -194,7 +181,7 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 }
 
@@ -214,7 +201,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), 0U);
         EXPECT_EQ(rp.getId(), 1U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
@@ -226,7 +213,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 1U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
@@ -238,7 +225,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 1U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
@@ -248,7 +235,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), 0);
         EXPECT_EQ(rp.getId(), 2U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
@@ -260,7 +247,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 2U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
@@ -272,13 +259,13 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), offset);
         EXPECT_EQ(rp.getId(), 2U);
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 
     {
         RelativePointer<TypeParam> rp;
         rp = nullptr;
-        EXPECT_EQ(rp, nullptr);
+        EXPECT_FALSE(rp);
     }
 
     {
@@ -288,7 +275,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
-        EXPECT_NE(rp, nullptr);
+        EXPECT_TRUE(rp);
     }
 }
 
@@ -551,8 +538,8 @@ TYPED_TEST(RelativePointer_test, DefaultConstructedRelativePtrIsNull)
     RelativePointer<TypeParam> rp1;
     RelativePointer<const TypeParam> rp2;
 
-    EXPECT_EQ(rp1, nullptr);
-    EXPECT_EQ(rp2, nullptr);
+    EXPECT_FALSE(rp1);
+    EXPECT_FALSE(rp2);
 }
 
 } // namespace

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.inl
@@ -146,7 +146,7 @@ inline void ChunkQueuePopper<ChunkQueueDataType>::unsetConditionVariable() noexc
 template <typename ChunkQueueDataType>
 inline bool ChunkQueuePopper<ChunkQueueDataType>::isConditionVariableSet() const noexcept
 {
-    return getMembers()->m_conditionVariableDataPtr != nullptr;
+    return getMembers()->m_conditionVariableDataPtr.operator bool();
 }
 
 } // namespace popo


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Add check for `nullptr` in `RelativePointer`
  * Activation/ deactivation of this check will be possible by the user after #1032 was implemented 

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1596 
