### PR TITLE
iox-1394 fix AUTOSAR violations in algorithm files

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -77,6 +77,7 @@
 - Set `SOVERSION` with project major version for shared libraries in CMake [\#1308](https://github.com/eclipse-iceoryx/iceoryx/issues/1308)
 - Monitoring feature of RouDi is now disabled by default [\#1580](https://github.com/eclipse-iceoryx/iceoryx/issues/1580)
 - Renamed `cxx::GenericRAII` to `cxx::ScopeGuard` [\#1450](https://github.com/eclipse-iceoryx/iceoryx/issues/1450)
+- Rename `algorithm::max` and `algorithm::min` to `algorithm::maxVal` and `algorithm::minVal` [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
 
 **Workflow:**
 
@@ -342,4 +343,17 @@
     {
         // do on destruction
     }};
+    ```
+
+19. Rename `algorithm::max` and `algorithm::min` to `algorithm::maxVal` and `algorithm::minVal`
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/cxx/algorithm.hpp"
+    constexpr uint32_t MAX_VAL = algorithm::max(3, 1890, 57);
+    constexpr uint32_t MIN_VAL = algorithm::min(3, 1890, 57);
+
+    // after
+    #include "iceoryx_hoofs/cxx/algorithm.hpp"
+    constexpr uint32_t MAX_VAL = algorithm::maxVal(3, 1890, 57);
+    constexpr uint32_t MIN_VAL = algorithm::minVal(3, 1890, 57);
     ```

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
@@ -26,6 +26,8 @@ namespace iox
 {
 namespace algorithm
 {
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which is required as generic
 ///          recursive template endpoint.
@@ -35,6 +37,8 @@ namespace algorithm
 template <typename T>
 constexpr T max(const T& left) noexcept;
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which takes two arguments and returns the
 ///          greater one.
@@ -45,6 +49,9 @@ constexpr T max(const T& left) noexcept;
 template <typename T>
 constexpr T max(const T& left, const T& right) noexcept;
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
+// max value of more than two values, initializer list from STL uses heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type.
 /// @param T type which implements operator<()
@@ -55,6 +62,8 @@ constexpr T max(const T& left, const T& right) noexcept;
 template <typename T, typename... Targs>
 constexpr T max(const T& left, const T& right, const Targs&... args) noexcept;
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which is required as generic
 ///          recursive template endpoint.
@@ -64,6 +73,8 @@ constexpr T max(const T& left, const T& right, const Targs&... args) noexcept;
 template <typename T>
 constexpr T min(const T& left) noexcept;
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which takes two arguments and returns the
 ///          smaller one.
@@ -74,6 +85,8 @@ constexpr T min(const T& left) noexcept;
 template <typename T>
 constexpr T min(const T& left, const T& right) noexcept;
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type.
 /// @param T type which implements operator<()

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
@@ -99,10 +99,9 @@ template <typename T, typename CompareType, typename Next, typename... Remainder
 constexpr bool doesContainType() noexcept;
 
 /// @brief Finalizes the recursion of doesContainValue
-/// @param[in] v type of the value to check
 /// @return always false
 template <typename T>
-inline constexpr bool doesContainValue(const T v) noexcept;
+inline constexpr bool doesContainValue(const T) noexcept;
 
 /// @brief Returns true if value of T is found in the ValueList, otherwise false
 /// @tparam T type of the value to check
@@ -111,8 +110,8 @@ inline constexpr bool doesContainValue(const T v) noexcept;
 /// @param[in] firstValueListEntry is the first variadic argument of ValueList
 /// @param[in] remainingValueListEntries are the remaining variadic arguments of ValueList
 /// @return true if value is contained in the ValueList, otherwise false
-/// @note be aware that value is tested for exact equality with the entries of ValueList which might lead to unexpected
-/// results for floating-point types
+/// @note be aware that value is tested for exact equality with the entries of ValueList and regular floating-point
+/// comparison rules apply
 template <typename T, typename... ValueList>
 inline constexpr bool
 doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
@@ -26,8 +26,6 @@ namespace iox
 {
 namespace algorithm
 {
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which is required as generic
 ///          recursive template endpoint.
@@ -35,10 +33,8 @@ namespace algorithm
 /// @param[in] left value which should be compared
 /// @return returns the given argument left
 template <typename T>
-constexpr T max(const T& left) noexcept;
+constexpr T maxVal(const T& left) noexcept;
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which takes two arguments and returns the
 ///          greater one.
@@ -47,11 +43,8 @@ constexpr T max(const T& left) noexcept;
 /// @param[in] right value which should be compared
 /// @return returns the maximum value of the set {left, right}
 template <typename T>
-constexpr T max(const T& left, const T& right) noexcept;
+constexpr T maxVal(const T& left, const T& right) noexcept;
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
-// max value of more than two values, initializer list from STL uses heap
 /// @brief Returns the maximum gained with operator<() of an arbitrary amount
 ///          of variables of the same type.
 /// @param T type which implements operator<()
@@ -60,10 +53,8 @@ constexpr T max(const T& left, const T& right) noexcept;
 /// @param[in] args... an arbitrary amount of values
 /// @return returns the maximum value of the set {left, right, args...}
 template <typename T, typename... Targs>
-constexpr T max(const T& left, const T& right, const Targs&... args) noexcept;
+constexpr T maxVal(const T& left, const T& right, const Targs&... args) noexcept;
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which is required as generic
 ///          recursive template endpoint.
@@ -71,10 +62,8 @@ constexpr T max(const T& left, const T& right, const Targs&... args) noexcept;
 /// @param[in] left value which should be compared
 /// @return returns the given argument left
 template <typename T>
-constexpr T min(const T& left) noexcept;
+constexpr T minVal(const T& left) noexcept;
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type. Helper function which takes two arguments and returns the
 ///          smaller one.
@@ -83,10 +72,8 @@ constexpr T min(const T& left) noexcept;
 /// @param[in] right value which should be compared
 /// @return returns the minimum of the set {left, right}
 template <typename T>
-constexpr T min(const T& left, const T& right) noexcept;
+constexpr T minVal(const T& left, const T& right) noexcept;
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 /// @brief Returns the minimum gained with operator<() of an arbitrary amount
 ///          of variables of the same type.
 /// @param T type which implements operator<()
@@ -95,7 +82,7 @@ constexpr T min(const T& left, const T& right) noexcept;
 /// @param[in] args... an arbitrary amount of values
 /// @return returns the minimum of the set {left, right, args...}
 template <typename T, typename... Targs>
-constexpr T min(const T& left, const T& right, const Targs&... args) noexcept;
+constexpr T minVal(const T& left, const T& right, const Targs&... args) noexcept;
 
 /// @brief Returns true if T is equal to CompareType, otherwise false
 /// @param T type to compare to

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/algorithm.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,6 +110,9 @@ inline constexpr bool doesContainValue(const T v) noexcept;
 /// @param[in] value to look for in the ValueList
 /// @param[in] firstValueListEntry is the first variadic argument of ValueList
 /// @param[in] remainingValueListEntries are the remaining variadic arguments of ValueList
+/// @return true if value is contained in the ValueList, otherwise false
+/// @note be aware that value is tested for exact equality with the entries of ValueList which might lead to unexpected
+/// results for floating-point types
 template <typename T, typename... ValueList>
 inline constexpr bool
 doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -107,7 +107,7 @@ class variant
 {
   private:
     /// @brief contains the size of the largest element
-    static constexpr uint64_t TYPE_SIZE = algorithm::max(sizeof(Types)...);
+    static constexpr uint64_t TYPE_SIZE = algorithm::maxVal(sizeof(Types)...);
 
   public:
     /// @brief the default constructor constructs a variant which does not contain
@@ -263,7 +263,7 @@ class variant
   private:
     /// @todo #1196 Replace with UninitializedArray
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
-    alignas(algorithm::max(alignof(Types)...)) internal::byte_t m_storage[TYPE_SIZE]{0U};
+    alignas(algorithm::maxVal(alignof(Types)...)) internal::byte_t m_storage[TYPE_SIZE]{0U};
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     uint64_t m_type_index{INVALID_VARIANT_INDEX};
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -71,9 +71,8 @@ inline constexpr bool doesContainType() noexcept
     return doesContainType<T, CompareType>() || doesContainType<T, Next, Remainder...>();
 }
 
-// AXIVION Next Construct AutosarC++19_03-A0.1.4 : function finalizes compile time recursion of doesContainValue
 template <typename T>
-inline constexpr bool doesContainValue(const T v IOX_MAYBE_UNUSED) noexcept
+inline constexpr bool doesContainValue(const T) noexcept
 {
     return false;
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ template <typename T, typename... ValueList>
 inline constexpr bool
 doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept
 {
+    // AXIVION Next Line AutosarC++19_03-M6.2.2 : intentional check for exact equality
     return (value == firstValueListEntry) ? true : doesContainValue(value, remainingValueListEntries...);
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -88,39 +88,39 @@ template <typename Container>
 inline Container uniqueMergeSortedContainers(const Container& v1, const Container& v2) noexcept
 {
     Container mergedContainer;
-    uint64_t indexV1 = 0U;
-    uint64_t indexV2 = 0U;
-    uint64_t v1Size = v1.size();
-    uint64_t v2Size = v2.size();
+    uint64_t indexV1{0U};
+    uint64_t indexV2{0U};
+    const uint64_t v1Size{v1.size()};
+    const uint64_t v2Size{v2.size()};
 
-    while (indexV1 < v1Size && indexV2 < v2Size)
+    while ((indexV1 < v1Size) && (indexV2 < v2Size))
     {
         if (v1[indexV1] == v2[indexV2])
         {
-            mergedContainer.emplace_back(v1[indexV1]);
+            IOX_DISCARD_RESULT(mergedContainer.emplace_back(v1[indexV1]));
             ++indexV1;
             ++indexV2;
         }
         else if (v1[indexV1] < v2[indexV2])
         {
-            mergedContainer.emplace_back(v1[indexV1]);
+            IOX_DISCARD_RESULT(mergedContainer.emplace_back(v1[indexV1]));
             ++indexV1;
         }
         else
         {
-            mergedContainer.emplace_back(v2[indexV2]);
+            IOX_DISCARD_RESULT(mergedContainer.emplace_back(v2[indexV2]));
             ++indexV2;
         }
     }
 
     while (indexV2 < v2Size)
     {
-        mergedContainer.emplace_back(v2[indexV2++]);
+        IOX_DISCARD_RESULT(mergedContainer.emplace_back(v2[indexV2++]));
     }
 
     while (indexV1 < v1Size)
     {
-        mergedContainer.emplace_back(v1[indexV1++]);
+        IOX_DISCARD_RESULT(mergedContainer.emplace_back(v1[indexV1++]));
     }
 
     return mergedContainer;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -23,52 +23,40 @@ namespace iox
 {
 namespace algorithm
 {
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
-inline constexpr T max(const T& left) noexcept
+inline constexpr T maxVal(const T& left) noexcept
 {
     return left;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
-inline constexpr T max(const T& left, const T& right) noexcept
+inline constexpr T maxVal(const T& left, const T& right) noexcept
 {
     return (right < left) ? left : right;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T, typename... Targs>
-inline constexpr T max(const T& left, const T& right, const Targs&... args) noexcept
+inline constexpr T maxVal(const T& left, const T& right, const Targs&... args) noexcept
 {
-    return max(max(left, right), args...);
+    return maxVal(maxVal(left, right), args...);
 }
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
-inline constexpr T min(const T& left) noexcept
+inline constexpr T minVal(const T& left) noexcept
 {
     return left;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
-inline constexpr T min(const T& left, const T& right) noexcept
+inline constexpr T minVal(const T& left, const T& right) noexcept
 {
     return (left < right) ? left : right;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
-// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T, typename... Targs>
-inline constexpr T min(const T& left, const T& right, const Targs&... args) noexcept
+inline constexpr T minVal(const T& left, const T& right, const Targs&... args) noexcept
 {
-    return min(min(left, right), args...);
+    return minVal(minVal(left, right), args...);
 }
 
 template <typename T, typename CompareType>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/algorithm.inl
@@ -23,36 +23,48 @@ namespace iox
 {
 namespace algorithm
 {
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
 inline constexpr T max(const T& left) noexcept
 {
     return left;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
 inline constexpr T max(const T& left, const T& right) noexcept
 {
     return (right < left) ? left : right;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// maximum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T, typename... Targs>
 inline constexpr T max(const T& left, const T& right, const Targs&... args) noexcept
 {
     return max(max(left, right), args...);
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
 inline constexpr T min(const T& left) noexcept
 {
     return left;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T>
 inline constexpr T min(const T& left, const T& right) noexcept
 {
     return (left < right) ? left : right;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : standard library function intentionally overridden to retrieve the
+// minimum of an arbitrary amount of arguments without using an initializer list which uses the heap
 template <typename T, typename... Targs>
 inline constexpr T min(const T& left, const T& right, const Targs&... args) noexcept
 {
@@ -71,6 +83,7 @@ inline constexpr bool doesContainType() noexcept
     return doesContainType<T, CompareType>() || doesContainType<T, Next, Remainder...>();
 }
 
+// AXIVION Next Construct AutosarC++19_03-A0.1.4 : function finalizes compile time recursion of doesContainValue
 template <typename T>
 inline constexpr bool doesContainValue(const T v IOX_MAYBE_UNUSED) noexcept
 {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
@@ -45,37 +45,37 @@ class algorithm_test : public Test
 TEST_F(algorithm_test, MaxOfOneElement)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3fba70b4-252b-4c13-a98c-87b026254bba");
-    EXPECT_THAT(max(12.34F), Eq(12.34F));
+    EXPECT_THAT(maxVal(12.34F), Eq(12.34F));
 }
 
 TEST_F(algorithm_test, MaxOfTwoElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0443931f-3eb4-4ae2-99b3-029637f94d0f");
-    EXPECT_THAT(max(56.78F, 12.34F), Eq(56.78F));
+    EXPECT_THAT(maxVal(56.78F, 12.34F), Eq(56.78F));
 }
 
 TEST_F(algorithm_test, MaxOfManyElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "83c16bb2-90c5-4226-bed2-7e5cc5b34f22");
-    EXPECT_THAT(max(56.78F, 33.44F, 12.34F, -0.1F, 5.5F, 10001.F), Eq(10001.F));
+    EXPECT_THAT(maxVal(56.78F, 33.44F, 12.34F, -0.1F, 5.5F, 10001.F), Eq(10001.F));
 }
 
 TEST_F(algorithm_test, MinOfOneElement)
 {
     ::testing::Test::RecordProperty("TEST_ID", "384d8139-1a79-40ae-8caf-b468470c48d2");
-    EXPECT_THAT(min(0.0123F), Eq(0.0123F));
+    EXPECT_THAT(minVal(0.0123F), Eq(0.0123F));
 }
 
 TEST_F(algorithm_test, MinOfTwoElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c0ad7d53-03f6-4ee2-9a0b-ee929dc047a7");
-    EXPECT_THAT(min(0.0123F, -91.12F), Eq(-91.12F));
+    EXPECT_THAT(minVal(0.0123F, -91.12F), Eq(-91.12F));
 }
 
 TEST_F(algorithm_test, MinOfManyElements)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8ec6db69-2260-4af9-83fe-73ae58c878b3");
-    EXPECT_THAT(min(0.0123F, -91.12F, 123.92F, -1021.2F, 0.0F), Eq(-1021.2F));
+    EXPECT_THAT(minVal(0.0123F, -91.12F, 123.92F, -1021.2F, 0.0F), Eq(-1021.2F));
 }
 
 TEST_F(algorithm_test, DoesContainValue_ValueListOfZeroDoesNotContainValue)

--- a/iceoryx_posh/source/mepoo/chunk_settings.cpp
+++ b/iceoryx_posh/source/mepoo/chunk_settings.cpp
@@ -105,7 +105,7 @@ uint64_t ChunkSettings::calculateRequiredChunkSize(const uint32_t userPayloadSiz
     constexpr uint64_t ALIGNMENT_OF_USER_PAYLOAD_OFFSET_T{alignof(ChunkHeader::UserPayloadOffset_t)};
     uint64_t headerSize = sizeof(ChunkHeader) + userHeaderSize;
     uint64_t preUserPayloadAlignmentOverhang = cxx::align(headerSize, ALIGNMENT_OF_USER_PAYLOAD_OFFSET_T);
-    uint64_t maxPadding = algorithm::max(SIZE_OF_USER_PAYLOAD_OFFSET_T, static_cast<uint64_t>(userPayloadAlignment));
+    uint64_t maxPadding = algorithm::maxVal(SIZE_OF_USER_PAYLOAD_OFFSET_T, static_cast<uint64_t>(userPayloadAlignment));
     uint64_t requiredChunkSize = preUserPayloadAlignmentOverhang + maxPadding + userPayloadSize;
 
     return requiredChunkSize;

--- a/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
@@ -47,7 +47,7 @@ uint64_t MemPoolCollectionMemoryBlock::size() const noexcept
 uint64_t MemPoolCollectionMemoryBlock::alignment() const noexcept
 {
     const uint64_t memoryManagerAlignment = alignof(mepoo::MemoryManager);
-    return algorithm::max(memoryManagerAlignment, mepoo::MemPool::CHUNK_MEMORY_ALIGNMENT);
+    return algorithm::maxVal(memoryManagerAlignment, mepoo::MemPool::CHUNK_MEMORY_ALIGNMENT);
 }
 
 void MemPoolCollectionMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept

--- a/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
@@ -43,7 +43,7 @@ uint64_t MemPoolSegmentManagerMemoryBlock::size() const noexcept
 uint64_t MemPoolSegmentManagerMemoryBlock::alignment() const noexcept
 {
     const uint64_t segmentManagerAlignment = alignof(mepoo::SegmentManager<>);
-    return algorithm::max(segmentManagerAlignment, mepoo::MemPool::CHUNK_MEMORY_ALIGNMENT);
+    return algorithm::maxVal(segmentManagerAlignment, mepoo::MemPool::CHUNK_MEMORY_ALIGNMENT);
 }
 
 void MemPoolSegmentManagerMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
@@ -448,7 +448,7 @@ void checkUserPayloadNotOverlappingWithUserHeader(const ChunkHeader& sut, const 
     const uint64_t chunkStartAddress{reinterpret_cast<uint64_t>(&sut)};
     const uint64_t userPayloadStartAddress{reinterpret_cast<uint64_t>(sut.userPayload())};
     const uint64_t userHeaderSizeAndPadding{
-        iox::algorithm::max(userHeaderSize, static_cast<uint32_t>(alignof(UserPayloadOffset_t)))};
+        iox::algorithm::maxVal(userHeaderSize, static_cast<uint32_t>(alignof(UserPayloadOffset_t)))};
     constexpr uint64_t BACK_OFFSET_SIZE{sizeof(UserPayloadOffset_t)};
     const uint64_t expectedRequiredSpace{sizeof(ChunkHeader) + userHeaderSizeAndPadding + BACK_OFFSET_SIZE};
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
@@ -351,7 +351,7 @@ INSTANTIATE_TEST_SUITE_P(ChunkSettings_test,
 uint32_t expectedChunkSizeWithUserHeader(const PayloadParams& userPayload, uint32_t userHeaderSize)
 {
     const uint32_t userHeaderSizeAndPaddingToBackOffset =
-        iox::algorithm::max(userHeaderSize, static_cast<uint32_t>(alignof(UserPayloadOffset_t)));
+        iox::algorithm::maxVal(userHeaderSize, static_cast<uint32_t>(alignof(UserPayloadOffset_t)));
 
     if (userPayload.alignment <= alignof(UserPayloadOffset_t))
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
Despite other changes this PR
- renames `algorithm::max` and `algorithm::min` to make a clear distinction to `std::max` and `std::min`
- suppresses the warning about an equality check for floating-point-types in `doesContainValue`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partially closes #1394 
