### PR TITLE
iox-1394 fix AUTOSAR violations in vector

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@
 1. [ ] Branch follows the naming format (`iox-123-this-is-a-branch`)
 1. [ ] Commits messages are according to this [guideline][commit-guidelines]
     - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
-    - [ ] Commit messages are signed (`git commit -s`)
     - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
 1. [ ] Update the PR title
    - Follow the same conventions as for commit messages

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -36,7 +36,7 @@ namespace cxx
 template <typename T, uint64_t Capacity>
 // NOLINTJUSTIFICATION @todo iox-#1614 will be solved with upcoming uninitialized array
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
-class vector
+class vector final
 {
   public:
     using iterator = T*;
@@ -218,21 +218,29 @@ class vector
 
     void clearFrom(const uint64_t startPosition) noexcept;
 
-    /// @todo iox-#1614 Replace with UninitializedArray
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
+    // the vector class
+    /// @todo #1196 Replace with UninitializedArray
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     using element_t = uint8_t[sizeof(T)];
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
+    // the vector class
     alignas(T) element_t m_data[Capacity];
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     uint64_t m_size{0U};
 };
+
+// AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
+// comparison of vectors with different capacity
+template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
+bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
+
+// AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
+// comparison of vectors with different capacity
+template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
+bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
 } // namespace cxx
 } // namespace iox
-
-template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-bool operator==(const iox::cxx::vector<T, CapacityLeft>& lhs, const iox::cxx::vector<T, CapacityRight>& rhs) noexcept;
-
-template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-bool operator!=(const iox::cxx::vector<T, CapacityLeft>& lhs, const iox::cxx::vector<T, CapacityRight>& rhs) noexcept;
 
 #include "iceoryx_hoofs/internal/cxx/vector.inl"
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -17,6 +17,7 @@
 #ifndef IOX_HOOFS_CXX_VECTOR_HPP
 #define IOX_HOOFS_CXX_VECTOR_HPP
 
+#include "iceoryx_hoofs/cxx/algorithm.hpp"
 #include "iceoryx_hoofs/cxx/attributes.hpp"
 #include "iceoryx_hoofs/cxx/requires.hpp"
 
@@ -152,7 +153,7 @@ class vector final
 
     /// @brief returns the capacity of the vector which was given via the template
     ///         argument
-    uint64_t capacity() const noexcept;
+    static constexpr uint64_t capacity() noexcept;
 
     /// @brief returns the number of elements which are currently stored in the
     ///         vector
@@ -218,13 +219,13 @@ class vector final
 
     void clearFrom(const uint64_t startPosition) noexcept;
 
-    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
-    // the vector class
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the C-style array is wrapped
+    // inside the vector class
     /// @todo #1196 Replace with UninitializedArray
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     using element_t = uint8_t[sizeof(T)];
-    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the char array is wrapped inside
-    // the vector class
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the C-style array is wrapped
+    // inside the vector class
     alignas(T) element_t m_data[Capacity];
     // NOLINTEND(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     uint64_t m_size{0U};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -20,6 +20,7 @@
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
 #include "iceoryx_hoofs/cxx/attributes.hpp"
 #include "iceoryx_hoofs/cxx/requires.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 #include <algorithm>
 #include <cstdint>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -235,12 +235,12 @@ class vector final
 // AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
 // comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
+constexpr bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
 
 // AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
 // comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
+constexpr bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept;
 } // namespace cxx
 } // namespace iox
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/vector.hpp
@@ -222,7 +222,7 @@ class vector final
 
     // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the C-style array is wrapped
     // inside the vector class
