### PR TITLE
iox-605 Introduce `memory` namespace

### DIFF
--- a/doc/shared-memory-communication.md
+++ b/doc/shared-memory-communication.md
@@ -76,8 +76,8 @@ Memory chunks are returned to the pool once all attached consumers indicate they
 
 As already discussed, shared memory segments may be mapped to different memory areas in the virtual address space of a
 process.
-To deal with this, iceoryx utilizes specialized pointer types: the `iox::rp::RelativePointer` and
-the `iox::rp::relocatable_ptr`.
+To deal with this, iceoryx utilizes specialized pointer types: the `iox::memory::RelativePointer` and
+the `iox::memory::relocatable_ptr`.
 
 Using these types, the difference in memory mapping is not a factor when it comes to locating a memory chunk.
 

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -403,19 +403,19 @@
     }
     ```
 
-20. Renamed `BaseRelativePointer` to `UntypedRelativePointer`
+21. Renamed `BaseRelativePointer` to `UntypedRelativePointer`
 
     ```cpp
     // before
-    #include "iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp"
-    iox::rp::BaseRelativePointer myUntypedRelativePointer;
+    #include "iceoryx_hoofs/internal/memory/base_relative_pointer.hpp"
+    iox::memory::BaseRelativePointer myUntypedRelativePointer;
 
     // after
-    #include "iceoryx_hoofs/memory/relative_pointer.hpp" /// @todo #605 adapt namespace and directory
+    #include "iceoryx_hoofs/memory/relative_pointer.hpp"
     iox::memory::UntypedRelativePointer myUntypedRelativePointer;
     ```
 
-20. The `CMakeLists.txt` of apps using iceoryx need to add `iceoryx_platform`
+22. The `CMakeLists.txt` of apps using iceoryx need to add `iceoryx_platform`
 
     ```cmake
     // before
@@ -441,7 +441,7 @@
     include(IceoryxPlatformSettings)                // new
     ```
 
-21. `iceoryx_hoofs/platform` was moved into separate package `iceoryx_platform`. All includes must
+23. `iceoryx_hoofs/platform` was moved into separate package `iceoryx_platform`. All includes must
     be adjusted.
 
     ```cxx
@@ -452,7 +452,7 @@
     #include "iceoryx_platform/some_header.hpp"
     ```
 
-22. `cxx::unique_ptr` is no longer nullable.
+24. `cxx::unique_ptr` is no longer nullable.
 
     ```cxx
     // before
@@ -482,7 +482,7 @@
     will warn the user with a used after move warning when one accesses a moved object. Accessing
     a moved `unique_ptr` is well defined and behaves like dereferencing a `nullptr`.
 
-23. `mutex` must be always stored inside an `cxx::optional` and must use the builder pattern for
+25. `mutex` must be always stored inside an `cxx::optional` and must use the builder pattern for
     construction
 
     ```cpp
@@ -499,7 +499,7 @@
     myMutex->lock();
     ```
 
-24. Change return type of `cxx::vector::erase` from iterator to bool
+26. Change return type of `cxx::vector::erase` from iterator to bool
 
     ```cpp
     // before

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -403,12 +403,12 @@
     }
     ```
 
