### PR TITLE
iox-#1345 fix axivion warnings in logger files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,6 +40,7 @@ BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true
 ColumnLimit:     120
+CommentPragmas: '^(AXIVION|NOLINT)'
 CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/console_logger.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/console_logger.inl
@@ -24,8 +24,9 @@ namespace iox
 {
 namespace log
 {
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
+// AXIVION Next Construct AutosarC++19_03-A18.1.1 : See at declaration in header
 template <uint32_t N>
-// NOLINTJUSTIFICATION see at declaration in header
 // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
 inline constexpr uint32_t ConsoleLogger::bufferSize(const char (&)[N]) noexcept
 {
@@ -33,11 +34,11 @@ inline constexpr uint32_t ConsoleLogger::bufferSize(const char (&)[N]) noexcept
 }
 
 template <typename T>
-inline void ConsoleLogger::unused(T&&) const noexcept
+inline constexpr void ConsoleLogger::unused(T&&) noexcept
 {
 }
 
-template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool>>
 inline void ConsoleLogger::logDec(const T value) noexcept
 {
     logArithmetic(value, LOG_FORMAT_DEC<T>);
@@ -46,28 +47,29 @@ inline void ConsoleLogger::logDec(const T value) noexcept
 template <typename T,
           typename std::enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value)
                                         || std::is_floating_point<T>::value || std::is_pointer<T>::value,
-                                    int>>
+                                    bool>>
 inline void ConsoleLogger::logHex(const T value) noexcept
 {
     logArithmetic(value, LOG_FORMAT_HEX<T>);
 }
 
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, bool>>
 inline void ConsoleLogger::logOct(const T value) noexcept
 {
     logArithmetic(value, LOG_FORMAT_OCT<T>);
 }
 
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
 template <typename T>
 inline void ConsoleLogger::logArithmetic(const T value, const char* format) noexcept
 {
     auto& data = getThreadLocalData();
     // NOLINTJUSTIFICATION it is ensured that the index cannot be out of bounds
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-    auto retVal = snprintf(&data.buffer[data.bufferWriteIndex],
-                           ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE - data.bufferWriteIndex,
-                           format,
-                           value);
+    const auto retVal = snprintf(&data.buffer[data.bufferWriteIndex],
+                                 ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE - data.bufferWriteIndex,
+                                 format,
+                                 value);
     if (retVal < 0)
     {
         /// @todo iox-#1345 this path should never be reached since we ensured the correct encoding of the character
@@ -76,8 +78,8 @@ inline void ConsoleLogger::logArithmetic(const T value, const char* format) noex
         return;
     }
 
-    auto stringSizeToLog = static_cast<uint32_t>(retVal);
-    auto bufferWriteIndexNext = data.bufferWriteIndex + stringSizeToLog;
+    const auto stringSizeToLog = static_cast<uint32_t>(retVal);
+    const auto bufferWriteIndexNext = data.bufferWriteIndex + stringSizeToLog;
     if (bufferWriteIndexNext <= ThreadLocalData::BUFFER_SIZE)
     {
         data.bufferWriteIndex = bufferWriteIndexNext;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/console_logger.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/console_logger.inl
@@ -45,7 +45,7 @@ inline void ConsoleLogger::logDec(const T value) noexcept
 
 template <typename T,
           typename std::enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value)
-                                        || std::is_floating_point<T>::value,
+                                        || std::is_floating_point<T>::value || std::is_pointer<T>::value,
                                     int>>
 inline void ConsoleLogger::logHex(const T value) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
@@ -81,7 +81,7 @@ template <typename>
 constexpr bool always_false_v{false};
 
 template <typename T>
-constexpr const char* logFormatDec() noexcept
+inline constexpr const char* logFormatDec() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for decimal output!");
     return nullptr;
@@ -153,85 +153,85 @@ inline constexpr const char* logFormatDec<long double>() noexcept
 }
 
 template <typename T>
-constexpr const char* logFormatHex() noexcept
+inline constexpr const char* logFormatHex() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for hexadecimal output!");
     return nullptr;
 }
 template <>
-constexpr const char* logFormatHex<unsigned char>() noexcept
+inline constexpr const char* logFormatHex<unsigned char>() noexcept
 {
     return "%hhx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned short>() noexcept
+inline constexpr const char* logFormatHex<unsigned short>() noexcept
 {
     return "%hx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned int>() noexcept
+inline constexpr const char* logFormatHex<unsigned int>() noexcept
 {
     return "%x";
 }
 template <>
-constexpr const char* logFormatHex<unsigned long>() noexcept
+inline constexpr const char* logFormatHex<unsigned long>() noexcept
 {
     return "%lx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned long long>() noexcept
+inline constexpr const char* logFormatHex<unsigned long long>() noexcept
 {
     return "%llx";
 }
 template <>
-constexpr const char* logFormatHex<float>() noexcept
+inline constexpr const char* logFormatHex<float>() noexcept
 {
     return "%a";
 }
 template <>
-constexpr const char* logFormatHex<double>() noexcept
+inline constexpr const char* logFormatHex<double>() noexcept
 {
     return "%la";
 }
 template <>
-constexpr const char* logFormatHex<long double>() noexcept
+inline constexpr const char* logFormatHex<long double>() noexcept
 {
     return "%La";
 }
 template <>
-constexpr const char* logFormatHex<const void*>() noexcept
+inline constexpr const char* logFormatHex<const void*>() noexcept
 {
     return "%p";
 }
 
 template <typename T>
-constexpr const char* logFormatOct() noexcept
+inline constexpr const char* logFormatOct() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for octal output!");
     return nullptr;
 }
 template <>
-constexpr const char* logFormatOct<unsigned char>() noexcept
+inline constexpr const char* logFormatOct<unsigned char>() noexcept
 {
     return "%hho";
 }
 template <>
-constexpr const char* logFormatOct<unsigned short>() noexcept
+inline constexpr const char* logFormatOct<unsigned short>() noexcept
 {
     return "%ho";
 }
 template <>
-constexpr const char* logFormatOct<unsigned int>() noexcept
+inline constexpr const char* logFormatOct<unsigned int>() noexcept
 {
     return "%o";
 }
 template <>
-constexpr const char* logFormatOct<unsigned long>() noexcept
+inline constexpr const char* logFormatOct<unsigned long>() noexcept
 {
     return "%lo";
 }
 template <>
-constexpr const char* logFormatOct<unsigned long long>() noexcept
+inline constexpr const char* logFormatOct<unsigned long long>() noexcept
 {
     return "%llo";
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
@@ -25,7 +25,7 @@ namespace log
 {
 // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : See at declaration in header
 // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Octal numbers are required for the terminal color codes and it is
-// checked that only valid digis are used
+// checked that only valid digits are used
 
 inline constexpr const char* logLevelDisplayColor(const LogLevel value) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
@@ -197,6 +197,11 @@ constexpr const char* logFormatHex<long double>()
 {
     return "%La";
 }
+template <>
+constexpr const char* logFormatHex<const void*>()
+{
+    return "%p";
+}
 
 template <typename T>
 constexpr const char* logFormatOct()

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logformat.inl
@@ -19,15 +19,14 @@
 
 #include "iceoryx_hoofs/log/building_blocks/logformat.hpp"
 
-#include <atomic>
-#include <cstdint>
-#include <cstring>
-#include <mutex>
-
 namespace iox
 {
 namespace log
 {
+// AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : See at declaration in header
+// AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Octal numbers are required for the terminal color codes and it is
+// checked that only valid digis are used
+
 inline constexpr const char* logLevelDisplayColor(const LogLevel value) noexcept
 {
     switch (value)
@@ -74,167 +73,171 @@ inline constexpr const char* logLevelDisplayText(const LogLevel value) noexcept
     return "[UNDEF]";
 }
 
+// AXIVION ENABLE STYLE AutosarC++19_03-M2.13.2
+
 namespace internal
 {
 template <typename>
 constexpr bool always_false_v{false};
 
 template <typename T>
-constexpr const char* logFormatDec()
+constexpr const char* logFormatDec() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for decimal output!");
     return nullptr;
 }
 template <>
-inline constexpr const char* logFormatDec<signed char>()
+inline constexpr const char* logFormatDec<signed char>() noexcept
 {
     return "%hhi";
 }
 template <>
-inline constexpr const char* logFormatDec<unsigned char>()
+inline constexpr const char* logFormatDec<unsigned char>() noexcept
 {
     return "%hhu";
 }
 template <>
-inline constexpr const char* logFormatDec<short>()
+inline constexpr const char* logFormatDec<short>() noexcept
 {
     return "%hi";
 }
 template <>
-inline constexpr const char* logFormatDec<unsigned short>()
+inline constexpr const char* logFormatDec<unsigned short>() noexcept
 {
     return "%hu";
 }
 template <>
-inline constexpr const char* logFormatDec<int>()
+inline constexpr const char* logFormatDec<int>() noexcept
 {
     return "%i";
 }
 template <>
-inline constexpr const char* logFormatDec<unsigned int>()
+inline constexpr const char* logFormatDec<unsigned int>() noexcept
 {
     return "%u";
 }
 template <>
-inline constexpr const char* logFormatDec<long>()
+inline constexpr const char* logFormatDec<long>() noexcept
 {
     return "%li";
 }
 template <>
-inline constexpr const char* logFormatDec<unsigned long>()
+inline constexpr const char* logFormatDec<unsigned long>() noexcept
 {
     return "%lu";
 }
 template <>
-inline constexpr const char* logFormatDec<long long>()
+inline constexpr const char* logFormatDec<long long>() noexcept
 {
     return "%lli";
 }
 template <>
-inline constexpr const char* logFormatDec<unsigned long long>()
+inline constexpr const char* logFormatDec<unsigned long long>() noexcept
 {
     return "%llu";
 }
 template <>
-inline constexpr const char* logFormatDec<float>()
+inline constexpr const char* logFormatDec<float>() noexcept
 {
     return "%.5e";
 }
 template <>
-inline constexpr const char* logFormatDec<double>()
+inline constexpr const char* logFormatDec<double>() noexcept
 {
     return "%.5le";
 }
 template <>
-inline constexpr const char* logFormatDec<long double>()
+inline constexpr const char* logFormatDec<long double>() noexcept
 {
     return "%.5Le";
 }
 
 template <typename T>
-constexpr const char* logFormatHex()
+constexpr const char* logFormatHex() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for hexadecimal output!");
     return nullptr;
 }
 template <>
-constexpr const char* logFormatHex<unsigned char>()
+constexpr const char* logFormatHex<unsigned char>() noexcept
 {
     return "%hhx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned short>()
+constexpr const char* logFormatHex<unsigned short>() noexcept
 {
     return "%hx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned int>()
+constexpr const char* logFormatHex<unsigned int>() noexcept
 {
     return "%x";
 }
 template <>
-constexpr const char* logFormatHex<unsigned long>()
+constexpr const char* logFormatHex<unsigned long>() noexcept
 {
     return "%lx";
 }
 template <>
-constexpr const char* logFormatHex<unsigned long long>()
+constexpr const char* logFormatHex<unsigned long long>() noexcept
 {
     return "%llx";
 }
 template <>
-constexpr const char* logFormatHex<float>()
+constexpr const char* logFormatHex<float>() noexcept
 {
     return "%a";
 }
 template <>
-constexpr const char* logFormatHex<double>()
+constexpr const char* logFormatHex<double>() noexcept
 {
     return "%la";
 }
 template <>
-constexpr const char* logFormatHex<long double>()
+constexpr const char* logFormatHex<long double>() noexcept
 {
     return "%La";
 }
 template <>
-constexpr const char* logFormatHex<const void*>()
+constexpr const char* logFormatHex<const void*>() noexcept
 {
     return "%p";
 }
 
 template <typename T>
-constexpr const char* logFormatOct()
+constexpr const char* logFormatOct() noexcept
 {
     static_assert(always_false_v<T>, "This type is not supported for octal output!");
     return nullptr;
 }
 template <>
-constexpr const char* logFormatOct<unsigned char>()
+constexpr const char* logFormatOct<unsigned char>() noexcept
 {
     return "%hho";
 }
 template <>
-constexpr const char* logFormatOct<unsigned short>()
+constexpr const char* logFormatOct<unsigned short>() noexcept
 {
     return "%ho";
 }
 template <>
-constexpr const char* logFormatOct<unsigned int>()
+constexpr const char* logFormatOct<unsigned int>() noexcept
 {
     return "%o";
 }
 template <>
-constexpr const char* logFormatOct<unsigned long>()
+constexpr const char* logFormatOct<unsigned long>() noexcept
 {
     return "%lo";
 }
 template <>
-constexpr const char* logFormatOct<unsigned long long>()
+constexpr const char* logFormatOct<unsigned long long>() noexcept
 {
     return "%llo";
 }
 } // namespace internal
+
+// AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
 
 } // namespace log
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logger.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/building_blocks/logger.inl
@@ -30,7 +30,7 @@ namespace iox
 namespace log
 {
 template <uint32_t N>
-// NOLINTJUSTIFICATION see at declaration in header
+// NOLINTJUSTIFICATION See at declaration in header
 // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
 inline bool equalStrings(const char* lhs, const char (&rhs)[N]) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -24,8 +24,8 @@
 
 namespace iox
 {
-// AXIVION Next Construct AutosarC++19_03-M2.10.1 log is a sensible namespace for a logger; furthermore it is in the iox
-// namespace and when used as function the compiler will complain
+// AXIVION Next Construct AutosarC++19_03-M2.10.1 : log is a sensible namespace for a logger; furthermore it is in the
+// iox namespace and when used as function the compiler will complain
 namespace log
 {
 template <typename T>
@@ -35,14 +35,14 @@ constexpr LogHex<T>::LogHex(const T value) noexcept
 {
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : See at declaration in header
 template <typename T, typename>
-// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
 inline constexpr LogHex<T> hex(const T value) noexcept
 {
     return LogHex<T>(value);
 }
 
-// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : See at declaration in header
 inline LogHex<const void* const> hex(const void* const ptr) noexcept
 {
     return LogHex<const void* const>(ptr);
@@ -55,15 +55,15 @@ constexpr LogOct<T>::LogOct(const T value) noexcept
 {
 }
 
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : See at declaration in header
 template <typename T, typename>
-// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
 inline constexpr LogOct<T> oct(const T value) noexcept
 {
     return LogOct<T>(value);
 }
 
 /// @todo iox-#1345 use something like 'source_location'
-// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
 // NOLINTNEXTLINE(readability-function-size)
 inline LogStream::LogStream(
     Logger& logger, const char* file, const int line, const char* function, LogLevel logLevel) noexcept
@@ -72,7 +72,7 @@ inline LogStream::LogStream(
     m_logger.createLogMessageHeader(file, line, function, logLevel);
 }
 
-// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
 inline LogStream::LogStream(const char* file, const int line, const char* function, LogLevel logLevel) noexcept
     : LogStream(Logger::get(), file, line, function, logLevel)
 {
@@ -105,9 +105,9 @@ inline LogStream& LogStream::self() noexcept
     return *this;
 }
 
-// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const char* cstr) noexcept
 {
     m_logger.logString(cstr);
@@ -115,8 +115,8 @@ inline LogStream& LogStream::operator<<(const char* cstr) noexcept
     return *this;
 }
 
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const std::string& str) noexcept
 {
     m_logger.logString(str.c_str());
@@ -124,17 +124,17 @@ inline LogStream& LogStream::operator<<(const std::string& str) noexcept
     return *this;
 }
 
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const bool val) noexcept
 {
     m_logger.logBool(val);
     return *this;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool>>
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
 inline LogStream& LogStream::operator<<(const T val) noexcept
 {
     m_logger.logDec(val);
@@ -142,9 +142,9 @@ inline LogStream& LogStream::operator<<(const T val) noexcept
     return *this;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
     m_logger.logString("0x");
@@ -153,9 +153,9 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, bool>>
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
     m_logger.logHex(val.m_value);
@@ -163,8 +163,8 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<const void* const> val) noexcept
 {
     m_logger.logHex(val.m_value);
@@ -172,9 +172,9 @@ inline LogStream& LogStream::operator<<(const LogHex<const void* const> val) noe
     return *this;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
 {
     m_logger.logString("0o");
@@ -183,16 +183,16 @@ inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
     return *this;
 }
 
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 template <typename Callable, typename>
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
 inline LogStream& LogStream::operator<<(const Callable& c) noexcept
 {
     return c(*this);
 }
 
-// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
-// require to implement '<<='
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogLevel value) noexcept
 {
     m_logger.logString(asStringLiteral(value));

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -43,11 +43,9 @@ inline constexpr LogHex<T> hex(const T value) noexcept
 }
 
 // AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
-inline LogHex<uint64_t> hex(const void* const ptr) noexcept
+inline LogHex<const void* const> hex(const void* const ptr) noexcept
 {
-    /// @todo iox-#1345 don't cast but print a pointer with the '%p' format specifier instead
-    // to JUSTIFICATION needed to print the pointer NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return LogHex<uint64_t>(reinterpret_cast<uint64_t>(ptr));
+    return LogHex<const void* const>(ptr);
 }
 
 template <typename T>
@@ -165,6 +163,15 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
+inline LogStream& LogStream::operator<<(const LogHex<const void* const> val) noexcept
+{
+    m_logger.logHex(val.m_value);
+    m_isFlushed = false;
+    return *this;
+}
+
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
 // AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
 // require to implement '<<='
@@ -179,7 +186,7 @@ inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
 template <typename Callable, typename>
 // AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
 // require to implement '<<='
-inline LogStream& LogStream::operator<<(const Callable&& c) noexcept
+inline LogStream& LogStream::operator<<(const Callable& c) noexcept
 {
     return c(*this);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -24,6 +24,8 @@
 
 namespace iox
 {
+// AXIVION Next Construct AutosarC++19_03-M2.10.1 log is a sensible namespace for a logger; furthermore it is in the iox
+// namespace and when used as function the compiler will complain
 namespace log
 {
 template <typename T>
@@ -34,15 +36,17 @@ constexpr LogHex<T>::LogHex(const T value) noexcept
 }
 
 template <typename T, typename>
+// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
 inline constexpr LogHex<T> hex(const T value) noexcept
 {
     return LogHex<T>(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
 inline LogHex<uint64_t> hex(const void* const ptr) noexcept
 {
-    // JUSTIFICATION needed to print the pointer
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    /// @todo iox-#1345 don't cast but print a pointer with the '%p' format specifier instead
+    // to JUSTIFICATION needed to print the pointer NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return LogHex<uint64_t>(reinterpret_cast<uint64_t>(ptr));
 }
 
@@ -54,12 +58,14 @@ constexpr LogOct<T>::LogOct(const T value) noexcept
 }
 
 template <typename T, typename>
+// AXIVION Next Line AutosarC++19_03-M17.0.3 see corresponding header
 inline constexpr LogOct<T> oct(const T value) noexcept
 {
     return LogOct<T>(value);
 }
 
 /// @todo iox-#1345 use something like 'source_location'
+// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
 // NOLINTNEXTLINE(readability-function-size)
 inline LogStream::LogStream(
     Logger& logger, const char* file, const int line, const char* function, LogLevel logLevel) noexcept
@@ -68,6 +74,7 @@ inline LogStream::LogStream(
     m_logger.createLogMessageHeader(file, line, function, logLevel);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
 inline LogStream::LogStream(const char* file, const int line, const char* function, LogLevel logLevel) noexcept
     : LogStream(Logger::get(), file, line, function, logLevel)
 {
@@ -100,6 +107,9 @@ inline LogStream& LogStream::self() noexcept
     return *this;
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 see corresponding header
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const char* cstr) noexcept
 {
     m_logger.logString(cstr);
@@ -107,6 +117,8 @@ inline LogStream& LogStream::operator<<(const char* cstr) noexcept
     return *this;
 }
 
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const std::string& str) noexcept
 {
     m_logger.logString(str.c_str());
@@ -114,13 +126,17 @@ inline LogStream& LogStream::operator<<(const std::string& str) noexcept
     return *this;
 }
 
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const bool val) noexcept
 {
     m_logger.logBool(val);
     return *this;
 }
 
-template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool>>
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const T val) noexcept
 {
     m_logger.logDec(val);
@@ -128,7 +144,9 @@ inline LogStream& LogStream::operator<<(const T val) noexcept
     return *this;
 }
 
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
     m_logger.logString("0x");
@@ -137,7 +155,9 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
-template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, bool>>
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
     m_logger.logHex(val.m_value);
@@ -145,7 +165,9 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
-template <typename T, typename std::enable_if_t<std::is_integral<T>::value, int>>
+template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
 {
     m_logger.logString("0o");
@@ -155,11 +177,15 @@ inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
 }
 
 template <typename Callable, typename>
-inline LogStream& LogStream::operator<<(const Callable&& c)
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
+inline LogStream& LogStream::operator<<(const Callable&& c) noexcept
 {
     return c(*this);
 }
 
+// AXIVION Next Line AutosarC++19_03-M5.17.1 this is not used as shift operator but as stream operator and does not
+// require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogLevel value) noexcept
 {
     m_logger.logString(asStringLiteral(value));

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -78,6 +78,7 @@ inline LogStream::LogStream(const char* file, const int line, const char* functi
 {
 }
 
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
 inline LogStream::LogStream(
     const char* file, const int line, const char* function, LogLevel logLevel, bool doFlush) noexcept
     : m_logger(Logger::get())

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
@@ -58,6 +58,9 @@ class ConsoleLogger
 
     virtual void initLogger(const LogLevel) noexcept;
 
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : file, line and function are used in conjunction with '__FILE__',
+    // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
+    // platform agnostic way
     virtual void
     createLogMessageHeader(const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
 
@@ -67,35 +70,39 @@ class ConsoleLogger
 
     void assumeFlushed() noexcept;
 
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but a low-level C-style string
     void logString(const char* message) noexcept;
 
     void logBool(const bool value) noexcept;
 
-    template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
-    void logDec(const T val) noexcept;
+    template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool> = 0>
+    void logDec(const T value) noexcept;
 
     template <typename T,
               typename std::enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value)
                                             || std::is_floating_point<T>::value || std::is_pointer<T>::value,
-                                        int> = 0>
-    void logHex(const T val) noexcept;
+                                        bool> = 0>
+    void logHex(const T value) noexcept;
 
-    template <typename T, typename std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, int> = 0>
-    void logOct(const T val) noexcept;
+    template <typename T, typename std::enable_if_t<std::is_integral<T>::value && std::is_unsigned<T>::value, bool> = 0>
+    void logOct(const T value) noexcept;
 
   private:
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as actual character
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : C-style array is used to acquire size of the array safely. Safe
+    // access is guaranteed since the char array is not accessed but only the size is obtained
     template <uint32_t N>
-    // NOLINTJUSTIFICATION safe access is guaranteed since the char array is not accessed but only the size is obtained
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
-    inline static constexpr uint32_t bufferSize(const char (&)[N]) noexcept;
+    static constexpr uint32_t bufferSize(const char (&)[N]) noexcept;
 
     template <typename T>
-    inline void unused(T&&) const noexcept;
+    static constexpr void unused(T&&) noexcept;
 
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but format string literal
     template <typename T>
-    inline void logArithmetic(const T value, const char* format) noexcept;
+    static void logArithmetic(const T value, const char* format) noexcept;
 
-    struct ThreadLocalData
+    struct ThreadLocalData final
     {
         ThreadLocalData() noexcept = default;
         ~ThreadLocalData() = default;
@@ -110,14 +117,16 @@ class ConsoleLogger
         static constexpr uint32_t BUFFER_SIZE{1024};
         static constexpr uint32_t NULL_TERMINATED_BUFFER_SIZE{BUFFER_SIZE + 1};
 
-        // NOLINTJUSTIFICATION safe access is guaranteed since the char array is wrapped inside the class
+        // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as actual character
+        // AXIVION Next Construct AutosarC++19_03-A18.1.1 : This is a low-level component with minimal dependencies.
+        // Safe access is guaranteed since the char array is wrapped inside the class
         // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
         char buffer[NULL_TERMINATED_BUFFER_SIZE];
         uint32_t bufferWriteIndex; // initialized in corresponding cpp file
         /// @todo iox-#1345 add thread local storage with thread id and print it in the log messages
     };
 
-    static ThreadLocalData& getThreadLocalData();
+    static ThreadLocalData& getThreadLocalData() noexcept;
 
   private:
     // NOLINTJUSTIFICATION needed for the functionality and a private member of the class

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
@@ -36,6 +36,9 @@ class ConsoleLogger
   public:
     /// @brief Obtain the current log level
     /// @return the current log level
+    /// @note In case this class is used as template for a custom logger implementation keep in mind that this method
+    /// must not have any side effects
+    /// @todo iox-#1345 update the design document with the requirement that this method must not have side effects
     static LogLevel getLogLevel() noexcept;
 
     /// @brief Sets a new log level
@@ -119,7 +122,7 @@ class ConsoleLogger
   private:
     // NOLINTJUSTIFICATION needed for the functionality and a private member of the class
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-    static std::atomic<LogLevel> m_activeLogLevel; // initialized in corresponding cpp file
+    static std::atomic<LogLevel> s_activeLogLevel; // initialized in corresponding cpp file
 };
 
 } // namespace log

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/console_logger.hpp
@@ -76,7 +76,7 @@ class ConsoleLogger
 
     template <typename T,
               typename std::enable_if_t<(std::is_integral<T>::value && std::is_unsigned<T>::value)
-                                            || std::is_floating_point<T>::value,
+                                            || std::is_floating_point<T>::value || std::is_pointer<T>::value,
                                         int> = 0>
     void logHex(const T val) noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logformat.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logformat.hpp
@@ -52,31 +52,31 @@ namespace internal
 template <typename T>
 constexpr const char* logFormatDec() noexcept;
 template <>
-inline constexpr const char* logFormatDec<signed char>() noexcept;
+constexpr const char* logFormatDec<signed char>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<unsigned char>() noexcept;
+constexpr const char* logFormatDec<unsigned char>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<short>() noexcept;
+constexpr const char* logFormatDec<short>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<unsigned short>() noexcept;
+constexpr const char* logFormatDec<unsigned short>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<int>() noexcept;
+constexpr const char* logFormatDec<int>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<unsigned int>() noexcept;
+constexpr const char* logFormatDec<unsigned int>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<long>() noexcept;
+constexpr const char* logFormatDec<long>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<unsigned long>() noexcept;
+constexpr const char* logFormatDec<unsigned long>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<long long>() noexcept;
+constexpr const char* logFormatDec<long long>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<unsigned long long>() noexcept;
+constexpr const char* logFormatDec<unsigned long long>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<float>() noexcept;
+constexpr const char* logFormatDec<float>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<double>() noexcept;
+constexpr const char* logFormatDec<double>() noexcept;
 template <>
-inline constexpr const char* logFormatDec<long double>() noexcept;
+constexpr const char* logFormatDec<long double>() noexcept;
 
 template <typename T>
 constexpr const char* logFormatHex() noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logformat.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logformat.hpp
@@ -26,6 +26,10 @@ namespace iox
 {
 namespace log
 {
+// AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : Basic numeric types are used in order to get the correct format string
+// on all platforms. Fixed width types are used on a higher abstraction layer. Furthermore are 'const char*' used for
+// string literals with static lifetime and as a pointer to a buffer of character
+
 /// @brief converts LogLevel into a string literal color code
 /// @param[in] value the LogLevel to convert
 /// @return string literal of the corresponding color code
@@ -46,26 +50,82 @@ struct LogBuffer
 namespace internal
 {
 template <typename T>
-constexpr const char* logFormatDec();
+constexpr const char* logFormatDec() noexcept;
+template <>
+inline constexpr const char* logFormatDec<signed char>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<unsigned char>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<short>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<unsigned short>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<int>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<unsigned int>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<long>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<unsigned long>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<long long>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<unsigned long long>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<float>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<double>() noexcept;
+template <>
+inline constexpr const char* logFormatDec<long double>() noexcept;
 
 template <typename T>
-constexpr const char* logFormatHex();
+constexpr const char* logFormatHex() noexcept;
+template <>
+constexpr const char* logFormatHex<unsigned char>() noexcept;
+template <>
+constexpr const char* logFormatHex<unsigned short>() noexcept;
+template <>
+constexpr const char* logFormatHex<unsigned int>() noexcept;
+template <>
+constexpr const char* logFormatHex<unsigned long>() noexcept;
+template <>
+constexpr const char* logFormatHex<unsigned long long>() noexcept;
+template <>
+constexpr const char* logFormatHex<float>() noexcept;
+template <>
+constexpr const char* logFormatHex<double>() noexcept;
+template <>
+constexpr const char* logFormatHex<long double>() noexcept;
+template <>
+constexpr const char* logFormatHex<const void*>() noexcept;
 
 template <typename T>
-constexpr const char* logFormatOct();
+constexpr const char* logFormatOct() noexcept;
+template <>
+constexpr const char* logFormatOct<unsigned char>() noexcept;
+template <>
+constexpr const char* logFormatOct<unsigned short>() noexcept;
+template <>
+constexpr const char* logFormatOct<unsigned int>() noexcept;
+template <>
+constexpr const char* logFormatOct<unsigned long>() noexcept;
+template <>
+constexpr const char* logFormatOct<unsigned long long>() noexcept;
 } // namespace internal
 
 /// @brief printf-like format string for decimal formatting of numbers
 template <typename T>
-static constexpr const char* LOG_FORMAT_DEC = internal::logFormatDec<T>();
+static constexpr const char* LOG_FORMAT_DEC{internal::logFormatDec<T>()};
 
 /// @brief printf-like format string for hexadecimal formatting of numbers
 template <typename T>
-static constexpr const char* LOG_FORMAT_HEX = internal::logFormatHex<T>();
+static constexpr const char* LOG_FORMAT_HEX{internal::logFormatHex<T>()};
 
 /// @brief printf-like format string for octal formatting of numbers
 template <typename T>
-static constexpr const char* LOG_FORMAT_OCT = internal::logFormatOct<T>();
+static constexpr const char* LOG_FORMAT_OCT{internal::logFormatOct<T>()};
+
+// AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
 
 } // namespace log
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logger.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/building_blocks/logger.hpp
@@ -77,8 +77,8 @@ class Logger : public BaseLogger
 
     /// @brief Initializes the logger
     /// @param[in] logLevel the log level which will be used to determine which messages will be logged. By default it
-    /// is everything with a log level higher than specified by the `IOX_LOG_LEVEL` environment variable or equal to
-    /// `INFO` if the environment variable is not set.
+    /// is everything with a log level higher than specified by the 'IOX_LOG_LEVEL' environment variable or equal to
+    /// 'INFO' if the environment variable is not set.
     /// @note The function uses 'getenv' which is not thread safe and can result in undefined behavior when it is called
     /// from multiple threads or the env variable is changed while the function holds a pointer to the data. For this
     /// reason the function should only be used in the startup phase of the application and only in the main thread.
@@ -86,7 +86,7 @@ class Logger : public BaseLogger
 
     /// @brief Replaces the default logger with the specified one
     /// @param[in] newLogger is the logger which shall be used after the call
-    /// @note this must be called before `init`. If this is called after `init` or called multiple times, the current
+    /// @note this must be called before 'init'. If this is called after 'init' or called multiple times, the current
     /// logger will not be replaced and an error message will be logged in the current and the provided new logger.
     static void setActiveLogger(Logger& newLogger) noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
@@ -53,10 +53,11 @@ inline bool isLogLevelActive(LogLevel logLevel) noexcept
 ///     IOX_LOG(INFO) << "Hello World";
 /// @endcode
 // AXIVION Next Construct AutosarC++19_03-A16.0.1 needed for source code location, safely wrapped in macro
-// AXIVION Next Construct AutosarC++19_03-M16.0.6 brackets around macro parameter would lead to compile time
-// failures in this case// NOLINTJUSTIFICATION __PRETTY_FUNCTION__ would work better in lambdas but especially with
+// AXIVION Next Construct AutosarC++19_03-M16.0.6 brackets around macro parameter would lead to compile time failures in this case
+// NOLINTJUSTIFICATION __PRETTY_FUNCTION__ would work better in lambdas but especially with
 // templates the resulting string is too large; we also get the file name and the line of the invocation which should be
-// sufficient for debugging NOLINTBEGIN(bugprone-lambda-function-name)
+// sufficient for debugging
+// NOLINTBEGIN(bugprone-lambda-function-name)
 #define IOX_LOG(level)                                                                                                 \
     IOX_LOG_INTERNAL(__FILE__, __LINE__, static_cast<const char*>(__FUNCTION__), iox::log::LogLevel::level)
 // NOLINTEND(bugprone-lambda-function-name)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
@@ -44,7 +44,7 @@ inline bool isLogLevelActive(LogLevel logLevel) noexcept
 // intended lazy evaluation technique with the if statement
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define IOX_LOG_INTERNAL(file, line, function, level)                                                                  \
-    /* if (iox::log::internal::isLogLevelActive(level)) @todo iox-#1345 temporary workaround */                        \
+    /* if (iox::log::internal::isLogLevelActive(level)) @todo iox-#1345 lazy evaluation causes issues with Axivion */  \
     iox::log::LogStream(file, line, function, level, iox::log::internal::isLogLevelActive(level)).self()
 
 /// @brief Macro for logging

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -116,7 +116,17 @@ class LogStream
     // platform agnostic way
     LogStream(const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
 
-    /// @todo iox-#1345 temporary workaround
+    /// @brief Constructor for a LogStream object with the logger from iox::log::Logger::get
+    /// @note This is not intended for public use! Use the 'IOX_LOG' macro instead
+    /// @param[in] file the file of the log message. Please use the '__FILE__' compiler intrinsic
+    /// @param[in] line the line of the log message. Please use the '__LINE__' compiler intrinsic
+    /// @param[in] function the function of the log message. Please use the '__FUNCTION__' compiler intrinsic
+    /// @param[in] logLevel is the log level for the log message
+    /// @todo iox-#1345 temporary workaround due to lazy evaluation issues with Axivion; should be removed when the
+    /// lazy evaluation can be implemented in an way Axivion does not complain
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : file, line and function are used in conjunction with '__FILE__',
+    // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
+    // platform agnostic way
     LogStream(const char* file, const int line, const char* function, LogLevel logLevel, bool doFlush) noexcept;
 
     virtual ~LogStream() noexcept;
@@ -213,7 +223,7 @@ class LogStream
     Logger& m_logger;
     bool m_isFlushed{false};
 
-    /// @todo iox-#1345 temporary workaround
+    /// @todo iox-#1345 workaround due to deactivation of lazy evaluation
     bool m_doFlush{true};
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -47,14 +47,14 @@ class LogHex
 /// @tparam[in] T the arithmetic data type of the value to log
 /// @param[in] value to be logged
 /// @return a helper struct which will be used by the LogStream
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : The function is in the iox::log namespace which prevents easy misuse
 template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
-// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
 constexpr LogHex<T> hex(const T value) noexcept;
 
 /// @brief Log a pointer in hexadecimal format
 /// @param[in] ptr is the pointer to be logged
 /// @return a helper struct which will be used by the LogStream
-// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : The function is in the iox::log namespace which prevents easy misuse
 LogHex<const void* const> hex(const void* const ptr) noexcept;
 
 /// @brief Helper struct to log in octal format
@@ -75,8 +75,8 @@ class LogOct
 /// @tparam[in] T the arithmetic data type of the value to log
 /// @param[in] value to be logged
 /// @return a helper struct which will be used by the LogStream
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : The function is in the iox::log namespace which prevents easy misuse
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
-// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
 inline constexpr LogOct<T> oct(const T value) noexcept;
 
 /// @todo iox-#1345 implement LogBin and LogRawBuffer
@@ -100,7 +100,7 @@ class LogStream
     /// @param[in] line the line of the log message. Please use the '__LINE__' compiler intrinsic
     /// @param[in] function the function of the log message. Please use the '__FUNCTION__' compiler intrinsic
     /// @param[in] logLevel is the log level for the log message
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 file, line and function are used in conjunction with '__FILE__',
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : file, line and function are used in conjunction with '__FILE__',
     // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
     // platform agnostic way
     LogStream(Logger& logger, const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
@@ -111,7 +111,7 @@ class LogStream
     /// @param[in] line the line of the log message. Please use the '__LINE__' compiler intrinsic
     /// @param[in] function the function of the log message. Please use the '__FUNCTION__' compiler intrinsic
     /// @param[in] logLevel is the log level for the log message
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 file, line and function are used in conjunction with '__FILE__',
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : file, line and function are used in conjunction with '__FILE__',
     // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
     // platform agnostic way
     LogStream(const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
@@ -136,7 +136,7 @@ class LogStream
     /// @brief Logging support for C-style strings
     /// @param[in] cstr is the C-style string to log
     /// @return a reference to the LogStream instance
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 logging support for C-style strings
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Logging support for C-style strings
     LogStream& operator<<(const char* cstr) noexcept;
 
     /// @brief Logging support for std::string

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -48,11 +48,13 @@ class LogHex
 /// @param[in] value to be logged
 /// @return a helper struct which will be used by the LogStream
 template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
 constexpr LogHex<T> hex(const T value) noexcept;
 
 /// @brief Log a pointer in hexadecimal format
 /// @param[in] ptr is the pointer to be logged
 /// @return a helper struct which will be used by the LogStream
+// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
 LogHex<uint64_t> hex(const void* const ptr) noexcept;
 
 /// @brief Helper struct to log in octal format
@@ -74,12 +76,13 @@ class LogOct
 /// @param[in] value to be logged
 /// @return a helper struct which will be used by the LogStream
 template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
+// AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
 inline constexpr LogOct<T> oct(const T value) noexcept;
 
 /// @todo iox-#1345 implement LogBin and LogRawBuffer
 
-/// @brief This class provides the public interface to the logger and is used with the `IOX_LOG` macro. In order to add
-/// support for custom data types `operator<<` needs to be implement for the custom type.
+/// @brief This class provides the public interface to the logger and is used with the 'IOX_LOG' macro. In order to add
+/// support for custom data types 'operator<<' needs to be implement for the custom type.
 /// @code
 /// iox::log::LogStream& operator<<(iox::log::LogStream& stream, const MyType& myType) noexcept
 /// {
@@ -91,20 +94,26 @@ class LogStream
 {
   public:
     /// @brief Constructor for a LogStream object with an externally provided logger
-    /// @note This is not intended for public use! Use the `IOX_LOG` macro instead
+    /// @note This is not intended for public use! Use the 'IOX_LOG' macro instead
     /// @param[in] logger to be used by the LogStream instance
-    /// @param[in] file the file of the log message. Please use the `__FILE__` compiler intrinsic
-    /// @param[in] line the line of the log message. Please use the `__LINE__` compiler intrinsic
-    /// @param[in] function the function of the log message. Please use the `__FUNCTION__` compiler intrinsic
+    /// @param[in] file the file of the log message. Please use the '__FILE__' compiler intrinsic
+    /// @param[in] line the line of the log message. Please use the '__LINE__' compiler intrinsic
+    /// @param[in] function the function of the log message. Please use the '__FUNCTION__' compiler intrinsic
     /// @param[in] logLevel is the log level for the log message
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 file, line and function are used in conjunction with '__FILE__',
+    // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
+    // platform agnostic way
     LogStream(Logger& logger, const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
 
     /// @brief Constructor for a LogStream object with the logger from iox::log::Logger::get
-    /// @note This is not intended for public use! Use the `IOX_LOG` macro instead
-    /// @param[in] file the file of the log message. Please use the `__FILE__` compiler intrinsic
-    /// @param[in] line the line of the log message. Please use the `__LINE__` compiler intrinsic
-    /// @param[in] function the function of the log message. Please use the `__FUNCTION__` compiler intrinsic
+    /// @note This is not intended for public use! Use the 'IOX_LOG' macro instead
+    /// @param[in] file the file of the log message. Please use the '__FILE__' compiler intrinsic
+    /// @param[in] line the line of the log message. Please use the '__LINE__' compiler intrinsic
+    /// @param[in] function the function of the log message. Please use the '__FUNCTION__' compiler intrinsic
     /// @param[in] logLevel is the log level for the log message
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 file, line and function are used in conjunction with '__FILE__',
+    // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
+    // platform agnostic way
     LogStream(const char* file, const int line, const char* function, LogLevel logLevel) noexcept;
 
     /// @todo iox-#1345 temporary workaround
@@ -127,6 +136,7 @@ class LogStream
     /// @brief Logging support for C-style strings
     /// @param[in] cstr is the C-style string to log
     /// @return a reference to the LogStream instance
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 logging support for C-style strings
     LogStream& operator<<(const char* cstr) noexcept;
 
     /// @brief Logging support for std::string
@@ -145,33 +155,33 @@ class LogStream
     /// @tparam[in] T is the arithmetic data type of the value to log
     /// @param[in] val is the number to log
     /// @return a reference to the LogStream instance
-    template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
+    template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool> = 0>
     LogStream& operator<<(const T val) noexcept;
 
     /// @brief Logging support for integral numbers in hexadecimal format
     /// @tparam[in] T is the integral data type of the value to log
     /// @param[in] val is the number to log
     /// @return a reference to the LogStream instance
-    template <typename T, typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+    template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = 0>
     LogStream& operator<<(const LogHex<T> val) noexcept;
 
     /// @brief Logging support for floating point numbers in hexadecimal format
     /// @tparam[in] T is the floating point data type of the value to log
     /// @param[in] val is the number to log
     /// @return a reference to the LogStream instance
-    template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, int> = 0>
+    template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, bool> = 0>
     LogStream& operator<<(const LogHex<T> val) noexcept;
 
     /// @brief Logging support for integral numbers in octal format
     /// @tparam[in] T is the integral data type of the value to log
     /// @param[in] val is the number to log
     /// @return a reference to the LogStream instance
-    template <typename T, typename std::enable_if_t<std::is_integral<T>::value, int> = 0>
+    template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool> = 0>
     LogStream& operator<<(const LogOct<T> val) noexcept;
 
     /// @brief Logging support for callable. This gives access to the LogStream instance which e.g. can be used in a
     /// loop
-    /// @tparam[in] Callable with a signature `iox::log::LogStream&(iox::log::LogStream&)`
+    /// @tparam[in] Callable with a signature 'iox::log::LogStream&(iox::log::LogStream&)'
     /// @param[in] c is the callable which receives a LogStream object for the actual logging
     /// @code
     /// IOX_LOG(INFO) << [] (auto& stream) -> auto& {
@@ -183,7 +193,7 @@ class LogStream
     /// @endcode
     template <typename Callable,
               typename = std::enable_if_t<cxx::is_invocable_r<LogStream&, Callable, LogStream&>::value>>
-    LogStream& operator<<(const Callable&& c);
+    LogStream& operator<<(const Callable&& c) noexcept;
 
     /// @brief Logging support for LogLevel
     /// @param[in] value is the LogLevel to log

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -36,7 +36,7 @@ class LogHex
   public:
     friend class LogStream;
 
-    template <typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+    template <typename = std::enable_if_t<std::is_arithmetic<T>::value || std::is_pointer<T>::value>>
     explicit constexpr LogHex(const T value) noexcept;
 
   private:
@@ -55,7 +55,7 @@ constexpr LogHex<T> hex(const T value) noexcept;
 /// @param[in] ptr is the pointer to be logged
 /// @return a helper struct which will be used by the LogStream
 // AXIVION Next Line AutosarC++19_03-M17.0.3 the function is in the iox::log namespace which prevents easy misuse
-LogHex<uint64_t> hex(const void* const ptr) noexcept;
+LogHex<const void* const> hex(const void* const ptr) noexcept;
 
 /// @brief Helper struct to log in octal format
 template <typename T>
@@ -172,6 +172,11 @@ class LogStream
     template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, bool> = 0>
     LogStream& operator<<(const LogHex<T> val) noexcept;
 
+    /// @brief Logging support for pointer in hexadecimal format
+    /// @param[in] val is the pointer to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const LogHex<const void* const> val) noexcept;
+
     /// @brief Logging support for integral numbers in octal format
     /// @tparam[in] T is the integral data type of the value to log
     /// @param[in] val is the number to log
@@ -193,7 +198,7 @@ class LogStream
     /// @endcode
     template <typename Callable,
               typename = std::enable_if_t<cxx::is_invocable_r<LogStream&, Callable, LogStream&>::value>>
-    LogStream& operator<<(const Callable&& c) noexcept;
+    LogStream& operator<<(const Callable& c) noexcept;
 
     /// @brief Logging support for LogLevel
     /// @param[in] value is the LogLevel to log

--- a/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
+++ b/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
@@ -27,11 +27,11 @@ namespace iox
 {
 namespace log
 {
-// NOLINTJUSTIFICATION see at declaration in header
+// NOLINTJUSTIFICATION See at declaration in header
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<LogLevel> ConsoleLogger::s_activeLogLevel{LogLevel::INFO};
 
-ConsoleLogger::ThreadLocalData& ConsoleLogger::getThreadLocalData()
+ConsoleLogger::ThreadLocalData& ConsoleLogger::getThreadLocalData() noexcept
 {
     thread_local static ThreadLocalData data;
     return data;
@@ -47,6 +47,9 @@ void ConsoleLogger::setLogLevel(const LogLevel logLevel) noexcept
     s_activeLogLevel.store(logLevel, std::memory_order_relaxed);
 }
 
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
+// AXIVION Next Construct AutosarC++19_03-M9.3.3 : This is the default implementation for a logger. The design requires
+// this to be non-static to not restrict custom implementations
 void ConsoleLogger::createLogMessageHeader(const char* file,
                                            const int line,
                                            const char* function,
@@ -59,21 +62,23 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
         // intentionally do nothing since a timestamp from 01.01.1970 already indicates  an issue with the clock
     }
 
-    time_t time = timestamp.tv_sec;
+    const time_t time{timestamp.tv_sec};
 
 /// @todo iox-#1345 since this will be part of the platform at one point, we might not be able to handle this via the
 /// platform abstraction; re-evaluate this when the move to the platform happens
 #if defined(_WIN32)
     // seems to be thread-safe on Windows
-    auto* timeInfo = localtime(&time);
+    const auto* timeInfo = localtime(&time);
 #else
     // NOLINTJUSTIFICATION will be initialized with the call to localtime_r in the statement after the declaration
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
     struct tm calendarData;
-    auto* timeInfo = localtime_r(&time, &calendarData);
+    const auto* timeInfo = localtime_r(&time, &calendarData);
 #endif
 
-    // NOLINTJUSTIFICATION this is used to get the size for the buffer where strftime writes the local time
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as actual character
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : This is used to get the size for the buffer where strftime
+    // writes the local time
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     constexpr const char TIME_FORMAT[]{"0000-00-00 00:00:00"};
     constexpr uint32_t NULL_TERMINATION{1};
@@ -81,16 +86,18 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
     constexpr auto NULL_TERMINATED_TIMESTAMP_BUFFER_SIZE{ConsoleLogger::bufferSize(TIME_FORMAT) + YEAR_1M_PROBLEM
                                                          + NULL_TERMINATION};
 
-    // NOLINTJUSTIFICATION required for strftime and safe since array bounds are taken into account
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as actual character
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : Required for strftime and safe since array bounds are taken into
+    // account
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     char timestampString[NULL_TERMINATED_TIMESTAMP_BUFFER_SIZE]{0};
 
     bool timeStampConversionSuccessful{false};
     if (timeInfo != nullptr)
     {
-        auto strftimeRetVal =
+        const auto strftimeRetVal =
             strftime(&timestampString[0], NULL_TERMINATED_TIMESTAMP_BUFFER_SIZE, "%Y-%m-%d %H:%M:%S", timeInfo);
-        timeStampConversionSuccessful = (strftimeRetVal != 0);
+        timeStampConversionSuccessful = strftimeRetVal != 0;
     }
 
     if (!timeStampConversionSuccessful)
@@ -100,30 +107,34 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
         strncpy(&timestampString[0], &TIME_FORMAT[0], ConsoleLogger::bufferSize(TIME_FORMAT));
     }
 
-    constexpr auto MILLISECS_PER_SECOND{1000};
-    auto milliseconds = static_cast<int32_t>(timestamp.tv_nsec % MILLISECS_PER_SECOND);
+    constexpr uint32_t MILLISECS_PER_SECOND{1000};
+    const auto milliseconds = static_cast<int32_t>(timestamp.tv_nsec % MILLISECS_PER_SECOND);
 
     /// @todo iox-#1345 do we also want to always log the iceoryx version and commit sha? Maybe do that only in
-    /// `initLogger` with LogDebug
+    /// 'initLogger' with LogDebug
 
     /// @todo iox-#1345 add an option to also print file, line and function
     unused(file);
     unused(line);
     unused(function);
 
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as string literal
+    // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
     constexpr const char* COLOR_GRAY{"\033[0;90m"};
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as string literal
+    // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
     constexpr const char* COLOR_RESET{"\033[m"};
     // NOLINTJUSTIFICATION snprintf required to populate char array so that it can be flushed in one piece
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
-    auto retVal = snprintf(&getThreadLocalData().buffer[0],
-                           ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE,
-                           "%s%s.%03d %s%s%s: ",
-                           COLOR_GRAY,
-                           &timestampString[0],
-                           milliseconds,
-                           logLevelDisplayColor(logLevel),
-                           logLevelDisplayText(logLevel),
-                           COLOR_RESET);
+    const auto retVal = snprintf(&getThreadLocalData().buffer[0],
+                                 ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE,
+                                 "%s%s.%03d %s%s%s: ",
+                                 COLOR_GRAY,
+                                 &timestampString[0],
+                                 milliseconds,
+                                 logLevelDisplayColor(logLevel),
+                                 logLevelDisplayText(logLevel),
+                                 COLOR_RESET);
     if (retVal < 0)
     {
         /// @todo iox-#1345 this path should never be reached since we ensured the correct encoding of the character
@@ -132,7 +143,7 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
     }
     else
     {
-        auto stringSizeToLog = static_cast<uint32_t>(retVal);
+        const auto stringSizeToLog = static_cast<uint32_t>(retVal);
         if (stringSizeToLog <= ThreadLocalData::BUFFER_SIZE)
         {
             getThreadLocalData().bufferWriteIndex = stringSizeToLog;
@@ -157,7 +168,8 @@ void ConsoleLogger::flush() noexcept
     assumeFlushed();
 }
 
-// NOLINTJUSTIFICATION member access is required
+// AXIVION Next Construct AutosarC++19_03-M9.3.3 : This is the default implementation for a logger. The design requires
+// this to be non-static to not restrict custom implementations
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 LogBuffer ConsoleLogger::getLogBuffer() const noexcept
 {
@@ -165,7 +177,8 @@ LogBuffer ConsoleLogger::getLogBuffer() const noexcept
     return LogBuffer{&data.buffer[0], data.bufferWriteIndex};
 }
 
-// NOLINTJUSTIFICATION member access is required
+// AXIVION Next Construct AutosarC++19_03-M9.3.3 : This is the default implementation for a logger. The design requires
+// this to be non-static to not restrict custom implementations
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void ConsoleLogger::assumeFlushed() noexcept
 {
@@ -174,7 +187,8 @@ void ConsoleLogger::assumeFlushed() noexcept
     data.bufferWriteIndex = 0;
 }
 
-// NOLINTJUSTIFICATION member access is required
+// AXIVION Next Construct AutosarC++19_03-M9.3.3 : This is the default implementation for a logger. The design requires
+// this to be non-static to not restrict custom implementations
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 void ConsoleLogger::logString(const char* message) noexcept
 {
@@ -183,10 +197,10 @@ void ConsoleLogger::logString(const char* message) noexcept
     // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
     // NOLINTJUSTIFICATION it is ensured that the index cannot be out of bounds
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-    auto retVal = snprintf(&data.buffer[data.bufferWriteIndex],
-                           ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE - data.bufferWriteIndex,
-                           "%s",
-                           message);
+    const auto retVal = snprintf(&data.buffer[data.bufferWriteIndex],
+                                 ThreadLocalData::NULL_TERMINATED_BUFFER_SIZE - data.bufferWriteIndex,
+                                 "%s",
+                                 message);
     // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 
     if (retVal < 0)
@@ -197,8 +211,8 @@ void ConsoleLogger::logString(const char* message) noexcept
     }
     else
     {
-        auto stringSizeToLog = static_cast<uint32_t>(retVal);
-        auto bufferWriteIndexNext = data.bufferWriteIndex + stringSizeToLog;
+        const auto stringSizeToLog = static_cast<uint32_t>(retVal);
+        const auto bufferWriteIndexNext = data.bufferWriteIndex + stringSizeToLog;
         if (bufferWriteIndexNext <= ThreadLocalData::BUFFER_SIZE)
         {
             data.bufferWriteIndex = bufferWriteIndexNext;
@@ -218,6 +232,8 @@ void ConsoleLogger::logBool(const bool value) noexcept
     logString(value ? "true" : "false");
 }
 
+// AXIVION Next Construct AutosarC++19_03-M9.3.3 : This is the default implementation for a logger. The design requires
+// this to be non-const to enable custom initialization
 void ConsoleLogger::initLogger(const LogLevel) noexcept
 {
     // nothing to do in the base implementation

--- a/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
+++ b/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
@@ -29,7 +29,7 @@ namespace log
 {
 // NOLINTJUSTIFICATION see at declaration in header
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::atomic<LogLevel> ConsoleLogger::m_activeLogLevel{LogLevel::INFO};
+std::atomic<LogLevel> ConsoleLogger::s_activeLogLevel{LogLevel::INFO};
 
 ConsoleLogger::ThreadLocalData& ConsoleLogger::getThreadLocalData()
 {
@@ -39,12 +39,12 @@ ConsoleLogger::ThreadLocalData& ConsoleLogger::getThreadLocalData()
 
 LogLevel ConsoleLogger::getLogLevel() noexcept
 {
-    return m_activeLogLevel.load(std::memory_order_relaxed);
+    return s_activeLogLevel.load(std::memory_order_relaxed);
 }
 
 void ConsoleLogger::setLogLevel(const LogLevel logLevel) noexcept
 {
-    m_activeLogLevel.store(logLevel, std::memory_order_relaxed);
+    s_activeLogLevel.store(logLevel, std::memory_order_relaxed);
 }
 
 void ConsoleLogger::createLogMessageHeader(const char* file,

--- a/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
+++ b/iceoryx_hoofs/source/log/building_blocks/console_logger.cpp
@@ -119,10 +119,10 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
     unused(function);
 
     // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as string literal
-    // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
+    // AXIVION Next Construct AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
     constexpr const char* COLOR_GRAY{"\033[0;90m"};
     // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Not used as an integer but as string literal
-    // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
+    // AXIVION Next Construct AutosarC++19_03-M2.13.2 : Required for the color codes; only valid octal digits are used
     constexpr const char* COLOR_RESET{"\033[m"};
     // NOLINTJUSTIFICATION snprintf required to populate char array so that it can be flushed in one piece
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -60,13 +60,23 @@ static void memsetSigbusHandler(int) noexcept
 cxx::expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder::create() noexcept
 {
     auto printErrorDetails = [this] {
+        auto logBaseAddressHint = [this](log::LogStream& stream) noexcept -> log::LogStream& {
+            if (this->m_baseAddressHint)
+            {
+                stream << iox::log::hex(this->m_baseAddressHint.value());
+            }
+            else
+            {
+                stream << " (no hint set)";
+            }
+            return stream;
+        };
+
         IOX_LOG(ERROR) << "Unable to create a shared memory object with the following properties [ name = " << m_name
                        << ", sizeInBytes = " << m_memorySizeInBytes
                        << ", access mode = " << asStringLiteral(m_accessMode)
-                       << ", open mode = " << asStringLiteral(m_openMode) << ", baseAddressHint = "
-                       << ((m_baseAddressHint) ? iox::log::hex(m_baseAddressHint.value())
-                                               : iox::log::hex(static_cast<uint64_t>(0U)))
-                       << ((m_baseAddressHint) ? "" : " (no hint set)")
+                       << ", open mode = " << asStringLiteral(m_openMode)
+                       << ", baseAddressHint = " << logBaseAddressHint
                        << ", permissions = " << iox::log::oct(static_cast<mode_t>(m_permissions)) << " ]";
     };
 

--- a/iceoryx_hoofs/test/moduletests/test_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_logstream.cpp
@@ -53,7 +53,8 @@ TEST_F(IoxLogStream_test, CTorDelegatesParameterToLogger)
     constexpr const char* EXPECTED_FUNCTION{"void all_glory_to_the_hypnotoad()"};
     constexpr int EXPECTED_LINE{42};
     constexpr auto EXPECTED_LOG_LEVEL{iox::log::LogLevel::WARN};
-    iox::log::LogStream(loggerMock, EXPECTED_FILE, EXPECTED_LINE, EXPECTED_FUNCTION, EXPECTED_LOG_LEVEL) << "";
+    iox::log::LogStream(loggerMock, EXPECTED_FILE, EXPECTED_LINE, EXPECTED_FUNCTION, EXPECTED_LOG_LEVEL)
+        << [&](iox::log::LogStream& stream) -> iox::log::LogStream& { return stream; };
 
     ASSERT_THAT(loggerMock.logs.size(), Eq(1U));
     EXPECT_THAT(loggerMock.logs.back().file, StrEq(EXPECTED_FILE));

--- a/iceoryx_hoofs/test/moduletests/test_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_logstream.cpp
@@ -53,8 +53,7 @@ TEST_F(IoxLogStream_test, CTorDelegatesParameterToLogger)
     constexpr const char* EXPECTED_FUNCTION{"void all_glory_to_the_hypnotoad()"};
     constexpr int EXPECTED_LINE{42};
     constexpr auto EXPECTED_LOG_LEVEL{iox::log::LogLevel::WARN};
-    iox::log::LogStream(loggerMock, EXPECTED_FILE, EXPECTED_LINE, EXPECTED_FUNCTION, EXPECTED_LOG_LEVEL)
-        << [&](iox::log::LogStream& stream) -> iox::log::LogStream& { return stream; };
+    iox::log::LogStream(loggerMock, EXPECTED_FILE, EXPECTED_LINE, EXPECTED_FUNCTION, EXPECTED_LOG_LEVEL) << "";
 
     ASSERT_THAT(loggerMock.logs.size(), Eq(1U));
     EXPECT_THAT(loggerMock.logs.back().file, StrEq(EXPECTED_FILE));

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/logger.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/logger.hpp
@@ -29,8 +29,8 @@ namespace iox
 namespace testing
 {
 /// @brief This logger is used for tests. It caches all the log messages and prints them to the console when a test
-/// fails. For debug purposes this behaviour can be overwritten with the `IOX_TESTING_ALLOW_LOG` environment variable,
-/// e.g. `IOX_TESTING_ALLOW_LOG=ON ./hoofs_moduletests --gtest_filter=SharedMemoryObject_Test\*`. Furthermore, it can
+/// fails. For debug purposes this behaviour can be overwritten with the 'IOX_TESTING_ALLOW_LOG' environment variable,
+/// e.g. 'IOX_TESTING_ALLOW_LOG=ON ./hoofs_moduletests --gtest_filter=SharedMemoryObject_Test\*'. Furthermore, it can
 /// also be used to check for the occurrence on specific log messages, e.g. when a function is expected to log an error.
 /// @code
 /// callToFunctionWhichLogsAnError();

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/mocks/logger_mock.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/mocks/logger_mock.hpp
@@ -33,7 +33,7 @@ namespace testing
     iox::log::LogStream((logger), "file", 42, "function", iox::log::LogLevel::TRACE).self()
 
 /// @brief This mock can be used to test implementations of LogStream::operator<< for custom types. It should be used
-/// with the `IOX_LOGSTREAM_MOCK` macro
+/// with the 'IOX_LOGSTREAM_MOCK' macro
 /// @code
 /// iox::testing::Logger_Mock loggerMock;
 ///


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes/suppresses most of the Axivion warnings for the refactored logger. There are a few which are not tackled and might need more discussion. It is a good start though and the remaining ones could be fixed in a follow up.

In order to fix one warning, the logging for pointer was refactored.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1345 and #1394
