### PR TITLE
iox-#1635 Use GTEST_SKIP for test which require additional user

### DIFF
--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/test_definitions.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/test_definitions.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +17,30 @@
 #ifndef IOX_HOOFS_TESTUTILS_TEST_DEFINITIONS_HPP
 #define IOX_HOOFS_TESTUTILS_TEST_DEFINITIONS_HPP
 
+namespace iox
+{
+namespace testing
+{
+struct GTestSkipDummy
+{
+    template <typename T>
+    GTestSkipDummy& operator<<(T&)
+    {
+        return *this;
+    }
+};
+
+} // namespace testing
+} // namespace iox
+
+// NOLINTBEGIN(cppcoreguidelines-macro-usage) required to wrap the GTEST_SKIP macro
 /// @note this can be used to enable/disable tests where additional users are needed
-/// e.g.: TEST_F(FOO, ADD_TEST_WITH_ADDITIONAL_USER(barTest))
+/// e.g.: GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
 #ifdef TEST_WITH_ADDITIONAL_USER
-#define ADD_TEST_WITH_ADDITIONAL_USER(TestName) TestName
+#define GTEST_SKIP_FOR_ADDITIONAL_USER iox::testing::GTestSkipDummy
 #else
-#define ADD_TEST_WITH_ADDITIONAL_USER(TestName) DISABLED_##TestName
+#define GTEST_SKIP_FOR_ADDITIONAL_USER() GTEST_SKIP()
 #endif
+// NOLINTEND(cppcoreguidelines-macro-usage)
 
 #endif // IOX_HOOFS_TESTUTILS_TEST_DEFINITIONS_HPP

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -163,9 +163,11 @@ TEST_F(MePooSegment_test, SharedMemoryFileHandleRightsAfterConstructor)
     GTEST_SKIP() << "@todo iox-#611 Test needs to be written";
 }
 
-TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(SharedMemoryCreationParameter))
+TEST_F(MePooSegment_test, SharedMemoryCreationParameter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0fcfefd4-3a84-43a5-9805-057a60239184");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [](const SharedMemory::Name_t f_name,
                                                                        const uint64_t,
                                                                        const iox::posix::AccessMode f_accessMode,
@@ -182,9 +184,11 @@ TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(SharedMemoryCreationPara
         MePooSegment_test::SharedMemoryObject_MOCK::createFct();
 }
 
-TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetSharedMemoryObject))
+TEST_F(MePooSegment_test, GetSharedMemoryObject)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e1c12dd0-fd7d-4be3-918b-08d16a68c8e0");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     uint64_t memorySizeInBytes{0};
     MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [&](const SharedMemory::Name_t,
                                                                         const uint64_t f_memorySizeInBytes,
@@ -202,21 +206,27 @@ TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetSharedMemoryObject))
     EXPECT_THAT(sut2.getSharedMemoryObject().getSizeInBytes(), Eq(memorySizeInBytes));
 }
 
-TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetReaderGroup))
+TEST_F(MePooSegment_test, GetReaderGroup)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ad3fd360-3765-45ae-8285-fe4ae60c91ae");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     EXPECT_THAT(sut.getReaderGroup(), Eq(iox::posix::PosixGroup("iox_roudi_test1")));
 }
 
-TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetWriterGroup))
+TEST_F(MePooSegment_test, GetWriterGroup)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3aa34489-bd46-4e77-89d6-20e82211e1a4");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     EXPECT_THAT(sut.getWriterGroup(), Eq(iox::posix::PosixGroup("iox_roudi_test2")));
 }
 
-TEST_F(MePooSegment_test, ADD_TEST_WITH_ADDITIONAL_USER(GetMemoryManager))
+TEST_F(MePooSegment_test, GetMemoryManager)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4bc4af78-4beb-42eb-aee4-0f7cffb66411");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     ASSERT_THAT(sut.getMemoryManager().getNumberOfMemPools(), Eq(1U));
     auto config = sut.getMemoryManager().getMemPoolInfo(0);
     ASSERT_THAT(config.m_numChunks, Eq(100U));

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
@@ -98,39 +98,49 @@ class SegmentManager_test : public Test
     SegmentManager<> sut{segmentConfig, &allocator};
 };
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForReadUser))
+TEST_F(SegmentManager_test, getSegmentMappingsForReadUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a3af818a-c119-4182-948a-1e709c29d97f");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     auto mapping = sut.getSegmentMappings(PosixUser{"iox_roudi_test1"});
     ASSERT_THAT(mapping.size(), Eq(1u));
     EXPECT_THAT(mapping[0].m_isWritable, Eq(false));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsForWriteUser))