-21. Renamed `BaseRelativePointer` to `UntypedRelativePointer`
+21. Renamed `BaseRelativePointer` to `UntypedRelativePointer` and moved it from namespace `rp::` to `memory::`
 
     ```cpp
     // before
-    #include "iceoryx_hoofs/internal/memory/base_relative_pointer.hpp"
-    iox::memory::BaseRelativePointer myUntypedRelativePointer;
+    #include "iceoryx_hoofs/internal/relocatable_pointer/base_relative_pointer.hpp"
+    iox::rp::BaseRelativePointer myUntypedRelativePointer;
 
     // after
     #include "iceoryx_hoofs/memory/relative_pointer.hpp"

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp
@@ -22,7 +22,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 /// @brief Smart pointer type that allows objects using it to able to be copied by memcpy
 ///        without invalidating the pointer.
@@ -149,7 +149,7 @@ bool operator==(const relocatable_ptr<T>& lhs, const relocatable_ptr<T>& rhs) no
 template <typename T>
 bool operator!=(const relocatable_ptr<T>& lhs, const relocatable_ptr<T>& rhs) noexcept;
 
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #include "iceoryx_dust/relocatable_pointer/relocatable_ptr.inl"

--- a/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
+++ b/iceoryx_dust/include/iceoryx_dust/relocatable_pointer/relocatable_ptr.inl
@@ -21,7 +21,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 template <typename T>
 inline relocatable_ptr<T>::relocatable_ptr(T* ptr) noexcept
@@ -161,7 +161,7 @@ inline bool operator!=(const relocatable_ptr<T>& lhs, const relocatable_ptr<T>& 
     return !operator==(lhs, rhs);
 }
 
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #endif // IOX_DUST_RELOCATABLE_POINTER_RELOCATABLE_PTR_INL

--- a/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
+++ b/iceoryx_dust/test/moduletests/test_relocatable_ptr.cpp
@@ -24,7 +24,7 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::rp;
+using namespace iox::memory;
 
 // Needed especially for void implementation tests where we cannot
 // construct a corresponding object of type void to point to.
@@ -134,7 +134,7 @@ class RelocatableType
     RelocatableType& operator=(RelocatableType&&) = delete;
 
     int data;
-    iox::rp::relocatable_ptr<int> rp;
+    iox::memory::relocatable_ptr<int> rp;
 };
 
 // Not all tests make sense to be run as typed tests
@@ -191,7 +191,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, wrappedPointerTypeIsCorrect)
 {
     ::testing::Test::RecordProperty("TEST_ID", "12de29e3-673c-487c-9808-67e5c3e25c73");
     using T = typename TestFixture::DataType;
-    using P = typename iox::rp::relocatable_ptr<T>::ptr_t;
+    using P = typename iox::memory::relocatable_ptr<T>::ptr_t;
     constexpr bool pointerTypeIsCorrect = std::is_same<P, T*>::value;
     EXPECT_TRUE(pointerTypeIsCorrect);
 }
@@ -200,7 +200,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, defaulCtorCreatesNullpointer)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6823533f-9594-4f53-9493-d80a73706013");
     using T = typename TestFixture::DataType;
-    iox::rp::relocatable_ptr<T> rp;
+    iox::memory::relocatable_ptr<T> rp;
     EXPECT_EQ(rp.get(), nullptr);
 }
 
@@ -208,8 +208,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, copyCtorOfNullptrWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "de23e14d-1c06-4005-ba61-45e5aeedaf47");
     using T = typename TestFixture::DataType;
-    iox::rp::relocatable_ptr<T> rp1;
-    iox::rp::relocatable_ptr<T> rp2(rp1);
+    iox::memory::relocatable_ptr<T> rp1;
+    iox::memory::relocatable_ptr<T> rp2(rp1);
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), nullptr);
 }
@@ -218,8 +218,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, moveCtorOfNullptrWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f0ecd49e-c165-4e25-985c-5bc44a072f2e");
     using T = typename TestFixture::DataType;
-    iox::rp::relocatable_ptr<T> rp1;
-    iox::rp::relocatable_ptr<T> rp2(std::move(rp1));
+    iox::memory::relocatable_ptr<T> rp1;
+    iox::memory::relocatable_ptr<T> rp2(std::move(rp1));
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), nullptr);
 }
@@ -231,8 +231,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, copyAssignmentOfNullptrWorks)
     // we cannot construct an actual object if T = void
     // and it is not necessary fro most tests, we just need some non-nullptr
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1;
-    iox::rp::relocatable_ptr<T> rp2(p);
+    iox::memory::relocatable_ptr<T> rp1;
+    iox::memory::relocatable_ptr<T> rp2(p);
     rp2 = rp1;
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), nullptr);
@@ -243,8 +243,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, moveAssignmentOfNullptrWorks)
     ::testing::Test::RecordProperty("TEST_ID", "b15da71c-bb71-4059-a3fb-7d5d8f8020a6");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1;
-    iox::rp::relocatable_ptr<T> rp2(p);
+    iox::memory::relocatable_ptr<T> rp1;
+    iox::memory::relocatable_ptr<T> rp2(p);
     rp2 = std::move(rp1);
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), nullptr);
@@ -255,7 +255,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, nonNullPointerConstructionWorks)
     ::testing::Test::RecordProperty("TEST_ID", "6258b81c-97b4-4d5b-9543-ca7e2fc8e6f0");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp(p);
+    iox::memory::relocatable_ptr<T> rp(p);
     EXPECT_EQ(rp.get(), p);
 }
 
@@ -264,8 +264,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, copyCtorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "453b6c32-e5ba-4b15-86af-d7601ee5b97e");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2(rp1);
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2(rp1);
     EXPECT_EQ(rp1.get(), p);
     EXPECT_EQ(rp2.get(), p);
 }
@@ -275,8 +275,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, moveCtorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "42c3a34d-4dc8-4bf6-bf1e-1fc742570ee2");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2(std::move(rp1));
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2(std::move(rp1));
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), p);
 }
@@ -286,8 +286,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, copyAssignmentWorks)
     ::testing::Test::RecordProperty("TEST_ID", "431354d5-400d-49cd-8554-4ee797661cf7");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2;
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2;
     rp2 = rp1;
     EXPECT_EQ(rp1.get(), p);
     EXPECT_EQ(rp2.get(), p);
@@ -298,8 +298,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, moveAssignmentWorks)
     ::testing::Test::RecordProperty("TEST_ID", "5041782e-2c57-4739-ab21-2d7c1dfc3991");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2;
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2;
     rp2 = std::move(rp1);
     EXPECT_EQ(rp1.get(), nullptr);
     EXPECT_EQ(rp2.get(), p);
@@ -311,7 +311,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, constGetWorks)
     ::testing::Test::RecordProperty("TEST_ID", "1b478221-d1fb-44aa-905e-7f40d961eaff");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    const iox::rp::relocatable_ptr<T> rp(p);
+    const iox::memory::relocatable_ptr<T> rp(p);
     EXPECT_EQ(rp.get(), p);
 
     constexpr bool isConst = getReturns<decltype(rp), const T*>();
@@ -323,7 +323,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, conversionToRawPointerWorks)
     ::testing::Test::RecordProperty("TEST_ID", "d7e46b17-62bc-4b05-a827-b91d2a4b9f23");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp(p);
+    iox::memory::relocatable_ptr<T> rp(p);
     T* q = rp;
     EXPECT_EQ(q, p);
 
@@ -336,7 +336,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, conversionToConstRawPointerWorks)
     ::testing::Test::RecordProperty("TEST_ID", "82f40725-67d9-4f80-812a-1fcbdd1cbf60");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    const iox::rp::relocatable_ptr<T> rp(p);
+    const iox::memory::relocatable_ptr<T> rp(p);
     const T* q = rp;
     EXPECT_EQ(q, p);
 
@@ -349,7 +349,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, arrowOperatorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "6f3a7428-fd7b-4a98-b3ce-90ac73655ac8");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp(p);
+    iox::memory::relocatable_ptr<T> rp(p);
     EXPECT_EQ(rp.operator->(), p);
 
     constexpr bool isNotConst = arrowReturns<decltype(rp), T*>();
@@ -361,7 +361,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, arrowOperatorConstWorks)
     ::testing::Test::RecordProperty("TEST_ID", "38bf2bb7-6550-4534-b0fe-6ec07632c6d3");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    const iox::rp::relocatable_ptr<T> rp(p);
+    const iox::memory::relocatable_ptr<T> rp(p);
     EXPECT_EQ(rp.operator->(), p);
 
     constexpr bool isConst = arrowReturns<decltype(rp), const T*>();
@@ -373,8 +373,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, nullptrIsEqualToNullptr)
 {
     ::testing::Test::RecordProperty("TEST_ID", "45d24a0b-5a46-4a10-bbb8-7f8b7647a992");
     using T = typename TestFixture::DataType;
-    iox::rp::relocatable_ptr<T> rp1;
-    iox::rp::relocatable_ptr<T> rp2;
+    iox::memory::relocatable_ptr<T> rp1;
+    iox::memory::relocatable_ptr<T> rp2;
 
     EXPECT_TRUE(rp1 == rp2);
     EXPECT_TRUE(rp2 == rp1);
@@ -392,8 +392,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, nullptrIsNotEqualToNonNullptr)
     ::testing::Test::RecordProperty("TEST_ID", "a3fd804d-9e53-4fef-9b34-bb43bd778c02");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2;
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2;
 
     EXPECT_FALSE(rp1 == rp2);
     EXPECT_FALSE(rp2 == rp1);
@@ -411,8 +411,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, equalNonNullptrComparisonWorks)
     ::testing::Test::RecordProperty("TEST_ID", "c3ed8892-db76-4d62-8c04-51819696c7dc");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p);
-    iox::rp::relocatable_ptr<T> rp2(p);
+    iox::memory::relocatable_ptr<T> rp1(p);
+    iox::memory::relocatable_ptr<T> rp2(p);
 
     EXPECT_TRUE(rp1 == rp2);
     EXPECT_TRUE(rp2 == rp1);
@@ -431,8 +431,8 @@ TYPED_TEST(Relocatable_ptr_typed_test, nonEqualNonNullptrComparisonWorks)
     using T = typename TestFixture::DataType;
     T* p1 = nonNullPtr<T>();
     T* p2 = otherNonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp1(p1);
-    iox::rp::relocatable_ptr<T> rp2(p2);
+    iox::memory::relocatable_ptr<T> rp1(p1);
+    iox::memory::relocatable_ptr<T> rp2(p2);
 
     EXPECT_FALSE(rp1 == rp2);
     EXPECT_FALSE(rp2 == rp1);
@@ -450,7 +450,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, negativeNullPointerCheckWithIfWorks)
     ::testing::Test::RecordProperty("TEST_ID", "77225288-be1d-4105-b2fb-7f5f452cad89");
     using T = typename TestFixture::DataType;
     T* p = nonNullPtr<T>();
-    iox::rp::relocatable_ptr<T> rp(p);
+    iox::memory::relocatable_ptr<T> rp(p);
 
     if (rp)
     {
@@ -466,7 +466,7 @@ TYPED_TEST(Relocatable_ptr_typed_test, positiveNullPointerCheckWithIfWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4a57801b-3f52-4027-a2f1-474274e83515");
     using T = typename TestFixture::DataType;
-    iox::rp::relocatable_ptr<T> rp;
+    iox::memory::relocatable_ptr<T> rp;
 
     if (rp)
     {
@@ -479,7 +479,7 @@ TEST_F(Relocatable_ptr_test, dereferencingWorks)
     ::testing::Test::RecordProperty("TEST_ID", "ea67f218-6ff8-4a82-a81e-52ae988546dc");
     constexpr int VALUE = 666;
     int x = VALUE;
-    iox::rp::relocatable_ptr<int> rp(&x);
+    iox::memory::relocatable_ptr<int> rp(&x);
     EXPECT_EQ(*rp, VALUE);
 
     constexpr bool isNotConst = dereferencingReturns<decltype(rp), int&>();
@@ -491,7 +491,7 @@ TEST_F(Relocatable_ptr_test, dereferencingConstWorks)
     ::testing::Test::RecordProperty("TEST_ID", "64a7e44e-b9eb-428a-bd50-3bd9e14400bc");
     constexpr int VALUE = 314;
     int x = VALUE;
-    const iox::rp::relocatable_ptr<int> rp(&x);
+    const iox::memory::relocatable_ptr<int> rp(&x);
     EXPECT_EQ(*rp, VALUE);
 
     constexpr bool isConst = dereferencingReturns<decltype(rp), const int&>();
@@ -503,7 +503,7 @@ TEST_F(Relocatable_ptr_test, dereferencingComplexTypeWorks)
     ::testing::Test::RecordProperty("TEST_ID", "e4a2bda1-c3f2-424e-b6dd-a4da6703b699");
     constexpr int VALUE = 69;
     Data x(VALUE);
-    iox::rp::relocatable_ptr<Data> rp(&x);
+    iox::memory::relocatable_ptr<Data> rp(&x);
     EXPECT_EQ((*rp).value, x.value);
     EXPECT_EQ(rp->value, x.value);
 }
@@ -513,7 +513,7 @@ TEST_F(Relocatable_ptr_test, dereferencingConstComplexTypeWorks)
     ::testing::Test::RecordProperty("TEST_ID", "b60f0fd5-ff9b-40a5-ad0d-d13965eff578");
     constexpr int VALUE = 69;
     Data x(VALUE);
-    const iox::rp::relocatable_ptr<Data> rp(&x);
+    const iox::memory::relocatable_ptr<Data> rp(&x);
     EXPECT_EQ((*rp).value, x.value);
     EXPECT_EQ(rp->value, x.value);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
@@ -71,7 +71,7 @@ class LoFFLi
     uint32_t m_size{0U};
     Index_t m_invalidIndex{0U};
     std::atomic<Node> m_head{{0U, 1U}};
-    iox::rp::RelativePointer<Index_t> m_nextFreeIndex;
+    iox::memory::RelativePointer<Index_t> m_nextFreeIndex;
 
   public:
     LoFFLi() noexcept = default;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/loffli.hpp
@@ -18,7 +18,7 @@
 #define IOX_HOOFS_CONCURRENT_LOFFLI_HPP
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 #include <atomic>
 #include <cstdint>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
@@ -115,6 +115,6 @@ class PointerRepository
 } // namespace rp
 } // namespace iox
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/pointer_repository.inl"
+#include "iceoryx_hoofs/internal/memory/pointer_repository.inl"
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
@@ -26,7 +26,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 constexpr uint64_t MAX_POINTER_REPO_CAPACITY{10000U};
 
@@ -112,7 +112,7 @@ class PointerRepository
 
     bool addPointerIfIndexIsFree(const id_t id, const ptr_t ptr, const uint64_t size) noexcept;
 };
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #include "iceoryx_hoofs/internal/memory/pointer_repository.inl"

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
@@ -110,7 +110,7 @@ class PointerRepository
     iox::cxx::vector<Info, CAPACITY> m_info;
     uint64_t m_maxRegistered{0U};
 
-    bool addPointerIfIndexIsFree(const id_t id, const ptr_t ptr, const uint64_t size) noexcept;
+    bool addPointerIfIdIsFree(const id_t id, const ptr_t ptr, const uint64_t size) noexcept;
 };
 } // namespace memory
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.hpp
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_HPP
-#define IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_HPP
+#ifndef IOX_HOOFS_MEMORY_POINTER_REPOSITORY_HPP
+#define IOX_HOOFS_MEMORY_POINTER_REPOSITORY_HPP
 
 #include "iceoryx_hoofs/cxx/optional.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
@@ -117,4 +117,4 @@ class PointerRepository
 
 #include "iceoryx_hoofs/internal/memory/pointer_repository.inl"
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_HPP
+#endif // IOX_HOOFS_MEMORY_POINTER_REPOSITORY_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
@@ -39,7 +39,7 @@ inline bool PointerRepository<id_t, ptr_t, CAPACITY>::registerPtrWithId(const id
     {
         return false;
     }
-    return addPointerIfIndexIsFree(id, ptr, size);
+    return addPointerIfIdIsFree(id, ptr, size);
 }
 
 template <typename id_t, typename ptr_t, uint64_t CAPACITY>
@@ -48,7 +48,7 @@ inline cxx::optional<id_t> PointerRepository<id_t, ptr_t, CAPACITY>::registerPtr
 {
     for (id_t id = 1U; id <= MAX_ID; ++id)
     {
-        if (addPointerIfIndexIsFree(id, ptr, size))
+        if (addPointerIfIdIsFree(id, ptr, size))
         {
             return id;
         }
@@ -115,7 +115,7 @@ inline id_t PointerRepository<id_t, ptr_t, CAPACITY>::searchId(ptr_t ptr) const 
     return RAW_POINTER_BEHAVIOUR_ID;
 }
 template <typename id_t, typename ptr_t, uint64_t CAPACITY>
-inline bool PointerRepository<id_t, ptr_t, CAPACITY>::addPointerIfIndexIsFree(const id_t id,
+inline bool PointerRepository<id_t, ptr_t, CAPACITY>::addPointerIfIdIsFree(const id_t id,
                                                                               const ptr_t ptr,
                                                                               const uint64_t size) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
@@ -22,7 +22,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 template <typename id_t, typename ptr_t, uint64_t CAPACITY>
 inline PointerRepository<id_t, ptr_t, CAPACITY>::PointerRepository() noexcept
@@ -136,7 +136,7 @@ inline bool PointerRepository<id_t, ptr_t, CAPACITY>::addPointerIfIndexIsFree(co
     return false;
 }
 
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL
-#define IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL
+#ifndef IOX_HOOFS_MEMORY_POINTER_REPOSITORY_INL
+#define IOX_HOOFS_MEMORY_POINTER_REPOSITORY_INL
 
 #include "iceoryx_hoofs/internal/memory/pointer_repository.hpp"
 
@@ -139,4 +139,4 @@ inline bool PointerRepository<id_t, ptr_t, CAPACITY>::addPointerIfIdIsFree(const
 } // namespace memory
 } // namespace iox
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL
+#endif // IOX_HOOFS_MEMORY_POINTER_REPOSITORY_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
@@ -116,8 +116,8 @@ inline id_t PointerRepository<id_t, ptr_t, CAPACITY>::searchId(ptr_t ptr) const 
 }
 template <typename id_t, typename ptr_t, uint64_t CAPACITY>
 inline bool PointerRepository<id_t, ptr_t, CAPACITY>::addPointerIfIdIsFree(const id_t id,
-                                                                              const ptr_t ptr,
-                                                                              const uint64_t size) noexcept
+                                                                           const ptr_t ptr,
+                                                                           const uint64_t size) noexcept
 {
     if (m_info[id].basePtr == nullptr)
     {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/pointer_repository.inl
@@ -18,7 +18,7 @@
 #ifndef IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL
 #define IOX_HOOFS_RELOCATABLE_POINTER_POINTER_REPOSITORY_INL
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/pointer_repository.hpp"
+#include "iceoryx_hoofs/internal/memory/pointer_repository.hpp"
 
 namespace iox
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_HPP
-#define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_HPP
+#ifndef IOX_HOOFS_MEMORY_RELATIVE_POINTER_HPP
+#define IOX_HOOFS_MEMORY_RELATIVE_POINTER_HPP
 
 #include "iceoryx_hoofs/cxx/newtype.hpp"
 #include "iceoryx_hoofs/internal/memory/pointer_repository.hpp"
@@ -213,4 +213,4 @@ PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t>& getRe
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer.inl"
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_HPP
+#endif // IOX_HOOFS_MEMORY_RELATIVE_POINTER_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
@@ -19,7 +19,7 @@
 #define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_HPP
 
 #include "iceoryx_hoofs/cxx/newtype.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/pointer_repository.hpp"
+#include "iceoryx_hoofs/internal/memory/pointer_repository.hpp"
 
 #include <cstdint>
 #include <iostream>
@@ -211,6 +211,6 @@ PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t>& getRe
 } // namespace rp
 } // namespace iox
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.inl"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.inl"
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.hpp
@@ -27,7 +27,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 struct segment_id_t : public cxx::NewType<uint64_t,
                                           cxx::newtype::DefaultConstructable,
@@ -208,7 +208,7 @@ using UntypedRelativePointer = RelativePointer<void>;
 PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t>& getRepository() noexcept;
 
 
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer.inl"

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
@@ -62,8 +62,11 @@ inline RelativePointer<T>& RelativePointer<T>::operator=(const RelativePointer& 
 
 template <typename T>
 RelativePointer<T>::RelativePointer(RelativePointer&& other) noexcept
+    : m_id(std::move(other.m_id))
+    , m_offset(std::move(other.m_offset))
 {
-    *this = std::move(other);
+    other.m_id = NULL_POINTER_ID;
+    other.m_offset = NULL_POINTER_OFFSET;
 }
 
 template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL
-#define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL
+#ifndef IOX_HOOFS_MEMORY_RELATIVE_POINTER_INL
+#define IOX_HOOFS_MEMORY_RELATIVE_POINTER_INL
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
@@ -247,4 +247,4 @@ inline PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t>
 } // namespace memory
 } // namespace iox
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL
+#endif // IOX_HOOFS_MEMORY_RELATIVE_POINTER_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
@@ -18,7 +18,7 @@
 #ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL
 #define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 namespace iox
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer.inl
@@ -22,7 +22,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 template <typename T>
 // NOLINTJUSTIFICATION NewType size is comparable to an integer, hence pass by value is preferred
@@ -241,7 +241,7 @@ inline PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t>
     static PointerRepository<segment_id_underlying_t, UntypedRelativePointer::ptr_t> repository;
     return repository;
 }
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_HPP
-#define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_HPP
+#ifndef IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_HPP
+#define IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_HPP
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
 
@@ -84,4 +84,4 @@ class RelativePointerData
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer_data.inl"
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_HPP
+#endif // IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
@@ -82,6 +82,6 @@ class RelativePointerData
 } // namespace rp
 } // namespace iox
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.inl"
+#include "iceoryx_hoofs/internal/memory/relative_pointer_data.inl"
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_HPP

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
@@ -23,7 +23,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 /// @brief This are the data for a relative pointer. To be able so safely be used in the shared memory and prevent torn
 /// writes/reads, the class must not be larger than 64 bits and trivially copy-able.
@@ -79,7 +79,7 @@ class RelativePointerData
     uint64_t m_idAndOffset{LOGICAL_NULLPTR};
 };
 
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer_data.inl"

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
-#define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
+#ifndef IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_INL
+#define IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_INL
 
 #include "iceoryx_hoofs/internal/memory/relative_pointer_data.hpp"
 
@@ -35,4 +35,4 @@ constexpr RelativePointerData::RelativePointerData(identifier_t id, offset_t off
 } // namespace memory
 } // namespace iox
 
-#endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
+#endif // IOX_HOOFS_MEMORY_RELATIVE_POINTER_DATA_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
@@ -17,7 +17,7 @@
 #ifndef IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
 #define IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer_data.hpp"
 
 namespace iox
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.inl
@@ -21,7 +21,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 // AXIVION Next Construct AutosarC++19_03-A12.1.2 : NSDMI with null value is more explicit
 constexpr RelativePointerData::RelativePointerData(identifier_t id, offset_t offset) noexcept
@@ -32,7 +32,7 @@ constexpr RelativePointerData::RelativePointerData(identifier_t id, offset_t off
         m_idAndOffset = LOGICAL_NULLPTR;
     }
 }
-} // namespace rp
+} // namespace memory
 } // namespace iox
 
 #endif // IOX_HOOFS_RELOCATABLE_POINTER_RELATIVE_POINTER_DATA_INL

--- a/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+++ b/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
@@ -19,7 +19,7 @@
 
 namespace iox
 {
-namespace rp
+namespace memory
 {
 // This is necessary if an supervising application needs to do a cleanup of resources hold by a crashed application. If
 // the size is larger than 8 bytes on a 64 bit system, torn writes happens and if the application crashes at the wrong
@@ -67,5 +67,5 @@ bool RelativePointerData::isLogicalNullptr() const noexcept
     return m_idAndOffset == LOGICAL_NULLPTR;
 }
 
-} // namespace rp
+} // namespace memory
 } // namespace iox

--- a/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
+++ b/iceoryx_hoofs/source/relocatable_pointer/relative_pointer_data.cpp
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer_data.hpp"
 #include <cstdint>
 
 namespace iox

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 #include "test.hpp"
 

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -25,7 +25,7 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::rp;
+using namespace iox::memory;
 
 constexpr uint64_t SHARED_MEMORY_SIZE = 4096UL * 32UL;
 constexpr uint64_t NUMBER_OF_MEMORY_PARTITIONS = 2U;
@@ -78,11 +78,11 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
     ::testing::Test::RecordProperty("TEST_ID", "cae7b4d4-86eb-42f6-b938-90a76f01bea5");
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
-    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::rp::segment_id_t{1U},
+    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::memory::segment_id_t{1U},
                                                             reinterpret_cast<TypeParam*>(this->memoryPartition[0]),
                                                             SHARED_MEMORY_SIZE),
               true);
-    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::rp::segment_id_t{2U},
+    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::memory::segment_id_t{2U},
                                                             reinterpret_cast<TypeParam*>(this->memoryPartition[1]),
                                                             SHARED_MEMORY_SIZE),
               true);
@@ -190,10 +190,10 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
-                  iox::rp::segment_id_t{1U}, reinterpret_cast<TypeParam*>(ptr0), SHARED_MEMORY_SIZE),
+                  iox::memory::segment_id_t{1U}, reinterpret_cast<TypeParam*>(ptr0), SHARED_MEMORY_SIZE),
               true);
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
-                  iox::rp::segment_id_t{2U}, reinterpret_cast<TypeParam*>(ptr1), SHARED_MEMORY_SIZE),
+                  iox::memory::segment_id_t{2U}, reinterpret_cast<TypeParam*>(ptr1), SHARED_MEMORY_SIZE),
               true);
     // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
@@ -289,8 +289,8 @@ TYPED_TEST(RelativePointer_test, IdAndOffsetAreTranslatedToRawPointerCorrectly)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(rp1.getOffset(), reinterpret_cast<std::ptrdiff_t>(typedPtr));
@@ -300,7 +300,7 @@ TYPED_TEST(RelativePointer_test, IdAndOffsetAreTranslatedToRawPointerCorrectly)
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::rp::segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1U});
     EXPECT_EQ(rp2.getOffset(), offset);
     EXPECT_EQ(rp2.getId(), 1U);
     EXPECT_EQ(rp2.get(), addressAtOffset);
@@ -313,16 +313,16 @@ TYPED_TEST(RelativePointer_test, GetOffsetReturnsCorrectOffset)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::rp::segment_id_t{1U}, typedPtr), 0U);
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::memory::segment_id_t{1U}, typedPtr), 0U);
 
     int offset = SHARED_MEMORY_SIZE / 2U;
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::rp::segment_id_t{1U});
-    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::rp::segment_id_t{1U}, addressAtOffset), offset);
+    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1U});
+    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::memory::segment_id_t{1U}, addressAtOffset), offset);
 }
 
 TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
@@ -331,16 +331,16 @@ TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
     auto* ptr = this->partitionPtr(0U);
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::rp::segment_id_t{1U}, 0), typedPtr);
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::memory::segment_id_t{1U}, 0), typedPtr);
 
     uint64_t offset = SHARED_MEMORY_SIZE / 2U;
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::rp::segment_id_t{1});
-    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::rp::segment_id_t{1U}, offset), addressAtOffset);
+    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1});
+    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::memory::segment_id_t{1U}, offset), addressAtOffset);
 }
 
 TYPED_TEST(RelativePointer_test, RegisteringAndUnregisteringRelativePointerWorks)
@@ -349,12 +349,12 @@ TYPED_TEST(RelativePointer_test, RegisteringAndUnregisteringRelativePointerWorks
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), false);
-    EXPECT_EQ(rp1.unregisterPtr(iox::rp::segment_id_t{1U}), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), false);
+    EXPECT_EQ(rp1.unregisterPtr(iox::memory::segment_id_t{1U}), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
 }
 
 
@@ -365,11 +365,11 @@ TYPED_TEST(RelativePointer_test, UnRegisteringOneRelativePointerWorks)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
 
-    rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr);
-    EXPECT_EQ(rp1.unregisterPtr(iox::rp::segment_id_t{1U}), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr), true);
+    rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr);
+    EXPECT_EQ(rp1.unregisterPtr(iox::memory::segment_id_t{1U}), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
 }
 
 TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
@@ -380,14 +380,14 @@ TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
     auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
     auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr0, iox::rp::segment_id_t{1U});
-    RelativePointer<TypeParam> rp2(typedPtr1, iox::rp::segment_id_t{9999U});
+    RelativePointer<TypeParam> rp1(typedPtr0, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(typedPtr1, iox::memory::segment_id_t{9999U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::rp::segment_id_t{9999U}, typedPtr1), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{9999U}, typedPtr1), true);
     UntypedRelativePointer::unregisterAll();
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::rp::segment_id_t{9999U}, typedPtr1), true);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{9999U}, typedPtr1), true);
 }
 
 TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
@@ -397,11 +397,11 @@ TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
     auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
     auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr0, iox::rp::segment_id_t{1U});
-    RelativePointer<TypeParam> rp2(typedPtr1, iox::rp::segment_id_t{10000U});
+    RelativePointer<TypeParam> rp1(typedPtr0, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(typedPtr1, iox::memory::segment_id_t{10000U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::rp::segment_id_t{10000U}, typedPtr1), false);
+    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{10000U}, typedPtr1), false);
 }
 
 TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
@@ -410,10 +410,10 @@ TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
-    EXPECT_EQ(rp1.getBasePtr(iox::rp::segment_id_t{1U}), nullptr);
-    rp1.registerPtrWithId(iox::rp::segment_id_t{1U}, typedPtr);
-    EXPECT_EQ(typedPtr, rp1.getBasePtr(iox::rp::segment_id_t{1U}));
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    EXPECT_EQ(rp1.getBasePtr(iox::memory::segment_id_t{1U}), nullptr);
+    rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr);
+    EXPECT_EQ(typedPtr, rp1.getBasePtr(iox::memory::segment_id_t{1U}));
 }
 
 TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAndOffset)
@@ -422,7 +422,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAnd
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
     // NOLINTJUSTIFICATION Copy needed for tests
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     RelativePointer<TypeParam> rp2 = rp1;
@@ -439,7 +439,7 @@ TYPED_TEST(RelativePointer_test, DereferencingOperatorResultsInSameValue)
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
     *typedPtr = static_cast<TypeParam>(88);
-    RelativePointer<TypeParam> rp1(typedPtr, iox::rp::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
 
     EXPECT_EQ(*rp1, *typedPtr);
     *typedPtr = static_cast<TypeParam>(99);
@@ -484,13 +484,13 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
     EXPECT_EQ(*adr1, 12);
     EXPECT_EQ(*adr2, 21);
 
-    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::rp::segment_id_t{1U}, base1), true);
-    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::rp::segment_id_t{2U}, base2), true);
+    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{1U}, base1), true);
+    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{2U}, base2), true);
 
     {
         // the relative pointers point to base 1 and base 2l
-        RelativePointer<uint8_t> rp1(base1, iox::rp::segment_id_t{1U});
-        RelativePointer<uint8_t> rp2(base2, iox::rp::segment_id_t{2U});
+        RelativePointer<uint8_t> rp1(base1, iox::memory::segment_id_t{1U});
+        RelativePointer<uint8_t> rp2(base2, iox::memory::segment_id_t{2U});
 
         EXPECT_EQ(rp1.getId(), 1U);
         EXPECT_EQ(rp2.getId(), 2U);
@@ -504,8 +504,8 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
 
     {
         // now test with a type that is larger than 1 byte
-        RelativePointer<int> rp1(adr1, iox::rp::segment_id_t{1U});
-        RelativePointer<int> rp2(adr2, iox::rp::segment_id_t{2U});
+        RelativePointer<int> rp1(adr1, iox::memory::segment_id_t{1U});
+        RelativePointer<int> rp2(adr2, iox::memory::segment_id_t{2U});
 
         EXPECT_EQ(rp1.getId(), 1U);
         EXPECT_EQ(rp2.getId(), 2U);
@@ -519,11 +519,11 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
         EXPECT_EQ(*rp2, 21);
 
         // simulate a remapping, index 1 now refers to base 2 and vice versa ...
-        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::rp::segment_id_t{1U}), true);
-        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::rp::segment_id_t{2U}), true);
+        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::memory::segment_id_t{1U}), true);
+        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::memory::segment_id_t{2U}), true);
 
-        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::rp::segment_id_t{1}, base2), true);
-        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::rp::segment_id_t{2}, base1), true);
+        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{1}, base2), true);
+        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{2}, base1), true);
 
         // which, despite the relative pointer objects not having changed themselves,
         // leads to them referencing the respective other value now (compared to *** above)

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -78,13 +78,11 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
     ::testing::Test::RecordProperty("TEST_ID", "cae7b4d4-86eb-42f6-b938-90a76f01bea5");
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
-    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::memory::segment_id_t{1U},
-                                                            reinterpret_cast<TypeParam*>(this->memoryPartition[0]),
-                                                            SHARED_MEMORY_SIZE),
+    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
+                  segment_id_t{1U}, reinterpret_cast<TypeParam*>(this->memoryPartition[0]), SHARED_MEMORY_SIZE),
               true);
-    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(iox::memory::segment_id_t{2U},
-                                                            reinterpret_cast<TypeParam*>(this->memoryPartition[1]),
-                                                            SHARED_MEMORY_SIZE),
+    EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
+                  segment_id_t{2U}, reinterpret_cast<TypeParam*>(this->memoryPartition[1]), SHARED_MEMORY_SIZE),
               true);
     // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
@@ -190,10 +188,10 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
-                  iox::memory::segment_id_t{1U}, reinterpret_cast<TypeParam*>(ptr0), SHARED_MEMORY_SIZE),
+                  segment_id_t{1U}, reinterpret_cast<TypeParam*>(ptr0), SHARED_MEMORY_SIZE),
               true);
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
-                  iox::memory::segment_id_t{2U}, reinterpret_cast<TypeParam*>(ptr1), SHARED_MEMORY_SIZE),
+                  segment_id_t{2U}, reinterpret_cast<TypeParam*>(ptr1), SHARED_MEMORY_SIZE),
               true);
     // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
@@ -289,8 +287,8 @@ TYPED_TEST(RelativePointer_test, IdAndOffsetAreTranslatedToRawPointerCorrectly)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(rp1.getOffset(), reinterpret_cast<std::ptrdiff_t>(typedPtr));
@@ -300,7 +298,7 @@ TYPED_TEST(RelativePointer_test, IdAndOffsetAreTranslatedToRawPointerCorrectly)
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1U});
     EXPECT_EQ(rp2.getOffset(), offset);
     EXPECT_EQ(rp2.getId(), 1U);
     EXPECT_EQ(rp2.get(), addressAtOffset);
@@ -313,16 +311,16 @@ TYPED_TEST(RelativePointer_test, GetOffsetReturnsCorrectOffset)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::memory::segment_id_t{1U}, typedPtr), 0U);
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(UntypedRelativePointer::getOffset(segment_id_t{1U}, typedPtr), 0U);
 
     int offset = SHARED_MEMORY_SIZE / 2U;
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1U});
-    EXPECT_EQ(UntypedRelativePointer::getOffset(iox::memory::segment_id_t{1U}, addressAtOffset), offset);
+    RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1U});
+    EXPECT_EQ(UntypedRelativePointer::getOffset(segment_id_t{1U}, addressAtOffset), offset);
 }
 
 TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
@@ -331,16 +329,16 @@ TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
     auto* ptr = this->partitionPtr(0U);
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::memory::segment_id_t{1U}, 0), typedPtr);
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(UntypedRelativePointer::getPtr(segment_id_t{1U}, 0), typedPtr);
 
     uint64_t offset = SHARED_MEMORY_SIZE / 2U;
     // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
-    RelativePointer<TypeParam> rp2(addressAtOffset, iox::memory::segment_id_t{1});
-    EXPECT_EQ(UntypedRelativePointer::getPtr(iox::memory::segment_id_t{1U}, offset), addressAtOffset);
+    RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1});
+    EXPECT_EQ(UntypedRelativePointer::getPtr(segment_id_t{1U}, offset), addressAtOffset);
 }
 
 TYPED_TEST(RelativePointer_test, RegisteringAndUnregisteringRelativePointerWorks)
@@ -349,12 +347,12 @@ TYPED_TEST(RelativePointer_test, RegisteringAndUnregisteringRelativePointerWorks
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), false);
-    EXPECT_EQ(rp1.unregisterPtr(iox::memory::segment_id_t{1U}), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), false);
+    EXPECT_EQ(rp1.unregisterPtr(segment_id_t{1U}), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
 }
 
 
@@ -365,11 +363,11 @@ TYPED_TEST(RelativePointer_test, UnRegisteringOneRelativePointerWorks)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
 
-    rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr);
-    EXPECT_EQ(rp1.unregisterPtr(iox::memory::segment_id_t{1U}), true);
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr), true);
+    rp1.registerPtrWithId(segment_id_t{1U}, typedPtr);
+    EXPECT_EQ(rp1.unregisterPtr(segment_id_t{1U}), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
 }
 
 TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
@@ -380,14 +378,14 @@ TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
     auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
     auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr0, iox::memory::segment_id_t{1U});
-    RelativePointer<TypeParam> rp2(typedPtr1, iox::memory::segment_id_t{9999U});
+    RelativePointer<TypeParam> rp1(typedPtr0, segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(typedPtr1, segment_id_t{9999U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{9999U}, typedPtr1), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(segment_id_t{9999U}, typedPtr1), true);
     UntypedRelativePointer::unregisterAll();
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{9999U}, typedPtr1), true);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(segment_id_t{9999U}, typedPtr1), true);
 }
 
 TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
@@ -397,11 +395,11 @@ TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
     auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
     auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr0, iox::memory::segment_id_t{1U});
-    RelativePointer<TypeParam> rp2(typedPtr1, iox::memory::segment_id_t{10000U});
+    RelativePointer<TypeParam> rp1(typedPtr0, segment_id_t{1U});
+    RelativePointer<TypeParam> rp2(typedPtr1, segment_id_t{10000U});
 
-    EXPECT_EQ(rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr0), true);
-    EXPECT_EQ(rp2.registerPtrWithId(iox::memory::segment_id_t{10000U}, typedPtr1), false);
+    EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr0), true);
+    EXPECT_EQ(rp2.registerPtrWithId(segment_id_t{10000U}, typedPtr1), false);
 }
 
 TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
@@ -410,10 +408,10 @@ TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
-    EXPECT_EQ(rp1.getBasePtr(iox::memory::segment_id_t{1U}), nullptr);
-    rp1.registerPtrWithId(iox::memory::segment_id_t{1U}, typedPtr);
-    EXPECT_EQ(typedPtr, rp1.getBasePtr(iox::memory::segment_id_t{1U}));
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
+    EXPECT_EQ(rp1.getBasePtr(segment_id_t{1U}), nullptr);
+    rp1.registerPtrWithId(segment_id_t{1U}, typedPtr);
+    EXPECT_EQ(typedPtr, rp1.getBasePtr(segment_id_t{1U}));
 }
 
 TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAndOffset)
@@ -422,7 +420,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAnd
     // No pointer arithmetic involved hence reinterpret_cast can be avoided
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     // NOLINTJUSTIFICATION Copy needed for tests
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     RelativePointer<TypeParam> rp2 = rp1;
@@ -439,7 +437,7 @@ TYPED_TEST(RelativePointer_test, DereferencingOperatorResultsInSameValue)
     auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
 
     *typedPtr = static_cast<TypeParam>(88);
-    RelativePointer<TypeParam> rp1(typedPtr, iox::memory::segment_id_t{1U});
+    RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
 
     EXPECT_EQ(*rp1, *typedPtr);
     *typedPtr = static_cast<TypeParam>(99);
@@ -484,13 +482,13 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
     EXPECT_EQ(*adr1, 12);
     EXPECT_EQ(*adr2, 21);
 
-    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{1U}, base1), true);
-    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{2U}, base2), true);
+    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(segment_id_t{1U}, base1), true);
+    EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(segment_id_t{2U}, base2), true);
 
     {
         // the relative pointers point to base 1 and base 2l
-        RelativePointer<uint8_t> rp1(base1, iox::memory::segment_id_t{1U});
-        RelativePointer<uint8_t> rp2(base2, iox::memory::segment_id_t{2U});
+        RelativePointer<uint8_t> rp1(base1, segment_id_t{1U});
+        RelativePointer<uint8_t> rp2(base2, segment_id_t{2U});
 
         EXPECT_EQ(rp1.getId(), 1U);
         EXPECT_EQ(rp2.getId(), 2U);
@@ -504,8 +502,8 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
 
     {
         // now test with a type that is larger than 1 byte
-        RelativePointer<int> rp1(adr1, iox::memory::segment_id_t{1U});
-        RelativePointer<int> rp2(adr2, iox::memory::segment_id_t{2U});
+        RelativePointer<int> rp1(adr1, segment_id_t{1U});
+        RelativePointer<int> rp2(adr2, segment_id_t{2U});
 
         EXPECT_EQ(rp1.getId(), 1U);
         EXPECT_EQ(rp2.getId(), 2U);
@@ -519,11 +517,11 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
         EXPECT_EQ(*rp2, 21);
 
         // simulate a remapping, index 1 now refers to base 2 and vice versa ...
-        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::memory::segment_id_t{1U}), true);
-        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(iox::memory::segment_id_t{2U}), true);
+        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(segment_id_t{1U}), true);
+        EXPECT_EQ(UntypedRelativePointer::unregisterPtr(segment_id_t{2U}), true);
 
-        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{1}, base2), true);
-        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(iox::memory::segment_id_t{2}, base1), true);
+        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(segment_id_t{1}, base2), true);
+        EXPECT_EQ(UntypedRelativePointer::registerPtrWithId(segment_id_t{2}, base1), true);
 
         // which, despite the relative pointer objects not having changed themselves,
         // leads to them referencing the respective other value now (compared to *** above)

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer_data.hpp"
 
 #include "test.hpp"
 

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer_data.cpp
@@ -22,7 +22,7 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::rp;
+using namespace iox::memory;
 
 TEST(RelativePointerData_test, DefaultConstructedResultsInNullptrIdAndOffset)
 {

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/chunk_management.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/chunk_management.hpp
@@ -41,11 +41,11 @@ struct ChunkManagement
                     const cxx::not_null<MemPool*> mempool,
                     const cxx::not_null<MemPool*> chunkManagementPool) noexcept;
 
-    iox::rp::RelativePointer<base_t> m_chunkHeader;
+    iox::memory::RelativePointer<base_t> m_chunkHeader;
     referenceCounter_t m_referenceCounter{1U};
     /// @todo optimization: check if this can be replaced by an offset relative to the this pointer
-    iox::rp::RelativePointer<MemPool> m_mempool;
-    iox::rp::RelativePointer<MemPool> m_chunkManagementPool;
+    iox::memory::RelativePointer<MemPool> m_mempool;
+    iox::memory::RelativePointer<MemPool> m_chunkManagementPool;
 };
 } // namespace mepoo
 } // namespace iox

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/chunk_management.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/chunk_management.hpp
@@ -18,7 +18,7 @@
 #define IOX_POSH_MEPOO_CHUNK_MANAGEMENT_HPP
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 #include <atomic>
 #include <cstdint>

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -20,7 +20,7 @@
 #include "iceoryx_hoofs/cxx/helplets.hpp"
 #include "iceoryx_hoofs/internal/concurrent/loffli.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 
 #include <atomic>

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -73,7 +73,7 @@ class MemPool
     void adjustMinFree() noexcept;
     bool isMultipleOfAlignment(const uint32_t value) const noexcept;
 
-    rp::RelativePointer<uint8_t> m_rawMemory;
+    memory::RelativePointer<uint8_t> m_rawMemory;
 
     uint32_t m_chunkSize{0U};
     /// needs to be 32 bit since loffli supports only 32 bit numbers

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -19,8 +19,8 @@
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
 #include "iceoryx_hoofs/internal/concurrent/loffli.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 
 #include <atomic>

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -76,8 +76,8 @@ inline SharedMemoryObjectType MePooSegment<SharedMemoryObjectType, MemoryManager
             .permissions(SEGMENT_PERMISSIONS)
             .create()
             .and_then([this](auto& sharedMemoryObject) {
-                auto maybeSegmentId = iox::memory::UntypedRelativePointer::registerPtr(sharedMemoryObject.getBaseAddress(),
-                                                                                   sharedMemoryObject.getSizeInBytes());
+                auto maybeSegmentId = iox::memory::UntypedRelativePointer::registerPtr(
+                    sharedMemoryObject.getBaseAddress(), sharedMemoryObject.getSizeInBytes());
                 if (!maybeSegmentId.has_value())
                 {
                     errorHandler(PoshError::MEPOO__SEGMENT_INSUFFICIENT_SEGMENT_IDS);

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_MEPOO_MEPOO_SEGMENT_INL
 #define IOX_POSH_MEPOO_MEPOO_SEGMENT_INL
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"
 #include "iceoryx_posh/internal/mepoo/mepoo_segment.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -76,7 +76,7 @@ inline SharedMemoryObjectType MePooSegment<SharedMemoryObjectType, MemoryManager
             .permissions(SEGMENT_PERMISSIONS)
             .create()
             .and_then([this](auto& sharedMemoryObject) {
-                auto maybeSegmentId = iox::rp::UntypedRelativePointer::registerPtr(sharedMemoryObject.getBaseAddress(),
+                auto maybeSegmentId = iox::memory::UntypedRelativePointer::registerPtr(sharedMemoryObject.getBaseAddress(),
                                                                                    sharedMemoryObject.getSizeInBytes());
                 if (!maybeSegmentId.has_value())
                 {

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_chunk.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_chunk.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_MEPOO_SHARED_CHUNK_HPP
 #define IOX_POSH_MEPOO_SHARED_CHUNK_HPP
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/internal/mepoo/chunk_management.hpp"
 #include "iceoryx_posh/internal/mepoo/mem_pool.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_MEPOO_SHM_SAFE_UNMANAGED_CHUNK_HPP
 #define IOX_POSH_MEPOO_SHM_SAFE_UNMANAGED_CHUNK_HPP
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer_data.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer_data.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 
 namespace iox

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp
@@ -60,7 +60,7 @@ class ShmSafeUnmanagedChunk
     bool isNotLogicalNullptrAndHasNoOtherOwners() const noexcept;
 
   private:
-    rp::RelativePointerData m_chunkManagement;
+    memory::RelativePointerData m_chunkManagement;
 };
 
 } // namespace mepoo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -54,7 +54,7 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(cxx::not_null<ChunkQueue
     const auto alreadyKnownReceiver =
         std::find_if(getMembers()->m_queues.begin(),
                      getMembers()->m_queues.end(),
-                     [&](const rp::RelativePointer<ChunkQueueData_t> queue) { return queue.get() == queueToAdd; });
+                     [&](const memory::RelativePointer<ChunkQueueData_t> queue) { return queue.get() == queueToAdd; });
 
     // check if the queue is not already in the list
     if (alreadyKnownReceiver == getMembers()->m_queues.end())
@@ -63,7 +63,7 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(cxx::not_null<ChunkQueue
         {
             // AXIVION Next Construct AutosarC++19_03-A0.1.2, AutosarC++19_03-M0-3-2 : we checked the capacity, so
             // pushing will be fine
-            getMembers()->m_queues.push_back(rp::RelativePointer<ChunkQueueData_t>(queueToAdd));
+            getMembers()->m_queues.push_back(memory::RelativePointer<ChunkQueueData_t>(queueToAdd));
 
             const auto currChunkHistorySize = getMembers()->m_history.size();
 
@@ -177,8 +177,8 @@ inline uint64_t ChunkDistributor<ChunkDistributorDataType>::deliverToAllStoredQu
             //          and without this intersection we would deliver to dead queues
             typename MemberType_t::LockGuard_t lock(*getMembers());
             typename ChunkDistributorDataType::QueueContainer_t queueIntersection(remainingQueues.size());
-            auto greaterThan = [](rp::RelativePointer<ChunkQueueData_t>& a,
-                                  rp::RelativePointer<ChunkQueueData_t>& b) -> bool {
+            auto greaterThan = [](memory::RelativePointer<ChunkQueueData_t>& a,
+                                  memory::RelativePointer<ChunkQueueData_t>& b) -> bool {
                 return reinterpret_cast<uint64_t>(a.get()) > reinterpret_cast<uint64_t>(b.get());
             };
             std::sort(getMembers()->m_queues.begin(), getMembers()->m_queues.end(), greaterThan);

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
@@ -49,7 +49,7 @@ struct ChunkDistributorData : public LockingPolicy
     const uint64_t m_historyCapacity;
 
     using QueueContainer_t =
-        cxx::vector<rp::RelativePointer<ChunkQueueData_t>, ChunkDistributorDataProperties_t::MAX_QUEUES>;
+        cxx::vector<memory::RelativePointer<ChunkQueueData_t>, ChunkDistributorDataProperties_t::MAX_QUEUES>;
     QueueContainer_t m_queues;
 
     /// @todo If we would make the ChunkDistributor lock-free, can we than extend the UsedChunkList to

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
@@ -19,8 +19,8 @@
 
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/mutex.hpp"
 #include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/posix_wrapper/mutex.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp
@@ -20,7 +20,7 @@
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/mutex.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
@@ -47,7 +47,7 @@ struct ChunkQueueData : public LockingPolicy
     cxx::VariantQueue<mepoo::ShmSafeUnmanagedChunk, MAX_CAPACITY> m_queue;
     std::atomic_bool m_queueHasLostChunks{false};
 
-    rp::RelativePointer<ConditionVariableData> m_conditionVariableDataPtr;
+    memory::RelativePointer<ConditionVariableData> m_conditionVariableDataPtr;
     cxx::optional<uint64_t> m_conditionVariableNotificationIndex;
     const QueueFullPolicy m_queueFullPolicy;
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_hoofs/internal/cxx/unique_id.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/condition_notifier.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender_data.hpp
@@ -39,7 +39,7 @@ struct ChunkSenderData : public ChunkDistributorDataType
 
     using ChunkDistributorData_t = ChunkDistributorDataType;
 
-    const rp::RelativePointer<mepoo::MemoryManager> m_memoryMgr;
+    const memory::RelativePointer<mepoo::MemoryManager> m_memoryMgr;
     mepoo::MemoryInfo m_memoryInfo;
     UsedChunkList<MaxChunksAllocatedSimultaneously> m_chunksInUse;
     mepoo::SequenceNumber_t m_sequenceNumber{0U};

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/base_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/base_port_data.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_POPO_PORTS_BASE_PORT_DATA_HPP
 #define IOX_POSH_POPO_PORTS_BASE_PORT_DATA_HPP
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/capro/service_description.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/capro/capro_message.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/process_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/process_manager.hpp
@@ -225,7 +225,7 @@ class ProcessManager : public ProcessManagerInterface
     PortManager& m_portManager;
     mepoo::SegmentManager<>* m_segmentManager{nullptr};
     mepoo::MemoryManager* m_introspectionMemoryManager{nullptr};
-    rp::segment_id_underlying_t m_mgmtSegmentId{rp::UntypedRelativePointer::NULL_POINTER_ID};
+    memory::segment_id_underlying_t m_mgmtSegmentId{memory::UntypedRelativePointer::NULL_POINTER_ID};
     ProcessList_t m_processList;
     ProcessIntrospectionType* m_processIntrospection{nullptr};
     version::CompatibilityCheckLevel m_compatibilityCheckLevel;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi.hpp
@@ -129,7 +129,7 @@ class RouDi
 
     void monitorAndDiscoveryUpdate() noexcept;
 
-    cxx::ScopeGuard m_unregisterRelativePtr{[] { rp::UntypedRelativePointer::unregisterAll(); }};
+    cxx::ScopeGuard m_unregisterRelativePtr{[] { memory::UntypedRelativePointer::unregisterAll(); }};
     bool m_killProcessesInDestructor;
     std::atomic_bool m_runMonitoringAndDiscoveryThread;
     std::atomic_bool m_runHandleRuntimeMessageThread;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi.hpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_hoofs/cxx/scope_guard.hpp"
 #include "iceoryx_hoofs/internal/concurrent/smart_lock.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
 #include "iceoryx_platform/file.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -20,7 +20,7 @@
 
 #include "iceoryx_hoofs/cxx/deadline_timer.hpp"
 #include "iceoryx_hoofs/cxx/optional.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"
 #include "iceoryx_platform/errno.hpp"
 #include "iceoryx_platform/fcntl.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp
@@ -55,8 +55,8 @@ class IpcRuntimeInterface
     bool sendRequestToRouDi(const IpcMessage& msg, IpcMessage& answer) noexcept;
 
     /// @brief get the adress offset of the segment manager
-    /// @return address offset as rp::RelativePointer::offset_t
-    rp::UntypedRelativePointer::offset_t getSegmentManagerAddressOffset() const noexcept;
+    /// @return address offset as memory::RelativePointer::offset_t
+    memory::UntypedRelativePointer::offset_t getSegmentManagerAddressOffset() const noexcept;
 
     /// @brief get the size of the management shared memory object
     /// @return size in bytes
@@ -79,7 +79,7 @@ class IpcRuntimeInterface
 
   private:
     RuntimeName_t m_runtimeName;
-    cxx::optional<rp::UntypedRelativePointer::offset_t> m_segmentManagerAddressOffset;
+    cxx::optional<memory::UntypedRelativePointer::offset_t> m_segmentManagerAddressOffset;
     cxx::optional<IpcInterfaceCreator> m_AppIpcInterface;
     IpcInterfaceUser m_RoudiIpcInterface;
     uint64_t m_shmTopicSize{0U};

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
@@ -19,8 +19,8 @@
 
 #include "iceoryx_hoofs/cxx/optional.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
@@ -20,7 +20,7 @@
 #include "iceoryx_hoofs/cxx/optional.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
@@ -39,11 +39,11 @@ class SharedMemoryUser
     /// address space
     SharedMemoryUser(const size_t topicSize,
                      const uint64_t segmentId,
-                     const rp::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept;
+                     const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept;
 
   private:
     void openDataSegments(const uint64_t segmentId,
-                          const rp::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept;
+                          const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept;
 
   private:
     cxx::optional<posix::SharedMemoryObject> m_shmObject;

--- a/iceoryx_posh/source/mepoo/shared_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shared_chunk.cpp
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 namespace iox
 {

--- a/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
@@ -41,14 +41,14 @@ ShmSafeUnmanagedChunk::ShmSafeUnmanagedChunk(mepoo::SharedChunk chunk) noexcept
     // this is only necessary if it's not an empty chunk
     if (chunk)
     {
-        rp::RelativePointer<mepoo::ChunkManagement> ptr{chunk.release()};
+        memory::RelativePointer<mepoo::ChunkManagement> ptr{chunk.release()};
         auto id = ptr.getId();
         auto offset = ptr.getOffset();
-        cxx::Ensures(id <= rp::RelativePointerData::ID_RANGE && "RelativePointer id must fit into id type!");
-        cxx::Ensures(offset <= rp::RelativePointerData::OFFSET_RANGE
+        cxx::Ensures(id <= memory::RelativePointerData::ID_RANGE && "RelativePointer id must fit into id type!");
+        cxx::Ensures(offset <= memory::RelativePointerData::OFFSET_RANGE
                      && "RelativePointer offset must fit into offset type!");
         /// @todo #1196 Unify types to uint64_t
-        m_chunkManagement = rp::RelativePointerData(static_cast<rp::RelativePointerData::identifier_t>(id), offset);
+        m_chunkManagement = memory::RelativePointerData(static_cast<memory::RelativePointerData::identifier_t>(id), offset);
     }
 }
 
@@ -58,8 +58,8 @@ SharedChunk ShmSafeUnmanagedChunk::releaseToSharedChunk() noexcept
     {
         return SharedChunk();
     }
-    auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 rp::segment_id_t{m_chunkManagement.id()});
+    auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
+                                                                 memory::segment_id_t{m_chunkManagement.id()});
     m_chunkManagement.reset();
     return SharedChunk(chunkMgmt.get());
 }
@@ -70,8 +70,8 @@ SharedChunk ShmSafeUnmanagedChunk::cloneToSharedChunk() noexcept
     {
         return SharedChunk();
     }
-    auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 rp::segment_id_t{m_chunkManagement.id()});
+    auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
+                                                                 memory::segment_id_t{m_chunkManagement.id()});
     chunkMgmt->m_referenceCounter.fetch_add(1U, std::memory_order_relaxed);
     return SharedChunk(chunkMgmt.get());
 }
@@ -87,8 +87,8 @@ ChunkHeader* ShmSafeUnmanagedChunk::getChunkHeader() noexcept
     {
         return nullptr;
     }
-    auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 rp::segment_id_t{m_chunkManagement.id()});
+    auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
+                                                                 memory::segment_id_t{m_chunkManagement.id()});
     return chunkMgmt->m_chunkHeader.get();
 }
 
@@ -104,8 +104,8 @@ bool ShmSafeUnmanagedChunk::isNotLogicalNullptrAndHasNoOtherOwners() const noexc
         return false;
     }
 
-    auto chunkMgmt = rp::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 rp::segment_id_t{m_chunkManagement.id()});
+    auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
+                                                                 memory::segment_id_t{m_chunkManagement.id()});
     return chunkMgmt->m_referenceCounter.load(std::memory_order_relaxed) == 1U;
 }
 

--- a/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shm_safe_unmanaged_chunk.cpp
@@ -48,7 +48,8 @@ ShmSafeUnmanagedChunk::ShmSafeUnmanagedChunk(mepoo::SharedChunk chunk) noexcept
         cxx::Ensures(offset <= memory::RelativePointerData::OFFSET_RANGE
                      && "RelativePointer offset must fit into offset type!");
         /// @todo #1196 Unify types to uint64_t
-        m_chunkManagement = memory::RelativePointerData(static_cast<memory::RelativePointerData::identifier_t>(id), offset);
+        m_chunkManagement =
+            memory::RelativePointerData(static_cast<memory::RelativePointerData::identifier_t>(id), offset);
     }
 }
 
@@ -59,7 +60,7 @@ SharedChunk ShmSafeUnmanagedChunk::releaseToSharedChunk() noexcept
         return SharedChunk();
     }
     auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 memory::segment_id_t{m_chunkManagement.id()});
+                                                                     memory::segment_id_t{m_chunkManagement.id()});
     m_chunkManagement.reset();
     return SharedChunk(chunkMgmt.get());
 }
@@ -71,7 +72,7 @@ SharedChunk ShmSafeUnmanagedChunk::cloneToSharedChunk() noexcept
         return SharedChunk();
     }
     auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 memory::segment_id_t{m_chunkManagement.id()});
+                                                                     memory::segment_id_t{m_chunkManagement.id()});
     chunkMgmt->m_referenceCounter.fetch_add(1U, std::memory_order_relaxed);
     return SharedChunk(chunkMgmt.get());
 }
@@ -88,7 +89,7 @@ ChunkHeader* ShmSafeUnmanagedChunk::getChunkHeader() noexcept
         return nullptr;
     }
     auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 memory::segment_id_t{m_chunkManagement.id()});
+                                                                     memory::segment_id_t{m_chunkManagement.id()});
     return chunkMgmt->m_chunkHeader.get();
 }
 
@@ -105,7 +106,7 @@ bool ShmSafeUnmanagedChunk::isNotLogicalNullptrAndHasNoOtherOwners() const noexc
     }
 
     auto chunkMgmt = memory::RelativePointer<mepoo::ChunkManagement>(m_chunkManagement.offset(),
-                                                                 memory::segment_id_t{m_chunkManagement.id()});
+                                                                     memory::segment_id_t{m_chunkManagement.id()});
     return chunkMgmt->m_referenceCounter.load(std::memory_order_relaxed) == 1U;
 }
 

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -17,7 +17,7 @@
 
 #include "iceoryx_posh/roudi/memory/memory_provider.hpp"
 #include "iceoryx_hoofs/cxx/helplets.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"
 #include "iceoryx_posh/roudi/memory/memory_block.hpp"

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -85,7 +85,7 @@ cxx::expected<MemoryProviderError> MemoryProvider::create() noexcept
 
     m_memory = memoryResult.value();
     m_size = totalSize;
-    auto maybeSegmentId = rp::UntypedRelativePointer::registerPtr(m_memory, m_size);
+    auto maybeSegmentId = memory::UntypedRelativePointer::registerPtr(m_memory, m_size);
 
     if (!maybeSegmentId.has_value())
     {
@@ -122,7 +122,7 @@ cxx::expected<MemoryProviderError> MemoryProvider::destroy() noexcept
 
     if (!destructionResult.has_error())
     {
-        rp::UntypedRelativePointer::unregisterPtr(rp::segment_id_t{m_segmentId});
+        memory::UntypedRelativePointer::unregisterPtr(memory::segment_id_t{m_segmentId});
         m_memory = nullptr;
         m_size = 0U;
     }

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -372,7 +372,8 @@ void ProcessManager::addNodeForProcess(const RuntimeName_t& runtimeName, const N
         .and_then([&](auto& process) {
             m_portManager.acquireNodeData(runtimeName, nodeName)
                 .and_then([&](auto nodeData) {
-                    auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, nodeData);
+                    auto offset =
+                        memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, nodeData);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_NODE_ACK)
@@ -424,8 +425,8 @@ void ProcessManager::addSubscriberForProcess(const RuntimeName_t& name,
             if (!maybeSubscriber.has_error())
             {
                 // send SubscriberPort to app as a serialized relative pointer
-                auto offset =
-                    memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, maybeSubscriber.value());
+                auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId},
+                                                                        maybeSubscriber.value());
 
                 runtime::IpcMessage sendBuffer;
                 sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_SUBSCRIBER_ACK)
@@ -477,8 +478,8 @@ void ProcessManager::addPublisherForProcess(const RuntimeName_t& name,
             if (!maybePublisher.has_error())
             {
                 // send PublisherPort to app as a serialized relative pointer
-                auto offset =
-                    memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, maybePublisher.value());
+                auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId},
+                                                                        maybePublisher.value());
 
                 runtime::IpcMessage sendBuffer;
                 sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_PUBLISHER_ACK)
@@ -636,7 +637,8 @@ void ProcessManager::addConditionVariableForProcess(const RuntimeName_t& runtime
         .and_then([&](auto& process) { // Try to create a condition variable
             m_portManager.acquireConditionVariableData(runtimeName)
                 .and_then([&](auto condVar) {
-                    auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, condVar);
+                    auto offset =
+                        memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, condVar);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -265,7 +265,7 @@ bool ProcessManager::addProcess(const RuntimeName_t& name,
     runtime::IpcMessage sendBuffer;
     const bool sendKeepAlive = isMonitored;
 
-    auto offset = rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, m_segmentManager);
+    auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, m_segmentManager);
     sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::REG_ACK)
                << m_roudiMemoryInterface.mgmtMemoryProvider()->size() << offset << transmissionTimestamp
                << m_mgmtSegmentId << sendKeepAlive;
@@ -354,7 +354,7 @@ void ProcessManager::addInterfaceForProcess(const RuntimeName_t& name,
             popo::InterfacePortData* port = m_portManager.acquireInterfacePortData(interface, name, node);
 
             // send ReceiverPort to app as a serialized relative pointer
-            auto offset = rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, port);
+            auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, port);
 
             runtime::IpcMessage sendBuffer;
             sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_INTERFACE_ACK)
@@ -372,7 +372,7 @@ void ProcessManager::addNodeForProcess(const RuntimeName_t& runtimeName, const N
         .and_then([&](auto& process) {
             m_portManager.acquireNodeData(runtimeName, nodeName)
                 .and_then([&](auto nodeData) {
-                    auto offset = rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, nodeData);
+                    auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, nodeData);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_NODE_ACK)
@@ -425,7 +425,7 @@ void ProcessManager::addSubscriberForProcess(const RuntimeName_t& name,
             {
                 // send SubscriberPort to app as a serialized relative pointer
                 auto offset =
-                    rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, maybeSubscriber.value());
+                    memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, maybeSubscriber.value());
 
                 runtime::IpcMessage sendBuffer;
                 sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_SUBSCRIBER_ACK)
@@ -478,7 +478,7 @@ void ProcessManager::addPublisherForProcess(const RuntimeName_t& name,
             {
                 // send PublisherPort to app as a serialized relative pointer
                 auto offset =
-                    rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, maybePublisher.value());
+                    memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, maybePublisher.value());
 
                 runtime::IpcMessage sendBuffer;
                 sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_PUBLISHER_ACK)
@@ -551,7 +551,7 @@ void ProcessManager::addClientForProcess(const RuntimeName_t& name,
                     service, clientOptions, name, &segmentInfo.m_memoryManager.value().get(), portConfigInfo)
                 .and_then([&](auto& clientPort) {
                     auto relativePtrToClientPort =
-                        rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, clientPort);
+                        memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, clientPort);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_CLIENT_ACK)
@@ -603,7 +603,7 @@ void ProcessManager::addServerForProcess(const RuntimeName_t& name,
                     service, serverOptions, name, &segmentInfo.m_memoryManager.value().get(), portConfigInfo)
                 .and_then([&](auto& serverPort) {
                     auto relativePtrToServerPort =
-                        rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, serverPort);
+                        memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, serverPort);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::CREATE_SERVER_ACK)
@@ -636,7 +636,7 @@ void ProcessManager::addConditionVariableForProcess(const RuntimeName_t& runtime
         .and_then([&](auto& process) { // Try to create a condition variable
             m_portManager.acquireConditionVariableData(runtimeName)
                 .and_then([&](auto condVar) {
-                    auto offset = rp::UntypedRelativePointer::getOffset(rp::segment_id_t{m_mgmtSegmentId}, condVar);
+                    auto offset = memory::UntypedRelativePointer::getOffset(memory::segment_id_t{m_mgmtSegmentId}, condVar);
 
                     runtime::IpcMessage sendBuffer;
                     sendBuffer << runtime::IpcMessageTypeToString(

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_hoofs/cxx/convert.hpp"
 #include "iceoryx_hoofs/cxx/deadline_timer.hpp"
 #include "iceoryx_hoofs/cxx/vector.hpp"
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/signal.hpp"
 #include "iceoryx_platform/types.hpp"

--- a/iceoryx_posh/source/runtime/ipc_runtime_interface.cpp
+++ b/iceoryx_posh/source/runtime/ipc_runtime_interface.cpp
@@ -150,7 +150,7 @@ bool IpcRuntimeInterface::sendKeepalive() noexcept
                : true;
 }
 
-rp::UntypedRelativePointer::offset_t IpcRuntimeInterface::getSegmentManagerAddressOffset() const noexcept
+memory::UntypedRelativePointer::offset_t IpcRuntimeInterface::getSegmentManagerAddressOffset() const noexcept
 {
     cxx::Ensures(m_segmentManagerAddressOffset.has_value()
                  && "No segment manager available! Should have been fetched in the c'tor");
@@ -234,7 +234,7 @@ IpcRuntimeInterface::RegAckResult IpcRuntimeInterface::waitForRegAck(int64_t tra
 
                 // read out the shared memory base address and save it
                 iox::cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), m_shmTopicSize);
-                rp::UntypedRelativePointer::offset_t offset{0U};
+                memory::UntypedRelativePointer::offset_t offset{0U};
                 iox::cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), offset);
                 m_segmentManagerAddressOffset.emplace(offset);
 

--- a/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
@@ -164,11 +164,11 @@ PoshRuntimeImpl::requestPublisherFromRoudi(const IpcMessage& sendBuffer) noexcep
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_PUBLISHER_ACK)
 
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return cxx::success<PublisherPortUserType::MemberType_t*>(
                 reinterpret_cast<PublisherPortUserType::MemberType_t*>(ptr));
         }
@@ -272,11 +272,11 @@ PoshRuntimeImpl::requestSubscriberFromRoudi(const IpcMessage& sendBuffer) noexce
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_SUBSCRIBER_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return cxx::success<SubscriberPortUserType::MemberType_t*>(
                 reinterpret_cast<SubscriberPortUserType::MemberType_t*>(ptr));
         }
@@ -374,11 +374,11 @@ PoshRuntimeImpl::requestClientFromRoudi(const IpcMessage& sendBuffer) noexcept
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_CLIENT_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return cxx::success<popo::ClientPortUser::MemberType_t*>(
                 reinterpret_cast<popo::ClientPortUser::MemberType_t*>(ptr));
         }
@@ -476,11 +476,11 @@ PoshRuntimeImpl::requestServerFromRoudi(const IpcMessage& sendBuffer) noexcept
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_SERVER_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return cxx::success<popo::ServerPortUser::MemberType_t*>(
                 reinterpret_cast<popo::ServerPortUser::MemberType_t*>(ptr));
         }
@@ -521,11 +521,11 @@ popo::InterfacePortData* PoshRuntimeImpl::getMiddlewareInterface(const capro::In
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_INTERFACE_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return reinterpret_cast<popo::InterfacePortData*>(ptr);
         }
     }
@@ -555,11 +555,11 @@ NodeData* PoshRuntimeImpl::createNode(const NodeProperty& nodeProperty) noexcept
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_NODE_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return reinterpret_cast<NodeData*>(ptr);
         }
     }
@@ -584,11 +584,11 @@ PoshRuntimeImpl::requestConditionVariableFromRoudi(const IpcMessage& sendBuffer)
 
         if (stringToIpcMessageType(IpcMessage.c_str()) == IpcMessageType::CREATE_CONDITION_VARIABLE_ACK)
         {
-            rp::segment_id_underlying_t segmentId{0U};
+            memory::segment_id_underlying_t segmentId{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(2U).c_str(), segmentId);
-            rp::UntypedRelativePointer::offset_t offset{0U};
+            memory::UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
-            auto ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, offset);
+            auto ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, offset);
             return cxx::success<popo::ConditionVariableData*>(reinterpret_cast<popo::ConditionVariableData*>(ptr));
         }
     }

--- a/iceoryx_posh/source/runtime/shared_memory_user.cpp
+++ b/iceoryx_posh/source/runtime/shared_memory_user.cpp
@@ -40,8 +40,10 @@ SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
         .permissions(SHM_SEGMENT_PERMISSIONS)
         .create()
         .and_then([this, segmentId, segmentManagerAddressOffset](auto& sharedMemoryObject) {
-            auto registeredSuccessfully = memory::UntypedRelativePointer::registerPtrWithId(
-                memory::segment_id_t{segmentId}, sharedMemoryObject.getBaseAddress(), sharedMemoryObject.getSizeInBytes());
+            auto registeredSuccessfully =
+                memory::UntypedRelativePointer::registerPtrWithId(memory::segment_id_t{segmentId},
+                                                                  sharedMemoryObject.getBaseAddress(),
+                                                                  sharedMemoryObject.getSizeInBytes());
 
             if (!registeredSuccessfully)
             {
@@ -59,8 +61,8 @@ SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
         .or_else([](auto&) { errorHandler(PoshError::POSH__SHM_APP_MAPP_ERR); });
 }
 
-void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
-                                        const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
+void SharedMemoryUser::openDataSegments(
+    const uint64_t segmentId, const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
 {
     auto* ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, segmentManagerAddressOffset);
     auto* segmentManager = static_cast<mepoo::SegmentManager<>*>(ptr);
@@ -84,8 +86,8 @@ void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
 
                 auto registeredSuccessfully =
                     memory::UntypedRelativePointer::registerPtrWithId(memory::segment_id_t{segment.m_segmentId},
-                                                                  sharedMemoryObject.getBaseAddress(),
-                                                                  sharedMemoryObject.getSizeInBytes());
+                                                                      sharedMemoryObject.getBaseAddress(),
+                                                                      sharedMemoryObject.getSizeInBytes());
 
                 if (!registeredSuccessfully)
                 {

--- a/iceoryx_posh/source/runtime/shared_memory_user.cpp
+++ b/iceoryx_posh/source/runtime/shared_memory_user.cpp
@@ -30,7 +30,7 @@ constexpr cxx::perms SharedMemoryUser::SHM_SEGMENT_PERMISSIONS;
 
 SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
                                    const uint64_t segmentId,
-                                   const rp::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
+                                   const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
 {
     posix::SharedMemoryObjectBuilder()
         .name(roudi::SHM_NAME)
@@ -40,8 +40,8 @@ SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
         .permissions(SHM_SEGMENT_PERMISSIONS)
         .create()
         .and_then([this, segmentId, segmentManagerAddressOffset](auto& sharedMemoryObject) {
-            auto registeredSuccessfully = rp::UntypedRelativePointer::registerPtrWithId(
-                rp::segment_id_t{segmentId}, sharedMemoryObject.getBaseAddress(), sharedMemoryObject.getSizeInBytes());
+            auto registeredSuccessfully = memory::UntypedRelativePointer::registerPtrWithId(
+                memory::segment_id_t{segmentId}, sharedMemoryObject.getBaseAddress(), sharedMemoryObject.getSizeInBytes());
 
             if (!registeredSuccessfully)
             {
@@ -60,9 +60,9 @@ SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
 }
 
 void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
-                                        const rp::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
+                                        const memory::UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
 {
-    auto* ptr = rp::UntypedRelativePointer::getPtr(rp::segment_id_t{segmentId}, segmentManagerAddressOffset);
+    auto* ptr = memory::UntypedRelativePointer::getPtr(memory::segment_id_t{segmentId}, segmentManagerAddressOffset);
     auto* segmentManager = static_cast<mepoo::SegmentManager<>*>(ptr);
 
     auto segmentMapping = segmentManager->getSegmentMappings(posix::PosixUser::getUserOfCurrentProcess());
@@ -83,7 +83,7 @@ void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
                 }
 
                 auto registeredSuccessfully =
-                    rp::UntypedRelativePointer::registerPtrWithId(rp::segment_id_t{segment.m_segmentId},
+                    memory::UntypedRelativePointer::registerPtrWithId(memory::segment_id_t{segment.m_segmentId},
                                                                   sharedMemoryObject.getBaseAddress(),
                                                                   sharedMemoryObject.getSizeInBytes());
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
@@ -53,7 +53,7 @@ class SegmentManager_test : public Test
     }
     void TearDown() override
     {
-        iox::rp::UntypedRelativePointer::unregisterAll();
+        iox::memory::UntypedRelativePointer::unregisterAll();
     }
 
     MePooConfig getMempoolConfig()

--- a/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
@@ -104,11 +104,11 @@ class SharedPointer_Test : public Test
 
     void SetUp() override
     {
-        iox::rp::UntypedRelativePointer::registerPtr(memory, 4096);
+        iox::memory::UntypedRelativePointer::registerPtr(memory, 4096);
     }
     void TearDown() override
     {
-        iox::rp::UntypedRelativePointer::unregisterAll();
+        iox::memory::UntypedRelativePointer::unregisterAll();
     }
 
     ChunkManagement* GetChunkManagement(void* memoryChunk)

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -17,7 +17,7 @@
 
 #include "iceoryx_posh/roudi/memory/memory_provider.hpp"
 
-#include "iceoryx_hoofs/internal/relocatable_pointer/relative_pointer.hpp"
+#include "iceoryx_hoofs/internal/memory/relative_pointer.hpp"
 
 #include "mocks/roudi_memory_block_mock.hpp"
 #include "mocks/roudi_memory_provider_mock.hpp"

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -54,13 +54,13 @@ class MemoryProvider_Test : public Test
     {
         // since the MemoryProvider registers for relative pointer, it is necessary to call unregisterAll, to have a
         // clean environment especially for the first test
-        iox::rp::UntypedRelativePointer::unregisterAll();
+        iox::memory::UntypedRelativePointer::unregisterAll();
     }
 
     void TearDown() override
     {
         // unregisterAll is also called to leave a clean environment after the last test
-        iox::rp::UntypedRelativePointer::unregisterAll();
+        iox::memory::UntypedRelativePointer::unregisterAll();
     }
 
     static constexpr uint64_t COMMON_SETUP_MEMORY_SIZE{16};
@@ -341,7 +341,7 @@ TEST_F(MemoryProvider_Test, SegmentIdValueAfterCreationIsValid)
     ::testing::Test::RecordProperty("TEST_ID", "56307b8c-724b-4bb2-8619-a127205db184");
     constexpr uint64_t DummyMemorySize{1024};
     uint8_t dummy[DummyMemorySize];
-    auto segmentIdOffset = iox::rp::UntypedRelativePointer::registerPtr(dummy, DummyMemorySize);
+    auto segmentIdOffset = iox::memory::UntypedRelativePointer::registerPtr(dummy, DummyMemorySize);
 
     ASSERT_TRUE(segmentIdOffset.has_value());
     ASSERT_FALSE(commonSetup().has_error());

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
@@ -104,7 +104,7 @@ class PortManager_test : public Test
     {
         delete m_portManager;
         delete m_roudiMemoryManager;
-        iox::rp::UntypedRelativePointer::unregisterAll();
+        iox::memory::UntypedRelativePointer::unregisterAll();
     }
 
     void addInternalPublisherOfPortManagerToVector()


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Rename directory from `reloctable_pointer` to `memory`
* Rename namespace `rp` to `memory`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #605 (partly)
