### PR TITLE
iox-1394 fix autosar violations in variant

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -135,7 +135,7 @@ The features are tested at module(unit) -integration and system test level. The 
 
 ### Coverage [4.iii]
 
-The Eclipse iceoryx project use [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) to measure the following code coverage metrics:
+The Eclipse iceoryx project use [gcov](https://gcc.gnu.org/onlinedocs/gcc/gcov.html) to measure the following code coverage metrics:
 
 - Line Coverage
 - Function Coverage

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -135,7 +135,7 @@ The features are tested at module(unit) -integration and system test level. The 
 
 ### Coverage [4.iii]
 
-The Eclipse iceoryx project use [gcov](https://gcc.gnu.org/onlinedocs/gcc/gcov.html) to measure the following code coverage metrics:
+The Eclipse iceoryx project use [gcov](https://gcc.gnu.org/onlinedocs/gcc/Gcov.html) to measure the following code coverage metrics:
 
 - Line Coverage
 - Function Coverage

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -100,6 +100,7 @@
 - Renamed `BaseRelativePointer` to `UntypedRelativePointer` [\#605](https://github.com/eclipse-iceoryx/iceoryx/issues/605)
 - Prevent building GoogleTest when `GTest_DIR` is defined [\#1758](https://github.com/eclipse-iceoryx/iceoryx/issues/1758)
 - Refactored `iceoryx_posh_testing` library into own CMakeLists.txt [\#1516](https://github.com/eclipse-iceoryx/iceoryx/issues/1516)
+- Change return type of `cxx::variant::emplace_at_index` and `emplace` to void [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
 
 **Workflow:**
 

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -10,7 +10,7 @@
 - Add clear method for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - Add at method and operator[] for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - expected inherits from FunctionalInterface, adds .expect() method [\#996](https://github.com/eclipse-iceoryx/iceoryx/issues/996)
-- Added CI check of used headers against a list [\#1252](https://github.com/eclipse-iceoryx/iceoryx/issues/1252)
+- Add CI check of used headers against a list [\#1252](https://github.com/eclipse-iceoryx/iceoryx/issues/1252)
 - Add insert method for `iox::cxx::string` [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - Extend compare method of `iox::cxx::string` to compare additionally with std::string and char array [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
 - Add compare method for `iox::cxx::string` and chars [\#208](https://github.com/eclipse-iceoryx/iceoryx/issues/208)
@@ -28,7 +28,7 @@
 - Apps send only the heartbeat when monitoring is enabled in roudi [\#1436](https://github.com/eclipse-iceoryx/iceoryx/issues/1436)
 - Support [Bazel](https://bazel.build/) as optional build system [\#1542](https://github.com/eclipse-iceoryx/iceoryx/issues/1542)
 - Support user defined platforms with cmake switch `-DIOX_PLATFORM_PATH` [\#1619](https://github.com/eclipse-iceoryx/iceoryx/issues/1619)
-- Added equality and inequality operators for `iox::variant` and `iox::expected` [\#1751](https://github.com/eclipse-iceoryx/iceoryx/issues/1751)
+- Add equality and inequality operators for `iox::variant` and `iox::expected` [\#1751](https://github.com/eclipse-iceoryx/iceoryx/issues/1751)
 - Implement UninitializedArray [\#1614](https://github.com/eclipse-iceoryx/iceoryx/issues/1614)
 
 **Bugfixes:**
@@ -55,7 +55,7 @@
 - Implement destructor, copy and move operations in `cxx::stack` [\#1469](https://github.com/eclipse-iceoryx/iceoryx/issues/1469)
 - `gw::GatewayGeneric` sometimes terminates discovery and forward threads immediately [\#1666](https://github.com/eclipse-iceoryx/iceoryx/issues/1666)
 - `m_originId` in `mepoo::ChunkHeader` sometimes not set [\#1668](https://github.com/eclipse-iceoryx/iceoryx/issues/1668)
-- Removed `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
+- Remove `cxx::unique_ptr::reset` [\#1655](https://github.com/eclipse-iceoryx/iceoryx/issues/1655)
 - CI uses outdated clang-format [\#1736](https://github.com/eclipse-iceoryx/iceoryx/issues/1736)
 - Avoid UB when accessing `iox::expected` [\#1750](https://github.com/eclipse-iceoryx/iceoryx/issues/1750)
 
@@ -81,15 +81,15 @@
 - Remove AtomicRelocatablePointer [\#1512](https://github.com/eclipse-iceoryx/iceoryx/issues/1512)
 - `SignalHandler` returns an `expected` in `registerSignalHandler` [\#1196](https://github.com/eclipse-iceoryx/iceoryx/issues/1196)
 - Remove the unused `PosixRights` struct [\#1556](https://github.com/eclipse-iceoryx/iceoryx/issues/1556)
-- Moved quality level 2 classes to new package `iceoryx_dust` [\#590](https://github.com/eclipse-iceoryx/iceoryx/issues/590)
-- Removed unused classes from `iceoryx_hoofs` [\#590](https://github.com/eclipse-iceoryx/iceoryx/issues/590)
+- Move quality level 2 classes to new package `iceoryx_dust` [\#590](https://github.com/eclipse-iceoryx/iceoryx/issues/590)
+- Remove unused classes from `iceoryx_hoofs` [\#590](https://github.com/eclipse-iceoryx/iceoryx/issues/590)
   - `cxx::PoorMansHeap`
   - Other `internal` classes
 - Cleanup helplets [\#1560](https://github.com/eclipse-iceoryx/iceoryx/issues/1560)
-- Moved package `iceoryx_dds` to [separate repository](https://github.com/eclipse-iceoryx/iceoryx-gateway-dds) [\#1564](https://github.com/eclipse-iceoryx/iceoryx/issues/1564)
+- Move package `iceoryx_dds` to [separate repository](https://github.com/eclipse-iceoryx/iceoryx-gateway-dds) [\#1564](https://github.com/eclipse-iceoryx/iceoryx/issues/1564)
 - Set `SOVERSION` with project major version for shared libraries in CMake [\#1308](https://github.com/eclipse-iceoryx/iceoryx/issues/1308)
 - Monitoring feature of RouDi is now disabled by default [\#1580](https://github.com/eclipse-iceoryx/iceoryx/issues/1580)
-- Renamed `cxx::GenericRAII` to `cxx::ScopeGuard` [\#1450](https://github.com/eclipse-iceoryx/iceoryx/issues/1450)
+- Rename `cxx::GenericRAII` to `cxx::ScopeGuard` [\#1450](https://github.com/eclipse-iceoryx/iceoryx/issues/1450)
 - Rename `algorithm::max` and `algorithm::min` to `algorithm::maxVal` and `algorithm::minVal` [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
 - Extract `iceoryx_hoofs/platform` into separate package `iceoryx_platform` [\#1615](https://github.com/eclipse-iceoryx/iceoryx/issues/1615)
 - `cxx::unique_ptr` is no longer nullable [\#1104](https://github.com/eclipse-iceoryx/iceoryx/issues/1104)
@@ -97,9 +97,9 @@
 - Change return type of `cxx::vector::erase` to bool [\#1662](https://github.com/eclipse-iceoryx/iceoryx/issues/1662)
 - `ReleativePointer::registerPtr` returns `cxx::optional` [\#605](https://github.com/eclipse-iceoryx/iceoryx/issues/605)
 - `cxx::function` is no longer nullable [\#1104](https://github.com/eclipse-iceoryx/iceoryx/issues/1104)
-- Renamed `BaseRelativePointer` to `UntypedRelativePointer` [\#605](https://github.com/eclipse-iceoryx/iceoryx/issues/605)
+- Rename `BaseRelativePointer` to `UntypedRelativePointer` [\#605](https://github.com/eclipse-iceoryx/iceoryx/issues/605)
 - Prevent building GoogleTest when `GTest_DIR` is defined [\#1758](https://github.com/eclipse-iceoryx/iceoryx/issues/1758)
-- Refactored `iceoryx_posh_testing` library into own CMakeLists.txt [\#1516](https://github.com/eclipse-iceoryx/iceoryx/issues/1516)
+- Refactor `iceoryx_posh_testing` library into own CMakeLists.txt [\#1516](https://github.com/eclipse-iceoryx/iceoryx/issues/1516)
 - Change return type of `cxx::variant::emplace_at_index` and `emplace` to void [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
 
 **Workflow:**

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -192,19 +192,17 @@ class variant final
     /// @tparam TypeIndex index of the type which will be created
     /// @tparam CTorArguments variadic types of the c'tor arguments
     /// @param[in] args arguments which will be forwarded to the constructor to the type at TypeIndex
-    /// @return if the variant already contains a different type it returns false, if the construction
-    ///         was successful it returns true
+    /// @note terminates if the given TypeIndex is out of bounds
     template <uint64_t TypeIndex, typename... CTorArguments>
-    bool emplace_at_index(CTorArguments&&... args) noexcept;
+    void emplace_at_index(CTorArguments&&... args) noexcept;
 
     /// @brief calls the constructor of the type T and perfectly forwards the arguments
     ///         to the constructor of T.
     /// @tparam[in] T type which is created inside the variant
     /// @tparam[in] CTorArguments variadic types of the c'tor arguments
-    /// @return if the variant already contains a different type it returns false, if the construction
-    ///         was successful it returns true
+    /// @note terminates if the variant does not contain the given type
     template <typename T, typename... CTorArguments>
-    bool emplace(CTorArguments&&... args) noexcept;
+    void emplace(CTorArguments&&... args) noexcept;
 
     /// @brief returns a pointer to the type stored at index TypeIndex. (not stl compliant)
     /// @tparam[in] TypeIndex index of the stored type

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -18,7 +18,6 @@
 #define IOX_HOOFS_CXX_VARIANT_HPP
 
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
-#include "iceoryx_hoofs/cxx/string.hpp"
 #include "iceoryx_hoofs/internal/cxx/variant_internal.hpp"
 
 #include <cstdint>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -192,7 +192,6 @@ class variant final
     /// @tparam TypeIndex index of the type which will be created
     /// @tparam CTorArguments variadic types of the c'tor arguments
     /// @param[in] args arguments which will be forwarded to the constructor to the type at TypeIndex
-    /// @note terminates if the given TypeIndex is out of bounds
     template <uint64_t TypeIndex, typename... CTorArguments>
     void emplace_at_index(CTorArguments&&... args) noexcept;
 
@@ -200,7 +199,6 @@ class variant final
     ///         to the constructor of T.
     /// @tparam[in] T type which is created inside the variant
     /// @tparam[in] CTorArguments variadic types of the c'tor arguments
-    /// @note terminates if the variant does not contain the given type
     template <typename T, typename... CTorArguments>
     void emplace(CTorArguments&&... args) noexcept;
 
@@ -267,6 +265,7 @@ class variant final
     // AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive. internal::byte_t is a type alias for uint8_t
     struct alignas(Types...) storage_t
     {
+        // AXIVION Next Construct AutosarC++19_03-M0.1.3 : data provides the actual storage and is accessed via m_storage since &m_storage.data = &m_storage
         // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the variant class
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
         internal::byte_t data[TYPE_SIZE];
@@ -277,14 +276,15 @@ class variant final
   private:
     template <typename T>
     bool has_bad_variant_element_access() const noexcept;
+    // AXIVION Next Construct AutosarC++19_03-A3.9.1 : internal convenience function to easily use IOX_LOG
     static void error_message(const char* source, const char* msg) noexcept;
 
     void call_element_destructor() noexcept;
 
     template <typename... Ts>
-    friend constexpr bool operator==(const variant<Ts...>& lhs, const variant<Ts...>& rhs);
+    friend constexpr bool operator==(const variant<Ts...>& lhs, const variant<Ts...>& rhs) noexcept;
     template <typename... Ts>
-    friend constexpr bool operator!=(const variant<Ts...>& lhs, const variant<Ts...>& rhs);
+    friend constexpr bool operator!=(const variant<Ts...>& lhs, const variant<Ts...>& rhs) noexcept;
 };
 
 /// @brief returns true if the variant holds a given type T, otherwise false
@@ -297,7 +297,7 @@ constexpr bool holds_alternative(const variant<Types...>& variant) noexcept;
 /// @param[in] rhs right side of the comparison
 /// @return true if the variants are equal, otherwise false
 template <typename... Types>
-constexpr bool operator==(const variant<Types...>& lhs, const variant<Types...>& rhs);
+constexpr bool operator==(const variant<Types...>& lhs, const variant<Types...>& rhs) noexcept;
 
 /// @brief inequality check for two distinct variant types
 /// @tparam Types variadic number of types which can be stored in the variant
@@ -305,7 +305,7 @@ constexpr bool operator==(const variant<Types...>& lhs, const variant<Types...>&
 /// @param[in] rhs right side of the comparison
 /// @return true if the variants are not equal, otherwise false
 template <typename... Types>
-constexpr bool operator!=(const variant<Types...>& lhs, const variant<Types...>& rhs);
+constexpr bool operator!=(const variant<Types...>& lhs, const variant<Types...>& rhs) noexcept;
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_CXX_VARIANT_HPP
 
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
+#include "iceoryx_hoofs/cxx/string.hpp"
 #include "iceoryx_hoofs/internal/cxx/variant_internal.hpp"
 
 #include <cstdint>
@@ -40,7 +41,7 @@ namespace cxx
 template <uint64_t N>
 struct in_place_index
 {
-    static constexpr uint64_t value = N;
+    static constexpr uint64_t value{N};
 };
 
 /// @brief helper struct to perform an emplacement of a predefined type in
@@ -67,7 +68,7 @@ struct in_place_type
 ///     // variant with setted value therefore the index is not invalid
 ///     if ( someVariant.index() != INVALID_VARIANT_INDEX ) ...
 /// @endcode
-static constexpr uint64_t INVALID_VARIANT_INDEX = std::numeric_limits<uint64_t>::max();
+static constexpr uint64_t INVALID_VARIANT_INDEX{std::numeric_limits<uint64_t>::max()};
 
 /// @brief Variant implementation from the C++17 standard with C++11. The
 ///         interface is inspired by the C++17 standard but it has changes in
@@ -103,11 +104,11 @@ static constexpr uint64_t INVALID_VARIANT_INDEX = std::numeric_limits<uint64_t>:
 ///
 /// @endcode
 template <typename... Types>
-class variant
+class variant final
 {
   private:
     /// @brief contains the size of the largest element
-    static constexpr uint64_t TYPE_SIZE = algorithm::maxVal(sizeof(Types)...);
+    static constexpr uint64_t TYPE_SIZE{algorithm::maxVal(sizeof(Types)...)};
 
   public:
     /// @brief the default constructor constructs a variant which does not contain
@@ -265,9 +266,10 @@ class variant
     constexpr uint64_t index() const noexcept;
 
   private:
+    // AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive. internal::byte_t is a type alias for uint8_t
     struct alignas(Types...) storage_t
     {
-        // NOLINTJUSTIFICATION safe access is guaranteed since the c-array is wrapped inside the variant class
+        // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the variant class
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)
         internal::byte_t data[TYPE_SIZE];
     };

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
@@ -64,12 +64,7 @@ inline constexpr variant<Types...>::variant(T&& arg) noexcept
 {
 }
 
-// AXIVION Next Construct AutosarC++19_03-A13.3.1 : False positive. Overloading excluded via std::enable_if in
-// template <typename T,
-// typename = std::enable_if_t<!std::is_same<std::decay_t<T>, variant>::value>,
-// typename std::enable_if_t<!internal::is_in_place_index<std::decay_t<T>>::value, bool> = false,
-// typename std::enable_if_t<!internal::is_in_place_type<std::decay_t<T>>::value, bool> = false>
-// constexpr explicit variant(T&& arg) noexcept;
+// AXIVION Next Construct AutosarC++19_03-A13.3.1 : False positive. Overload excluded via std::enable_if in operator=(T&& rhs)
 template <typename... Types>
 inline constexpr variant<Types...>& variant<Types...>::operator=(const variant& rhs) noexcept
 {
@@ -106,12 +101,7 @@ inline constexpr variant<Types...>::variant(variant&& rhs) noexcept
     }
 }
 
-// AXIVION Next Construct AutosarC++19_03-A13.3.1 : False positive. Overloading excluded via std::enable_if in
-// template <typename T,
-// typename = std::enable_if_t<!std::is_same<std::decay_t<T>, variant>::value>,
-// typename std::enable_if_t<!internal::is_in_place_index<std::decay_t<T>>::value, bool> = false,
-// typename std::enable_if_t<!internal::is_in_place_type<std::decay_t<T>>::value, bool> = false>
-// constexpr explicit variant(T&& arg) noexcept;
+// AXIVION Next Construct AutosarC++19_03-A13.3.1 : False positive. Overload excluded via std::enable_if in operator=(T&& rhs)
 template <typename... Types>
 inline constexpr variant<Types...>& variant<Types...>::operator=(variant&& rhs) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant.inl
@@ -201,10 +201,7 @@ inline void variant<Types...>::emplace(CTorArguments&&... args) noexcept
 {
     static_assert(internal::does_contain_type<T, Types...>::value, "variant does not contain given type");
 
-    if (m_type_index != INVALID_VARIANT_INDEX)
-    {
-        call_element_destructor();
-    }
+    call_element_destructor();
 
     new (&m_storage) T(std::forward<CTorArguments>(args)...);
     m_type_index = internal::get_index_of_type<0, T, Types...>::index;
@@ -221,7 +218,7 @@ inline typename internal::get_type_at_index<0, TypeIndex, Types...>::type* varia
 
     using T = typename internal::get_type_at_index<0, TypeIndex, Types...>::type;
 
-    // AXIVION Next Construct AutosarC++19_03-M5.2.8: conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
+    // AXIVION Next Construct AutosarC++19_03-M5.2.8 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
     return static_cast<T*>(static_cast<void*>(&m_storage));
 }
 
@@ -244,9 +241,7 @@ inline const T* variant<Types...>::get() const noexcept
     {
         return nullptr;
     }
-    // AXIVION Next Construct AutosarC++19_03-M5.2.8: conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
-    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : avoid code duplication
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    // AXIVION Next Construct AutosarC++19_03-M5.2.8 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
     return static_cast<const T*>(static_cast<const void*>(&m_storage));
 }
 
@@ -295,6 +290,7 @@ inline bool variant<Types...>::has_bad_variant_element_access() const noexcept
 }
 
 template <typename... Types>
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : see at declaration in header
 inline void variant<Types...>::error_message(const char* source, const char* msg) noexcept
 {
     IOX_LOG(ERROR) << source << " ::: " << msg;
@@ -307,7 +303,7 @@ inline constexpr bool holds_alternative(const variant<Types...>& variant) noexce
 }
 
 template <typename... Types>
-inline constexpr bool operator==(const variant<Types...>& lhs, const variant<Types...>& rhs)
+inline constexpr bool operator==(const variant<Types...>& lhs, const variant<Types...>& rhs) noexcept
 {
     if ((lhs.index() == INVALID_VARIANT_INDEX) && (rhs.index() == INVALID_VARIANT_INDEX))
     {
@@ -321,7 +317,7 @@ inline constexpr bool operator==(const variant<Types...>& lhs, const variant<Typ
 }
 
 template <typename... Types>
-inline constexpr bool operator!=(const variant<Types...>& lhs, const variant<Types...>& rhs)
+inline constexpr bool operator!=(const variant<Types...>& lhs, const variant<Types...>& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
@@ -58,26 +58,25 @@ using byte_t = uint8_t;
 template <typename TypeToCheck, typename T, typename... Targs>
 struct does_contain_type
 {
-    static constexpr bool value =
-        std::is_same<TypeToCheck, T>::value || does_contain_type<TypeToCheck, Targs...>::value;
+    static constexpr bool value{std::is_same<TypeToCheck, T>::value || does_contain_type<TypeToCheck, Targs...>::value};
 };
 
 template <typename TypeToCheck, typename T>
 struct does_contain_type<TypeToCheck, T>
 {
-    static constexpr bool value = std::is_same<TypeToCheck, T>::value;
+    static constexpr bool value{std::is_same<TypeToCheck, T>::value};
 };
 
 template <uint64_t N, typename Type, typename T, typename... Targs>
 struct get_index_of_type
 {
-    static constexpr uint64_t index = get_index_of_type<N + 1, Type, Targs...>::index;
+    static constexpr uint64_t index{get_index_of_type<N + 1, Type, Targs...>::index};
 };
 
 template <uint64_t N, typename Type, typename... Targs>
 struct get_index_of_type<N, Type, Type, Targs...>
 {
-    static constexpr uint64_t index = N;
+    static constexpr uint64_t index{N};
 };
 
 template <uint64_t N, uint64_t Index, typename T, typename... Targs>
@@ -92,6 +91,10 @@ struct get_type_at_index<N, N, T, Targs...>
     using type = T;
 };
 
+// AXIVION DISABLE STYLE AutosarC++19_03-M5.2.8, AutosarC++19_03-A5.2.4 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design of variant; note that this is an internal class used by variant
+// AXIVION DISABLE STYLE AutosarC++19_03-A18.5.10, FaultDetection-IndirectAssignmentOverflow : destination is aligned to the maximum alignment of Types, see variant.hpp
+// AXIVION DISABLE STYLE AutosarC++19_03-A5.3.2 : this is an internal struct used only by variant; all pointer arguments are checked in the variant class before the static functions are called
+// NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
 template <uint64_t N, typename T, typename... Targs>
 struct call_at_index
 {
@@ -99,8 +102,6 @@ struct call_at_index
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<T*>(ptr)->~T();
         }
         else
@@ -113,9 +114,7 @@ struct call_at_index
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<T* const>(destination) = std::move(*reinterpret_cast<T*>(source));
+            *reinterpret_cast<T*>(destination) = std::move(*reinterpret_cast<T*>(source));
         }
         else
         {
@@ -127,8 +126,6 @@ struct call_at_index
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             new (destination) T(std::move(*reinterpret_cast<T*>(source)));
         }
         else
@@ -141,9 +138,7 @@ struct call_at_index
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<T* const>(destination) = *reinterpret_cast<const T* const>(source);
+            *reinterpret_cast<T*>(destination) = *reinterpret_cast<const T*>(source);
         }
         else
         {
@@ -155,9 +150,7 @@ struct call_at_index
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            new (destination) T(*reinterpret_cast<const T* const>(source));
+            new (destination) T(*reinterpret_cast<const T*>(source));
         }
         else
         {
@@ -165,13 +158,11 @@ struct call_at_index
         }
     }
 
-    static bool equality(const uint64_t index, const void* const lhs, const void* const rhs)
+    static bool equality(const uint64_t index, const void* const lhs, const void* const rhs) noexcept
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter and encapsulated in this class
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            return *reinterpret_cast<const T* const>(lhs) == *reinterpret_cast<const T* const>(rhs);
+            return *reinterpret_cast<const T*>(lhs) == *reinterpret_cast<const T*>(rhs);
         }
         return call_at_index<N + 1, Targs...>::equality(index, lhs, rhs);
     }
@@ -180,14 +171,10 @@ struct call_at_index
 template <uint64_t N, typename T>
 struct call_at_index<N, T>
 {
-    // NOLINTJUSTIFICATION d'tor changes the data to which ptr is pointing to
-    // NOLINTNEXTLINE(readability-non-const-parameter)
     static void destructor(const uint64_t index, void* ptr) noexcept
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             reinterpret_cast<T*>(ptr)->~T();
         }
         else
@@ -196,15 +183,11 @@ struct call_at_index<N, T>
         }
     }
 
-    // NOLINTJUSTIFICATION move c'tor changes the data to which source is pointing to
-    // NOLINTNEXTLINE(readability-non-const-parameter)
     static void move(const uint64_t index, void* source, void* const destination) noexcept
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<T* const>(destination) = std::move(*reinterpret_cast<T*>(source));
+            *reinterpret_cast<T*>(destination) = std::move(*reinterpret_cast<T*>(source));
         }
         else
         {
@@ -212,14 +195,10 @@ struct call_at_index<N, T>
         }
     }
 
-    // NOLINTJUSTIFICATION Both 'source' and 'destination' will be changed and can't be const
-    // NOLINTNEXTLINE(readability-non-const-parameter)
     static void moveConstructor(const uint64_t index, void* source, void* const destination) noexcept
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             new (destination) T(std::move(*reinterpret_cast<T*>(source)));
         }
         else
@@ -232,9 +211,7 @@ struct call_at_index<N, T>
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            *reinterpret_cast<T* const>(destination) = *reinterpret_cast<const T* const>(source);
+            *reinterpret_cast<T*>(destination) = *reinterpret_cast<const T*>(source);
         }
         else
         {
@@ -246,9 +223,7 @@ struct call_at_index<N, T>
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            new (destination) T(*reinterpret_cast<const T* const>(source));
+            new (destination) T(*reinterpret_cast<const T*>(source));
         }
         else
         {
@@ -260,14 +235,16 @@ struct call_at_index<N, T>
     {
         if (N == index)
         {
-            // AXIVION Next Construct AutosarC++19_03-A5.2.4 : Type safety ensured through template parameter and encapsulated in this class
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            return *reinterpret_cast<const T* const>(lhs) == *reinterpret_cast<const T* const>(rhs);
+            return *reinterpret_cast<const T*>(lhs) == *reinterpret_cast<const T*>(rhs);
         }
         ExpectsWithMsg(false, "Could not call equality operator for variant element");
         return false;
     }
 };
+// NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+// AXIVION DISABLE STYLE AutosarC++19_03-A5.3.2
+// AXIVION ENABLE STYLE AutosarC++19_03-A18.5.10, FaultDetection-IndirectAssignmentOverflow
+// AXIVION ENABLE STYLE AutosarC++19_03-M5.2.8, AutosarC++19_03-A5.2.4
 
 } // namespace internal
 } // namespace cxx

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
@@ -242,7 +242,7 @@ struct call_at_index<N, T>
     }
 };
 // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
-// AXIVION DISABLE STYLE AutosarC++19_03-A5.3.2
+// AXIVION ENABLE STYLE AutosarC++19_03-A5.3.2
 // AXIVION ENABLE STYLE AutosarC++19_03-A18.5.10, FaultDetection-IndirectAssignmentOverflow
 // AXIVION ENABLE STYLE AutosarC++19_03-M5.2.8, AutosarC++19_03-A5.2.4
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ TEST_F(variant_Test, CreatingVariantWithSameTypeChoosesFirstFittingType)
 TEST_F(variant_Test, EmplaceValidElementWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "24021bd7-3749-4ca3-9b35-db3cb4837bff");
-    ASSERT_THAT(sut.emplace<ComplexClass>(123, 456.789F), Eq(true));
+    sut.emplace<ComplexClass>(123, 456.789F);
     ASSERT_THAT(sut.get<ComplexClass>(), Ne(nullptr));
     EXPECT_THAT(sut.get<ComplexClass>()->a, Eq(123));
     EXPECT_THAT(sut.get<ComplexClass>()->b, Eq(456.789F));
@@ -187,7 +187,7 @@ TEST_F(variant_Test, EmplaceSecondValidElementWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb4ba160-dd0c-4255-9916-cc56d950e970");
     sut.emplace<ComplexClass>(123, 456.789F);
-    ASSERT_THAT(sut.emplace<ComplexClass>(912, 65.03F), Eq(true));
+    sut.emplace<ComplexClass>(912, 65.03F);
     ASSERT_THAT(sut.get<ComplexClass>(), Ne(nullptr));
     EXPECT_THAT(sut.get<ComplexClass>()->a, Eq(912));
     EXPECT_THAT(sut.get<ComplexClass>()->b, Eq(65.03F));
@@ -197,14 +197,7 @@ TEST_F(variant_Test, EmplaceInvalidElementCompileTimeCheck)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6fa3b290-8249-4825-8eac-72235a06710e");
     GTEST_SKIP() << "Compile time check, if you uncomment this test, the compiler will fail";
-    // EXPECT_THAT(sut.emplace< unsigned int >(0), Eq(false));
-}
-
-TEST_F(variant_Test, EmplaceWhenAlreadyDifferentTypeAssignedDoesNotWork)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "f2c0825a-349c-4acb-9643-cb046f7e0310");
-    sut.emplace<int>(123);
-    EXPECT_THAT(sut.emplace<float>(123.F), Eq(false));
+    // sut.emplace<unsigned int>(0);
 }
 
 TEST_F(variant_Test, GetOnUninitializedVariantFails)
@@ -511,7 +504,7 @@ TEST_F(variant_Test, SameTypeVariantAndEmplaceWithIndexResultsInCorrectValue)
     ::testing::Test::RecordProperty("TEST_ID", "fb55e6d8-d42d-4073-b5db-5300c56df540");
     iox::cxx::variant<int, float, int> schlomo;
 
-    ASSERT_THAT(schlomo.emplace_at_index<2>(123), Eq(true));
+    schlomo.emplace_at_index<2>(123);
     EXPECT_THAT(*schlomo.get_at_index<2>(), Eq(123));
 }
 
@@ -520,7 +513,7 @@ TEST_F(variant_Test, SameTypeVariantResultsInCorrectIndex)
     ::testing::Test::RecordProperty("TEST_ID", "10994259-9fb5-411f-9e12-365f2d8e09fd");
     iox::cxx::variant<int, float, int> schlomo;
 
-    EXPECT_THAT(schlomo.emplace_at_index<1>(1.23F), Eq(true));
+    schlomo.emplace_at_index<1>(1.23F);
     EXPECT_THAT(schlomo.index(), Eq(1U));
 }
 
@@ -529,7 +522,7 @@ TEST_F(variant_Test, SameTypeVariantReturnsNothingForIncorrectIndex)
     ::testing::Test::RecordProperty("TEST_ID", "04c16cb1-f67f-47fa-bde8-f15ff0d044c3");
     iox::cxx::variant<int, float, int> schlomo;
 
-    ASSERT_THAT(schlomo.emplace_at_index<2>(123), Eq(true));
+    schlomo.emplace_at_index<2>(123);
     EXPECT_THAT(schlomo.get_at_index<1>(), Eq(nullptr));
 }
 
@@ -539,7 +532,7 @@ TEST_F(variant_Test, ConstSameTypeVariantAndEmplaceWithIndexResultsInCorrectValu
     iox::cxx::variant<int, float, int> schlomo;
     const iox::cxx::variant<int, float, int>* ignatz = &schlomo;
 
-    ASSERT_THAT(schlomo.emplace_at_index<2>(4123), Eq(true));
+    schlomo.emplace_at_index<2>(4123);
     EXPECT_THAT(*ignatz->get_at_index<2>(), Eq(4123));
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes/suppresses the AUTOSAR warnings for `variant` and `variant_internal`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partially)
