### PR TITLE
Iox 1394 fix axivion violations in cxx function

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ template <uint64_t Capacity, uint64_t Align = 1>
 /// @NOLINTJUSTIFICATION static_storage provides uninitialized memory, correct initialization is the users
 ///                      responsibility whenever memory with "allocate" is acquired
 /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-class static_storage
+class static_storage final
 {
   public:
     constexpr static_storage() noexcept = default;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/static_storage.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,12 +26,12 @@ namespace cxx
 template <uint64_t Capacity, uint64_t Align>
 constexpr uint64_t static_storage<Capacity, Align>::align_mismatch(uint64_t align, uint64_t requiredAlign) noexcept
 {
-    auto r = align % requiredAlign;
+    const auto r = align % requiredAlign;
 
     // If r != 0 we are not aligned with requiredAlign and need to add r to an align
     // aligned address to be aligned with requiredAlign.
     // In the worst case r is requiredAlign - 1
-    return r != 0 ? requiredAlign - r : 0;
+    return (r != 0) ? (requiredAlign - r) : 0;
 }
 
 template <uint64_t Capacity, uint64_t Align>
@@ -54,6 +54,8 @@ template <typename T>
 constexpr T* static_storage<Capacity, Align>::allocate() noexcept
 {
     static_assert(is_allocatable<T>(), "type does not fit into static storage");
+    // AXIVION Next Construct AutosarC++19_03-M5.2.8: conversion to typed pointer is intentional,
+    // it is correctly aligned and points to sufficient memory for a T by design
     return static_cast<T*>(allocate(alignof(T), sizeof(T)));
 }
 
@@ -65,7 +67,7 @@ constexpr void* static_storage<Capacity, Align>::allocate(const uint64_t align, 
         return nullptr; // cannot allocate, already in use
     }
 
-    size_t space = Capacity;
+    size_t space{Capacity};
     m_ptr = m_bytes;
     if (std::align(align, size, m_ptr, space) != nullptr)
     {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -45,7 +45,7 @@ class storable_function;
 /// @tparam ReturnType  The return type of the stored callable.
 /// @tparam Args        The arguments of the stored callable.
 template <uint64_t Capacity, typename ReturnType, typename... Args>
-class storable_function<Capacity, signature<ReturnType, Args...>>
+class storable_function<Capacity, signature<ReturnType, Args...>> final
 {
   public:
     using StorageType = static_storage<Capacity>;
@@ -56,6 +56,7 @@ class storable_function<Capacity, signature<ReturnType, Args...>>
               typename = typename std::enable_if<std::is_class<Functor>::value
                                                      && is_invocable_r<ReturnType, Functor, Args...>::value,
                                                  void>::type>
+    // AXIVION Next Construct AutosarC++19_03-A12.1.4: implicit conversion of functors is intentional
     /// @NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
     ///                      explicit would require a static_cast. Furthermore, the storable_functor stores a copy
     ///                      which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
@@ -93,19 +94,13 @@ class storable_function<Capacity, signature<ReturnType, Args...>>
     /// @param args arguments to invoke the stored function with
     /// @return return value of the stored function
     ///
-    /// @note 1) Invoking the function if there is no stored function (i.e. operator bool returns false)
-    ///          leads to terminate being called.
-    ///
-    ///       2) Deliberately not noexcept but can only throw if the stored callable can throw an exception (hence
-    ///          will never throw if we use only our own noexcept functions).
-    ///
-    ///       3) If arguments are passed by value, the copy constructor may be invoked twice:
+    /// @note 1) If arguments are passed by value, the copy constructor may be invoked twice:
     ///          once when passing the arguments to operator() and once when they are passed to the stored callable
     ///          itself. This appears to be unavoidable and also happens in std::function.
     ///          The user can always provide a wrapped callable which takes a reference,
     ///          which is generally preferable for large objects anyway.
     ///
-    ///       4) Arguments of class type cannot have the move constructor explicitly deleted since the arguments
+    ///       2) Arguments of class type cannot have the move constructor explicitly deleted since the arguments
     ///          must be forwarded internally which is done by move or, if no move is specified, by copy.
     ///          If the move operation is explicitly deleted the compiler will not fall back to copy but emit an error.
     ///          Not specifying move or using a default implementation is fine.
@@ -136,7 +131,7 @@ class storable_function<Capacity, signature<ReturnType, Args...>>
     // This means storable_function cannot be used where pointers become invalid, e.g. across process boundaries
     // Therefore we cannot store a storable_function in shared memory (the same holds for std::function).
     // This is inherent to the type erasure technique we (have to) use.
-    struct operations
+    struct operations final
     {
         // function pointers defining copy, move and destroy semantics
         void (*copyFunction)(const storable_function& src, storable_function& dest){nullptr};
@@ -150,11 +145,11 @@ class storable_function<Capacity, signature<ReturnType, Args...>>
         operations& operator=(operations&& other) noexcept = default;
         ~operations() = default;
 
-        void copy(const storable_function& src, storable_function& dest) noexcept;
+        void copy(const storable_function& src, storable_function& dest) const noexcept;
 
-        void move(storable_function& src, storable_function& dest) noexcept;
+        void move(storable_function& src, storable_function& dest) const noexcept;
 
-        void destroy(storable_function& f) noexcept;
+        void destroy(storable_function& f) const noexcept;
     };
 
   private:
@@ -187,12 +182,15 @@ class storable_function<Capacity, signature<ReturnType, Args...>>
     static void destroy(storable_function& f) noexcept;
 
     template <typename CallableType>
-    static ReturnType invoke(void* callable, Args&&... args);
+    static ReturnType invoke(void* callable, Args&&... args) noexcept;
 
     static void copyFreeFunction(const storable_function& src, storable_function& dest) noexcept;
 
     static void moveFreeFunction(storable_function& src, storable_function& dest) noexcept;
 
+    // AXIVION Next Construct AutosarC++19_03-M7.1.2: callable cannot be const void* since
+    // m_invoker is initialized with this function and has to work with functors as well
+    // (functors may change due to invocation)
     static ReturnType invokeFreeFunction(void* callable, Args&&... args);
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -56,10 +56,10 @@ class storable_function<Capacity, signature<ReturnType, Args...>> final
               typename = typename std::enable_if<std::is_class<Functor>::value
                                                      && is_invocable_r<ReturnType, Functor, Args...>::value,
                                                  void>::type>
-    // AXIVION Next Construct AutosarC++19_03-A12.1.4: implicit conversion of functors is intentional
-    /// @NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
-    ///                      explicit would require a static_cast. Furthermore, the storable_functor stores a copy
-    ///                      which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
+    // AXIVION Next Construct AutosarC++19_03-A12.1.4: implicit conversion of functors is intentional,
+    // the storable function should implicitly behave like any generic constructor, adding
+    // explicit would require a static_cast. Furthermore, the storable_functor stores a copy
+    // which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
     /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
     storable_function(const Functor& functor) noexcept;
 
@@ -191,7 +191,7 @@ class storable_function<Capacity, signature<ReturnType, Args...>> final
     // AXIVION Next Construct AutosarC++19_03-M7.1.2: callable cannot be const void* since
     // m_invoker is initialized with this function and has to work with functors as well
     // (functors may change due to invocation)
-    static ReturnType invokeFreeFunction(void* callable, Args&&... args);
+    static ReturnType invokeFreeFunction(void* callable, Args&&... args) noexcept;
 };
 
 /// @brief swap two storable functions

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -146,6 +146,7 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::~storable_fu
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 inline ReturnType storable_function<Capacity, signature<ReturnType, Args...>>::operator()(Args... args) const noexcept
 {
+    cxx::Expects(m_callable != nullptr); // should not happen unless incorrectly used after move
     // AXIVION Next Construct AutosarC++19_03-M0.3.1: m_invoker is initialized in ctor or assignment,
     // can only be nullptr if this was moved from (calling operator() is illegal in this case)
     return m_invoker(m_callable, std::forward<Args>(args)...);
@@ -198,9 +199,8 @@ inline void storable_function<Capacity, signature<ReturnType, Args...>>::copy(co
 
     // AXIVION Next Construct AutosarC++19_03-M5.2.8: type erasure - conversion to compatible type
     const auto obj = static_cast<CallableType*>(src.m_callable);
+    cxx::Expects(obj != nullptr); // should not happen unless src is incorrectly used after move
 
-    // AXIVION Next Construct AutosarC++19_03-A5.3.2: obj is guaranteed not to be
-    // nullptr unless src was invalidated by move (illegal use of src)
     // AXIVION Next Construct AutosarC++19_03-A18.5.10: false positive, m_storage.allocate<T>
     // provides a properly aligned ptr and sufficient memory (static_storage satisfies this)
     /// @NOLINTJUSTIFICATION ownership is encapsulated in storable_function and will be released in destroy
@@ -209,6 +209,7 @@ inline void storable_function<Capacity, signature<ReturnType, Args...>>::copy(co
     dest.m_callable = ptr;
     dest.m_invoker = src.m_invoker;
 }
+
 // AXIVION Next Construct AutosarC++19_03-A8.4.4, AutosarC++19_03-A8.4.8: output parameter required by design and for
 // efficiency
 template <uint64_t Capacity, typename ReturnType, typename... Args>
@@ -221,9 +222,8 @@ inline void storable_function<Capacity, signature<ReturnType, Args...>>::move(st
 
     // AXIVION Next Construct AutosarC++19_03-M5.2.8: type erasure - conversion to compatible type
     const auto obj = static_cast<CallableType*>(src.m_callable);
+    cxx::Expects(obj != nullptr); // should not happen unless src is incorrectly used after move
 
-    // AXIVION Next Construct AutosarC++19_03-A5.3.2: obj is guaranteed not to be nullptr
-    // unless src was invalidated by move (illegal use of src)
     // AXIVION Next Construct AutosarC++19_03-A18.5.10: false positive, m_storage.allocate<T>
     // provides a properly aligned ptr and sufficient memory (static_storage satisfies this)
     /// @NOLINTJUSTIFICATION ownership is encapsulated in storable_function and will be released in destroy


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1394 (partial)