+TEST_F(SegmentManager_test, getSegmentMappingsForWriteUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5e5d3128-5e4b-41e9-b541-ba9dc0bd57e3");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     auto mapping = sut.getSegmentMappings(PosixUser{"iox_roudi_test2"});
     ASSERT_THAT(mapping.size(), Eq(2u));
     EXPECT_THAT(mapping[0].m_isWritable == mapping[1].m_isWritable, Eq(false));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsEmptyForNonRegisteredUser))
+TEST_F(SegmentManager_test, getSegmentMappingsEmptyForNonRegisteredUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7cf9a658-bb2d-444f-af67-0355e8f45ea2");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     auto mapping = sut.getSegmentMappings(PosixUser{"roudi_test4"});
     ASSERT_THAT(mapping.size(), Eq(0u));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getSegmentMappingsEmptyForNonExistingUser))
+TEST_F(SegmentManager_test, getSegmentMappingsEmptyForNonExistingUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ca869fa8-49cd-43bc-8d72-4024b45f1f5f");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     auto mapping = sut.getSegmentMappings(PosixUser{"no_user"});
     ASSERT_THAT(mapping.size(), Eq(0u));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserWithWriteUser))
+TEST_F(SegmentManager_test, getMemoryManagerForUserWithWriteUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2fd4262a-20d2-4631-9b63-610944f28120");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     auto memoryManager = sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"iox_roudi_test2"}).m_memoryManager;
     ASSERT_TRUE(memoryManager.has_value());
     ASSERT_THAT(memoryManager.value().get().getNumberOfMemPools(), Eq(2u));
@@ -141,22 +151,28 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUse
     EXPECT_THAT(poolInfo2.m_numChunks, Eq(7u));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserFailWithReadOnlyUser))
+TEST_F(SegmentManager_test, getMemoryManagerForUserFailWithReadOnlyUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9d7c18fd-b8db-425a-830d-22c781091244");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     EXPECT_FALSE(
         sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"iox_roudi_test1"}).m_memoryManager.has_value());
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(getMemoryManagerForUserFailWithNonExistingUser))
+TEST_F(SegmentManager_test, getMemoryManagerForUserFailWithNonExistingUser)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bff18ab5-89ff-45e0-97ea-5409169ddf9a");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     EXPECT_FALSE(sut.getSegmentInformationWithWriteAccessForUser(PosixUser{"no_user"}).m_memoryManager.has_value());
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMoreThanOneWriterGroupFails))
+TEST_F(SegmentManager_test, addingMoreThanOneWriterGroupFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3fa29560-7341-43bf-a22e-2d3550b49e4e");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     SegmentConfig segmentConfig = getInvalidSegmentConfig();
     SegmentManager<> sut{segmentConfig, &allocator};
 
@@ -173,9 +189,11 @@ TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMoreThanOneWrite
     EXPECT_THAT(detectedError.value(), Eq(iox::PoshError::MEPOO__USER_WITH_MORE_THAN_ONE_WRITE_SEGMENT));
 }
 
-TEST_F(SegmentManager_test, ADD_TEST_WITH_ADDITIONAL_USER(addingMaximumNumberOfSegmentsWorks))
+TEST_F(SegmentManager_test, addingMaximumNumberOfSegmentsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "79db009a-da1a-4140-b375-f174af615d54");
+    GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
+
     SegmentConfig segmentConfig = getSegmentConfigWithMaximumNumberOfSegements();
     SegmentManager<MePooSegmentMock> sut{segmentConfig, &allocator};
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR removes the `ADD_TEST_WITH_ADDITIONAL_USER` macro which adds a `DISABLED_` in front of the test name when the `TEST_WITH_ADDITIONAL_USER` cmake parameter is set to `OFF`, which is the default.

As replacement a `GTEST_SKIP_FOR_ADDITIONAL_USER` macro is introduced which uses `GTEST_SKIP` when the previous mentioned cmake parameter is `OFF`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1635
