### PR TITLE
iox-1655 Remove `reset` method from `cxx::unique_ptr`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -53,6 +53,7 @@
 - Implement destructor, copy and move operations in `cxx::stack` [\#1469](https://github.com/eclipse-iceoryx/iceoryx/issues/1469)
 - `gw::GatewayGeneric` sometimes terminates discovery and forward threads immediately [\#1666](https://github.com/eclipse-iceoryx/iceoryx/issues/1666)
 - `m_originId` in `mepoo::ChunkHeader` sometimes not set [\#1668](https://github.com/eclipse-iceoryx/iceoryx/issues/1668)
+- Removed `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
 
 **Refactoring:**
 
@@ -453,7 +454,7 @@
     #include "iceoryx_platform/some_header.hpp"
     ```
 
-24. `cxx::unique_ptr` is no longer nullable.
+24. `cxx::unique_ptr` is no longer nullable and does not have a `reset` method anymore
 
     ```cpp
     // before
@@ -475,7 +476,7 @@
     // no more null check required since it is no longer nullable
     std::cout << *myPtr << std::endl;
 
-    myPtr.reset(ptrToOtherInt);
+    myPtr = std::move(uniquePtrToAnotherInt); // deleter(myPtr) is called before move
     cxx::unique_ptr<int>::release(std::move(myPtr)); // release consumes myPtr
     ```
 
@@ -510,7 +511,7 @@
     bool success = myCxxVector.erase(myCxxVector.begin());
     ```
 
-25. `cxx::function` is no longer nullable.
+27. `cxx::function` is no longer nullable.
 
     ```cpp
     // before
@@ -533,7 +534,7 @@
     will warn the user with a used after move warning when one accesses a moved object. Accessing
     a moved `function` is well defined and behaves like dereferencing a `nullptr`.
 
-26. `LogLevel` enum tags are renamed to better match the log4j log levels
+28. `LogLevel` enum tags are renamed to better match the log4j log levels
 
     | before     | after   |
     |:----------:|:-------:|
@@ -545,12 +546,11 @@
     | `kDebug`   | `DEBUG` |
     | `kVerbose` | `TRACE` |
 
-
     In the C binding the `Iceoryx_LogLevel_Verbose` changed to `Iceoryx_LogLevel_Trace`.
 
-27. `LogLevel` enum moved from `iceoryx_hoofs/log/logcommon.hpp` to `iceoryx_hoofs/iceoryx_hoofs_types.hpp`
+29. `LogLevel` enum moved from `iceoryx_hoofs/log/logcommon.hpp` to `iceoryx_hoofs/iceoryx_hoofs_types.hpp`
 
-28. Using multiple logger instances and logging directly via a logger instance in not supported anymore out of the box
+30. Using multiple logger instances and logging directly via a logger instance in not supported anymore out of the box
 
     ```cpp
     // before
@@ -568,7 +568,7 @@
     IOX_LOG(INFO) << "Hello World";
     ```
 
-29. Setting the default log level changed
+31. Setting the default log level changed
 
     ```cpp
     // before
@@ -584,7 +584,7 @@
 
     Please look at the logger design document for more details like setting the log level via environment variables.
 
-30. Changing the log level at runtime changed
+32. Changing the log level at runtime changed
 
     ```cpp
     // before
@@ -594,7 +594,7 @@
     iox::log::Logger::setLogLevel(iox::log::LogLevel::DEBUG);
     ```
 
-31. Using the logger in libraries is massively simplified
+33. Using the logger in libraries is massively simplified
 
     ```cpp
     // before
@@ -656,7 +656,7 @@
     }
     ```
 
-32. Free function logger calls changed
+34. Free function logger calls changed
 
     | before         | after            |
     |:--------------:|:----------------:|
@@ -667,7 +667,7 @@
     | `LogDebug()`   | `IOX_LOG(DEBUG)` |
     | `LogVerbose()` | `IOX_LOG(TRACE)` |
 
-33. Logger formatting changed
+35. Logger formatting changed
 
     ```cpp
     // before
@@ -680,7 +680,7 @@
     IOX_LOG(INFO) << iox::log::oct(42);
     ```
 
-34. Creating an instance of `LogStream` does not work anymore
+36. Creating an instance of `LogStream` does not work anymore
 
     ```cpp
     // before
@@ -705,7 +705,7 @@
     };
     ```
 
-35. Testing of `LogStream::operator<<` overload for custom types changed
+37. Testing of `LogStream::operator<<` overload for custom types changed
 
     ```cpp
     // before
@@ -723,7 +723,7 @@
     EXPECT_THAT(loggerMock.logs[0].message, StrEq(EXPECTED_STRING));
     ```
 
-36. Suppressing the logger output in tests
+38. Suppressing the logger output in tests
 
     ```cpp
     // before
@@ -752,7 +752,7 @@
     the `IOX_TESTING_ALLOW_LOG` environment variable can be used,
     e.g. `IOX_TESTING_ALLOW_LOG=ON ./unittests --gtest_filter=MyTest\*`. This might be helpful to debug tests.
 
-37. Checking the log message of test objects in unit tests
+39. Checking the log message of test objects in unit tests
 
     ```cpp
     // before

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/unique_ptr.inl
@@ -25,7 +25,7 @@ namespace iox
 namespace cxx
 {
 template <typename T>
-inline unique_ptr<T>::unique_ptr(T* const object, const function<void(T*)>& deleter) noexcept
+inline unique_ptr<T>::unique_ptr(T* const object, const function<DeleterType>& deleter) noexcept
     : m_ptr(object)
     , m_deleter(deleter)
 {
@@ -94,14 +94,6 @@ inline T* unique_ptr<T>::release(unique_ptr&& ptrToBeReleased) noexcept
     auto ptr = ptrToBeReleased.m_ptr;
     ptrToBeReleased.m_ptr = nullptr;
     return ptr;
-}
-
-template <typename T>
-inline void unique_ptr<T>::reset(T* const ptr) noexcept
-{
-    Ensures(ptr != nullptr);
-    destroy();
-    m_ptr = ptr;
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
@@ -46,7 +46,7 @@ cxx::expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
-    auto request = cxx::unique_ptr<Req>(static_cast<Req*>(payload), [this](auto* payload) {
+    auto request = cxx::unique_ptr<Req>(static_cast<Req*>(payload), [this](Req* payload) {
         auto* requestHeader = iox::popo::RequestHeader::fromPayload(payload);
         this->port().releaseRequest(requestHeader);
     });
@@ -80,7 +80,7 @@ cxx::expected<Response<const Res>, ChunkReceiveResult> ClientImpl<Req, Res, Base
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();
-    auto response = cxx::unique_ptr<const Res>(static_cast<const Res*>(payload), [this](auto* payload) {
+    auto response = cxx::unique_ptr<const Res>(static_cast<const Res*>(payload), [this](const Res* payload) {
         auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
         this->port().releaseResponse(responseHeader);
     });

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
@@ -96,8 +96,9 @@ inline Sample<T, H>
 PublisherImpl<T, H, BasePublisherType>::convertChunkHeaderToSample(mepoo::ChunkHeader* const header) noexcept
 {
     return Sample<T, H>(cxx::unique_ptr<T>(reinterpret_cast<T*>(header->userPayload()),
-                                           [this](auto* userPayload) {
-                                               auto chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
+                                           [this](T* userPayload) {
+                                               auto* chunkHeader =
+                                                   iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
                                                this->port().releaseChunk(chunkHeader);
                                            }),
                         *this);

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
@@ -46,7 +46,7 @@ cxx::expected<Request<const Req>, ServerRequestResult> ServerImpl<Req, Res, Base
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
-    auto request = cxx::unique_ptr<const Req>(static_cast<const Req*>(payload), [this](auto* payload) {
+    auto request = cxx::unique_ptr<const Req>(static_cast<const Req*>(payload), [this](const Req* payload) {
         auto* requestHeader = iox::popo::RequestHeader::fromPayload(payload);
         this->port().releaseRequest(requestHeader);
     });
@@ -65,7 +65,7 @@ ServerImpl<Req, Res, BaseServerT>::loanUninitialized(const Request<const Req>& r
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();
-    auto response = cxx::unique_ptr<Res>(static_cast<Res*>(payload), [this](auto* payload) {
+    auto response = cxx::unique_ptr<Res>(static_cast<Res*>(payload), [this](Res* payload) {
         auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
         this->port().releaseResponse(responseHeader);
     });

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
@@ -41,8 +41,8 @@ SubscriberImpl<T, H, BaseSubscriberType>::take() noexcept
         return cxx::error<ChunkReceiveResult>(result.get_error());
     }
     auto userPayloadPtr = static_cast<const T*>(result.value()->userPayload());
-    auto samplePtr = cxx::unique_ptr<const T>(userPayloadPtr, [this](auto* userPayload) {
-        auto chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
+    auto samplePtr = cxx::unique_ptr<const T>(userPayloadPtr, [this](const T* userPayload) {
+        auto* chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
         this->port().releaseChunk(chunkHeader);
     });
     return cxx::success<Sample<const T, const H>>(std::move(samplePtr));


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
* Remove `cxx::unique_ptr::reset`
* Derive cv-qualifier for `deleter` with `add_const_conditionally_t` from T

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1655
