### PR TITLE
iox-1662 change vector::erase return type to bool

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -87,6 +87,7 @@
 - Extract `iceoryx_hoofs/platform` into separate package `iceoryx_platform` [\#1615](https://github.com/eclipse-iceoryx/iceoryx/issues/1615)
 - `cxx::unique_ptr` is no longer nullable [\#1104](https://github.com/eclipse-iceoryx/iceoryx/issues/1104)
 - Use builder pattern in mutex [\#1036](https://github.com/eclipse-iceoryx/iceoryx/issues/1036)
+- Change return type of `cxx::vector::erase` to bool [\#1662](https://github.com/eclipse-iceoryx/iceoryx/issues/1662)
 
 **Workflow:**
 
@@ -460,4 +461,14 @@
         .mutexType(iox::posix::MutexType::RECURSIVE)
         .create(myMutex);
     myMutex->lock();
+    ```
+
+24. Change return type of `cxx::vector::erase` from iterator to bool
+
+    ```cpp
+    // before
+    auto* iter = myCxxVector.erase(myCxxVector.begin());
+
+    // after
+    bool success = myCxxVector.erase(myCxxVector.begin());
     ```

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -211,8 +211,8 @@ class vector
     ///         the middle of the vector every element is moved one place to the
     ///         left to ensure that the elements are stored contiguously
     /// @param[in] position at which the element shall be removed
-    /// @return iterator following the removed element if begin() <= position < end(), otherwise nullptr
-    iterator erase(iterator position) noexcept;
+    /// @return true if the element was removed, i.e. begin() <= position < end(), otherwise false
+    bool erase(iterator position) noexcept;
 
   private:
     T& at_unchecked(const uint64_t index) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -347,7 +347,7 @@ inline typename vector<T, Capacity>::const_iterator vector<T, Capacity>::end() c
 }
 
 template <typename T, uint64_t Capacity>
-inline typename vector<T, Capacity>::iterator vector<T, Capacity>::erase(iterator position) noexcept
+inline bool vector<T, Capacity>::erase(iterator position) noexcept
 {
     if (begin() <= position && position < end())
     {
@@ -359,9 +359,9 @@ inline typename vector<T, Capacity>::iterator vector<T, Capacity>::erase(iterato
         }
         at(n).~T();
         m_size--;
-        return &at_unchecked(index);
+        return true;
     }
-    return nullptr;
+    return false;
 }
 
 template <typename T, uint64_t Capacity>

--- a/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
@@ -907,40 +907,11 @@ TEST_F(vector_test, IterateUsingConstSquareBracket)
     }
 }
 
-TEST_F(vector_test, EraseReturnsNullWhenElementIsInvalid)
+TEST_F(vector_test, EraseFailsWhenElementIsInvalid)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ff7c1c4a-4ef5-4905-a107-6f1d27462d47");
     auto* i = sut.begin() + 5U;
-    EXPECT_THAT(sut.erase(i), Eq(nullptr));
-}
-
-TEST_F(vector_test, EraseReturnsCorrectIteratorWhenElementIsValid)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "4ebc10a8-8cb3-4151-aa70-824d4c0b5597");
-    sut.emplace_back(1U);
-    sut.emplace_back(2U);
-    sut.emplace_back(3U);
-    sut.emplace_back(4U);
-
-    auto* iter = sut.erase(sut.begin());
-    ASSERT_THAT(sut.size(), Eq(3));
-    ASSERT_NE(iter, nullptr);
-    EXPECT_THAT(iter, Eq(sut.begin()));
-
-    iter = sut.erase(sut.end() - 1);
-    ASSERT_THAT(sut.size(), Eq(2));
-    ASSERT_NE(iter, nullptr);
-    EXPECT_THAT(iter, Eq(sut.end()));
-
-    iter = sut.erase(sut.begin() + 1);
-    ASSERT_THAT(sut.size(), Eq(1));
-    ASSERT_NE(iter, nullptr);
-    EXPECT_THAT(iter, Eq(sut.end()));
-
-    iter = sut.erase(sut.begin());
-    ASSERT_THAT(sut.size(), Eq(0));
-    ASSERT_NE(iter, nullptr);
-    EXPECT_THAT(iter, Eq(sut.end()));
+    EXPECT_FALSE(sut.erase(i));
 }
 
 TEST_F(vector_test, ErasingElementDecreasesSize)
@@ -949,8 +920,8 @@ TEST_F(vector_test, ErasingElementDecreasesSize)
     sut.emplace_back(3U);
     sut.emplace_back(4U);
     sut.emplace_back(5U);
-    sut.erase(sut.begin() + 2U);
-    sut.erase(sut.begin());
+    EXPECT_TRUE(sut.erase(sut.begin() + 2U));
+    EXPECT_TRUE(sut.erase(sut.begin()));
     EXPECT_THAT(sut.size(), Eq(1U));
 }
 
@@ -962,7 +933,7 @@ TEST_F(vector_test, EraseOfLastElementCallsDTorOnly)
     sut1.emplace_back(8U);
     sut1.emplace_back(9U);
 
-    sut1.erase(sut1.begin() + 2U);
+    EXPECT_TRUE(sut1.erase(sut1.begin() + 2U));
 
     EXPECT_THAT(dTor, Eq(1U));
     EXPECT_THAT(classValue, Eq(9U));
@@ -978,7 +949,7 @@ TEST_F(vector_test, EraseOfMiddleElementCallsDTorAndMove)
     sut1.emplace_back(10U);
     sut1.emplace_back(11U);
 
-    sut1.erase(sut1.begin() + 2U);
+    EXPECT_TRUE(sut1.erase(sut1.begin() + 2U));
 
     EXPECT_THAT(dTor, Eq(1U));
     EXPECT_THAT(moveAssignment, Eq(2U));
@@ -994,7 +965,7 @@ TEST_F(vector_test, EraseOfFrontElementCallsDTorAndMove)
     sut1.emplace_back(10U);
     sut1.emplace_back(11U);
 
-    sut1.erase(sut1.begin());
+    EXPECT_TRUE(sut1.erase(sut1.begin()));
 
     EXPECT_THAT(dTor, Eq(1U));
     EXPECT_THAT(moveAssignment, Eq(4U));
@@ -1008,7 +979,7 @@ TEST_F(vector_test, EraseMiddleElementDataCorrectAfterwards)
     sut.emplace_back(98U);
     sut.emplace_back(99U);
 
-    sut.erase(sut.begin() + 1U);
+    EXPECT_TRUE(sut.erase(sut.begin() + 1U));
 
     for (uint64_t k = 0U; k < sut.size(); ++k)
     {
@@ -1024,7 +995,7 @@ TEST_F(vector_test, EraseFrontElementDataCorrectAfterwards)
     sut.emplace_back(598U);
     sut.emplace_back(599U);
 
-    sut.erase(sut.begin());
+    EXPECT_TRUE(sut.erase(sut.begin()));
 
     for (uint64_t k = 0U; k < sut.size(); ++k)
     {
@@ -1042,7 +1013,7 @@ TEST_F(vector_test, EraseLastElementDataCorrectAfterwards)
     sut.emplace_back(7601U);
     sut.emplace_back(76101U);
 
-    sut.erase(sut.begin() + 5U);
+    EXPECT_TRUE(sut.erase(sut.begin() + 5U));
 
     for (uint64_t k = 0U; k < sut.size(); ++k)
     {
@@ -1058,7 +1029,7 @@ TEST_F(vector_test, EraseLastElementOfFullVectorDataCorrectAfterwards)
         sut.emplace_back(i * 123U);
     }
 
-    sut.erase(sut.begin() + sut.size() - 1U);
+    EXPECT_TRUE(sut.erase(sut.begin() + sut.size() - 1U));
 
     for (uint64_t k = 0; k < sut.size(); ++k)
     {

--- a/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
@@ -912,6 +912,8 @@ TEST_F(vector_test, EraseFailsWhenElementIsInvalid)
     ::testing::Test::RecordProperty("TEST_ID", "ff7c1c4a-4ef5-4905-a107-6f1d27462d47");
     auto* i = sut.begin() + 5U;
     EXPECT_FALSE(sut.erase(i));
+    EXPECT_FALSE(sut.erase(sut.end()));
+    EXPECT_FALSE(sut.erase(sut.begin() - 1));
 }
 
 TEST_F(vector_test, ErasingElementDecreasesSize)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
This PR replaces the iterator return type (actually `T*`) of `cxx::vector::erase` with bool to prevent from dereferencing invalid pointers.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1662 