-    /// @todo #1196 Replace with UninitializedArray
+    /// @todo iox-#1614 Replace with UninitializedArray
     // NOLINTBEGIN(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
     using element_t = uint8_t[sizeof(T)];
     // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the C-style array is wrapped

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -33,9 +33,8 @@ inline vector<T, Capacity>::vector(const uint64_t count, const T& value) noexcep
 {
     if (count > Capacity)
     {
-        std::cerr << "Attempting to initialize a vector of capacity " << Capacity << " with " << count
-                  << " elements. This exceeds the capacity and only " << Capacity << " elements will be created!"
-                  << std::endl;
+        IOX_LOG(ERROR) << "Attempting to initialize a vector of capacity " << Capacity << " with " << count
+                       << " elements. This exceeds the capacity and only " << Capacity << " elements will be created!";
     }
 
     for (uint64_t i{0U}; (i < count) && (i < Capacity); ++i)
@@ -45,16 +44,14 @@ inline vector<T, Capacity>::vector(const uint64_t count, const T& value) noexcep
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1 : false positive, m_data is initialized via placement new in for loop
-// NOLINTJUSTIFICATION Not all elements in the array shall be initialized
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline vector<T, Capacity>::vector(const uint64_t count) noexcept
 {
     if (count > Capacity)
     {
-        std::cerr << "Attempting to initialize a vector of capacity " << Capacity << " with " << count
-                  << " elements. This exceeds the capacity and only " << Capacity << " elements will be created!"
-                  << std::endl;
+        IOX_LOG(ERROR) << "Attempting to initialize a vector of capacity " << Capacity << " with " << count
+                       << " elements. This exceeds the capacity and only " << Capacity << " elements will be created!";
     }
 
     m_size = std::min(count, Capacity);
@@ -66,7 +63,6 @@ inline vector<T, Capacity>::vector(const uint64_t count) noexcept
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1 : false positive, m_data is initialized via emplace_back method
-// NOLINTJUSTIFICATION Not all elements in the array shall be initialized
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline vector<T, Capacity>::vector(const vector& rhs) noexcept
@@ -75,7 +71,6 @@ inline vector<T, Capacity>::vector(const vector& rhs) noexcept
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1 : false positive, m_data is initialized via emplace_back method
-// NOLINTJUSTIFICATION Not all elements in the array shall be initialized
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline vector<T, Capacity>::vector(vector&& rhs) noexcept
@@ -136,7 +131,7 @@ inline vector<T, Capacity>& vector<T, Capacity>::operator=(vector&& rhs) noexcep
         // move using move ctor
         for (; i < rhsSize; ++i)
         {
-            emplace_back(std::move(rhs.at(i)));
+            IOX_DISCARD_RESULT(emplace_back(std::move(rhs.at(i))));
         }
 
         // delete remaining elements
@@ -197,7 +192,7 @@ inline bool vector<T, Capacity>::emplace(const uint64_t position, Targs&&... arg
     {
         return emplace_back(std::forward<Targs>(args)...);
     }
-    emplace_back(std::move(at_unchecked(m_size - 1U)));
+    IOX_DISCARD_RESULT(emplace_back(std::move(at_unchecked(m_size - 1U))));
     for (uint64_t i{m_size - 1U}; i > position; --i)
     {
         at_unchecked(i) = std::move(at_unchecked(i - 1U));

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -240,16 +240,12 @@ inline bool vector<T, Capacity>::resize(const uint64_t count, const Targs&... ar
     {
         clearFrom(count);
     }
-    else if (count > m_size)
+    else
     {
         while (count != m_size)
         {
             IOX_DISCARD_RESULT(emplace_back(args...));
         }
-    }
-    else
-    {
-        // count == m_size : no resize necessary
     }
     return true;
 }
@@ -404,7 +400,7 @@ inline void vector<T, Capacity>::clearFrom(const uint64_t startPosition) noexcep
 // AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
 // comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-inline bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
+inline constexpr bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {
     uint64_t vectorSize{lhs.size()};
     if (vectorSize != rhs.size())
@@ -425,7 +421,7 @@ inline bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, Capac
 // AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
 // comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-inline bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
+inline bool constexpr operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -188,7 +188,7 @@ template <typename T, uint64_t Capacity>
 template <typename... Targs>
 inline bool vector<T, Capacity>::emplace(const uint64_t position, Targs&&... args) noexcept
 {
-    if ((m_size >= Capacity) || (position >= Capacity) || (position > m_size))
+    if ((m_size >= Capacity) || ((position >= Capacity) || (position > m_size)))
     {
         return false;
     }
@@ -369,9 +369,10 @@ inline bool vector<T, Capacity>::erase(iterator position) noexcept
     {
         uint64_t index{static_cast<uint64_t>(position - begin()) % (sizeof(element_t) * Capacity)};
         size_t n{index};
-        for (; (n + 1U) < size(); ++n)
+        while ((n + 1U) < size())
         {
             at(n) = std::move(at(n + 1U));
+            ++n;
         }
         at(n).~T();
         m_size--;
@@ -392,9 +393,8 @@ template <typename T, uint64_t Capacity>
 inline const T& vector<T, Capacity>::at_unchecked(const uint64_t index) const noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type-safety ensured by template parameter
-    // NOLINTJUSTIFICATION User accessible method at() performs bounds check
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    return reinterpret_cast<const T*>(m_data)[index];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return *reinterpret_cast<const T*>(&m_data[index]);
 }
 
 template <typename T, uint64_t Capacity>
@@ -406,6 +406,8 @@ inline void vector<T, Capacity>::clearFrom(const uint64_t startPosition) noexcep
     }
 }
 
+// AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
+// comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
 inline bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {
@@ -425,6 +427,8 @@ inline bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, Capac
     return true;
 }
 
+// AXIVION Next Construct AutosarC++19_03-A13.5.5 : intentional implementation with different parameters to enable
+// comparison of vectors with different capacity
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
 inline bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -390,12 +390,8 @@ inline void vector<T, Capacity>::clearFrom(const uint64_t startPosition) noexcep
     }
 }
 
-} // namespace cxx
-} // namespace iox
-
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-inline bool operator==(const iox::cxx::vector<T, CapacityLeft>& lhs,
-                       const iox::cxx::vector<T, CapacityRight>& rhs) noexcept
+inline bool operator==(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {
     uint64_t vectorSize = lhs.size();
     if (vectorSize != rhs.size())
@@ -414,11 +410,10 @@ inline bool operator==(const iox::cxx::vector<T, CapacityLeft>& lhs,
 }
 
 template <typename T, uint64_t CapacityLeft, uint64_t CapacityRight>
-inline bool operator!=(const iox::cxx::vector<T, CapacityLeft>& lhs,
-                       const iox::cxx::vector<T, CapacityRight>& rhs) noexcept
+inline bool operator!=(const vector<T, CapacityLeft>& lhs, const vector<T, CapacityRight>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
-
-
+} // namespace cxx
+} // namespace iox
 #endif // IOX_HOOFS_CXX_VECTOR_INL

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/vector.inl
@@ -26,7 +26,7 @@ namespace iox
 namespace cxx
 {
 // AXIVION Next Construct AutosarC++19_03-A12.6.1 : false positive, m_data is initialized via emplace_back method
-// NOLINTJUSTIFICATION See header and todo, using UninitializedArray will solve the issue
+// NOLINTJUSTIFICATION @todo iox-#1614 using UninitializedArray will solve the issue
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline vector<T, Capacity>::vector(const uint64_t count, const T& value) noexcept

--- a/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_vector.cpp
@@ -116,7 +116,8 @@ class vector_test : public Test
         dtorOrder.clear();
     }
 
-    vector<uint64_t, 10U> sut;
+    static constexpr uint64_t VECTOR_CAPACITY{10};
+    vector<uint64_t, VECTOR_CAPACITY> sut;
 };
 
 uint64_t vector_test::cTor;
