### PR TITLE
iox-1750 Add `Expects` to `cxx::expected::value()` and `get_error()`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -55,6 +55,7 @@
 - `m_originId` in `mepoo::ChunkHeader` sometimes not set [\#1668](https://github.com/eclipse-iceoryx/iceoryx/issues/1668)
 - Removed `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
 - CI uses outdated clang-format [\#1736](https://github.com/eclipse-iceoryx/iceoryx/issues/1736)
+- Avoid UB when accessing `iox::expected` [\#1750](https://github.com/eclipse-iceoryx/iceoryx/issues/1750)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
@@ -156,6 +156,8 @@ class IOX_NO_DISCARD expected<ErrorType> : public FunctionalInterface<expected<E
 
     /// @brief the move constructor calls the move constructor of the contained success value
     ///         or the error value - depending on what is stored in the expected
+    /// @note The move c'tor does not explicitly invalidate the moved-from object but relies on the move c'tor of
+    /// ErrorType to correctly invalidate the stored object
     expected(expected&& rhs) noexcept;
 
 #if defined(_WIN32)
@@ -179,6 +181,8 @@ class IOX_NO_DISCARD expected<ErrorType> : public FunctionalInterface<expected<E
 
     /// @brief  calls the move assignment operator of the contained success value
     ///         or the error value - depending on what is stored in the expected
+    /// @note The move assign operator does not explicitly invalidate the moved-from object but relies on the move
+    /// assign operator of ErrorType to correctly invalidate the stored object
     expected& operator=(expected&& rhs) noexcept;
 
 #if defined(_WIN32)
@@ -277,6 +281,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
 
     /// @brief the move constructor calls the move constructor of the contained success value
     ///         or the error value - depending on what is stored in the expected
+    /// @note The move c'tor does not explicitly invalidate the moved-from object but relies on the move c'tor of
+    /// ValueType or ErrorType to correctly invalidate the stored object
     expected(expected&& rhs) noexcept;
 
     /// @brief calls the destructor of the success value or error value - depending on what
@@ -289,6 +295,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
 
     /// @brief  calls the move assignment operator of the contained success value
     ///         or the error value - depending on what is stored in the expected
+    /// @note The move assign operator does not explicitly invalidate the moved-from object but relies on the move
+    /// assign operator of ValueType or ErrorType to correctly invalidate the stored object
     expected& operator=(expected&& rhs) noexcept;
 
     /// @brief  constructs an expected which is signaling success and uses the value

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
@@ -181,8 +181,8 @@ class IOX_NO_DISCARD expected<ErrorType> : public FunctionalInterface<expected<E
 
     /// @brief  calls the move assignment operator of the contained success value
     ///         or the error value - depending on what is stored in the expected
-    /// @note The move assign operator does not explicitly invalidate the moved-from object but relies on the move
-    /// assign operator of ErrorType to correctly invalidate the stored object
+    /// @note The move assignment operator does not explicitly invalidate the moved-from object but relies on the move
+    /// assignment operator of ErrorType to correctly invalidate the stored object
     expected& operator=(expected&& rhs) noexcept;
 
 #if defined(_WIN32)
@@ -243,21 +243,22 @@ class IOX_NO_DISCARD expected<ErrorType> : public FunctionalInterface<expected<E
     bool has_error() const noexcept;
 
     /// @brief  returns a reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return reference to the internally contained error
     ErrorType& get_error() & noexcept;
 
     /// @brief  returns a const reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return const reference to the internally contained error
     const ErrorType& get_error() const& noexcept;
 
     /// @brief  returns a rvalue reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return rvalue reference to the internally contained error
     ErrorType&& get_error() && noexcept;
 
   private:
+    const ErrorType& get_error_unchecked() const noexcept;
     explicit expected(variant<ErrorType>&& store) noexcept;
     variant<ErrorType> m_store;
     static constexpr uint64_t ERROR_INDEX = 0U;
@@ -295,8 +296,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
 
     /// @brief  calls the move assignment operator of the contained success value
     ///         or the error value - depending on what is stored in the expected
-    /// @note The move assign operator does not explicitly invalidate the moved-from object but relies on the move
-    /// assign operator of ValueType or ErrorType to correctly invalidate the stored object
+    /// @note The move assignment operator does not explicitly invalidate the moved-from object but relies on the move
+    /// assignment operator of ValueType or ErrorType to correctly invalidate the stored object
     expected& operator=(expected&& rhs) noexcept;
 
     /// @brief  constructs an expected which is signaling success and uses the value
@@ -358,38 +359,37 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
     bool has_error() const noexcept;
 
     /// @brief  returns a reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return reference to the internally contained error
     ErrorType& get_error() & noexcept;
 
     /// @brief  returns a const reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return const reference to the internally contained error
     const ErrorType& get_error() const& noexcept;
 
     /// @brief  returns a rvalue reference to the contained error value, if the expected
-    ///         does not contain an error this is undefined behavior
+    ///         does not contain an error the error handler is called
     /// @return rvalue reference to the internally contained error
     ErrorType&& get_error() && noexcept;
 
     /// @brief  returns a reference to the contained success value, if the expected
-    ///         does not contain a success value this is undefined behavior
+    ///         does not contain a success value the error handler is called
     /// @return reference to the internally contained value
     ValueType& value() & noexcept;
 
     /// @brief  returns a const reference to the contained success value, if the expected
-    ///         does not contain a success value this is undefined behavior
+    ///         does not contain a success value the error handler is called
     /// @return const reference to the internally contained value
     const ValueType& value() const& noexcept;
 
     /// @brief  returns a reference to the contained success value, if the expected
-    ///         does not contain a success value this is undefined behavior
+    ///         does not contain a success value the error handler is called
     /// @return rvalue reference to the internally contained value
     ValueType&& value() && noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
-    ///         success value. if the expected contains an error the behavior is
-    ///         undefined.
+    ///         success value. if the expected contains an error the error handler is called
     /// @return reference to the contained value
     /// @code
     ///     cxx::expected<int, float> frodo(success<int>(45));
@@ -399,8 +399,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
     ValueType& operator*() noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
-    ///         success value. if the expected contains an error the behavior is
-    ///         undefined.
+    ///         success value. if the expected contains an error the error handler is called
     /// @return const reference to the contained value
     /// @code
     ///     cxx::expected<int, float> frodo(success<int>(45));
@@ -409,8 +408,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
     /// @endcode
     const ValueType& operator*() const noexcept;
 
-    /// @brief arrow operator which returns the pointer to the contained success value.
-    ///         if the expected contains an error the behavior is undefined.
+    /// @brief arrow operator which returns the pointer to the contained success value
+    ///         if the expected contains an error the error handler is called
     /// @return pointer of type ValueType to the contained value
     /// @code
     ///     cxx::expected<std::vector<int>, int> holyPiotr(success<std::vector<int>>({1,2,3}));
@@ -418,8 +417,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
     /// @endcode
     ValueType* operator->() noexcept;
 
-    /// @brief arrow operator which returns the pointer to the contained success value.
-    ///         if the expected contains an error the behavior is undefined.
+    /// @brief arrow operator which returns the pointer to the contained success value
+    ///         if the expected contains an error the the error handler is called
     /// @return pointer of type const ValueType to the contained value
     /// @code
     ///     cxx::expected<std::vector<int>, int> holyPiotr(success<std::vector<int>>({1,2,3}));
@@ -449,6 +448,8 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
 
   private:
     explicit expected(variant<ValueType, ErrorType>&& store) noexcept;
+    const ErrorType& get_error_unchecked() const noexcept;
+    const ValueType& value_unchecked() const noexcept;
     variant<ValueType, ErrorType> m_store;
     static constexpr uint64_t VALUE_INDEX = 0U;
     static constexpr uint64_t ERROR_INDEX = 1U;
@@ -460,7 +461,6 @@ class IOX_NO_DISCARD expected<void, ErrorType> : public expected<ErrorType>
   public:
     using expected<ErrorType>::expected;
 };
-
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
@@ -440,7 +440,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType>
     optional<ValueType> to_optional() const noexcept;
 
   private:
-    explicit expected(variant<ValueType, ErrorType>&& f_store) noexcept;
+    explicit expected(variant<ValueType, ErrorType>&& store) noexcept;
     variant<ValueType, ErrorType> m_store;
     static constexpr uint64_t VALUE_INDEX = 0U;
     static constexpr uint64_t ERROR_INDEX = 1U;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/expected.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/expected.inl
@@ -156,11 +156,26 @@ inline bool expected<ValueType, ErrorType>::has_error() const noexcept
 template <typename ValueType, typename ErrorType>
 inline ErrorType&& expected<ValueType, ErrorType>::get_error() && noexcept
 {
-    return std::move(*m_store.template get_at_index<ERROR_INDEX>());
+    return std::move(get_error());
 }
 
 template <typename ValueType, typename ErrorType>
 inline ErrorType& expected<ValueType, ErrorType>::get_error() & noexcept
+{
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<ErrorType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->get_error());
+}
+
+template <typename ValueType, typename ErrorType>
+inline const ErrorType& expected<ValueType, ErrorType>::get_error() const& noexcept
+{
+    ExpectsWithMsg(has_error(), "Trying to access an error but a value is stored!");
+    return get_error_unchecked();
+}
+
+template <typename ValueType, typename ErrorType>
+inline const ErrorType& expected<ValueType, ErrorType>::get_error_unchecked() const noexcept
 {
     return *m_store.template get_at_index<ERROR_INDEX>();
 }
@@ -168,31 +183,28 @@ inline ErrorType& expected<ValueType, ErrorType>::get_error() & noexcept
 template <typename ValueType, typename ErrorType>
 inline ValueType&& expected<ValueType, ErrorType>::value() && noexcept
 {
-    return std::move(*m_store.template get_at_index<VALUE_INDEX>());
+    return std::move(value());
 }
 
 template <typename ValueType, typename ErrorType>
 inline const ValueType& expected<ValueType, ErrorType>::value() const& noexcept
 {
-    return *m_store.template get_at_index<VALUE_INDEX>();
+    ExpectsWithMsg(!has_error(), "Trying to access a value but an error is stored!");
+    return value_unchecked();
 }
 
 template <typename ValueType, typename ErrorType>
 inline ValueType& expected<ValueType, ErrorType>::value() & noexcept
 {
-    return *m_store.template get_at_index<VALUE_INDEX>();
-}
-
-template <typename ErrorType>
-inline const ErrorType& expected<ErrorType>::get_error() const& noexcept
-{
-    return *m_store.template get_at_index<ERROR_INDEX>();
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<ValueType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->value());
 }
 
 template <typename ValueType, typename ErrorType>
 inline ValueType* expected<ValueType, ErrorType>::operator->() noexcept
 {
-    return m_store.template get_at_index<VALUE_INDEX>();
+    return &value();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -206,7 +218,7 @@ inline const ValueType* expected<ValueType, ErrorType>::operator->() const noexc
 template <typename ValueType, typename ErrorType>
 inline ValueType& expected<ValueType, ErrorType>::operator*() noexcept
 {
-    return *m_store.template get_at_index<VALUE_INDEX>();
+    return value();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -215,6 +227,12 @@ inline const ValueType& expected<ValueType, ErrorType>::operator*() const noexce
     // const_cast avoids code duplication, is safe since the constness of the return value is restored
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<const ValueType&>(const_cast<expected*>(this)->operator*());
+}
+
+template <typename ValueType, typename ErrorType>
+const ValueType& expected<ValueType, ErrorType>::value_unchecked() const noexcept
+{
+    return *m_store.template get_at_index<VALUE_INDEX>();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -359,17 +377,26 @@ inline bool expected<ErrorType>::has_error() const noexcept
 template <typename ErrorType>
 inline ErrorType&& expected<ErrorType>::get_error() && noexcept
 {
-    return std::move(*m_store.template get_at_index<ERROR_INDEX>());
-}
-
-template <typename ValueType, typename ErrorType>
-inline const ErrorType& expected<ValueType, ErrorType>::get_error() const& noexcept
-{
-    return *m_store.template get_at_index<ERROR_INDEX>();
+    return std::move(get_error());
 }
 
 template <typename ErrorType>
 inline ErrorType& expected<ErrorType>::get_error() & noexcept
+{
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<ErrorType&>(const_cast<const expected<ErrorType>*>(this)->get_error());
+}
+
+template <typename ErrorType>
+inline const ErrorType& expected<ErrorType>::get_error() const& noexcept
+{
+    ExpectsWithMsg(has_error(), "Trying to access an error but a value is stored!");
+    return get_error_unchecked();
+}
+
+template <typename ErrorType>
+inline const ErrorType& expected<ErrorType>::get_error_unchecked() const noexcept
 {
     return *m_store.template get_at_index<ERROR_INDEX>();
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/expected.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/expected.inl
@@ -75,8 +75,8 @@ inline error<T>::error(Targs&&... args) noexcept
 
 
 template <typename ValueType, typename ErrorType>
-inline expected<ValueType, ErrorType>::expected(variant<ValueType, ErrorType>&& f_store) noexcept
-    : m_store(std::move(f_store))
+inline expected<ValueType, ErrorType>::expected(variant<ValueType, ErrorType>&& store) noexcept
+    : m_store(std::move(store))
 {
 }
 
@@ -240,8 +240,8 @@ inline optional<ValueType> expected<ValueType, ErrorType>::to_optional() const n
 }
 
 template <typename ErrorType>
-inline expected<ErrorType>::expected(variant<ErrorType>&& f_store) noexcept
-    : m_store(std::move(f_store))
+inline expected<ErrorType>::expected(variant<ErrorType>&& store) noexcept
+    : m_store(std::move(store))
 {
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_expected.cpp
@@ -578,4 +578,125 @@ TEST_F(expected_test, MoveAssignmentIsNotEnforcedInMoveConstructor)
         ASSERT_THAT(destination.has_error(), Eq(true));
     }
 }
+
+TEST_F(expected_test, AccessingErrorOfLValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "da162edf-06b5-47d2-b35f-361d6004a6c4");
+    auto sut = expected<TestError>::create_value();
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+}
+
+TEST_F(expected_test, AccessingErrorOfConstLValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "324cab7d-ba04-4ff0-870f-79af993c272f");
+    const auto sut = expected<TestError>::create_value();
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+}
+
+TEST_F(expected_test, AccessingErrorOfRValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "0a4309e8-d9f3-41a9-9c4b-bdcfda917277");
+    auto sut = expected<TestError>::create_value();
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ std::move(sut).get_error(); }, "Trying to access an error but a value is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithArrowOpLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "1a821c6f-83db-4fe1-8adf-873afa1251a1");
+    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithArrowOpLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c4f04d7c-9fa3-48f6-a6fd-b8e4e47b7632");
+    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithDerefOpLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "08ce6a3f-3813-46de-8e1e-3ffe8087521e");
+    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ *sut; }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithDerefOpLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "838dd364-f91f-40a7-9720-2b662a045b1e");
+    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ *sut; }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "92139583-b8d6-4d83-ae7e-f4109b98d214");
+    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.value(); }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "1bcbb835-8b4c-4430-a534-a26573c2380d");
+    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.value(); }, "Trying to access a value but an error is stored");
+}
+
+
+TEST_F(expected_test, AccessingValueOfRValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "32d59b52-81f5-417a-8670-dfb2c54fedfb");
+    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ std::move(sut).value(); }, "Trying to access a value but an error is stored");
+}
+
+TEST_F(expected_test, AccessingErrorOfLValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "aee85ead-e066-49fd-99fe-6f1a6045756d");
+    constexpr int VALID_VALUE{42};
+    auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+}
+
+TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a49cf02e-b165-4fd6-9c24-65cedc6cddb9");
+    constexpr int VALID_VALUE{42};
+    const auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+}
+
+TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "0ea90b5d-1af6-494a-b35c-da103bed2331");
+    constexpr int VALID_VALUE{42};
+    auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    // @todo iox-#1613 remove EXPECT_DEATH
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
+    EXPECT_DEATH({ std::move(sut).get_error(); }, "Trying to access an error but a value is stored");
+}
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Add `Expects` to `cxx::expected::value()` and `get_error()`
* Fix legacy coding rule and add two doxygen comments

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1750