### PR TITLE
iox-1766 Remove `char*`-only methods in `iox::string`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -58,6 +58,7 @@
 - Removed `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
 - CI uses outdated clang-format [\#1736](https://github.com/eclipse-iceoryx/iceoryx/issues/1736)
 - Avoid UB when accessing `iox::expected` [\#1750](https://github.com/eclipse-iceoryx/iceoryx/issues/1750)
+- Prevent potential out-of-bounds access in `ìox::string` [\#1766](https://github.com/eclipse-iceoryx/iceoryx/issues/1766)
 
 **Refactoring:**
 
@@ -801,4 +802,15 @@
 
     containers::UninitializedArray<T, Capacity> myAlignedArray;
 
+42. Removed `char*`-only methods from `iox::string`
+
+    ```cpp
+    // before
+    char fooStr[] = "foo";
+    iox::cxx::string<100> myString(TruncateToCapacity, fooStr);
+    myString.unsafe_assign(fooStr);
+
+    // after
+    char fooStr[] = "foo";
+    iox::cxx::string<100> myString(TruncateToCapacity, fooStr, 3);
     ```

--- a/iceoryx_binding_c/source/c_client.cpp
+++ b/iceoryx_binding_c/source/c_client.cpp
@@ -71,16 +71,18 @@ iox_client_t iox_client_init(iox_client_storage_t* self,
     if (options != nullptr)
     {
         clientOptions.responseQueueCapacity = options->responseQueueCapacity;
-        clientOptions.nodeName = iox::NodeName_t(TruncateToCapacity, options->nodeName);
+        clientOptions.nodeName = iox::NodeName_t(
+            TruncateToCapacity, options->nodeName, strnlen(options->nodeName, iox::NodeName_t::capacity()));
         clientOptions.connectOnCreate = options->connectOnCreate;
         clientOptions.responseQueueFullPolicy = c2cpp::queueFullPolicy(options->responseQueueFullPolicy);
         clientOptions.serverTooSlowPolicy = c2cpp::consumerTooSlowPolicy(options->serverTooSlowPolicy);
     }
 
-    auto* me = new UntypedClient(ServiceDescription{IdString_t(TruncateToCapacity, service),
-                                                    IdString_t(TruncateToCapacity, instance),
-                                                    IdString_t(TruncateToCapacity, event)},
-                                 clientOptions);
+    auto* me = new UntypedClient(
+        ServiceDescription{IdString_t(TruncateToCapacity, service, strnlen(service, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, instance, strnlen(instance, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, event, strnlen(event, IdString_t::capacity()))},
+        clientOptions);
 
     self->do_not_touch_me[0] = reinterpret_cast<uint64_t>(me);
     return me;

--- a/iceoryx_binding_c/source/c_node.cpp
+++ b/iceoryx_binding_c/source/c_node.cpp
@@ -48,7 +48,8 @@ class NodeBindingExtension : public iox::runtime::Node
 
 iox_node_t iox_node_create(const char* const nodeName)
 {
-    return PoshRuntime::getInstance().createNode(NodeProperty(NodeName_t(iox::cxx::TruncateToCapacity, nodeName), 0u));
+    return PoshRuntime::getInstance().createNode(NodeProperty(
+        NodeName_t(iox::cxx::TruncateToCapacity, nodeName, strnlen(nodeName, NodeName_t::capacity())), 0u));
 }
 
 void iox_node_destroy(iox_node_t const self)

--- a/iceoryx_binding_c/source/c_publisher.cpp
+++ b/iceoryx_binding_c/source/c_publisher.cpp
@@ -86,7 +86,8 @@ iox_pub_t iox_pub_init(iox_pub_storage_t* self,
         publisherOptions.historyCapacity = options->historyCapacity;
         if (options->nodeName != nullptr)
         {
-            publisherOptions.nodeName = NodeName_t(TruncateToCapacity, options->nodeName);
+            publisherOptions.nodeName =
+                NodeName_t(TruncateToCapacity, options->nodeName, strnlen(options->nodeName, NodeName_t::capacity()));
         }
         publisherOptions.offerOnCreate = options->offerOnCreate;
         publisherOptions.subscriberTooSlowPolicy = c2cpp::consumerTooSlowPolicy(options->subscriberTooSlowPolicy);
@@ -97,9 +98,9 @@ iox_pub_t iox_pub_init(iox_pub_storage_t* self,
 
     me->m_portData = PoshRuntime::getInstance().getMiddlewarePublisher(
         ServiceDescription{
-            IdString_t(TruncateToCapacity, service),
-            IdString_t(TruncateToCapacity, instance),
-            IdString_t(TruncateToCapacity, event),
+            IdString_t(TruncateToCapacity, service, strnlen(service, IdString_t::capacity())),
+            IdString_t(TruncateToCapacity, instance, strnlen(instance, IdString_t::capacity())),
+            IdString_t(TruncateToCapacity, event, strnlen(event, IdString_t::capacity())),
         },
         publisherOptions);
     return me;

--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -37,7 +37,8 @@ void iox_runtime_init(const char* const name)
         std::terminate();
     }
 
-    PoshRuntime::initRuntime(RuntimeName_t(iox::cxx::TruncateToCapacity, name));
+    PoshRuntime::initRuntime(
+        RuntimeName_t(iox::cxx::TruncateToCapacity, name, strnlen(name, RuntimeName_t::capacity())));
 }
 
 uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLength)

--- a/iceoryx_binding_c/source/c_server.cpp
+++ b/iceoryx_binding_c/source/c_server.cpp
@@ -69,16 +69,18 @@ iox_server_t iox_server_init(iox_server_storage_t* self,
     if (options != nullptr)
     {
         serverOptions.requestQueueCapacity = options->requestQueueCapacity;
-        serverOptions.nodeName = iox::NodeName_t(TruncateToCapacity, options->nodeName);
+        serverOptions.nodeName = iox::NodeName_t(
+            TruncateToCapacity, options->nodeName, strnlen(options->nodeName, iox::NodeName_t::capacity()));
         serverOptions.offerOnCreate = options->offerOnCreate;
         serverOptions.requestQueueFullPolicy = c2cpp::queueFullPolicy(options->requestQueueFullPolicy);
         serverOptions.clientTooSlowPolicy = c2cpp::consumerTooSlowPolicy(options->clientTooSlowPolicy);
     }
 
-    auto* me = new UntypedServer(ServiceDescription{IdString_t(TruncateToCapacity, service),
-                                                    IdString_t(TruncateToCapacity, instance),
-                                                    IdString_t(TruncateToCapacity, event)},
-                                 serverOptions);
+    auto* me = new UntypedServer(
+        ServiceDescription{IdString_t(TruncateToCapacity, service, strnlen(service, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, instance, strnlen(instance, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, event, strnlen(event, IdString_t::capacity()))},
+        serverOptions);
 
     self->do_not_touch_me[0] = reinterpret_cast<uint64_t>(me);
     return me;

--- a/iceoryx_binding_c/source/c_service_discovery.cpp
+++ b/iceoryx_binding_c/source/c_service_discovery.cpp
@@ -59,17 +59,17 @@ uint64_t iox_service_discovery_find_service(iox_service_discovery_t const self,
     cxx::optional<capro::IdString_t> maybeService;
     if (service != nullptr)
     {
-        maybeService.emplace(cxx::TruncateToCapacity, service);
+        maybeService.emplace(cxx::TruncateToCapacity, service, strnlen(service, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeInstance;
     if (instance != nullptr)
     {
-        maybeInstance.emplace(cxx::TruncateToCapacity, instance);
+        maybeInstance.emplace(cxx::TruncateToCapacity, instance, strnlen(instance, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeEvent;
     if (event != nullptr)
     {
-        maybeEvent.emplace(cxx::TruncateToCapacity, event);
+        maybeEvent.emplace(cxx::TruncateToCapacity, event, strnlen(event, capro::IdString_t::capacity()));
     }
 
     uint64_t currentSize = 0U;
@@ -102,17 +102,17 @@ void iox_service_discovery_find_service_apply_callable(iox_service_discovery_t c
     cxx::optional<capro::IdString_t> maybeService;
     if (service != nullptr)
     {
-        maybeService.emplace(cxx::TruncateToCapacity, service);
+        maybeService.emplace(cxx::TruncateToCapacity, service, strnlen(service, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeInstance;
     if (instance != nullptr)
     {
-        maybeInstance.emplace(cxx::TruncateToCapacity, instance);
+        maybeInstance.emplace(cxx::TruncateToCapacity, instance, strnlen(instance, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeEvent;
     if (event != nullptr)
     {
-        maybeEvent.emplace(cxx::TruncateToCapacity, event);
+        maybeEvent.emplace(cxx::TruncateToCapacity, event, strnlen(event, capro::IdString_t::capacity()));
     }
 
     auto filter = [&](const capro::ServiceDescription& s) { callable(TranslateServiceDescription(s)); };
@@ -134,17 +134,17 @@ void iox_service_discovery_find_service_apply_callable_with_context_data(
     cxx::optional<capro::IdString_t> maybeService;
     if (service != nullptr)
     {
-        maybeService.emplace(cxx::TruncateToCapacity, service);
+        maybeService.emplace(cxx::TruncateToCapacity, service, strnlen(service, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeInstance;
     if (instance != nullptr)
     {
-        maybeInstance.emplace(cxx::TruncateToCapacity, instance);
+        maybeInstance.emplace(cxx::TruncateToCapacity, instance, strnlen(instance, capro::IdString_t::capacity()));
     }
     cxx::optional<capro::IdString_t> maybeEvent;
     if (event != nullptr)
     {
-        maybeEvent.emplace(cxx::TruncateToCapacity, event);
+        maybeEvent.emplace(cxx::TruncateToCapacity, event, strnlen(event, capro::IdString_t::capacity()));
     }
 
     auto filter = [&](const capro::ServiceDescription& s) { callable(TranslateServiceDescription(s), contextData); };

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -99,7 +99,8 @@ iox_sub_t iox_sub_init(iox_sub_storage_t* self,
         subscriberOptions.historyRequest = options->historyRequest;
         if (options->nodeName != nullptr)
         {
-            subscriberOptions.nodeName = NodeName_t(TruncateToCapacity, options->nodeName);
+            subscriberOptions.nodeName =
+                NodeName_t(TruncateToCapacity, options->nodeName, strnlen(options->nodeName, NodeName_t::capacity()));
         }
         subscriberOptions.subscribeOnCreate = options->subscribeOnCreate;
         subscriberOptions.queueFullPolicy = c2cpp::queueFullPolicy(options->queueFullPolicy);
@@ -114,11 +115,11 @@ iox_sub_t iox_sub_init(iox_sub_storage_t* self,
     assert(reinterpret_cast<uint64_t>(me) - reinterpret_cast<uint64_t>(meWithStoragePointer) == sizeof(void*)
            && "Size mismatch for SubscriberWithStoragePointer!");
 
-    me->m_portData =
-        PoshRuntime::getInstance().getMiddlewareSubscriber(ServiceDescription{IdString_t(TruncateToCapacity, service),
-                                                                              IdString_t(TruncateToCapacity, instance),
-                                                                              IdString_t(TruncateToCapacity, event)},
-                                                           subscriberOptions);
+    me->m_portData = PoshRuntime::getInstance().getMiddlewareSubscriber(
+        ServiceDescription{IdString_t(TruncateToCapacity, service, strnlen(service, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, instance, strnlen(instance, IdString_t::capacity())),
+                           IdString_t(TruncateToCapacity, event, strnlen(event, IdString_t::capacity()))},
+        subscriberOptions);
 
     self->do_not_touch_me[0] = reinterpret_cast<uint64_t>(me);
     return me;

--- a/iceoryx_binding_c/test/moduletests/test_client.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_client.cpp
@@ -53,9 +53,9 @@ class iox_client_test : public Test
 
     ClientPortData* createClientPortData(const ClientOptions& options)
     {
-        sutPort.emplace(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE),
-                                           IdString_t(TruncateToCapacity, INSTANCE),
-                                           IdString_t(TruncateToCapacity, EVENT)},
+        sutPort.emplace(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE, SERVICE_STRING_LENGTH),
+                                           IdString_t(TruncateToCapacity, INSTANCE, INSTANCE_STRING_LENGTH),
+                                           IdString_t(TruncateToCapacity, EVENT, EVENT_STRING_LENGTH)},
                         RUNTIME_NAME,
                         options,
                         &memoryManager);
@@ -84,12 +84,13 @@ class iox_client_test : public Test
 
     void prepareClientInit(const ClientOptions& options = ClientOptions())
     {
-        EXPECT_CALL(*runtimeMock,
-                    getMiddlewareClient(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE),
-                                                           IdString_t(TruncateToCapacity, INSTANCE),
-                                                           IdString_t(TruncateToCapacity, EVENT)},
-                                        options,
-                                        _))
+        EXPECT_CALL(
+            *runtimeMock,
+            getMiddlewareClient(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE, SERVICE_STRING_LENGTH),
+                                                   IdString_t(TruncateToCapacity, INSTANCE, INSTANCE_STRING_LENGTH),
+                                                   IdString_t(TruncateToCapacity, EVENT, EVENT_STRING_LENGTH)},
+                                options,
+                                _))
             .WillOnce(Return(createClientPortData(options)));
     }
 
@@ -118,8 +119,11 @@ class iox_client_test : public Test
     ChunkQueuePopper<ServerChunkQueueData_t> serverRequestQueue{&serverChunkQueueData};
 
     static constexpr const char SERVICE[] = "allGlory";
+    static constexpr const uint64_t SERVICE_STRING_LENGTH{8};
     static constexpr const char INSTANCE[] = "ToThe";
+    static constexpr const uint64_t INSTANCE_STRING_LENGTH{5};
     static constexpr const char EVENT[] = "HYPNOTOAD";
+    static constexpr const uint64_t EVENT_STRING_LENGTH{9};
 };
 constexpr const char iox_client_test::RUNTIME_NAME[];
 constexpr const char iox_client_test::SERVICE[];

--- a/iceoryx_binding_c/test/moduletests/test_server.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_server.cpp
@@ -54,9 +54,9 @@ class iox_server_test : public Test
 
     ServerPortData* createServerPortData(const ServerOptions& options)
     {
-        sutPort.emplace(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE),
-                                           IdString_t(TruncateToCapacity, INSTANCE),
-                                           IdString_t(TruncateToCapacity, EVENT)},
+        sutPort.emplace(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE, SERVICE_STRING_LENGTH),
+                                           IdString_t(TruncateToCapacity, INSTANCE, INSTANCE_STRING_LENGTH),
+                                           IdString_t(TruncateToCapacity, EVENT, EVENT_STRING_LENGTH)},
                         RUNTIME_NAME,
                         options,
                         &memoryManager);
@@ -85,12 +85,13 @@ class iox_server_test : public Test
 
     void prepareServerInit(const ServerOptions& options = ServerOptions())
     {
-        EXPECT_CALL(*runtimeMock,
-                    getMiddlewareServer(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE),
-                                                           IdString_t(TruncateToCapacity, INSTANCE),
-                                                           IdString_t(TruncateToCapacity, EVENT)},
-                                        options,
-                                        _))
+        EXPECT_CALL(
+            *runtimeMock,
+            getMiddlewareServer(ServiceDescription{IdString_t(TruncateToCapacity, SERVICE, SERVICE_STRING_LENGTH),
+                                                   IdString_t(TruncateToCapacity, INSTANCE, INSTANCE_STRING_LENGTH),
+                                                   IdString_t(TruncateToCapacity, EVENT, EVENT_STRING_LENGTH)},
+                                options,
+                                _))
             .WillOnce(Return(createServerPortData(options)));
     }
 
@@ -111,8 +112,11 @@ class iox_server_test : public Test
     ChunkQueuePopper<ClientChunkQueueData_t> clientResponseQueue{&clientResponseQueueData};
 
     static constexpr const char SERVICE[] = "TheHoff";
+    static constexpr const uint64_t SERVICE_STRING_LENGTH{7};
     static constexpr const char INSTANCE[] = "IsAll";
+    static constexpr const uint64_t INSTANCE_STRING_LENGTH{5};
     static constexpr const char EVENT[] = "YouNeed";
+    static constexpr const uint64_t EVENT_STRING_LENGTH{7};
 };
 constexpr const char iox_server_test::RUNTIME_NAME[];
 constexpr const char iox_server_test::SERVICE[];
@@ -180,7 +184,8 @@ TEST_F(iox_server_test, InitializingServerWithCustomOptionsWorks)
 
     ServerOptions cppOptions;
     cppOptions.requestQueueCapacity = options.requestQueueCapacity;
-    cppOptions.nodeName = iox::NodeName_t(TruncateToCapacity, options.nodeName);
+    cppOptions.nodeName =
+        iox::NodeName_t(TruncateToCapacity, options.nodeName, strnlen(options.nodeName, iox::NodeName_t::capacity()));
     cppOptions.offerOnCreate = options.offerOnCreate;
     cppOptions.requestQueueFullPolicy = iox::popo::QueueFullPolicy::BLOCK_PRODUCER;
     cppOptions.clientTooSlowPolicy = iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -209,27 +209,6 @@ class string
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays, hicpp-explicit-conversions)
     string(const char (&other)[N]) noexcept;
 
-    /// @brief conversion constructor for cstring to string which truncates characters if the size is greater than
-    /// the string capacity
-    ///
-    /// @param [in] TruncateToCapacity_t is a compile time variable which is used to distinguish between
-    /// constructors with certain behavior
-    /// @param [in] other is the cstring to convert
-    /// @attention truncates characters if the size is greater than the string capacity
-    ///
-    /// @code
-    ///     #include "iceoryx_hoofs/cxx/string.hpp"
-    ///     using namespace iox::cxx;
-    ///
-    ///     int main()
-    ///     {
-    ///         string<4> fuu(TruncateToCapacity, "abcd");
-    ///     }
-    /// @endcode
-    // TruncateToCapacity_t is a compile time variable to distinguish between constructors
-    // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
-    string(TruncateToCapacity_t, const char* const other) noexcept;
-
     /// @brief conversion constructor for std::string to string which truncates characters if the std::string size is
     /// greater than the string capacity
     ///
@@ -250,6 +229,7 @@ class string
     /// @endcode
     // TruncateToCapacity_t is a compile time variable to distinguish between constructors
     // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
+    /// @todo Make this c'tor explicit to avoid implicit conversion from 'nullptr'
     string(TruncateToCapacity_t, const std::string& other) noexcept;
 
     /// @brief constructor from cstring to string. Constructs the string with the first count characters of the cstring
@@ -333,14 +313,6 @@ class string
     // We want to assign string literals to the cxx::string, like myString.assign("abc");
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     string& assign(const char (&str)[N]) noexcept;
-
-    /// @brief assigns a cstring to string. The assignment fails if the cstring size is greater than the string
-    /// capacity.
-    ///
-    /// @param [in] str is the cstring to assign
-    ///
-    /// @return true if the assignment succeeds, otherwise false
-    bool unsafe_assign(const char* const str) noexcept;
 
     /// @brief assigns a std::string to string. The assignment fails if the std::string size is greater than the string
     /// capacity.
@@ -446,7 +418,7 @@ class string
     ///
     /// @return a std::string with data equivalent to those stored in the string
     // NOLINTNEXTLINE(hicpp-explicit-conversions) @todo iox-#260 remove this conversion and implement toStdString method
-    operator std::string() const noexcept;
+    operator std::string() const;
 
     /// @brief since there are two valid options for what should happen when appending a string larger than this'
     /// capacity (failing or truncating), the fixed string does not support operator+=; use append for truncating or

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/string.hpp
@@ -229,8 +229,11 @@ class string
     /// @endcode
     // TruncateToCapacity_t is a compile time variable to distinguish between constructors
     // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
-    /// @todo Make this c'tor explicit to avoid implicit conversion from 'nullptr'
     string(TruncateToCapacity_t, const std::string& other) noexcept;
+
+    // Avoid any implicit conversion, as templates are always preferred in overload resolution
+    template <typename T>
+    string(TruncateToCapacity_t, const T other) = delete;
 
     /// @brief constructor from cstring to string. Constructs the string with the first count characters of the cstring
     /// including null characters. If count is greater than the string capacity the remainder of the characters are

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/convert.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/convert.inl
@@ -91,7 +91,7 @@ inline bool convert::fromString<char>(const char* v, char& dest) noexcept
 template <>
 inline bool convert::fromString<string<100>>(const char* v, string<100>& dest) noexcept
 {
-    dest = string<100>(TruncateToCapacity, v);
+    dest = string<100>(TruncateToCapacity, v, strnlen(v, string<100>::capacity()));
     return true;
 }
 /// @NOLINTEND(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -105,14 +105,6 @@ inline string<Capacity>::string(const char (&other)[N]) noexcept
 }
 
 template <uint64_t Capacity>
-// NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter) justification in header
-inline string<Capacity>::string(TruncateToCapacity_t, const char* const other) noexcept
-    : string(
-        TruncateToCapacity, other, [&]() -> uint64_t { return (other != nullptr) ? strnlen(other, Capacity) : 0U; }())
-{
-}
-
-template <uint64_t Capacity>
 // TruncateToCapacity_t is a compile time variable to distinguish between constructors
 // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
 inline string<Capacity>::string(TruncateToCapacity_t, const std::string& other) noexcept
@@ -196,26 +188,6 @@ inline string<Capacity>& string<Capacity>::assign(const char (&str)[N]) noexcept
 {
     *this = str;
     return *this;
-}
-
-template <uint64_t Capacity>
-inline bool string<Capacity>::unsafe_assign(const char* const str) noexcept
-{
-    if ((c_str() == str) || (str == nullptr))
-    {
-        return false;
-    }
-    const uint64_t strSize = strnlen(str, Capacity + 1U);
-    if (Capacity < strSize)
-    {
-        std::cerr << "Assignment failed. The given cstring is larger (" << strSize << ") than the capacity ("
-                  << Capacity << ") of the fixed string." << std::endl;
-        return false;
-    }
-    std::memcpy(&(m_rawstring[0]), str, strSize);
-    m_rawstring[strSize] = '\0';
-    m_rawstringSize = strSize;
-    return true;
 }
 
 template <uint64_t Capacity>
@@ -376,7 +348,7 @@ inline constexpr void string<Capacity>::clear() noexcept
 }
 
 template <uint64_t Capacity>
-inline string<Capacity>::operator std::string() const noexcept
+inline string<Capacity>::operator std::string() const
 {
     return std::string(c_str());
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/string.inl
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_CXX_STRING_INL
 
 #include "iceoryx_hoofs/cxx/string.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 namespace iox
 {
@@ -133,8 +134,8 @@ inline string<Capacity>::string(TruncateToCapacity_t, const char* const other, c
 #endif
         m_rawstring[Capacity] = '\0';
         m_rawstringSize = Capacity;
-        std::cerr << "Constructor truncates the last " << count - Capacity << " characters of " << other
-                  << ", because the char array length is larger than the capacity." << std::endl;
+        IOX_LOG(ERROR) << "Constructor truncates the last " << count - Capacity << " characters of " << other
+                       << ", because the char array length is larger than the capacity.";
     }
     else
     {
@@ -164,9 +165,8 @@ inline string<Capacity>& string<Capacity>::operator=(const char (&rhs)[N]) noexc
 
     if (rhs[m_rawstringSize] != '\0')
     {
-        std::cerr << "iox::cxx::string: Assignment of array which is not zero-terminated! Last value of array "
-                     "overwritten with 0!"
-                  << std::endl;
+        IOX_LOG(ERROR) << "iox::cxx::string: Assignment of array which is not zero-terminated! Last value of array "
+                          "overwritten with 0!";
     }
     return *this;
 }
@@ -196,8 +196,7 @@ inline bool string<Capacity>::unsafe_assign(const std::string& str) noexcept
     uint64_t strSize = str.size();
     if (Capacity < strSize)
     {
-        std::cerr << "Assignment failed. The given std::string is larger than the capacity of the fixed string."
-                  << std::endl;
+        IOX_LOG(ERROR) << "Assignment failed. The given std::string is larger than the capacity of the fixed string.";
         return false;
     }
     std::memcpy(&(m_rawstring[0]), str.c_str(), strSize);
@@ -437,7 +436,7 @@ inline IsStringOrCharArrayOrChar<T, bool> string<Capacity>::unsafe_append(const 
 
     if (tSize > clampedTSize)
     {
-        std::cerr << "Appending failed because the sum of sizes exceeds this' capacity." << std::endl;
+        IOX_LOG(ERROR) << "Appending failed because the sum of sizes exceeds this' capacity.";
         return false;
     }
 
@@ -461,8 +460,8 @@ inline IsStringOrCharArrayOrChar<T, string<Capacity>&> string<Capacity>::append(
     std::memcpy(&(m_rawstring[m_rawstringSize]), tData, clampedTSize);
     if (tSize > clampedTSize)
     {
-        std::cerr << "The last " << tSize - Capacity + m_rawstringSize << " characters of " << tData
-                  << " are truncated, because the length is larger than the capacity." << std::endl;
+        IOX_LOG(ERROR) << "The last " << tSize - Capacity + m_rawstringSize << " characters of " << tData
+                       << " are truncated, because the length is larger than the capacity.";
     }
 
     m_rawstringSize += clampedTSize;
@@ -477,7 +476,7 @@ inline string<Capacity>& string<Capacity>::append(TruncateToCapacity_t, char cst
 {
     if (m_rawstringSize == Capacity)
     {
-        std::cerr << "Appending of " << cstr << " failed because this' capacity would be exceeded." << std::endl;
+        IOX_LOG(ERROR) << "Appending of " << cstr << " failed because this' capacity would be exceeded.";
         return *this;
     }
     m_rawstring[m_rawstringSize] = cstr;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/log/logstream.inl
@@ -18,6 +18,7 @@
 #ifndef IOX_HOOFS_LOG_LOGSTREAM_INL
 #define IOX_HOOFS_LOG_LOGSTREAM_INL
 
+#include "iceoryx_hoofs/internal/containers/uninitialized_array.hpp"
 #include "iceoryx_hoofs/log/logstream.hpp"
 
 #include <string>
@@ -112,6 +113,17 @@ inline LogStream& LogStream::self() noexcept
 inline LogStream& LogStream::operator<<(const char* cstr) noexcept
 {
     m_logger.logString(cstr);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const char cstr) noexcept
+{
+    containers::UninitializedArray<char, 2> nullTerminatedStr;
+    nullTerminatedStr[0] = cstr;
+    nullTerminatedStr[1] = '\0';
+
+    m_logger.logString(nullTerminatedStr.begin());
     m_isFlushed = false;
     return *this;
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -60,13 +60,13 @@ inline PosixCallDetails<ReturnType>::PosixCallDetails(const char* posixFunctionN
 inline cxx::string<POSIX_CALL_ERROR_STRING_SIZE> errorLiteralToString(const int returnCode IOX_MAYBE_UNUSED,
                                                                       char* const buffer)
 {
-    return cxx::string<POSIX_CALL_ERROR_STRING_SIZE>(cxx::TruncateToCapacity, buffer);
+    return cxx::string<POSIX_CALL_ERROR_STRING_SIZE>(cxx::TruncateToCapacity, buffer, POSIX_CALL_ERROR_STRING_SIZE);
 }
 
 inline cxx::string<POSIX_CALL_ERROR_STRING_SIZE> errorLiteralToString(const char* msg,
                                                                       char* const buffer IOX_MAYBE_UNUSED)
 {
-    return cxx::string<POSIX_CALL_ERROR_STRING_SIZE>(cxx::TruncateToCapacity, msg);
+    return cxx::string<POSIX_CALL_ERROR_STRING_SIZE>(cxx::TruncateToCapacity, msg, POSIX_CALL_ERROR_STRING_SIZE);
 }
 } // namespace internal
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/log/logstream.hpp
@@ -149,6 +149,12 @@ class LogStream
     // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Logging support for C-style strings
     LogStream& operator<<(const char* cstr) noexcept;
 
+    /// @brief Logging support for single chars
+    /// @param[in] cstr is the C-style char to log
+    /// @return a reference to the LogStream instance
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Logging support for single chars
+    LogStream& operator<<(const char cstr) noexcept;
+
     /// @brief Logging support for std::string
     /// @param[in] str is the std::string to log
     /// @return a reference to the LogStream instance

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -81,8 +81,13 @@ cxx::optional<PosixGroup::groupName_t> PosixGroup::getGroupName(gid_t id) noexce
         std::cerr << "Error: Could not find group with id '" << id << "'." << std::endl;
         return cxx::nullopt_t();
     }
-
-    return cxx::make_optional<groupName_t>(groupName_t(iox::cxx::TruncateToCapacity, getgrgidCall->value->gr_name));
+    if (getgrgidCall->value->gr_name == nullptr)
+    {
+        return cxx::nullopt_t();
+    }
+    return cxx::make_optional<groupName_t>(groupName_t(iox::cxx::TruncateToCapacity,
+                                                       getgrgidCall->value->gr_name,
+                                                       strnlen(getgrgidCall->value->gr_name, groupName_t::capacity())));
 }
 
 PosixGroup::groupName_t PosixGroup::getName() const noexcept
@@ -127,7 +132,13 @@ cxx::optional<PosixUser::userName_t> PosixUser::getUserName(uid_t id) noexcept
         std::cerr << "Error: Could not find user with id'" << id << "'." << std::endl;
         return cxx::nullopt_t();
     }
-    return cxx::make_optional<userName_t>(userName_t(iox::cxx::TruncateToCapacity, getpwuidCall->value->pw_name));
+    if (getpwuidCall->value->pw_name == nullptr)
+    {
+        return cxx::nullopt_t();
+    }
+    return cxx::make_optional<userName_t>(userName_t(iox::cxx::TruncateToCapacity,
+                                                     getpwuidCall->value->pw_name,
+                                                     strnlen(getpwuidCall->value->pw_name, userName_t::capacity())));
 }
 
 PosixUser::groupVector_t PosixUser::getGroups() const noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -47,7 +47,7 @@ ThreadName_t getThreadName(iox_pthread_t thread) noexcept
             cxx::Ensures(false && "internal logic error");
         });
 
-    return ThreadName_t(cxx::TruncateToCapacity, &tempName[0]);
+    return ThreadName_t(cxx::TruncateToCapacity, &tempName[0], strnlen(&tempName[0], ThreadName_t::capacity()));
 }
 
 cxx::expected<ThreadError> ThreadBuilder::create(cxx::optional<Thread>& uninitializedThread,

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -265,71 +265,6 @@ TYPED_TEST(stringTyped_test, CharToStringConvConstrWithSizeCapaResultsInSizeCapa
     EXPECT_THAT(testSubject.c_str(), StrEq(&testChar[0]));
 }
 
-/// @note string(TruncateToCapacity_t, const char* const other) noexcept
-TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithSize0ResultsInSize0)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "3ed6360e-c4a0-474b-8ed7-e6b4e129a6c0");
-    using MyString = typename TestFixture::stringType;
-    constexpr auto STRINGCAP = MyString::capacity();
-    string<STRINGCAP> fuu(TruncateToCapacity, "");
-    EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
-    EXPECT_THAT(fuu.size(), Eq(0U));
-    EXPECT_THAT(fuu.c_str(), StrEq(""));
-}
-
-TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithSizeCapaResultsInSizeCapa)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "5c417b37-ee9d-42f9-bb25-c59c6929d4ca");
-    using MyString = typename TestFixture::stringType;
-    constexpr auto STRINGCAP = MyString::capacity();
-    // increase capacity by one to circumvent gcc -Werror=array-bounds
-    // required to verify string literal functionality of cxx::string
-    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
-    char testChar[STRINGCAP + 1];
-    for (uint64_t i = 0U; i < STRINGCAP - 1U; i++)
-    {
-        // NOLINTJUSTIFICATION no other way to populate testCharArray
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        testChar[i] = 'M';
-    }
-    testChar[STRINGCAP - 1U] = '\0';
-    string<STRINGCAP> testSubject(TruncateToCapacity, &testChar[0]);
-    EXPECT_THAT(testSubject.capacity(), Eq(STRINGCAP));
-    EXPECT_THAT(testSubject.size(), Eq(STRINGCAP - 1U));
-    EXPECT_THAT(testSubject.c_str(), StrEq(&testChar[0]));
-}
-
-TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithSizeGreaterCapaResultsInSizeCapa)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "5e0a2023-ea15-43d5-aae8-980a75be6122");
-    using MyString = typename TestFixture::stringType;
-    constexpr auto STRINGCAP = MyString::capacity();
-    // required to verify string literal functionality of cxx::string
-    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
-    char testChar[STRINGCAP + 1U];
-    for (uint64_t i = 0U; i < STRINGCAP; i++)
-    {
-        // NOLINTJUSTIFICATION no other way to populate testCharArray
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-        testChar[i] = 'M';
-    }
-    testChar[STRINGCAP] = '\0';
-    string<STRINGCAP> testSubject(TruncateToCapacity, &testChar[0]);
-    EXPECT_THAT(testSubject.capacity(), Eq(STRINGCAP));
-    EXPECT_THAT(testSubject.size(), Eq(STRINGCAP));
-}
-
-// TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithNullPtrResultsEmptyString)
-// {
-//     ::testing::Test::RecordProperty("TEST_ID", "c6bbcbc6-e049-4c2c-bf84-8d89dcf42ce8");
-//     using MyString = typename TestFixture::stringType;
-//     constexpr auto STRINGCAP = MyString::capacity();
-//     string<STRINGCAP> fuu(TruncateToCapacity, nullptr);
-//     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
-//     EXPECT_THAT(fuu.size(), Eq(0U));
-//     EXPECT_THAT(fuu.c_str(), StrEq(""));
-// }
-
 /// @note string(TruncateToCapacity_t, const std::string& other) noexcept
 TYPED_TEST(stringTyped_test, UnsafeSTDStringToStringConvConstrWithSize0ResultsInSize0)
 {
@@ -1853,7 +1788,8 @@ TYPED_TEST(stringTyped_test, StringWithContentIsNotEmtpy)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bb7fd1ff-82dc-4ae2-af70-9b080eb2265d");
     using MyString = typename TestFixture::stringType;
-    MyString sut(TruncateToCapacity, "Dr.SchluepferStrikesAgain!");
+    constexpr uint64_t STRING_LENGTH{26};
+    MyString sut(TruncateToCapacity, "Dr.SchluepferStrikesAgain!", STRING_LENGTH);
     EXPECT_THAT(sut.empty(), Eq(false));
 }
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -319,16 +319,16 @@ TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithSizeGreaterCapaResu
     EXPECT_THAT(testSubject.size(), Eq(STRINGCAP));
 }
 
-TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithNullPtrResultsEmptyString)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "c6bbcbc6-e049-4c2c-bf84-8d89dcf42ce8");
-    using MyString = typename TestFixture::stringType;
-    constexpr auto STRINGCAP = MyString::capacity();
-    string<STRINGCAP> fuu(TruncateToCapacity, nullptr);
-    EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
-    EXPECT_THAT(fuu.size(), Eq(0U));
-    EXPECT_THAT(fuu.c_str(), StrEq(""));
-}
+// TYPED_TEST(stringTyped_test, UnsafeCharToStringConvConstrWithNullPtrResultsEmptyString)
+// {
+//     ::testing::Test::RecordProperty("TEST_ID", "c6bbcbc6-e049-4c2c-bf84-8d89dcf42ce8");
+//     using MyString = typename TestFixture::stringType;
+//     constexpr auto STRINGCAP = MyString::capacity();
+//     string<STRINGCAP> fuu(TruncateToCapacity, nullptr);
+//     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
+//     EXPECT_THAT(fuu.size(), Eq(0U));
+//     EXPECT_THAT(fuu.c_str(), StrEq(""));
+// }
 
 /// @note string(TruncateToCapacity_t, const std::string& other) noexcept
 TYPED_TEST(stringTyped_test, UnsafeSTDStringToStringConvConstrWithSize0ResultsInSize0)
@@ -665,20 +665,6 @@ TYPED_TEST(stringTyped_test, UnsafeAssignOfInvalidCStringFails)
     EXPECT_THAT(this->testSubject.unsafe_assign(testCharstring.data()), Eq(false));
     EXPECT_THAT(this->testSubject.size(), Eq(1U));
     EXPECT_THAT(this->testSubject.c_str(), StrEq("L"));
-}
-
-TYPED_TEST(stringTyped_test, UnsafeAssignOfCharPointerPointingToSameAddress)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "a129add2-4d8e-4953-ba28-b78ece5a2f02");
-    this->testSubject = "M";
-    const char* fuu = this->testSubject.c_str();
-    EXPECT_THAT(this->testSubject.unsafe_assign(fuu), Eq(false));
-}
-
-TYPED_TEST(stringTyped_test, UnsafeAssignOfNullptrFails)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "140e5402-c6b5-4a07-a0f7-2a10f6d307fb");
-    EXPECT_THAT(this->testSubject.unsafe_assign(nullptr), Eq(false));
 }
 
 /// @note bool unsafe_assign(const std::string& str) noexcept

--- a/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
@@ -134,7 +134,8 @@ TEST_F(AccessController_test, writeSpecialUserPermissions)
 
     auto name = iox_getpwuid(geteuid());
     ASSERT_TRUE(name);
-    PosixUser::userName_t currentUserName(iox::cxx::TruncateToCapacity, name->pwd.pw_name);
+    PosixUser::userName_t currentUserName(
+        iox::cxx::TruncateToCapacity, name->pwd.pw_name, strnlen(name->pwd.pw_name, PosixUser::userName_t::capacity()));
 
     entryAdded = m_accessController.addUserPermission(AccessController::Permission::READWRITE, currentUserName);
     EXPECT_TRUE(entryAdded);
@@ -262,7 +263,8 @@ TEST_F(AccessController_test, addNameInWrongPlace)
     ::testing::Test::RecordProperty("TEST_ID", "2d2dbb0d-1fb6-4569-8651-d341a4525ea6");
     auto name = iox_getpwuid(geteuid());
     ASSERT_TRUE(name);
-    PosixUser::userName_t currentUserName(iox::cxx::TruncateToCapacity, name->pwd.pw_name);
+    PosixUser::userName_t currentUserName(
+        iox::cxx::TruncateToCapacity, name->pwd.pw_name, strnlen(name->pwd.pw_name, PosixUser::userName_t::capacity()));
 
     m_accessController.addPermissionEntry(AccessController::Category::GROUP, AccessController::Permission::READ);
     m_accessController.addPermissionEntry(AccessController::Category::OTHERS, AccessController::Permission::NONE);

--- a/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
@@ -36,7 +36,8 @@ class NamedSemaphoreTest : public Test
     }
 
     optional<NamedSemaphore> sut;
-    NamedSemaphore::Name_t sutName{TruncateToCapacity, "dr.peacock_rocks"};
+    static constexpr uint64_t STRING_LENGTH{16};
+    NamedSemaphore::Name_t sutName{TruncateToCapacity, "dr.peacock_rocks", STRING_LENGTH};
     const iox::cxx::perms sutPermission = iox::cxx::perms::owner_all;
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -82,9 +82,9 @@ GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription
                                                  const IceoryxPubSubOptions& options) noexcept
 {
     // Filter out wildcard services
-    if (service.getServiceIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*")
-        || service.getInstanceIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*")
-        || service.getEventIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*"))
+    if (service.getServiceIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*", 1)
+        || service.getInstanceIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*", 1)
+        || service.getEventIDString() == capro::IdString_t(cxx::TruncateToCapacity, "*", 1))
     {
         return cxx::error<GatewayError>(GatewayError::UNSUPPORTED_SERVICE_TYPE);
     }

--- a/iceoryx_posh/source/roudi/process.cpp
+++ b/iceoryx_posh/source/roudi/process.cpp
@@ -46,7 +46,7 @@ uint32_t Process::getPid() const noexcept
 
 const RuntimeName_t Process::getName() const noexcept
 {
-    return RuntimeName_t(cxx::TruncateToCapacity, m_ipcChannel.getRuntimeName());
+    return m_ipcChannel.getRuntimeName();
 }
 
 void Process::sendViaIpcChannel(const runtime::IpcMessage& data) noexcept

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -272,7 +272,7 @@ bool ProcessManager::addProcess(const RuntimeName_t& name,
     // set current timestamp again (already done in Process's constructor
     m_processList.back().setTimestamp(mepoo::BaseClock_t::now());
 
-    m_processIntrospection->addProcess(static_cast<int>(pid), RuntimeName_t(cxx::TruncateToCapacity, name.c_str()));
+    m_processIntrospection->addProcess(static_cast<int>(pid), name);
 
     LogDebug() << "Registered new application " << name;
     return true;
@@ -377,8 +377,7 @@ void ProcessManager::addNodeForProcess(const RuntimeName_t& runtimeName, const N
                                << cxx::convert::toString(offset) << cxx::convert::toString(m_mgmtSegmentId);
 
                     process->sendViaIpcChannel(sendBuffer);
-                    m_processIntrospection->addNode(RuntimeName_t(cxx::TruncateToCapacity, runtimeName.c_str()),
-                                                    NodeName_t(cxx::TruncateToCapacity, nodeName.c_str()));
+                    m_processIntrospection->addNode(runtimeName, nodeName);
                     LogDebug() << "Created new node " << nodeName << " for process " << runtimeName;
                 })
                 .or_else([&](PortPoolError error) {

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
@@ -62,7 +62,8 @@ cxx::expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption:
         }
         case 'c':
         {
-            m_customConfigFilePath = roudi::ConfigFilePathString_t(cxx::TruncateToCapacity, optarg);
+            m_customConfigFilePath = roudi::ConfigFilePathString_t(
+                cxx::TruncateToCapacity, optarg, strnlen(optarg, roudi::ConfigFilePathString_t::capacity()));
             break;
         }
         default:

--- a/iceoryx_posh/source/version/version_info.cpp
+++ b/iceoryx_posh/source/version/version_info.cpp
@@ -43,8 +43,12 @@ VersionInfo::VersionInfo(const cxx::Serialization& serial) noexcept
     SerializationString_t tmp_commitIdString;
     m_valid = serial.extract(
         m_versionMajor, m_versionMinor, m_versionPatch, m_versionTweak, tmp_m_buildDateString, tmp_commitIdString);
-    m_buildDateString = BuildDateString_t(cxx::TruncateToCapacity, tmp_m_buildDateString.c_str());
-    m_commitIdString = CommitIdString_t(cxx::TruncateToCapacity, tmp_commitIdString.c_str());
+    m_buildDateString = BuildDateString_t(cxx::TruncateToCapacity,
+                                          tmp_m_buildDateString.c_str(),
+                                          strnlen(tmp_m_buildDateString.c_str(), BuildDateString_t::capacity()));
+    m_commitIdString = CommitIdString_t(cxx::TruncateToCapacity,
+                                        tmp_commitIdString.c_str(),
+                                        strnlen(tmp_commitIdString.c_str(), CommitIdString_t::capacity()));
 }
 
 /// @brief Serialization of the VersionInfo.

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -78,7 +78,9 @@ class PortUser_IntegrationTest : public Test
             std::stringstream publisherRuntimeName;
             publisherRuntimeName << TEST_PUBLISHER_RUNTIME_NAME << i;
 
-            iox::RuntimeName_t runtimeName(TruncateToCapacity, publisherRuntimeName.str().c_str());
+            iox::RuntimeName_t runtimeName(TruncateToCapacity,
+                                           publisherRuntimeName.str().c_str(),
+                                           strnlen(publisherRuntimeName.str().c_str(), iox::RuntimeName_t::capacity()));
 
             m_publisherPortDataVector.emplace_back(
                 TEST_SERVICE_DESCRIPTION, runtimeName, &m_memoryManager, PublisherOptions());

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -163,7 +163,8 @@ TEST(PoshRuntime, RuntimeFailsWhenAppNameIsNotAFileName)
                    "",
                    "letsFlyInto "})
     {
-        const iox::RuntimeName_t invalidAppName(iox::cxx::TruncateToCapacity, i);
+        const iox::RuntimeName_t invalidAppName(
+            iox::cxx::TruncateToCapacity, i, strnlen(i, iox::RuntimeName_t::capacity()));
 
         EXPECT_DEATH(PoshRuntime::initRuntime(invalidAppName), ".*");
     }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [ ] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Prevent users from using `char*`-only methods which can lead to out-of-bounds accesses by removing the methods

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1766
