### PR TITLE
iox-#1683 Disable robust mutex test for qnx

### DIFF
--- a/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
@@ -223,6 +223,9 @@ TEST_F(Mutex_test,
        MutexWithOnReleaseWhenLockedBehaviorUnlocksLockedMutexWhenThreadTerminatesAndSetsItIntoInconsistentState)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4da7b1fb-23f1-421c-acf3-2a3d9e26b1a1");
+#if defined(QNX) || defined(__QNX) || defined(__QNX__) || defined(QNX__)
+    GTEST_SKIP() << "iox-#1683 QNX supports robust mutex not like the posix standard describes them.";
+#endif
     iox::cxx::optional<iox::posix::mutex> sut;
     ASSERT_FALSE(iox::posix::MutexBuilder()
                      .threadTerminationBehavior(iox::posix::MutexThreadTerminationBehavior::RELEASE_WHEN_LOCKED)

--- a/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
@@ -247,6 +247,9 @@ TEST_F(Mutex_test,
 TEST_F(Mutex_test, MutexWithStallWhenLockedBehaviorDoesntUnlockMutexWhenThreadTerminates)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9beae890-f18e-4878-a957-312920eb1833");
+#if defined(QNX) || defined(__QNX) || defined(__QNX__) || defined(QNX__)
+    GTEST_SKIP() << "iox-#1683 QNX supports robust mutex not like the posix standard describes them.";
+#endif
     iox::cxx::optional<iox::posix::mutex> sut;
     ASSERT_FALSE(iox::posix::MutexBuilder()
                      .threadTerminationBehavior(iox::posix::MutexThreadTerminationBehavior::STALL_WHEN_LOCKED)

--- a/iceoryx_posh/include/iceoryx_posh/popo/trigger_handle.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/trigger_handle.hpp
@@ -37,7 +37,8 @@ namespace popo
 class TriggerHandle
 {
   public:
-    TriggerHandle() noexcept = default;
+    /// @warning do not use =default here otherwise QNX will fail to compile!
+    TriggerHandle() noexcept;
 
     /// @brief Creates a TriggerHandle
     /// @param[in] conditionVariableDataRef reference to a condition variable data struct

--- a/iceoryx_posh/source/popo/trigger_handle.cpp
+++ b/iceoryx_posh/source/popo/trigger_handle.cpp
@@ -21,6 +21,10 @@ namespace iox
 {
 namespace popo
 {
+TriggerHandle::TriggerHandle() noexcept
+{
+}
+
 TriggerHandle::TriggerHandle(ConditionVariableData& conditionVariableData,
                              const cxx::function<void(uint64_t)>& resetCallback,
                              const uint64_t uniqueTriggerId) noexcept


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Mitigation for #1683 
