### PR TITLE
iox-1394 fix AUTOSAR and CERT violations in stack

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,18 +23,18 @@ namespace iox
 {
 namespace cxx
 {
-// AXIVION Construct AutosarC++19_03-A12.1.1 : it is guaranteed that the array elements are initialized on access
+// AXIVION Next Construct AutosarC++19_03-A12.1.1 : it is guaranteed that the array elements are initialized on access
+// AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive since no bit-fields are involved
 /// @brief stack implementation with a simple push pop interface
 /// @tparam T type which the stack contains
 /// @tparam Capacity the capacity of the stack
-/// @NOLINTJUSTIFICATION same as AXIVION comment
 template <typename T, uint64_t Capacity>
 class stack // NOLINT (cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 {
   public:
     /// @brief returns the last pushed element when the stack contains elements
     ///         otherwise a cxx::nullopt
-    auto pop() noexcept -> cxx::optional<T>;
+    cxx::optional<T> pop() noexcept;
 
     /// @brief pushed an element into the stack by forwarding all arguments
     ///        to the constructor of T

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
@@ -34,7 +34,7 @@ class stack // NOLINT (cppcoreguidelines-pro-type-member-init,hicpp-member-init)
   public:
     /// @brief returns the last pushed element when the stack contains elements
     ///         otherwise a cxx::nullopt
-    cxx::optional<T> pop() noexcept;
+    auto pop() noexcept -> cxx::optional<T>;
 
     /// @brief pushed an element into the stack by forwarding all arguments
     ///        to the constructor of T
@@ -50,15 +50,15 @@ class stack // NOLINT (cppcoreguidelines-pro-type-member-init,hicpp-member-init)
     static constexpr uint64_t capacity() noexcept;
 
   private:
-    // AXIVION Next Line AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside the
-    // stack class
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
+    // the stack class
     /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     using element_t = uint8_t[sizeof(T)];
-    // AXIVION Next Line AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside the
-    // stack class
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
+    // the stack class
     /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     alignas(T) element_t m_data[Capacity];
-    uint64_t m_size = 0U;
+    uint64_t m_size{0U};
 };
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/stack.hpp
@@ -23,7 +23,8 @@ namespace iox
 {
 namespace cxx
 {
-// AXIVION Next Construct AutosarC++19_03-A12.1.1 : it is guaranteed that the array elements are initialized on access
+// AXIVION Next Construct AutosarC++19_03-A12.1.1 : it is guaranteed that the array elements are initialized before read
+// access
 // AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive since no bit-fields are involved
 /// @brief stack implementation with a simple push pop interface
 /// @tparam T type which the stack contains

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -30,8 +30,9 @@ inline auto stack<T, Capacity>::pop() noexcept -> cxx::optional<T>
         return cxx::nullopt;
     }
 
-    // low level memory management with access to the topmost element on the untyped buffer;
-    // type safety is ensured by the template parameter
+    // AXIVION Next Construct CertC++-EXP36 : every entry of m_data is aligned to alignof(T)
+    // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
+    // the untyped buffer; type safety is ensured by the template parameter
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return *reinterpret_cast<T*>(m_data[--m_size]);
 }
@@ -45,8 +46,10 @@ inline bool stack<T, Capacity>::push(Targs&&... args) noexcept
         return false;
     }
 
-    // low level memory management with access to the topmost element on the untyped buffer;
-    // type safety is ensured by the template parameter
+    // AXIVION Next Construct CertC++-MEM54, CertC++-EXP36, AutosarC++19_03-A18.5.10 : every entry of m_data is aligned
+    // to alignof(T)
+    // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
+    // the untyped buffer; type safety is ensured by the template parameter
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     new (reinterpret_cast<T*>(m_data[m_size++])) T(std::forward<Targs>(args)...);
     return true;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -30,11 +30,10 @@ inline cxx::optional<T> stack<T, Capacity>::pop() noexcept
         return cxx::nullopt;
     }
 
-    // AXIVION Next Construct CertC++-EXP36 : every entry of m_data is aligned to alignof(T)
     // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
-    // the untyped buffer; type safety is ensured by the template parameter
+    // the untyped buffer; reinterpret_cast is safe since the size and the alignment of each array element is guaranteed
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return *reinterpret_cast<T*>(m_data[--m_size]);
+    return *reinterpret_cast<T*>(&m_data[--m_size]);
 }
 
 template <typename T, uint64_t Capacity>
@@ -46,12 +45,7 @@ inline bool stack<T, Capacity>::push(Targs&&... args) noexcept
         return false;
     }
 
-    // AXIVION Next Construct CertC++-MEM54, CertC++-EXP36, AutosarC++19_03-A18.5.10,
-    // FaultDetection-IndirectAssignmentOverflow : every entry of m_data is aligned to alignof(T)
-    // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
-    // the untyped buffer; type safety is ensured by the template parameter
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    new (reinterpret_cast<T*>(m_data[m_size++])) T(std::forward<Targs>(args)...);
+    new (&m_data[m_size++]) T(std::forward<Targs>(args)...);
     return true;
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ namespace iox
 namespace cxx
 {
 template <typename T, uint64_t Capacity>
-inline auto stack<T, Capacity>::pop() noexcept -> cxx::optional<T>
+inline cxx::optional<T> stack<T, Capacity>::pop() noexcept
 {
     if (m_size == 0U)
     {
@@ -46,8 +46,8 @@ inline bool stack<T, Capacity>::push(Targs&&... args) noexcept
         return false;
     }
 
-    // AXIVION Next Construct CertC++-MEM54, CertC++-EXP36, AutosarC++19_03-A18.5.10 : every entry of m_data is aligned
-    // to alignof(T)
+    // AXIVION Next Construct CertC++-MEM54, CertC++-EXP36, AutosarC++19_03-A18.5.10,
+    // FaultDetection-IndirectAssignmentOverflow : every entry of m_data is aligned to alignof(T)
     // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
     // the untyped buffer; type safety is ensured by the template parameter
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -23,7 +23,7 @@ namespace iox
 namespace cxx
 {
 template <typename T, uint64_t Capacity>
-inline cxx::optional<T> stack<T, Capacity>::pop() noexcept
+inline auto stack<T, Capacity>::pop() noexcept -> cxx::optional<T>
 {
     if (m_size == 0U)
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR adds some suppressions for alignment/size related warnings. In addition to reviewing the code and suppressions, please also take a look at the associated rules as some of them don't seem to apply to our code base.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Partially closes #1394 
