### PR TITLE
iox-#1655 Add `DeleterType` template parameter to `cxx::unique_ptr`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -53,6 +53,7 @@
 - Implement destructor, copy and move operations in `cxx::stack` [\#1469](https://github.com/eclipse-iceoryx/iceoryx/issues/1469)
 - `gw::GatewayGeneric` sometimes terminates discovery and forward threads immediately [\#1666](https://github.com/eclipse-iceoryx/iceoryx/issues/1666)
 - `m_originId` in `mepoo::ChunkHeader` sometimes not set [\#1668](https://github.com/eclipse-iceoryx/iceoryx/issues/1668)
+- Avoid move and assignment of `cxx::unique_ptr` with different `DeleterTypes`s [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
 
 **Refactoring:**
 
@@ -452,7 +453,7 @@
     #include "iceoryx_platform/some_header.hpp"
     ```
 
-22. `cxx::unique_ptr` is no longer nullable.
+22. `cxx::unique_ptr` is no longer nullable and needs `DeleterType` as 2nd template parameter
 
     ```cxx
     // before
@@ -468,21 +469,21 @@
 
 
     // after
-    cxx::unique_ptr<int> myPtr(ptrToInt, someDeleter);
-    cxx::optional<cxx::unique_ptr<int>> emptyPtr(cxx::nullopt); // if unique_ptr shall be nullable use cxx::optional
+    cxx::unique_ptr<int, SomeDeleterType> myPtr(ptrToInt, someDeleter);
+    cxx::optional<cxx::unique_ptr<int, SomeDeleterType>> emptyPtr(cxx::nullopt); // if unique_ptr shall be nullable use cxx::optional
 
     // no more null check required since it is no longer nullable
     std::cout << *myPtr << std::endl;
 
     myPtr.reset(ptrToOtherInt);
-    cxx::unique_ptr<int>::release(std::move(myPtr)); // release consumes myPtr
+    cxx::unique_ptr<int, SomeDeleterType>::release(std::move(myPtr)); // release consumes myPtr
     ```
 
     Compilers like ``gcc-12>`` and `clang>14` as well as static code analysis tools like `clang-tidy`
     will warn the user with a used after move warning when one accesses a moved object. Accessing
     a moved `unique_ptr` is well defined and behaves like dereferencing a `nullptr`.
 
-23. `mutex` must be always stored inside an `cxx::optional` and must use the builder pattern for
+24. `mutex` must be always stored inside an `cxx::optional` and must use the builder pattern for
     construction
 
     ```cpp
@@ -499,7 +500,7 @@
     myMutex->lock();
     ```
 
-24. Change return type of `cxx::vector::erase` from iterator to bool
+25. Change return type of `cxx::vector::erase` from iterator to bool
 
     ```cpp
     // before
@@ -509,7 +510,7 @@
     bool success = myCxxVector.erase(myCxxVector.begin());
     ```
 
-25. `cxx::function` is no longer nullable.
+26. `cxx::function` is no longer nullable.
 
     ```cxx
     // before

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
@@ -27,7 +27,8 @@ namespace cxx
 {
 ///
 /// @brief The unique_ptr class is a heap-less unique ptr implementation, unlike the STL.
-///
+/// @tparam[in] T Type to which the unique_ptr is pointing to
+/// @tparam[in] D Type of the callable provided as deleter
 template <typename T, typename D>
 class unique_ptr
 {
@@ -110,6 +111,7 @@ class unique_ptr
 /// @brief comparision for two distinct unique_ptr types
 /// @tparam T underlying type of lhs
 /// @tparam U underlying type of rhs
+/// @tparam D type of callable stored as deleter in lhs and rhs
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are equal, otherwise false
@@ -119,6 +121,7 @@ bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexce
 /// @brief inequality check for two distinct unique_ptr types
 /// @tparam T underlying type of lhs
 /// @tparam U underlying type of rhs
+/// @tparam D type of callable stored as deleter in lhs and rhs
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are not equal, otherwise false

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
@@ -115,8 +115,8 @@ class unique_ptr
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are equal, otherwise false
-template <typename T, typename U, typename D>
-bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept;
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator==(const unique_ptr<T1, D1>& lhs, const unique_ptr<T2, D2>& rhs) noexcept;
 
 /// @brief inequality check for two distinct unique_ptr types
 /// @tparam T underlying type of lhs
@@ -125,8 +125,8 @@ bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexce
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are not equal, otherwise false
-template <typename T, typename U, typename D>
-bool operator!=(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept;
+template <typename T1, typename T2, typename D1, typename D2>
+bool operator!=(const unique_ptr<T1, D1>& lhs, const unique_ptr<T2, D2>& rhs) noexcept;
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/unique_ptr.hpp
@@ -28,10 +28,7 @@ namespace cxx
 ///
 /// @brief The unique_ptr class is a heap-less unique ptr implementation, unlike the STL.
 ///
-/// Also unlike the STL implementation, the deleters are not encoded in the unique_ptr type, allowing unique_ptr
-/// instances with different deleters to be stored in the same containers.
-///
-template <typename T>
+template <typename T, typename D>
 class unique_ptr
 {
   public:
@@ -44,7 +41,7 @@ class unique_ptr
     /// @param object The pointer to the object to be managed.
     /// @param deleter The deleter function for cleaning up the managed object.
     ///
-    unique_ptr(T* const object, const function<void(T*)>& deleter) noexcept;
+    unique_ptr(T* const object, const function<D>& deleter) noexcept;
 
     unique_ptr(const unique_ptr& other) = delete;
     unique_ptr& operator=(const unique_ptr&) = delete;
@@ -107,7 +104,7 @@ class unique_ptr
 
   private:
     T* m_ptr = nullptr;
-    function<void(T* const)> m_deleter;
+    function<D> m_deleter;
 };
 
 /// @brief comparision for two distinct unique_ptr types
@@ -116,8 +113,8 @@ class unique_ptr
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are equal, otherwise false
-template <typename T, typename U>
-bool operator==(const unique_ptr<T>& lhs, const unique_ptr<U>& rhs) noexcept;
+template <typename T, typename U, typename D>
+bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept;
 
 /// @brief inequality check for two distinct unique_ptr types
 /// @tparam T underlying type of lhs
@@ -125,8 +122,8 @@ bool operator==(const unique_ptr<T>& lhs, const unique_ptr<U>& rhs) noexcept;
 /// @param[in] lhs left side of the comparision
 /// @param[in] rhs right side of the comparision
 /// @return true if the pointers are not equal, otherwise false
-template <typename T, typename U>
-bool operator!=(const unique_ptr<T>& lhs, const unique_ptr<U>& rhs) noexcept;
+template <typename T, typename U, typename D>
+bool operator!=(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept;
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -24,16 +24,16 @@ namespace iox
 {
 namespace cxx
 {
-template <typename T>
-inline unique_ptr<T>::unique_ptr(T* const object, const function<void(T*)>& deleter) noexcept
+template <typename T, typename D>
+inline unique_ptr<T, D>::unique_ptr(T* const object, const function<D>& deleter) noexcept
     : m_ptr(object)
     , m_deleter(deleter)
 {
     Ensures(object != nullptr);
 }
 
-template <typename T>
-inline unique_ptr<T>& unique_ptr<T>::operator=(unique_ptr&& rhs) noexcept
+template <typename T, typename D>
+inline unique_ptr<T, D>& unique_ptr<T, D>::operator=(unique_ptr&& rhs) noexcept
 {
     if (this != &rhs)
     {
@@ -45,67 +45,67 @@ inline unique_ptr<T>& unique_ptr<T>::operator=(unique_ptr&& rhs) noexcept
     return *this;
 }
 
-template <typename T>
-inline unique_ptr<T>::unique_ptr(unique_ptr&& rhs) noexcept
+template <typename T, typename D>
+inline unique_ptr<T, D>::unique_ptr(unique_ptr&& rhs) noexcept
     : m_ptr{rhs.m_ptr}
     , m_deleter{std::move(rhs.m_deleter)}
 {
     rhs.m_ptr = nullptr;
 }
 
-template <typename T>
-inline unique_ptr<T>::~unique_ptr() noexcept
+template <typename T, typename D>
+inline unique_ptr<T, D>::~unique_ptr() noexcept
 {
     destroy();
 }
 
-template <typename T>
-inline T* unique_ptr<T>::operator->() noexcept
+template <typename T, typename D>
+inline T* unique_ptr<T, D>::operator->() noexcept
 {
     cxx::Expects(m_ptr != nullptr);
     return get();
 }
 
-template <typename T>
-inline const T* unique_ptr<T>::operator->() const noexcept
+template <typename T, typename D>
+inline const T* unique_ptr<T, D>::operator->() const noexcept
 {
     // Avoid code duplication
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return const_cast<unique_ptr<T>*>(this)->operator->();
+    return const_cast<unique_ptr<T, D>*>(this)->operator->();
 }
 
-template <typename T>
-inline T* unique_ptr<T>::get() noexcept
+template <typename T, typename D>
+inline T* unique_ptr<T, D>::get() noexcept
 {
     return m_ptr;
 }
 
-template <typename T>
-inline const T* unique_ptr<T>::get() const noexcept
+template <typename T, typename D>
+inline const T* unique_ptr<T, D>::get() const noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A5.2.3 : Avoid code duplication
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return const_cast<unique_ptr<T>*>(this)->get();
+    return const_cast<unique_ptr<T, D>*>(this)->get();
 }
 
-template <typename T>
-inline T* unique_ptr<T>::release(unique_ptr&& ptrToBeReleased) noexcept
+template <typename T, typename D>
+inline T* unique_ptr<T, D>::release(unique_ptr&& ptrToBeReleased) noexcept
 {
     auto ptr = ptrToBeReleased.m_ptr;
     ptrToBeReleased.m_ptr = nullptr;
     return ptr;
 }
 
-template <typename T>
-inline void unique_ptr<T>::reset(T* const ptr) noexcept
+template <typename T, typename D>
+inline void unique_ptr<T, D>::reset(T* const ptr) noexcept
 {
     Ensures(ptr != nullptr);
     destroy();
     m_ptr = ptr;
 }
 
-template <typename T>
-inline void unique_ptr<T>::destroy() noexcept
+template <typename T, typename D>
+inline void unique_ptr<T, D>::destroy() noexcept
 {
     if (m_ptr)
     {
@@ -114,21 +114,21 @@ inline void unique_ptr<T>::destroy() noexcept
     m_ptr = nullptr;
 }
 
-template <typename T>
-inline void unique_ptr<T>::swap(unique_ptr<T>& other) noexcept
+template <typename T, typename D>
+inline void unique_ptr<T, D>::swap(unique_ptr<T, D>& other) noexcept
 {
     std::swap(m_ptr, other.m_ptr);
     std::swap(m_deleter, other.m_deleter);
 }
 
-template <typename T, typename U>
-inline bool operator==(const unique_ptr<T>& lhs, const unique_ptr<U>& rhs) noexcept
+template <typename T, typename U, typename D>
+inline bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept
 {
     return lhs.get() == rhs.get();
 }
 
-template <typename T, typename U>
-inline bool operator!=(const unique_ptr<T>& lhs, const unique_ptr<U>& rhs) noexcept
+template <typename T, typename U, typename D>
+inline bool operator!=(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -121,14 +121,14 @@ inline void unique_ptr<T, D>::swap(unique_ptr<T, D>& other) noexcept
     std::swap(m_deleter, other.m_deleter);
 }
 
-template <typename T, typename U, typename D>
-inline bool operator==(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept
+template <typename T1, typename T2, typename D1, typename D2>
+inline bool operator==(const unique_ptr<T1, D1>& lhs, const unique_ptr<T2, D2>& rhs) noexcept
 {
     return lhs.get() == rhs.get();
 }
 
-template <typename T, typename U, typename D>
-inline bool operator!=(const unique_ptr<T, D>& lhs, const unique_ptr<U, D>& rhs) noexcept
+template <typename T1, typename T2, typename D1, typename D2>
+inline bool operator!=(const unique_ptr<T1, D1>& lhs, const unique_ptr<T2, D2>& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/access_control.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/access_control.hpp
@@ -112,7 +112,7 @@ class AccessController
     bool writePermissionsToFile(const int32_t fileDescriptor) const noexcept;
 
   private:
-    using smartAclPointer_t = cxx::unique_ptr<std::remove_pointer<acl_t>::type>;
+    using smartAclPointer_t = cxx::unique_ptr<std::remove_pointer<acl_t>::type, void(acl_t)>;
 
     struct PermissionEntry
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
@@ -46,7 +46,7 @@ cxx::expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
-    auto request = cxx::unique_ptr<Req>(static_cast<Req*>(payload), [this](auto* payload) {
+    auto request = cxx::unique_ptr<Req, void(Req*)>(static_cast<Req*>(payload), [this](Req* payload) {
         auto* requestHeader = iox::popo::RequestHeader::fromPayload(payload);
         this->port().releaseRequest(requestHeader);
     });
@@ -80,10 +80,11 @@ cxx::expected<Response<const Res>, ChunkReceiveResult> ClientImpl<Req, Res, Base
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();
-    auto response = cxx::unique_ptr<const Res>(static_cast<const Res*>(payload), [this](auto* payload) {
-        auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
-        this->port().releaseResponse(responseHeader);
-    });
+    auto response =
+        cxx::unique_ptr<const Res, void(const Res*)>(static_cast<const Res*>(payload), [this](const Res* payload) {
+            auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
+            this->port().releaseResponse(responseHeader);
+        });
     return cxx::success<Response<const Res>>(Response<const Res>{std::move(response)});
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
@@ -95,11 +95,12 @@ template <typename T, typename H, typename BasePublisherType>
 inline Sample<T, H>
 PublisherImpl<T, H, BasePublisherType>::convertChunkHeaderToSample(mepoo::ChunkHeader* const header) noexcept
 {
-    return Sample<T, H>(cxx::unique_ptr<T>(reinterpret_cast<T*>(header->userPayload()),
-                                           [this](auto* userPayload) {
-                                               auto chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
-                                               this->port().releaseChunk(chunkHeader);
-                                           }),
+    return Sample<T, H>(cxx::unique_ptr<T, void(T*)>(reinterpret_cast<T*>(header->userPayload()),
+                                                     [this](T* userPayload) {
+                                                         auto* chunkHeader =
+                                                             iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
+                                                         this->port().releaseChunk(chunkHeader);
+                                                     }),
                         *this);
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
@@ -41,8 +41,8 @@ SubscriberImpl<T, H, BaseSubscriberType>::take() noexcept
         return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     auto userPayloadPtr = static_cast<const T*>(result.value()->userPayload());
-    auto samplePtr = cxx::unique_ptr<const T>(userPayloadPtr, [this](auto* userPayload) {
-        auto chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
+    auto samplePtr = cxx::unique_ptr<const T, void(const T*)>(userPayloadPtr, [this](const T* userPayload) {
+        auto* chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
         this->port().releaseChunk(chunkHeader);
     });
     return cxx::success<Sample<const T, const H>>(std::move(samplePtr));

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_header.cpp
@@ -217,7 +217,8 @@ TEST(ChunkHeader_test, UserHeaderFunctionCalledFromNonConstChunkHeaderWorks)
     ASSERT_FALSE(chunkSettingsResult.has_error());
     auto& chunkSettings = chunkSettingsResult.value();
 
-    iox::cxx::unique_ptr<ChunkHeader> sut{new (storage) ChunkHeader(CHUNK_SIZE, chunkSettings), [](ChunkHeader*) {}};
+    iox::cxx::unique_ptr<ChunkHeader, void(ChunkHeader*)> sut{new (storage) ChunkHeader(CHUNK_SIZE, chunkSettings),
+                                                              [](ChunkHeader*) {}};
 
     // the user-header is always adjacent to the ChunkHeader
     const uint64_t chunkStartAddress{reinterpret_cast<uint64_t>(sut.get())};
@@ -240,8 +241,8 @@ TEST(ChunkHeader_test, UserHeaderFunctionCalledFromConstChunkHeaderWorks)
     ASSERT_FALSE(chunkSettingsResult.has_error());
     auto& chunkSettings = chunkSettingsResult.value();
 
-    iox::cxx::unique_ptr<const ChunkHeader> sut{new (storage) ChunkHeader(CHUNK_SIZE, chunkSettings),
-                                                [](const ChunkHeader*) {}};
+    iox::cxx::unique_ptr<const ChunkHeader, void(const ChunkHeader*)> sut{
+        new (storage) ChunkHeader(CHUNK_SIZE, chunkSettings), [](const ChunkHeader*) {}};
 
     // the user-header is always adjacent to the ChunkHeader
     const uint64_t chunkStartAddress{reinterpret_cast<uint64_t>(sut.get())};

--- a/iceoryx_posh/test/moduletests/test_popo_smart_chunk_common.hpp
+++ b/iceoryx_posh/test/moduletests/test_popo_smart_chunk_common.hpp
@@ -79,12 +79,14 @@ struct SampleTestCase
     MockPublisherInterface mockInterface;
     ChunkMock<DummyData, DummyHeader> chunkMock;
     ChunkMock<DummyData, DummyHeader> chunkMockForMove;
-    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData>(chunkMock.sample(), [](DummyData*) {}), mockInterface};
-    ProducerType sutProducerForMove{iox::cxx::unique_ptr<DummyData>(chunkMockForMove.sample(), [](DummyData*) {}),
-                                    mockInterface};
-    ConsumerType sutConsumer{iox::cxx::unique_ptr<const DummyData>(chunkMock.sample(), [](const DummyData*) {})};
-    ConsumerType sutConsumerForMove{
-        iox::cxx::unique_ptr<const DummyData>(chunkMockForMove.sample(), [](const DummyData*) {})};
+    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMock.sample(), [](DummyData*) {}),
+                             mockInterface};
+    ProducerType sutProducerForMove{
+        iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMockForMove.sample(), [](DummyData*) {}), mockInterface};
+    ConsumerType sutConsumer{
+        iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(chunkMock.sample(), [](const DummyData*) {})};
+    ConsumerType sutConsumerForMove{iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(
+        chunkMockForMove.sample(), [](const DummyData*) {})};
 };
 
 using RequestProducerType = Request<DummyData>;
@@ -124,12 +126,14 @@ class RequestTestCase
     MockRequestInterface mockInterface;
     ChunkMock<DummyData, RequestHeader> chunkMock;
     ChunkMock<DummyData, RequestHeader> chunkMockForMove;
-    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData>(chunkMock.sample(), [](DummyData*) {}), mockInterface};
-    ProducerType sutProducerForMove{iox::cxx::unique_ptr<DummyData>(chunkMockForMove.sample(), [](DummyData*) {}),
-                                    mockInterface};
-    ConsumerType sutConsumer{iox::cxx::unique_ptr<const DummyData>(chunkMock.sample(), [](const DummyData*) {})};
-    ConsumerType sutConsumerForMove{
-        iox::cxx::unique_ptr<const DummyData>(chunkMockForMove.sample(), [](const DummyData*) {})};
+    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMock.sample(), [](DummyData*) {}),
+                             mockInterface};
+    ProducerType sutProducerForMove{
+        iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMockForMove.sample(), [](DummyData*) {}), mockInterface};
+    ConsumerType sutConsumer{
+        iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(chunkMock.sample(), [](const DummyData*) {})};
+    ConsumerType sutConsumerForMove{iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(
+        chunkMockForMove.sample(), [](const DummyData*) {})};
 };
 
 using ResponseProducerType = Response<DummyData>;
@@ -169,12 +173,14 @@ class ResponseTestCase
     MockResponseInterface mockInterface;
     ChunkMock<DummyData, ResponseHeader> chunkMock;
     ChunkMock<DummyData, ResponseHeader> chunkMockForMove;
-    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData>(chunkMock.sample(), [](DummyData*) {}), mockInterface};
-    ProducerType sutProducerForMove{iox::cxx::unique_ptr<DummyData>(chunkMockForMove.sample(), [](DummyData*) {}),
-                                    mockInterface};
-    ConsumerType sutConsumer{iox::cxx::unique_ptr<const DummyData>(chunkMock.sample(), [](const DummyData*) {})};
-    ConsumerType sutConsumerForMove{
-        iox::cxx::unique_ptr<const DummyData>(chunkMockForMove.sample(), [](const DummyData*) {})};
+    ProducerType sutProducer{iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMock.sample(), [](DummyData*) {}),
+                             mockInterface};
+    ProducerType sutProducerForMove{
+        iox::cxx::unique_ptr<DummyData, void(DummyData*)>(chunkMockForMove.sample(), [](DummyData*) {}), mockInterface};
+    ConsumerType sutConsumer{
+        iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(chunkMock.sample(), [](const DummyData*) {})};
+    ConsumerType sutConsumerForMove{iox::cxx::unique_ptr<const DummyData, void(const DummyData*)>(
+        chunkMockForMove.sample(), [](const DummyData*) {})};
 };
 
 } // namespace test_smart_chunk_common


### PR DESCRIPTION
Signed-off-by: Simon Hoinkis <simon.hoinkis@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* This prevents the misuse described in #1655 by introducing `DeleterType` as a 2nd template paramter to `cxx::unique_ptr`
  * This approach is similar to the one in the STL, a `DefaultDeleter` was not added on purpose as we don't use the heap and the user should instead explicitly write it's own deleter, which could also be `delete ptr`.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1655
