### PR TITLE
iox-#1673 Improve usability of cxx::Expects and cxx::Ensures

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/requires.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/requires.hpp
@@ -27,6 +27,13 @@ namespace internal
 {
 void Require(
     const bool condition, const char* file, const int line, const char* function, const char* conditionString) noexcept;
+
+void Require(const bool condition,
+             const char* file,
+             const int line,
+             const char* function,
+             const char* conditionString,
+             const char* msgString) noexcept;
 } // namespace internal
 
 // implementing C++ Core Guideline, I.6. Prefer Expects
@@ -40,6 +47,15 @@ void Require(
 /// @NOLINTEND(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 /// @NOLINTEND(cppcoreguidelines-macro-usage)
 
+/// @NOLINTJUSTIFICATION macro required to capture file, line, function origin of call implicitly
+/// @NOLINTBEGIN(cppcoreguidelines-macro-usage)
+/// @NOLINTJUSTIFICATION array decay: needed for source code location, safely wrapped in macro
+/// @NOLINTBEGIN(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+#define ExpectsWithMsg(condition, msg)                                                                                 \
+    internal::Require(condition, __FILE__, __LINE__, __PRETTY_FUNCTION__, #condition, #msg)
+/// @NOLINTEND(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+/// @NOLINTEND(cppcoreguidelines-macro-usage)
+
 // implementing C++ Core Guideline, I.8. Prefer Ensures
 // see:
 // https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-ensures
@@ -48,6 +64,15 @@ void Require(
 /// @NOLINTJUSTIFICATION array decay: needed for source code location, safely wrapped in macro
 /// @NOLINTBEGIN(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 #define Ensures(condition) internal::Require(condition, __FILE__, __LINE__, __PRETTY_FUNCTION__, #condition)
+/// @NOLINTEND(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+/// @NOLINTEND(cppcoreguidelines-macro-usage)
+
+/// @NOLINTJUSTIFICATION macro required to capture file, line, function origin of call implicitly
+/// @NOLINTBEGIN(cppcoreguidelines-macro-usage)
+/// @NOLINTJUSTIFICATION array decay: needed for source code location, safely wrapped in macro
+/// @NOLINTBEGIN(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+#define EnsuresWithMsg(condition, msg)                                                                                 \
+    internal::Require(condition, __FILE__, __LINE__, __PRETTY_FUNCTION__, #condition, #msg)
 /// @NOLINTEND(hicpp-no-array-decay, cppcoreguidelines-pro-bounds-array-to-pointer-decay)
 /// @NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -268,7 +268,7 @@ inline T& vector<T, Capacity>::at(const uint64_t index) noexcept
 template <typename T, uint64_t Capacity>
 inline const T& vector<T, Capacity>::at(const uint64_t index) const noexcept
 {
-    cxx::Expects((index < m_size) && "Out of bounds access");
+    cxx::ExpectsWithMsg(index < m_size, "Out of bounds access");
     return at_unchecked(index);
 }
 
@@ -287,7 +287,7 @@ inline const T& vector<T, Capacity>::operator[](const uint64_t index) const noex
 template <typename T, uint64_t Capacity>
 inline T& vector<T, Capacity>::front() noexcept
 {
-    cxx::Expects(!empty() && "Attempting to access the front of an empty vector");
+    cxx::ExpectsWithMsg(!empty(), "Attempting to access the front of an empty vector");
     return at(0);
 }
 
@@ -302,7 +302,7 @@ inline const T& vector<T, Capacity>::front() const noexcept
 template <typename T, uint64_t Capacity>
 inline T& vector<T, Capacity>::back() noexcept
 {
-    cxx::Expects(!empty() && "Attempting to access the back of an empty vector");
+    cxx::ExpectsWithMsg(!empty(), "Attempting to access the back of an empty vector");
     return at(size() - 1U);
 }
 

--- a/iceoryx_hoofs/source/cxx/requires.cpp
+++ b/iceoryx_hoofs/source/cxx/requires.cpp
@@ -26,7 +26,7 @@ namespace cxx
 {
 namespace internal
 {
-/// @NOLINTJUSTIFICATION todo #1196 will be obsolote with new error handler
+/// @NOLINTJUSTIFICATION todo #1196 will be obsolete with new error handler
 /// @NOLINTNEXTLINE(readability-function-size)
 void Require(
     const bool condition, const char* file, const int line, const char* function, const char* conditionString) noexcept
@@ -35,6 +35,23 @@ void Require(
     {
         std::cerr << "Condition: " << conditionString << " in " << function << " is violated. (" << file << ":" << line
                   << ")" << std::endl;
+        errorHandler(HoofsError::EXPECTS_ENSURES_FAILED, ErrorLevel::FATAL);
+    }
+}
+
+/// @NOLINTJUSTIFICATION todo #1196 will be obsolete with new error handler
+/// @NOLINTNEXTLINE(readability-function-size)
+void Require(const bool condition,
+             const char* file,
+             const int line,
+             const char* function,
+             const char* conditionString,
+             const char* msgString) noexcept
+{
+    if (!condition)
+    {
+        std::cerr << "Condition: " << conditionString << " in " << function << " is violated: " << msgString << ". ("
+                  << file << ":" << line << ")" << std::endl;
         errorHandler(HoofsError::EXPECTS_ENSURES_FAILED, ErrorLevel::FATAL);
     }
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR adds `cxx::ExpectsWithMsg` and `cxx::EnsuresWithMsg` which take, compared to `cxx::Expects` and `cxx::Ensures`, a second parameter to make it obvious that an error message can be passed. Additionally, `cxx::ExpectsWithMsg` is introduced in `cxx::vector`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1673 
