### PR TITLE
iox-#1196 Disable readability-static-accessed-through-instance rule

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -26,6 +26,7 @@ hicpp-*,
 -readability-identifier-length,
 -readability-redundant-access-specifiers,
 -readability-redundant-declaration,
+-readability-static-accessed-through-instance,
 
 -readability-identifier-naming,
 -readability-use-anyofallof,


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR disables the `readability-static-accessed-through-instance` rule which causes warnings when e.g. the static `vector::capacity()` function is accessed via the instance.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Relates to #1196
