### PR TITLE
iox-#1653 Remove Wgnu-zero-variadic-macro-arguments suppression from TYPED_TEST_SUITE

### DIFF
--- a/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
+++ b/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
@@ -185,14 +185,7 @@ class Relocatable_ptr_test : public Test
 
 typedef ::testing::Types<int, Data, void, char*, const Data, const void> TestTypes;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(Relocatable_ptr_typed_test, TestTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(Relocatable_ptr_typed_test, TestTypes, );
 
 TYPED_TEST(Relocatable_ptr_typed_test, wrappedPointerTypeIsCorrect)
 {

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_index_queue.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_index_queue.cpp
@@ -44,15 +44,7 @@ TEST(LockFreeQueueTest, capacityIsConsistent)
 
 typedef ::testing::Types<IndexQueue<1>, IndexQueue<10>, IndexQueue<1000>> TestQueues;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(IndexQueueTest, TestQueues);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(IndexQueueTest, TestQueues, );
 
 TYPED_TEST(IndexQueueTest, defaultConstructedQueueIsEmpty)
 {

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue.cpp
@@ -159,15 +159,7 @@ typedef ::testing::Types<LFFull1,
                          AlmostEmpty2>
     TestConfigs;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(LockFreeQueueTest, TestConfigs);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(LockFreeQueueTest, TestConfigs, );
 
 TEST(LockFreeQueueTest, capacityIsConsistent)
 {

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue_buffer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue_buffer.cpp
@@ -73,15 +73,7 @@ TEST(LockFreeQueueBufferTest, capacityIsCorrect)
 
 typedef ::testing::Types<Buffer<int, 10>, Buffer<Integer, 10>> TestBuffers;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(LockFreeQueueBufferTest, TestBuffers);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(LockFreeQueueBufferTest, TestBuffers, );
 
 TYPED_TEST(LockFreeQueueBufferTest, accessElements)
 {

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue_cyclic_index.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_lockfree_queue_cyclic_index.cpp
@@ -33,15 +33,7 @@ class LockFreeQueueCyclicIndexTest : public ::testing::Test
 
 typedef ::testing::Types<CyclicIndex<1>, CyclicIndex<2>, CyclicIndex<10>, CyclicIndex<1000>> TestIndices;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(LockFreeQueueCyclicIndexTest, TestIndices);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(LockFreeQueueCyclicIndexTest, TestIndices, );
 
 // note that in all tests we will check whether the getCycle and getIndex methods
 // behave as expected after certain operations (mainly addition),

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_loffli.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_loffli.cpp
@@ -29,14 +29,7 @@ using namespace ::testing;
 constexpr uint32_t Size{4};
 using LoFFLiTestSubjects = Types<iox::concurrent::LoFFLi>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(LoFFLi_test, LoFFLiTestSubjects);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(LoFFLi_test, LoFFLiTestSubjects, );
 
 template <typename LoFFLiType>
 class LoFFLi_test : public Test

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_resizeable_lockfree_queue.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_resizeable_lockfree_queue.cpp
@@ -71,16 +71,7 @@ using IntQueue = iox::concurrent::ResizeableLockFreeQueue<uint64_t, Capacity>;
 
 typedef ::testing::Types<IntegerQueue<1>, IntegerQueue<11>, IntQueue<10>> TestQueues;
 
-
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ResizeableLockFreeQueueTest, TestQueues);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ResizeableLockFreeQueueTest, TestQueues, );
 
 TEST(ResizeableLockFreeQueueTest, maxCapacityIsConsistent)
 {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_types.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_functional_interface_types.hpp
@@ -158,14 +158,7 @@ using FunctionalInterfaceImplementations = testing::Types<GenericValueErrorFacto
                                                           ExpectedValueErrorFactory,
                                                           ExpectedErrorFactory>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(FunctionalInterface_test, FunctionalInterfaceImplementations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(FunctionalInterface_test, FunctionalInterfaceImplementations, );
 
 } // namespace test_cxx_functional_interface
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_helplets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_helplets.cpp
@@ -226,14 +226,7 @@ class Helplets_test_isPowerOfTwo : public Helplets_test
 
 using HelpletsIsPowerOfTwoTypes = Types<uint8_t, uint16_t, uint32_t, uint64_t, size_t>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(Helplets_test_isPowerOfTwo, HelpletsIsPowerOfTwoTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(Helplets_test_isPowerOfTwo, HelpletsIsPowerOfTwoTypes, );
 
 TYPED_TEST(Helplets_test_isPowerOfTwo, OneIsPowerOfTwo)
 {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -34,14 +34,7 @@ class stringTyped_test : public Test
 
 using Implementations = Types<string<1>, string<15>, string<100>, string<1000>>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(stringTyped_test, Implementations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(stringTyped_test, Implementations, );
 
 TEST(string_test, CapacityReturnsSpecifiedCapacity)
 {

--- a/iceoryx_hoofs/test/moduletests/test_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_logstream.cpp
@@ -177,14 +177,7 @@ class IoxLogStreamHexOctBinIntegral_test : public IoxLogStream_test
 
 using LogHexOctBinIntegralTypes = Types<uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, uint64_t, int64_t>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(IoxLogStreamHexOctBinIntegral_test, LogHexOctBinIntegralTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(IoxLogStreamHexOctBinIntegral_test, LogHexOctBinIntegralTypes, );
 
 template <typename LogType>
 void testStreamOperatorLogHex(Logger_Mock& loggerMock, LogType logValue)
@@ -303,14 +296,7 @@ class IoxLogStreamHexFloatingPoint_test : public IoxLogStream_test
 
 using LogHexFloatingPointTypes = Types<float, double, long double>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(IoxLogStreamHexFloatingPoint_test, LogHexFloatingPointTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(IoxLogStreamHexFloatingPoint_test, LogHexFloatingPointTypes, );
 
 template <typename T>
 constexpr const char* floatingPointFormatSpecifier();
@@ -364,15 +350,7 @@ TYPED_TEST(IoxLogStreamHexFloatingPoint_test, StreamOperatorLogHex_ValueMax)
 using ArithmeticTypes =
     Types<bool, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t, size_t, float, double>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(IoxLogStreamArithmetic_test, ArithmeticTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(IoxLogStreamArithmetic_test, ArithmeticTypes, );
 
 template <typename Arithmetic>
 class IoxLogStreamArithmetic_test : public IoxLogStream_test

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -100,14 +100,8 @@ struct NamedSemaphoreTest
 };
 
 using Implementations = Types<UnnamedSemaphoreTest, NamedSemaphoreTest>;
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(SemaphoreInterfaceTest, Implementations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+
+TYPED_TEST_SUITE(SemaphoreInterfaceTest, Implementations, );
 
 TYPED_TEST(SemaphoreInterfaceTest, InitialValueIsSetCorrect)
 {

--- a/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
@@ -82,14 +82,7 @@ class SignalHandler_test : public Test
 using Implementations =
     Types<SignalType<Signal::INT>, SignalType<Signal::BUS>, SignalType<Signal::TERM>, SignalType<Signal::HUP>>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(SignalHandler_test, Implementations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(SignalHandler_test, Implementations, );
 
 TYPED_TEST(SignalHandler_test, RegisteringSignalGuardCallbackWorks)
 {

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -70,14 +70,7 @@ class RelativePointer_test : public Test
 
 typedef testing::Types<uint8_t, int8_t, double> Types;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(RelativePointer_test, Types);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(RelativePointer_test, Types, );
 
 /// @todo #605 the tests should be reworked in a refactoring of relative pointers
 TYPED_TEST(RelativePointer_test, ConstrTests)

--- a/iceoryx_hoofs/test/stresstests/test_lockfree_queue_stresstest.cpp
+++ b/iceoryx_hoofs/test/stresstests/test_lockfree_queue_stresstest.cpp
@@ -364,14 +364,7 @@ using LargeQueue = TestQueue<1000000>;
 typedef ::testing::Types<SingleElementQueue, SmallQueue, MediumQueue, LargeQueue> TestQueues;
 // typedef ::testing::Types<MediumQueue> TestQueues;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(LockFreeQueueStressTest, TestQueues);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(LockFreeQueueStressTest, TestQueues, );
 
 ///@brief Tests concurrent operation of one producer and one consumer
 /// The producer pushes a fixed number of data elements which the consumer pops and checks.

--- a/iceoryx_hoofs/test/stresstests/test_resizeable_lockfree_queue_stresstest.cpp
+++ b/iceoryx_hoofs/test/stresstests/test_resizeable_lockfree_queue_stresstest.cpp
@@ -398,15 +398,7 @@ using HalfFull3 = HalfFull<Data, Large>;
 /// @endcode
 typedef ::testing::Types<HalfFull2> TestConfigs;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ResizeableLockFreeQueueStressTest, TestConfigs);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ResizeableLockFreeQueueStressTest, TestConfigs, );
 
 ///@brief Tests concurrent operation of multiple producers and consumers
 ///       with respect to completeness of the data, i.e. nothing is lost.

--- a/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
+++ b/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
@@ -178,14 +178,8 @@ struct ReqRes
 };
 
 using CommunicationKind = Types<PubSub, ReqRes>;
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ServiceDiscovery_test, CommunicationKind);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+
+TYPED_TEST_SUITE(ServiceDiscovery_test, CommunicationKind, );
 
 //
 // Built-in topics can be found
@@ -790,14 +784,8 @@ using TestVariations = Types<PS_SIE,
 // note that testing all variations is costly but ensures coverage of every
 // combination of wildcards, communication type and many equivalence classes
 // of a search setup, i.e. the existing services in the system
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ServiceDiscoveryFindService_test, TestVariations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+
+TYPED_TEST_SUITE(ServiceDiscoveryFindService_test, TestVariations, );
 
 // *************************************************************************************************
 // All tests run for publishers and servers as well as all 8 search variations.

--- a/iceoryx_posh/test/moduletests/test_base_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_base_port.cpp
@@ -53,14 +53,7 @@ std::vector<UniquePortId> uniquePortIds;
 using PortDataTypes =
     Types<BasePortData, PublisherPortData, SubscriberPortData, ClientPortData, ServerPortData, InterfacePortData>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(BasePort_test, PortDataTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(BasePort_test, PortDataTypes, );
 
 // port data factories
 

--- a/iceoryx_posh/test/moduletests/test_popo_base_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_client.cpp
@@ -75,14 +75,7 @@ class TestBaseClient : public Base
 
 using BaseClientTypes = Types<BaseClientWithMocks, UntypedClientWithMocks, TypedClientWithMocks>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(BaseClient_test, BaseClientTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(BaseClient_test, BaseClientTypes, );
 
 template <typename SutType>
 class BaseClient_test : public Test

--- a/iceoryx_posh/test/moduletests/test_popo_base_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_server.cpp
@@ -75,14 +75,7 @@ class TestBaseServer : public Base
 
 using BaseServerTypes = Types<BaseServerWithMocks, UntypedServerWithMocks, TypedServerWithMocks>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(BaseServer_test, BaseServerTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(BaseServer_test, BaseServerTypes, );
 
 template <typename SutType>
 class BaseServer_test : public Test

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
@@ -39,15 +39,7 @@ using namespace iox::mepoo;
 
 using ChunkDistributorTestSubjects = Types<ThreadSafePolicy, SingleThreadedPolicy>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ChunkDistributor_test, ChunkDistributorTestSubjects);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ChunkDistributor_test, ChunkDistributorTestSubjects, );
 
 template <typename PolicyType>
 class ChunkDistributor_test : public Test

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
@@ -84,15 +84,7 @@ using ChunkQueueSubjects =
           TypeDefinitions<SingleThreadedPolicy, iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer>,
           TypeDefinitions<SingleThreadedPolicy, iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer>>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ChunkQueue_test, ChunkQueueSubjects);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ChunkQueue_test, ChunkQueueSubjects, );
 
 template <typename TestTypes>
 class ChunkQueue_test : public Test, public ChunkQueue_testBase
@@ -275,15 +267,7 @@ TYPED_TEST(ChunkQueue_test, AttachSecondConditionVariable)
 /// @note this could be changed to a parameterized ChunkQueueSaturatingFIFO_test when there are more FIFOs available
 using ChunkQueueFiFoTestSubjects = Types<ThreadSafePolicy, SingleThreadedPolicy>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ChunkQueueFiFo_test, ChunkQueueFiFoTestSubjects);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ChunkQueueFiFo_test, ChunkQueueFiFoTestSubjects, );
 
 template <typename PolicyType>
 class ChunkQueueFiFo_test : public Test, public ChunkQueue_testBase
@@ -347,15 +331,7 @@ TYPED_TEST(ChunkQueueFiFo_test, PushFull)
 /// @note this could be changed to a parameterized ChunkQueueOverflowingFIFO_test when there are more FIFOs available
 using ChunkQueueSoFiSubjects = Types<ThreadSafePolicy, SingleThreadedPolicy>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ChunkQueueSoFi_test, ChunkQueueSoFiSubjects);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
-
+TYPED_TEST_SUITE(ChunkQueueSoFi_test, ChunkQueueSoFiSubjects, );
 
 template <typename PolicyType>
 class ChunkQueueSoFi_test : public Test, public ChunkQueue_testBase

--- a/iceoryx_posh/test/moduletests/test_popo_smart_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_smart_chunk.cpp
@@ -35,14 +35,7 @@ class SmartChunkTest : public Test
 
 using Implementations = Types<SampleTestCase, RequestTestCase, ResponseTestCase>;
 
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(SmartChunkTest, Implementations);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+TYPED_TEST_SUITE(SmartChunkTest, Implementations, );
 
 TYPED_TEST(SmartChunkTest, ConstructedSmartChunkIsValid)
 {

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -165,14 +165,8 @@ class ServiceRegistry_test : public Test
 constexpr auto CAPACITY = ServiceRegistry::CAPACITY;
 
 typedef ::testing::Types<PublisherTest, ServerTest> TestTypes;
-#ifdef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-TYPED_TEST_SUITE(ServiceRegistry_test, TestTypes);
-#ifdef __clang__
-#pragma GCC diagnostic pop
-#endif
+
+TYPED_TEST_SUITE(ServiceRegistry_test, TestTypes, );
 
 TYPED_TEST(ServiceRegistry_test, AddNoServiceDescriptionsAndWildcardSearchReturnsNothing)
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Relates to #1653 
