### PR TITLE
iox-#1394 Address left-over AUTOSAR findings in `function_ref`

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function_ref.hpp
@@ -77,8 +77,8 @@ class function_ref<ReturnType(ArgTypes...)> final
     /// @brief Creates a function_ref with a callable whose lifetime has to be longer than function_ref
     /// @param[in] callable that is not a function_ref
     template <typename CallableType,
-              typename = std::enable_if_t<(!is_function_pointer<CallableType>::value)
-                                          && (!has_same_decayed_type<CallableType, function_ref>::value)
+              typename = std::enable_if_t<((!is_function_pointer<CallableType>::value)
+                                           && (!has_same_decayed_type<CallableType, function_ref>::value))
                                           && (is_invocable<CallableType, ArgTypes...>::value)>>
     // AXIVION Next Line AutosarC++19_03-A12.1.4 : Implicit conversion is needed for lambdas
     function_ref(CallableType&& callable) noexcept; // NOLINT(hicpp-explicit-conversions)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/function_ref.inl
@@ -29,20 +29,21 @@ namespace cxx
 {
 template <class ReturnType, class... ArgTypes>
 template <typename CallableType, typename>
-// AXIVION Next Construct AutosarC++19_03-A12.1.2 : Members are initialized in the same manner, NSDMI with nullptr is
-// explicit
+// AXIVION Next Construct AutosarC++19_03-A12.1.5 : Other c'tors can't be used as delegating c'tor
 // AXIVION Next Construct AutosarC++19_03-A8.4.6 : Only ArgTypes needs to be forwarded
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callable) noexcept
     // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.3, CertC++-EXP55 : Type-safety ensured by
     // casting back on call
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-type-const-cast)
     : m_pointerToCallable(const_cast<void*>(reinterpret_cast<const void*>(std::addressof(callable))))
-    // AXIVION Next Line AutosarC++19_03-A15.4.4 : Lambda not 'noexcept' as callable might throw
-    , m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
+    // AXIVION Next Construct AutosarC++19_03-A15.4.4, FaultDetection-NoexceptViolations : Lambda not 'noexcept' as callable might throw
+    // AXIVION Next Line AutosarC++19_03-M7.1.2 : Can't be const because the pointer to the callable needs to be mutable
+    , m_functionPointer([](void* const target, ArgTypes... args) -> ReturnType {
         // AXIVION Next Construct AutosarC++19_03-A5.2.4, CertC++-EXP36 : The class design ensures a cast to the actual
         // type of target
         // AXIVION Next Construct AutosarC++19_03-A5.3.2, AutosarC++19_03-M5.2.8 : Check for 'nullptr' is
-        // performed on call NOLINTNEXTLINE (cppcoreguidelines-pro-type-reinterpret-cast)
+        // performed on call
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         return (*reinterpret_cast<typename std::add_pointer<CallableType>::type>(target))(
             std::forward<ArgTypes>(args)...);
     })
@@ -52,18 +53,18 @@ inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callab
 template <class ReturnType, class... ArgTypes>
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(ReturnType (&function)(ArgTypes...)) noexcept
     // the cast is required to work on POSIX systems
-    // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.4-M5.2.6 : Type-safety ensured by casting
-    // back function pointer on call
+    // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-M5.2.6 : Type-safety ensured by casting
+    // back function pointer on call using the type provided as template parameter and encapsulated in this class
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     : m_pointerToCallable(reinterpret_cast<void*>(function))
     ,
     // the lambda does not capture and is thus convertible to a function pointer
     // (required by the C++ standard)
-    m_functionPointer([](void* target, ArgTypes... args) -> ReturnType {
+    m_functionPointer([](void* const target, ArgTypes... args) -> ReturnType {
         using PointerType = ReturnType (*)(ArgTypes...);
         // AXIVION Next Construct AutosarC++19_03-A5.2.4 : The class design ensures a cast to the actual type of target
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,hicpp-use-auto)
-        PointerType f = reinterpret_cast<PointerType>(target);
+        PointerType f{reinterpret_cast<PointerType>(target)};
         // AXIVION Next Line AutosarC++19_03-A5.3.2 : Check for 'nullptr' is performed on call
         return f(args...);
     })
@@ -96,7 +97,7 @@ inline ReturnType function_ref<ReturnType(ArgTypes...)>::operator()(ArgTypes... 
 {
     // Expect that a callable was assigned beforehand
     // AXIVION Next Line AutosarC++19_03-M5.3.1 : 'nullptr' check shall be performed explicitly
-    cxx::Expects((m_pointerToCallable != nullptr) && "Empty function_ref invoked");
+    cxx::ExpectsWithMsg(m_pointerToCallable != nullptr, "Empty function_ref invoked");
     return m_functionPointer(m_pointerToCallable, std::forward<ArgTypes>(args)...);
 }
 
@@ -108,7 +109,7 @@ inline void function_ref<ReturnType(ArgTypes...)>::swap(function_ref<ReturnType(
 }
 
 template <class ReturnType, class... ArgTypes>
-// AXIVION Next Line AutosarC++19_03-A2.10.4 : Overload for swap(function_ref, function_ref) as in STL
+// AXIVION Next Line AutosarC++19_03-A2.10.5 : False positive, overload for swap(function_ref, function_ref) as in STL
 inline void swap(function_ref<ReturnType(ArgTypes...)>& lhs, function_ref<ReturnType(ArgTypes...)>& rhs) noexcept
 {
     lhs.swap(rhs);

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -72,7 +72,7 @@ typedef testing::Types<uint8_t, int8_t, double> Types;
 
 TYPED_TEST_SUITE(RelativePointer_test, Types, );
 
-/// @todo iox-#605 the tests should be reworked in a refactoring of relative pointers
+/// @todo iox-#1745 the tests should be reworked
 TYPED_TEST(RelativePointer_test, ConstrTests)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cae7b4d4-86eb-42f6-b938-90a76f01bea5");


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] ~~Tests follow the [best practice for testing][testing]~~
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Address left-over AUTOSAR finding in `function_ref`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 
