### PR TITLE
iox-1394 fix axivion violation for attributes hpp

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/attributes.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/attributes.hpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+
 #ifndef IOX_HOOFS_CXX_ATTRIBUTES_HPP
 #define IOX_HOOFS_CXX_ATTRIBUTES_HPP
 
@@ -33,7 +34,6 @@ inline void IOX_DISCARD_RESULT_IMPL(T&&) noexcept
 
 // NOLINTJUSTIFICATION cannot be implemented with a function, required as inline code
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
-
 /// @brief if a function has a return value which you do not want to use then you can wrap the function with that macro.
 /// Purpose is to suppress the unused compiler warning by adding an attribute to the return value
 /// @param[in] expr name of the function where the return value is not used.
@@ -55,9 +55,9 @@ inline void IOX_DISCARD_RESULT_IMPL(T&&) noexcept
 #elif defined(__APPLE__) && defined(__clang__)
 // On APPLE we are using C++17 which makes the keyword [[nodiscard]] available
 #define IOX_NO_DISCARD [[nodiscard, gnu::warn_unused]]
-#elif (defined(__clang__) && __clang_major__ >= 4)
+#elif (defined(__clang__) && (__clang_major__ >= 4))
 #define IOX_NO_DISCARD [[gnu::warn_unused]]
-#elif (defined(__GNUC__) && __GNUC__ >= 5)
+#elif (defined(__GNUC__) && (__GNUC__ >= 5))
 #define IOX_NO_DISCARD [[nodiscard, gnu::warn_unused]]
 #else
 // on an unknown platform we use for now nothing since we do not know what is supported there
@@ -79,7 +79,7 @@ inline void IOX_DISCARD_RESULT_IMPL(T&&) noexcept
 #elif __cplusplus >= 201703L
 // clang prints a warning therefore we exclude it here
 #define IOX_FALLTHROUGH [[fallthrough]]
-#elif (defined(__GNUC__) && __GNUC__ >= 7) && !defined(__clang__)
+#elif (defined(__GNUC__) && (__GNUC__ >= 7)) && !defined(__clang__)
 #define IOX_FALLTHROUGH [[gnu::fallthrough]]
 #else
 // on an unknown platform we use for now nothing since we do not know what is supported there
@@ -99,7 +99,6 @@ inline void IOX_DISCARD_RESULT_IMPL(T&&) noexcept
 #else
 #define IOX_MAYBE_UNUSED
 #endif
-
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 } // namespace cxx


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partly)
