### PR TITLE
iox-#1725 Add refcounting to the PoshRuntime

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -18,6 +18,7 @@
 #define IOX_POSH_RUNTIME_POSH_RUNTIME_HPP
 
 #include "iceoryx_hoofs/cxx/optional.hpp"
+#include "iceoryx_hoofs/cxx/scope_guard.hpp"
 #include "iceoryx_posh/capro/service_description.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/condition_variable_data.hpp"
@@ -70,6 +71,17 @@ class PoshRuntime
     ///
     /// @return active runtime
     static PoshRuntime& initRuntime(const RuntimeName_t& name) noexcept;
+
+    /// @brief provides an object to extend the lifetime of the runtime
+    /// @details While the PoshRuntime has static lifetime, it may not live long enough
+    ///          when other static variables depend, possibly indirectly, on the PoshRuntime.
+    ///          This is why its lifetime can be extended with this refcounting mechanism.
+    ///          Those other static variables should store a lifetime participant object as a
+    ///          static variable in the same translation unit before itself, to ensure that the
+    ///          lifetime participant and thus the PoshRuntime lives long enough.
+    ///
+    /// @return an opaque RAII object
+    static cxx::ScopeGuard getLifetimeParticipant() noexcept;
 
     /// @brief get the name that was used to register with RouDi
     /// @return name of the registered application


### PR DESCRIPTION
This uses manual creation and destruction of the runtime, like in the nifty counter idiom. However, unlike the nifty counter idiom, the scope guard object is not a global static variable, but a local static, so that the factory can be set before the runtime is created.

## Pre-Review Checklist for the PR Author

1. [X] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [X] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [X] Commits messages are according to this [guideline][commit-guidelines]
    - [X] Commit messages have the issue ID (`iox-#123 commit text`)
    - [X] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [X] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [X] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [X] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1725
