### PR TITLE
iox-1394 fix AUTOSAR violations in newtype

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
@@ -72,6 +72,8 @@ namespace cxx
 ///     if ( a < c ) {}         // allowed since we are Sortable
 ///     a = 567;                // allowed since we are assignable
 /// @endcode
+/// AXIVION Next Construct AutosarC++19_03-A10.1.1 : Multiple inheritance needed to add several policies to NewType. The
+/// Diamond-Problem cannot occur since the policy structs do not inherit.
 template <typename T, template <typename> class... Policies>
 class NewType : public Policies<NewType<T, Policies...>>...
 {
@@ -116,6 +118,8 @@ class NewType : public Policies<NewType<T, Policies...>>...
     NewType& operator=(T&& rhs) noexcept;
 
     /// @brief conversion operator
+    /// AXIVION Next Construct AutosarC++19_03-A13.5.3 : needed to provide convertable policy so that the derived type
+    /// can be convertable
     explicit operator T() const noexcept;
 
     template <typename Type>
@@ -124,6 +128,9 @@ class NewType : public Policies<NewType<T, Policies...>>...
   private:
     T m_value;
 };
+
+} // namespace cxx
+} // namespace iox
 
 /// @brief This macro helps to create types with the NewType class.
 /// In case the functionality of the underlying type is sufficient and one just
@@ -145,7 +152,9 @@ class NewType : public Policies<NewType<T, Policies...>>...
 ///                  newtype::Sortable,
 ///                  newtype::AssignByValueCopy);
 /// @endcode
-/// @NOLINTJUSTIFICATION macro is used to reduce boilerplate code for 'NewType'
+/// AXIVION Next Construct AutosarC++19_03-M16.0.6 brackets around macro parameter would lead in this case to compile
+/// time failures
+/// AXIVION Next Construct AutosarC++19_03-A16.0.1 : macro is used to reduce boilerplate code for 'NewType'
 /// @NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_NEW_TYPE(TypeName, Type, ...)                                                                              \
     struct TypeName : public iox::cxx::NewType<Type, __VA_ARGS__>                                                      \
@@ -159,9 +168,6 @@ class NewType : public Policies<NewType<T, Policies...>>...
         TypeName& operator=(const TypeName&) noexcept = default;                                                       \
         TypeName& operator=(TypeName&&) noexcept = default;                                                            \
     }
-
-} // namespace cxx
-} // namespace iox
 
 #include "iceoryx_hoofs/internal/cxx/newtype.inl"
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
@@ -80,8 +80,20 @@ class NewType : public Policies<NewType<T, Policies...>>...
     /// @NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
     NewType(newtype::internal::ProtectedConstructor_t, const T& rhs) noexcept;
 
-    /// @note Since `using Foo = NewType<int>` and `using Bar = NewType<int>` result
-    /// in `Foo` and `Bar` being the same type, this enforces the creation of the
+    /// @brief copy constructor
+    NewType(const NewType& rhs) noexcept;
+
+    /// @brief move constructor
+    NewType(NewType&& rhs) noexcept;
+
+    /// @brief copy assignment
+    NewType& operator=(const NewType& rhs) noexcept;
+
+    /// @brief move assignment
+    NewType& operator=(NewType&& rhs) noexcept;
+
+    /// @note Since 'using Foo = NewType<int>' and 'using Bar = NewType<int>' result
+    /// in 'Foo' and 'Bar' being the same type, this enforces the creation of the
     /// new type by inheritance
     ~NewType() = default;
 
@@ -96,18 +108,6 @@ class NewType : public Policies<NewType<T, Policies...>>...
 
     /// @brief construct with value copy
     explicit NewType(const T& rhs) noexcept;
-
-    /// @brief copy constructor
-    NewType(const NewType& rhs) noexcept;
-
-    /// @brief move constructor
-    NewType(NewType&& rhs) noexcept;
-
-    /// @brief copy assignment
-    NewType& operator=(const NewType& rhs) noexcept;
-
-    /// @brief move assignment
-    NewType& operator=(NewType&& rhs) noexcept;
 
     /// @brief copy by value assignment
     NewType& operator=(const T& rhs) noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/newtype.hpp
