### PR TITLE
iox-#1516 Refactor iceoryx_posh testing lib into own CMake file

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -52,6 +52,7 @@ jobs:
       uses: vmactions/freebsd-vm@v0
       with:
         usesh: true
+        copyback: false
         mem: 4096
         prepare: pkg install -y cmake git ncurses bash wget
         run: |

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -96,6 +96,7 @@
 - `cxx::function` is no longer nullable [\#1104](https://github.com/eclipse-iceoryx/iceoryx/issues/1104)
 - Renamed `BaseRelativePointer` to `UntypedRelativePointer` [\#605](https://github.com/eclipse-iceoryx/iceoryx/issues/605)
 - Prevent building GoogleTest when `GTest_DIR` is defined [\#1758](https://github.com/eclipse-iceoryx/iceoryx/issues/1758)
+- Refactored `iceoryx_posh_testing` library into own CMakeLists.txt [\#1516](https://github.com/eclipse-iceoryx/iceoryx/issues/1516)
 
 **Workflow:**
 

--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -299,28 +299,7 @@ setup_install_directories_and_export_package(
     INCLUDE_DIRECTORIES include/
 )
 
-if(ROUDI_ENVIRONMENT OR BUILD_TEST)
-    #
-    ######### posh roudi environment ##########
-    #
-    find_package(iceoryx_hoofs_testing REQUIRED)
-    iox_add_library(
-        STATIC
-        TARGET                  iceoryx_posh_testing
-        NAMESPACE               iceoryx_posh_testing
-        PROJECT_PREFIX          ${PREFIX}
-        BUILD_INTERFACE         ${CMAKE_CURRENT_SOURCE_DIR}/testing/include
-        INSTALL_INTERFACE       include/${PREFIX}
-        EXPORT_INCLUDE_DIRS     include/
-        PRIVATE_LIBS            iceoryx_posh::iceoryx_posh
-                                iceoryx_hoofs::iceoryx_hoofs
-                                iceoryx_posh::iceoryx_posh_roudi
-                                iceoryx_hoofs_testing::iceoryx_hoofs_testing
-        FILES
-            testing/roudi_environment/runtime_test_interface.cpp
-            testing/roudi_environment/roudi_environment.cpp
-    )
-endif()
+add_subdirectory(testing)
 
 if(BUILD_TEST)
     add_subdirectory(test)

--- a/iceoryx_posh/testing/CMakeLists.txt
+++ b/iceoryx_posh/testing/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+# Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if(ROUDI_ENVIRONMENT OR BUILD_TEST)
+    #
+    ######### posh roudi environment ##########
+    #
+    find_package(GTest CONFIG REQUIRED)
+    find_package(iceoryx_hoofs_testing REQUIRED)
+    iox_add_library(
+        STATIC
+        TARGET                  iceoryx_posh_testing
+        NAMESPACE               iceoryx_posh_testing
+        PROJECT_PREFIX          ${PREFIX}
+        BUILD_INTERFACE         ${CMAKE_CURRENT_SOURCE_DIR}/include
+        INSTALL_INTERFACE       include/${PREFIX}
+        EXPORT_INCLUDE_DIRS     include/
+        PUBLIC_LIBS             GTest::gtest
+                                GTest::gmock
+        PRIVATE_LIBS            iceoryx_posh::iceoryx_posh
+                                iceoryx_hoofs::iceoryx_hoofs
+                                iceoryx_posh::iceoryx_posh_roudi
+                                iceoryx_hoofs_testing::iceoryx_hoofs_testing
+        FILES
+            roudi_environment/runtime_test_interface.cpp
+            roudi_environment/roudi_environment.cpp
+    )
+endif()


### PR DESCRIPTION
Signed-off-by: Dietrich Kroenke <dietrich.kroenke@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1516 
