### PR TITLE
iox-#1345 do not create logstream object when logging is off

### DIFF
--- a/iceoryx_hoofs/cmake/IceoryxHoofsDeployment.cmake
+++ b/iceoryx_hoofs/cmake/IceoryxHoofsDeployment.cmake
@@ -16,7 +16,7 @@
 
 message(STATUS "[i] <<<<<<<<<<<<< Start iceoryx_hoofs configuration: >>>>>>>>>>>>>")
 
-if(NOT IOX_MINIMAL_LOG_LEVEL)
+if(NOT DEFINED IOX_MINIMAL_LOG_LEVEL)
     set(IOX_MINIMAL_LOG_LEVEL "TRACE")
 endif()
 message(STATUS "[i] IOX_MINIMAL_LOG_LEVEL: " ${IOX_MINIMAL_LOG_LEVEL})

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -200,6 +200,27 @@ inline LogStream& LogStream::operator<<(const LogLevel value) noexcept
     return *this;
 }
 
+namespace internal
+{
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
+inline LogStreamOff::LogStreamOff(const char*, const int, const char*, LogLevel, bool) noexcept
+{
+}
+
+inline LogStreamOff& LogStreamOff::self() noexcept
+{
+    return *this;
+}
+
+// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// not require to implement '<<='
+template <typename T>
+inline LogStreamOff& LogStreamOff::operator<<(T&&) noexcept
+{
+    return *this;
+}
+} // namespace internal
+
 } // namespace log
 } // namespace iox
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logging.hpp
@@ -34,7 +34,6 @@ inline bool isLogLevelActive(LogLevel logLevel) noexcept
     // AXIVION Next Construct AutosarC++19_03-M5.14.1 getLogLevel is a static method without side effects
     return ((logLevel) <= MINIMAL_LOG_LEVEL) && (IGNORE_ACTIVE_LOG_LEVEL || ((logLevel) <= log::Logger::getLogLevel()));
 }
-
 } // namespace internal
 } // namespace log
 } // namespace iox
@@ -45,7 +44,8 @@ inline bool isLogLevelActive(LogLevel logLevel) noexcept
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define IOX_LOG_INTERNAL(file, line, function, level)                                                                  \
     /* if (iox::log::internal::isLogLevelActive(level)) @todo iox-#1345 lazy evaluation causes issues with Axivion */  \
-    iox::log::LogStream(file, line, function, level, iox::log::internal::isLogLevelActive(level)).self()
+    iox::log::internal::SelectedLogStream(file, line, function, level, iox::log::internal::isLogLevelActive(level))    \
+        .self()
 
 /// @brief Macro for logging
 /// @param[in] level is the log level to be used for the log message

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -227,6 +227,37 @@ class LogStream
     bool m_doFlush{true};
 };
 
+namespace internal
+{
+/// @brief This is an internal helper struct to fully remove the logger from the compiled binary
+/// when 'IOX_MINIMAL_LOG_LEVEL == OFF'. It is not intended for direct usage.
+struct LogStreamOff
+{
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : file, line and function are used in conjunction with '__FILE__',
+    // '__LINE__' and '__FUNCTION__'; these are compiler intrinsic and cannot be changed to fixed width types in a
+    // platform agnostic way
+    inline LogStreamOff(const char*, const int, const char*, LogLevel, bool) noexcept;
+    inline LogStreamOff& self() noexcept;
+
+    template <typename T>
+    inline LogStreamOff& operator<<(T&&) noexcept;
+};
+
+template <LogLevel level>
+struct LogStreamTypeSelector
+{
+    using type = iox::log::LogStream;
+};
+
+template <>
+struct LogStreamTypeSelector<iox::log::LogLevel::OFF>
+{
+    using type = iox::log::internal::LogStreamOff;
+};
+
+using SelectedLogStream = typename LogStreamTypeSelector<MINIMAL_LOG_LEVEL>::type;
+} // namespace internal
+
 } // namespace log
 } // namespace iox
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.inl
@@ -21,6 +21,8 @@ namespace iox
 {
 namespace popo
 {
+namespace internal
+{
 /// @todo iox-#1712 Add minVal() without reference to iox::algorithm?! C++11 needs a declaration for constexpr!
 ///       Ex.: constexpr uint32_t DefaultChunkDistributorConfig::MAX_HISTORY_CAPACITY;
 ///       This wouldn't be an issue in C++17.
@@ -29,18 +31,18 @@ constexpr T min(const T left, const T right) noexcept
 {
     return (left < right) ? left : right;
 }
+} // namespace internal
 
 template <typename ChunkDistributorDataProperties, typename LockingPolicy, typename ChunkQueuePusherType>
 inline ChunkDistributorData<ChunkDistributorDataProperties, LockingPolicy, ChunkQueuePusherType>::ChunkDistributorData(
     const ConsumerTooSlowPolicy policy, const uint64_t historyCapacity) noexcept
     : LockingPolicy()
-    , m_historyCapacity(min(historyCapacity, ChunkDistributorDataProperties_t::MAX_HISTORY_CAPACITY))
+    , m_historyCapacity(internal::min(historyCapacity, ChunkDistributorDataProperties_t::MAX_HISTORY_CAPACITY))
     , m_consumerTooSlowPolicy(policy)
 {
     if (m_historyCapacity != historyCapacity)
     {
-        LogWarn() << "Chunk history too large, reducing from " << historyCapacity << " to "
-                  << ChunkDistributorDataProperties_t::MAX_HISTORY_CAPACITY;
+        LogWarn() << "Chunk history too large, reducing from " << historyCapacity << " to " << m_historyCapacity;
     }
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PRs removes the logger from the compiled binary when `IOX_MINIMAL_LOG_LEVEL == OFF`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1345
