### PR TITLE
iox-#1736 use clang format 15 in ci

### DIFF
--- a/.github/actions/install-iceoryx-deps-and-clang/action.yml
+++ b/.github/actions/install-iceoryx-deps-and-clang/action.yml
@@ -13,6 +13,8 @@ runs:
         sudo rm /usr/bin/clang
         sudo rm /usr/bin/clang++
         sudo rm /usr/bin/clang-tidy
+        sudo rm /usr/bin/clang-format
         sudo ln -s /usr/bin/clang-15 /usr/bin/clang
         sudo ln -s /usr/bin/clang++-15 /usr/bin/clang++
         sudo ln -s /usr/bin/clang-tidy-15 /usr/bin/clang-tidy
+        sudo ln -s /usr/bin/clang-format-15 /usr/bin/clang-format

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install iceoryx dependencies and clang-tidy
+        uses: ./.github/actions/install-iceoryx-deps-and-clang
       - run: ./tools/scripts/clang_format.sh check
       - run: ./tools/scripts/list_stl_dependencies.sh check
       - run: ./tools/scripts/check_test_ids.sh

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -54,6 +54,7 @@
 - `gw::GatewayGeneric` sometimes terminates discovery and forward threads immediately [\#1666](https://github.com/eclipse-iceoryx/iceoryx/issues/1666)
 - `m_originId` in `mepoo::ChunkHeader` sometimes not set [\#1668](https://github.com/eclipse-iceoryx/iceoryx/issues/1668)
 - Removed `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
+- CI uses outdated clang-format [\#1736](https://github.com/eclipse-iceoryx/iceoryx/issues/1736)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
@@ -31,11 +31,11 @@ using ExternalTerminalPool = cxx::ObjectPool<ExternalTerminal, MAX_CHANNEL_NUMBE
 
 // Statics
 template <typename IceoryxTerminal, typename ExternalTerminal>
-IceoryxTerminalPool<IceoryxTerminal>
-    Channel<IceoryxTerminal, ExternalTerminal>::s_iceoryxTerminals = IceoryxTerminalPool();
+IceoryxTerminalPool<IceoryxTerminal> Channel<IceoryxTerminal, ExternalTerminal>::s_iceoryxTerminals =
+    IceoryxTerminalPool();
 template <typename IceoryxTerminal, typename ExternalTerminal>
-ExternalTerminalPool<ExternalTerminal>
-    Channel<IceoryxTerminal, ExternalTerminal>::s_externalTerminals = ExternalTerminalPool();
+ExternalTerminalPool<ExternalTerminal> Channel<IceoryxTerminal, ExternalTerminal>::s_externalTerminals =
+    ExternalTerminalPool();
 
 template <typename IceoryxTerminal, typename ExternalTerminal>
 inline constexpr Channel<IceoryxTerminal, ExternalTerminal>::Channel(

--- a/iceoryx_posh/include/iceoryx_posh/popo/enum_trigger_type.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/enum_trigger_type.hpp
@@ -33,12 +33,12 @@ using EventEnumIdentifier = int64_t;
 /// @brief contains true when T is an event based enum, otherwise false
 template <typename T>
 constexpr bool IS_EVENT_ENUM =
-    std::is_enum<T>::value&& std::is_same<std::underlying_type_t<T>, EventEnumIdentifier>::value;
+    std::is_enum<T>::value && std::is_same<std::underlying_type_t<T>, EventEnumIdentifier>::value;
 
 /// @brief contains true when T is a state based enum, otherwise false
 template <typename T>
 constexpr bool IS_STATE_ENUM =
-    std::is_enum<T>::value&& std::is_same<std::underlying_type_t<T>, StateEnumIdentifier>::value;
+    std::is_enum<T>::value && std::is_same<std::underlying_type_t<T>, StateEnumIdentifier>::value;
 } // namespace popo
 } // namespace iox
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Ported from #1656 in the hope to also fix #1731. Locally I could not reproduce the pre-flight-check failure with clang-format-15.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1736