@@ -72,8 +72,8 @@ namespace cxx
 ///     if ( a < c ) {}         // allowed since we are Sortable
 ///     a = 567;                // allowed since we are assignable
 /// @endcode
-/// AXIVION Next Construct AutosarC++19_03-A10.1.1 : Multiple inheritance needed to add several policies to NewType. The
-/// Diamond-Problem cannot occur since the policy structs do not inherit.
+// AXIVION Next Construct AutosarC++19_03-A10.1.1 : Multiple inheritance needed to add several policies to NewType. The
+// Diamond-Problem cannot occur since the policy structs do not inherit.
 template <typename T, template <typename> class... Policies>
 class NewType : public Policies<NewType<T, Policies...>>...
 {
@@ -118,8 +118,8 @@ class NewType : public Policies<NewType<T, Policies...>>...
     NewType& operator=(T&& rhs) noexcept;
 
     /// @brief conversion operator
-    /// AXIVION Next Construct AutosarC++19_03-A13.5.3 : needed to provide convertable policy so that the derived type
-    /// can be convertable
+    // AXIVION Next Construct AutosarC++19_03-A13.5.3 : needed to provide convertable policy so that the derived type
+    // can be convertable
     explicit operator T() const noexcept;
 
     template <typename Type>
@@ -152,9 +152,9 @@ class NewType : public Policies<NewType<T, Policies...>>...
 ///                  newtype::Sortable,
 ///                  newtype::AssignByValueCopy);
 /// @endcode
-/// AXIVION Next Construct AutosarC++19_03-M16.0.6 brackets around macro parameter would lead in this case to compile
-/// time failures
-/// AXIVION Next Construct AutosarC++19_03-A16.0.1 : macro is used to reduce boilerplate code for 'NewType'
+// AXIVION Next Construct AutosarC++19_03-M16.0.6 : brackets around macro parameter would lead in this case to compile
+// time failures
+// AXIVION Next Construct AutosarC++19_03-A16.0.1 : macro is used to reduce boilerplate code for 'NewType'
 /// @NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_NEW_TYPE(TypeName, Type, ...)                                                                              \
     struct TypeName : public iox::cxx::NewType<Type, __VA_ARGS__>                                                      \

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype.inl
@@ -24,8 +24,8 @@ namespace iox
 namespace cxx
 {
 template <typename T, template <typename> class... Policies>
-/// AXIVION Next Line AutosarC++19_03-A12.6.1 : m_value is initialized by the default constructor of T; the code will
-/// not compile, if the default constructor of T does not exist or the DefaultConstructable policy is not added
+// AXIVION Next Construct AutosarC++19_03-A12.6.1 : m_value is initialized by the default constructor of T; the code
+// will not compile, if the default constructor of T does not exist or the DefaultConstructable policy is not added
 inline NewType<T, Policies...>::NewType() noexcept
 {
     static_assert(algorithm::doesContainType<newtype::DefaultConstructable<T>, Policies<T>...>(),
@@ -33,8 +33,8 @@ inline NewType<T, Policies...>::NewType() noexcept
 }
 
 template <typename T, template <typename> class... Policies>
-/// AXIVION Next Line AutosarC++19_03-A12.1.5 : delegating wanted only to "ProtectedConstructByValueCopy" constructor of
-/// T
+// AXIVION Next Construct AutosarC++19_03-A12.1.5 : delegating wanted only to "ProtectedConstructByValueCopy"
+// constructor of T
 inline NewType<T, Policies...>::NewType(newtype::internal::ProtectedConstructor_t, const T& rhs) noexcept
     : m_value(rhs)
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ namespace iox
 namespace cxx
 {
 template <typename T, template <typename> class... Policies>
+/// AXIVION Next Line AutosarC++19_03-A12.6.1 : m_value is initialized by the default constructor of T; the code will
+/// not compile, if the default constructor of T does not exist or the DefaultConstructable policy is not added
 inline NewType<T, Policies...>::NewType() noexcept
 {
     static_assert(algorithm::doesContainType<newtype::DefaultConstructable<T>, Policies<T>...>(),
@@ -31,8 +33,9 @@ inline NewType<T, Policies...>::NewType() noexcept
 }
 
 template <typename T, template <typename> class... Policies>
-inline NewType<T, Policies...>::NewType(newtype::internal::ProtectedConstructor_t dummy IOX_MAYBE_UNUSED,
-                                        const T& rhs) noexcept
+/// AXIVION Next Line AutosarC++19_03-A12.1.5 : delegating wanted only to "ProtectedConstructByValueCopy" constructor of
+/// T
+inline NewType<T, Policies...>::NewType(newtype::internal::ProtectedConstructor_t, const T& rhs) noexcept
     : m_value(rhs)
 {
     static_assert(algorithm::doesContainType<newtype::ProtectedConstructByValueCopy<T>, Policies<T>...>(),

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/assignment.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/assignment.hpp
@@ -24,10 +24,11 @@ namespace cxx
 namespace newtype
 {
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct CopyAssignable
 {
@@ -36,10 +37,11 @@ struct CopyAssignable
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct MoveAssignable
 {
@@ -48,10 +50,11 @@ struct MoveAssignable
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AssignByValueCopy
 {
@@ -60,10 +63,11 @@ struct AssignByValueCopy
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AssignByValueMove
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/comparable.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/comparable.hpp
@@ -25,10 +25,11 @@ namespace cxx
 namespace newtype
 {
 template <typename T>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct Comparable
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/constructor.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/constructor.hpp
@@ -24,10 +24,11 @@ namespace cxx
 namespace newtype
 {
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct CopyConstructable
 {
@@ -36,10 +37,11 @@ struct CopyConstructable
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct MoveConstructable
 {
@@ -48,10 +50,11 @@ struct MoveConstructable
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ConstructByValueCopy
 {
@@ -60,10 +63,11 @@ struct ConstructByValueCopy
 };
 
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct DefaultConstructable
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/convertable.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/convertable.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ namespace cxx
 namespace newtype
 {
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct Convertable
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/internal.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/internal.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ struct ProtectedConstructor_t
 {
 };
 
-static constexpr ProtectedConstructor_t ProtectedConstructor = ProtectedConstructor_t();
+static constexpr ProtectedConstructor_t ProtectedConstructor{ProtectedConstructor_t()};
 
 template <typename T>
 inline typename T::value_type newTypeAccessor(const T& b) noexcept

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/protected_constructor.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/protected_constructor.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ namespace cxx
 namespace newtype
 {
 template <typename>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ProtectedConstructByValueCopy
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/sortable.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/newtype/sortable.hpp
@@ -25,10 +25,11 @@ namespace cxx
 namespace newtype
 {
 template <typename T>
-// not required since a default'ed destructor does not define a destructor, hence the copy/move operations are
-// not deleted.
-// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
-// explicitly calling the destructor of the base type.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : Not required since a default'ed destructor does not define a
+// destructor, hence the copy/move operations are not deleted. The only adaptation is that the dtor is protected to
+// prohibit the user deleting the child type by explicitly calling the destructor of the base type. Additionally, this
+// is a marker struct that adds only the described property to the new type. Adding copy/move operations would
+// contradict the purpose.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct Sortable
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/stack.inl
@@ -161,6 +161,7 @@ inline bool stack<T, Capacity>::push(Targs&&... args) noexcept
         return false;
     }
 
+    // AXIVION Next Line AutosarC++19_03-A18.5.10 : every entry of m_data is aligned to alignof(T)
     new (&m_data[m_size++]) T(std::forward<Targs>(args)...);
     return true;
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes/suppresses several AUTOSAR violations in `NewType`. Additionally, the last violation in `stack.inl` is suppressed.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 