@@ -441,15 +442,16 @@ TEST_F(vector_test, DestructorSomeElements)
 TEST_F(vector_test, DestructorWithFullVector)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c439128d-de50-4af0-bb56-b219d0326afd");
+    constexpr uint64_t CAPACITY{10};
     {
-        vector<CTorTest, 10U> sut1;
-        for (uint64_t i = 0U; i < sut1.capacity(); ++i)
+        vector<CTorTest, CAPACITY> sut1;
+        for (uint64_t i = 0U; i < CAPACITY; ++i)
         {
             sut1.emplace_back(1231U);
         }
     }
 
-    EXPECT_THAT(dTor, Eq(10U));
+    EXPECT_THAT(dTor, Eq(CAPACITY));
 }
 
 TEST_F(vector_test, EmplacingElementInTheMiddleCallsDTor)
@@ -460,7 +462,7 @@ TEST_F(vector_test, EmplacingElementInTheMiddleCallsDTor)
     constexpr uint64_t EMPLACE_POSITION{5U};
     {
         vector<CTorTest, CAPACITY_OF_VECTOR> sut;
-        for (uint64_t i = 0U; i < sut.capacity() - 1U; ++i)
+        for (uint64_t i = 0U; i < CAPACITY_OF_VECTOR - 1U; ++i)
         {
             sut.emplace_back(1234U);
         }
@@ -727,7 +729,7 @@ TEST_F(vector_test, BeginConstIteratorComesBeforeEndConstIteratorWhenNotEmpty)
 TEST_F(vector_test, BeginIteratorComesBeforeEndIteratorWhenFull)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f20cda46-0941-440e-87cb-a0a111719182");
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    for (uint64_t i = 0U; i < VECTOR_CAPACITY; ++i)
     {
         sut.emplace_back(i);
     }
@@ -737,7 +739,7 @@ TEST_F(vector_test, BeginIteratorComesBeforeEndIteratorWhenFull)
 TEST_F(vector_test, BeginConstIteratorComesBeforeEndConstIteratorWhenFull)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9912c12f-25a4-47f3-a3a6-714c543dd882");
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    for (uint64_t i = 0U; i < VECTOR_CAPACITY; ++i)
     {
         sut.emplace_back(i);
     }
@@ -788,7 +790,7 @@ TEST_F(vector_test, ConstIteratorIteratesThroughNonEmptyVector)
 TEST_F(vector_test, IteratorIteratesThroughFullVector)
 {
     ::testing::Test::RecordProperty("TEST_ID", "147f78a9-0e60-43aa-ac72-c7a012904f5b");
-    for (uint64_t k = 0U; k < sut.capacity(); ++k)
+    for (uint64_t k = 0U; k < VECTOR_CAPACITY; ++k)
     {
         sut.emplace_back(42U * k);
     }
@@ -805,7 +807,7 @@ TEST_F(vector_test, IteratorIteratesThroughFullVector)
 TEST_F(vector_test, ConstIteratorIteratesThroughFullVector)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0d8063b0-1a38-4130-a6cb-3e2a7f3c4304");
-    for (uint64_t k = 0U; k < sut.capacity(); ++k)
+    for (uint64_t k = 0U; k < VECTOR_CAPACITY; ++k)
     {
         sut.emplace_back(142U * k);
     }
@@ -1026,7 +1028,7 @@ TEST_F(vector_test, EraseLastElementDataCorrectAfterwards)
 TEST_F(vector_test, EraseLastElementOfFullVectorDataCorrectAfterwards)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fa4041c7-0fe4-43a9-8722-b1c6077b69d7");
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    for (uint64_t i = 0U; i < VECTOR_CAPACITY; ++i)
     {
         sut.emplace_back(i * 123U);
     }
@@ -1373,8 +1375,9 @@ TEST_F(vector_test, SizeIncreaseWithResizeAndTemplateValueWorks)
 TEST_F(vector_test, SizeDecreaseWithResizeAndDefaultCTorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bfd86fcc-c828-4b1b-ab9a-cff7e0f22164");
-    iox::cxx::vector<CTorTest, 10U> sut;
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    constexpr uint64_t CAPACITY{10};
+    iox::cxx::vector<CTorTest, CAPACITY> sut;
+    for (uint64_t i = 0U; i < CAPACITY; ++i)
     {
         sut.emplace_back(i);
     }
@@ -1390,8 +1393,9 @@ TEST_F(vector_test, SizeDecreaseWithResizeAndDefaultCTorWorks)
 TEST_F(vector_test, SizeDecreaseWithResizeAndTemplateValueWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6b2d81ce-1d46-47a6-bbb2-16f1c0ce46f3");
-    iox::cxx::vector<CTorTest, 10U> sut;
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    constexpr uint64_t CAPACITY{10};
+    iox::cxx::vector<CTorTest, CAPACITY> sut;
+    for (uint64_t i = 0U; i < CAPACITY; ++i)
     {
         sut.emplace_back(i + 10U);
     }
@@ -1439,7 +1443,7 @@ TEST_F(vector_test, EmplaceInEmptyVectorWorks)
 TEST_F(vector_test, EmplaceAtFrontTillFullWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c7074b38-8493-4b53-acc2-9a20d0f735ce");
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    for (uint64_t i = 0U; i < VECTOR_CAPACITY; ++i)
     {
         EXPECT_TRUE(sut.emplace(0U, i));
         ASSERT_THAT(sut.size(), Eq(i + 1U));
@@ -1471,12 +1475,12 @@ TEST_F(vector_test, EmplaceInTheMiddleMovesElementsToTheRight)
 TEST_F(vector_test, EmplaceWhenFullReturnsFalse)
 {
     ::testing::Test::RecordProperty("TEST_ID", "93e5d45c-9450-4ceb-8d1c-78aae413eca8");
-    for (uint64_t i = 0U; i < sut.capacity(); ++i)
+    for (uint64_t i = 0U; i < VECTOR_CAPACITY; ++i)
     {
         sut.emplace_back(i);
     }
 
-    auto index = sut.capacity() / 2;
+    auto index = VECTOR_CAPACITY / 2;
     EXPECT_FALSE(sut.emplace(index, 5U));
     EXPECT_THAT(sut.size(), Eq(sut.capacity()));
 }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes a first set of Axivion warnings in `vector`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partially)
