### PR TITLE
iox-#1394 Fix compiler warning in functional interface

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
@@ -59,6 +59,11 @@ struct HasGetErrorMethod<Derived, cxx::void_t<decltype(std::declval<Derived>().g
 void print_expect_message(const char* message) noexcept;
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct Expect
 {
     /// @brief Expects that the object is valid, otherwise the method prints the
@@ -68,17 +73,16 @@ struct Expect
     template <typename StringType>
     void expect(const StringType& msg) const noexcept;
 
-    Expect() noexcept = default;
-    Expect(const Expect&) noexcept = default;
-    Expect(Expect&&) noexcept = default;
-    Expect& operator=(const Expect&) noexcept = default;
-    Expect& operator=(Expect&&) noexcept = default;
-
   protected:
     ~Expect() = default;
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ExpectWithValue
 {
     /// @brief Expects that the object is valid and returns the contained value, otherwise
@@ -113,17 +117,16 @@ struct ExpectWithValue
     template <typename StringType>
     const ValueType&& expect(const StringType& msg) const&& noexcept;
 
-    ExpectWithValue() noexcept = default;
-    ExpectWithValue(const ExpectWithValue&) noexcept = default;
-    ExpectWithValue(ExpectWithValue&&) noexcept = default;
-    ExpectWithValue& operator=(const ExpectWithValue&) noexcept = default;
-    ExpectWithValue& operator=(ExpectWithValue&&) noexcept = default;
-
   protected:
     ~ExpectWithValue() = default;
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct ValueOr
 {
     /// @brief When the object contains a value a copy will be returned otherwise
@@ -144,17 +147,16 @@ struct ValueOr
     template <typename U>
     ValueType value_or(U&& alternative) && noexcept;
 
-    ValueOr() noexcept = default;
-    ValueOr(const ValueOr&) noexcept = default;
-    ValueOr(ValueOr&&) noexcept = default;
-    ValueOr& operator=(const ValueOr&) noexcept = default;
-    ValueOr& operator=(ValueOr&&) noexcept = default;
-
   protected:
     ~ValueOr() = default;
 };
 
 template <typename Derived, typename ValueType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AndThenWithValue
 {
     using and_then_callback_t = cxx::function_ref<void(ValueType&)>;
@@ -197,17 +199,16 @@ struct AndThenWithValue
     template <typename Functor>
     const Derived&& and_then(const Functor& callable) const&& noexcept;
 
-    AndThenWithValue() noexcept = default;
-    AndThenWithValue(const AndThenWithValue&) noexcept = default;
-    AndThenWithValue(AndThenWithValue&&) noexcept = default;
-    AndThenWithValue& operator=(const AndThenWithValue&) noexcept = default;
-    AndThenWithValue& operator=(AndThenWithValue&&) noexcept = default;
-
   protected:
     ~AndThenWithValue() = default;
 };
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct AndThen
 {
     using and_then_callback_t = cxx::function_ref<void()>;
@@ -236,17 +237,16 @@ struct AndThen
     /// @return const rvalue reference to *this
     const Derived&& and_then(const and_then_callback_t& callable) const&& noexcept;
 
-    AndThen() noexcept = default;
-    AndThen(const AndThen&) noexcept = default;
-    AndThen(AndThen&&) noexcept = default;
-    AndThen& operator=(const AndThen&) noexcept = default;
-    AndThen& operator=(AndThen&&) noexcept = default;
-
   protected:
     ~AndThen() = default;
 };
 
 template <typename Derived, typename ErrorType>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct OrElseWithValue
 {
     using or_else_callback_t = cxx::function_ref<void(ErrorType&)>;
@@ -289,17 +289,16 @@ struct OrElseWithValue
     template <typename Functor>
     const Derived&& or_else(const Functor& callable) const&& noexcept;
 
-    OrElseWithValue() noexcept = default;
-    OrElseWithValue(const OrElseWithValue&) noexcept = default;
-    OrElseWithValue(OrElseWithValue&&) noexcept = default;
-    OrElseWithValue& operator=(const OrElseWithValue&) noexcept = default;
-    OrElseWithValue& operator=(OrElseWithValue&&) noexcept = default;
-
   protected:
     ~OrElseWithValue() = default;
 };
 
 template <typename Derived>
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct OrElse
 {
     using or_else_callback_t = cxx::function_ref<void()>;
@@ -328,12 +327,6 @@ struct OrElse
     /// @return const rvalue reference to *this
     const Derived&& or_else(const or_else_callback_t& callable) const&& noexcept;
 
-    OrElse() noexcept = default;
-    OrElse(const OrElse&) noexcept = default;
-    OrElse(OrElse&&) noexcept = default;
-    OrElse& operator=(const OrElse&) noexcept = default;
-    OrElse& operator=(OrElse&&) noexcept = default;
-
   protected:
     ~OrElse() = default;
 };
@@ -346,17 +339,17 @@ template <typename Derived, typename ValueType, typename ErrorType>
 // All classes which are inherited from in FunctionalInterfaceImpl are also non-virtual stateless interface classes
 // with a default implementation. But they dont come with the downside of an explicit user-side
 // forward implementation.
+//
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl : public ExpectWithValue<Derived, ValueType>,
                                  public ValueOr<Derived, ValueType>,
                                  public AndThenWithValue<Derived, ValueType>,
                                  public OrElseWithValue<Derived, ErrorType>
 {
-    FunctionalInterfaceImpl() noexcept = default;
-    FunctionalInterfaceImpl(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl(FunctionalInterfaceImpl&&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(FunctionalInterfaceImpl&&) noexcept = default;
-
   protected:
     ~FunctionalInterfaceImpl() = default;
 };
@@ -369,15 +362,15 @@ template <typename Derived>
 // All classes which are inherited from in FunctionalInterfaceImpl are also non-virtual stateless interface classes
 // with a default implementation. But they dont come with the downside of an explicit user-side
 // forward implementation.
+//
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, void, void>
     : public Expect<Derived>, public AndThen<Derived>, public OrElse<Derived>
 {
-    FunctionalInterfaceImpl() noexcept = default;
-    FunctionalInterfaceImpl(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl(FunctionalInterfaceImpl&&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(FunctionalInterfaceImpl&&) noexcept = default;
-
   protected:
     ~FunctionalInterfaceImpl() = default;
 };
@@ -390,17 +383,17 @@ template <typename Derived, typename ValueType>
 // All classes which are inherited from in FunctionalInterfaceImpl are also non-virtual stateless interface classes
 // with a default implementation. But they dont come with the downside of an explicit user-side
 // forward implementation.
+//
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, ValueType, void> : public ExpectWithValue<Derived, ValueType>,
                                                            public ValueOr<Derived, ValueType>,
                                                            public AndThenWithValue<Derived, ValueType>,
                                                            public OrElse<Derived>
 {
-    FunctionalInterfaceImpl() noexcept = default;
-    FunctionalInterfaceImpl(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl(FunctionalInterfaceImpl&&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(FunctionalInterfaceImpl&&) noexcept = default;
-
   protected:
     ~FunctionalInterfaceImpl() = default;
 };
@@ -413,15 +406,15 @@ template <typename Derived, typename ErrorType>
 // All classes which are inherited from in FunctionalInterfaceImpl are also non-virtual stateless interface classes
 // with a default implementation. But they dont come with the downside of an explicit user-side
 // forward implementation.
+//
+// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// not deleted.
+// the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
+// explicitly calling the destructor of the base type.
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 struct FunctionalInterfaceImpl<Derived, void, ErrorType>
     : public Expect<Derived>, public AndThen<Derived>, public OrElseWithValue<Derived, ErrorType>
 {
-    FunctionalInterfaceImpl() noexcept = default;
-    FunctionalInterfaceImpl(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl(FunctionalInterfaceImpl&&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(const FunctionalInterfaceImpl&) noexcept = default;
-    FunctionalInterfaceImpl& operator=(FunctionalInterfaceImpl&&) noexcept = default;
-
   protected:
     ~FunctionalInterfaceImpl() = default;
 };


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes **TBD**
