### PR TITLE
iox-1756 use iceoryx logger instead of output streams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -325,7 +325,7 @@ Github [labels](https://github.com/eclipse-iceoryx/iceoryx/labels) are used to g
 
 | Ruleset name | Github issue label | Priority |
 |---|---|---|
-| [Adaptive AUTOSAR](https://www.autosar.org/fileadmin/user_upload/standards/adaptive/17-03/AUTOSAR_RS_CPP14Guidelines.pdf) C++14 | AUTOSAR | :star::star::star: |
+| [Adaptive AUTOSAR](https://www.autosar.org/fileadmin/standards/adaptive/19-11/AUTOSAR_RS_CPP14Guidelines.pdf) C++14 | AUTOSAR | :star::star::star: |
 | [SEI CERT C++](https://wiki.sei.cmu.edu/confluence/pages/viewpage.action?pageId=88046682) 2016 Coding Standard | CERT | :star::star: |
 | [MISRA](https://www.misra.org.uk/) C++ 2008 | MISRA | :star: |
 

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -104,6 +104,7 @@
 - Prevent building GoogleTest when `GTest_DIR` is defined [\#1758](https://github.com/eclipse-iceoryx/iceoryx/issues/1758)
 - Refactor `iceoryx_posh_testing` library into own CMakeLists.txt [\#1516](https://github.com/eclipse-iceoryx/iceoryx/issues/1516)
 - Change return type of `cxx::variant::emplace_at_index` and `emplace` to void [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
+- Replace uses of `std::cout`, `std::cerr` with the iceoryx logger [\#1756](https://github.com/eclipse-iceoryx/iceoryx/issues/1756)
 
 **Workflow:**
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/expected.hpp
@@ -124,10 +124,10 @@ class IOX_NO_DISCARD expected;
 ///
 ///     cxx::expected<float> errorOnlyMethod() {
 ///         return callMe().or_else([]{
-///             std::cerr << "Error Occured\n";
+///             IOX_LOG(ERROR) << "Error Occured\n";
 ///             /// perform some action
 ///         }).and_then([](cxx::expected<int, float> & result){
-///             std::cout << "Success, got " << result.value() << std::endl;
+///             IOX_LOG(INFO) << "Success, got " << result.value();
 ///             /// perform some action
 ///         });
 ///     }
@@ -389,7 +389,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     /// @code
     ///     cxx::expected<int, float> frodo(success<int>(45));
     ///     *frodo += 12;
-    ///     std::cout << *frodo << std::endl; // prints 57
+    ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
     ValueType& operator*() noexcept;
 
@@ -399,7 +399,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     /// @code
     ///     cxx::expected<int, float> frodo(success<int>(45));
     ///     *frodo += 12;
-    ///     std::cout << *frodo << std::endl; // prints 57
+    ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
     const ValueType& operator*() const noexcept;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/helplets.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/helplets.hpp
@@ -203,7 +203,7 @@ constexpr size_t maxSize() noexcept
 /// @brief Get the capacity of a C array at compile time
 /// @code
 /// constexpr uint32_t FOO[42]{};
-/// std::cout << arrayCapacity(FOO) << std::endl; // will print 42
+/// IOX_LOG(INFO) << arrayCapacity(FOO); // will print 42
 /// @endcode
 /// @tparam T the type of the array filled out by the compiler.
 /// @tparam CapacityValue the capacity of the array filled out by the compiler.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/list.hpp
@@ -364,8 +364,6 @@ class list
     void setPrevIdx(const size_type idx, const size_type prevIdx) noexcept;
     void setNextIdx(const size_type idx, const size_type nextIdx) noexcept;
 
-    static void errorMessage(const char* source, const char* msg) noexcept;
-
     //***************************************
     //    members
     //***************************************

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/scope_guard.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/scope_guard.hpp
@@ -35,9 +35,9 @@ namespace cxx
 /// // I am doing stuff
 /// // goodbye
 /// void someFunc() {
-///     ScopeGuard myScopeGuard{[](){ std::cout << "hello world\n"; },
-///                 [](){ std::cout << "goodbye\n"; }};
-///     std::cout << "I am doing stuff\n";
+///     ScopeGuard myScopeGuard{[](){ IOX_LOG(INFO) << "hello world\n"; },
+///                 [](){ IOX_LOG(INFO) << "goodbye"; }};
+///     IOX_LOG(INFO) << "I am doing stuff";
 ///     // myScopeGuard goes out of scope here and the cleanupFunction is called in the
 ///     // destructor
 /// }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/serialization.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/serialization.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ namespace cxx
 ///             5:hello3:1236:123.01
 /// @code
 ///     auto serial = cxx::Serialization::create("fuu", 123, 12.12f, 'c');
-///     std::cout << serial.toString() << std::endl;
+///     IOX_LOG(INFO) << serial.toString();
 ///
 ///     std::string v1;
 ///     int v2;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant.hpp
@@ -89,17 +89,17 @@ static constexpr uint64_t INVALID_VARIANT_INDEX{std::numeric_limits<uint64_t>::m
 ///     else if ( someVariant.index() == 1)
 ///     {
 ///         auto blubb = someVariant.template get_at_index<1>();
-///         std::cout << *blubb << std::endl;
+///         IOX_LOG(INFO) << *blubb;
 ///
 ///         auto sameAsBlubb = someVariant.get<float>();
-///         std::cout << *sameAsBlubb << std::endl;
+///         IOX_LOG(INFO) << *sameAsBlubb;
 ///     }
 ///
 ///     // .. do stuff
 ///
 ///     int defaultValue = 123;
 ///     int * fuu = someVariant.get_if<int>(&defaultValue);
-///     std::cout << *fuu << std::endl;
+///     IOX_LOG(INFO) << *fuu;
 ///
 /// @endcode
 template <typename... Types>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant_queue.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/variant_queue.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,12 +57,12 @@ enum class VariantQueueTypes : uint64_t
 ///     // overflow case
 ///     auto status = nonOverflowingQueue.push(123);
 ///     if ( !status ) {
-///         std::cout << "queue is full" << std::endl;
+///         IOX_LOG(INFO) << "queue is full";
 ///     }
 ///
 ///     auto overriddenElement = overflowingQueue.push(123);
 ///     if ( overriddenElement->has_value() ) {
-///         std::cout << "element " << overriddenElement->value() << " was overridden\n";
+///         IOX_LOG(INFO) << "element " << overriddenElement->value() << " was overridden";
 ///     }
 /// @endcode
 template <typename ValueType, uint64_t Capacity>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/concurrent/periodic_task.hpp
@@ -53,7 +53,7 @@ static constexpr PeriodicTaskManualStart_t PeriodicTaskManualStart;
 /// {
 ///     using namespace iox::units::duration_literals;
 ///     PeriodicTask<iox::cxx::function_ref<void()>> task{
-///         PeriodicTaskAutoStart, 1_s, "MyTask", [] { std::cout << "Hello World" << std::endl; }};
+///         PeriodicTaskAutoStart, 1_s, "MyTask", [] { IOX_LOG(INFO) << "Hello World"; }};
 ///
 ///         return 0;
 /// }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/adaptive_wait.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/adaptive_wait.hpp
@@ -93,7 +93,7 @@ class adaptive_wait
     ///       std::this_thread::yield();
     ///   }
     ///   auto end = std::chrono::steady_clock::now();
-    ///   std::cout << (end - start).count() << std::endl; // prints around 1ms
+    ///   IOX_LOG(INFO) << (end - start).count() // prints around 1ms
     /// @endcode
     static constexpr uint64_t YIELD_REPETITIONS = 10000U;
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/convert.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/convert.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2019, 2021 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_CXX_CONVERT_INL
 
 #include "iceoryx_hoofs/cxx/convert.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 namespace iox
 {
@@ -76,7 +77,7 @@ inline bool convert::fromString<char>(const char* v, char& dest) noexcept
 {
     if (strlen(v) != 1U)
     {
-        std::cerr << v << " is not a char" << std::endl;
+        IOX_LOG(DEBUG) << v << " is not a char";
         return false;
     }
 
@@ -137,26 +138,25 @@ inline bool convert::stringIsNumberWithErrorMessage(const char* v, const NumberT
 {
     if (!stringIsNumber(v, type))
     {
-        std::cerr << v << " is not ";
+        IOX_LOG(DEBUG) << v << " is not ";
         switch (type)
         {
         case NumberType::FLOAT:
         {
-            std::cerr << "a float";
+            IOX_LOG(DEBUG) << "a float";
             break;
         }
         case NumberType::INTEGER:
         {
-            std::cerr << "a signed integer";
+            IOX_LOG(DEBUG) << "a signed integer";
             break;
         }
         case NumberType::UNSIGNED_INTEGER:
         {
-            std::cerr << "an unsigned integer";
+            IOX_LOG(DEBUG) << "an unsigned integer";
             break;
         }
         }
-        std::cerr << std::endl;
         return false;
     }
     return true;
@@ -224,7 +224,7 @@ inline bool convert::fromString<uint64_t>(const char* v, uint64_t& dest) noexcep
 
     if (call->value > std::numeric_limits<uint64_t>::max())
     {
-        std::cerr << call->value << " too large, uint64_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " too large, uint64_t overflow";
         return false;
     }
 
@@ -262,7 +262,7 @@ inline bool convert::fromString<uint32_t>(const char* v, uint32_t& dest) noexcep
 
     if (call->value > std::numeric_limits<uint32_t>::max())
     {
-        std::cerr << call->value << " too large, uint32_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " too large, uint32_t overflow";
         return false;
     }
 
@@ -287,7 +287,7 @@ inline bool convert::fromString<uint16_t>(const char* v, uint16_t& dest) noexcep
 
     if (call->value > std::numeric_limits<uint16_t>::max())
     {
-        std::cerr << call->value << " too large, uint16_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " too large, uint16_t overflow";
         return false;
     }
 
@@ -312,7 +312,7 @@ inline bool convert::fromString<uint8_t>(const char* v, uint8_t& dest) noexcept
 
     if (call->value > std::numeric_limits<uint8_t>::max())
     {
-        std::cerr << call->value << " too large, uint8_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " too large, uint8_t overflow";
         return false;
     }
 
@@ -337,7 +337,7 @@ inline bool convert::fromString<int64_t>(const char* v, int64_t& dest) noexcept
 
     if (call->value > std::numeric_limits<int64_t>::max() || call->value < std::numeric_limits<int64_t>::min())
     {
-        std::cerr << call->value << " is out of range, int64_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " is out of range, int64_t overflow";
         return false;
     }
 
@@ -362,7 +362,7 @@ inline bool convert::fromString<int32_t>(const char* v, int32_t& dest) noexcept
 
     if (call->value > std::numeric_limits<int32_t>::max() || call->value < std::numeric_limits<int32_t>::min())
     {
-        std::cerr << call->value << " is out of range, int32_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " is out of range, int32_t overflow";
         return false;
     }
 
@@ -386,7 +386,7 @@ inline bool convert::fromString<int16_t>(const char* v, int16_t& dest) noexcept
 
     if (call->value > std::numeric_limits<int16_t>::max() || call->value < std::numeric_limits<int16_t>::min())
     {
-        std::cerr << call->value << " is out of range, int16_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " is out of range, int16_t overflow";
         return false;
     }
 
@@ -410,7 +410,7 @@ inline bool convert::fromString<int8_t>(const char* v, int8_t& dest) noexcept
 
     if (call->value > std::numeric_limits<int8_t>::max() || call->value < std::numeric_limits<int8_t>::min())
     {
-        std::cerr << call->value << " is out of range, int8_t overflow" << std::endl;
+        IOX_LOG(DEBUG) << call->value << " is out of range, int8_t overflow";
         return false;
     }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/list.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 
 #include "iceoryx_hoofs/cxx/list.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 
 namespace iox
@@ -235,7 +236,7 @@ inline typename list<T, Capacity>::iterator list<T, Capacity>::emplace(const_ite
 
     if (m_size >= Capacity)
     {
-        errorMessage(__PRETTY_FUNCTION__, " capacity exhausted ");
+        IOX_LOG(DEBUG) << "capacity exhausted";
         return end();
     }
 
@@ -274,7 +275,7 @@ inline typename list<T, Capacity>::iterator list<T, Capacity>::erase(const_itera
     // further narrow-down checks
     if (!isValidElementIdx(eraseIdx) || empty())
     {
-        errorMessage(__PRETTY_FUNCTION__, " iterator is end() or list is empty");
+        IOX_LOG(DEBUG) << "list is empty";
         return end();
     }
 
@@ -697,13 +698,6 @@ inline bool list<T, Capacity>::isInvalidIterOrDifferentLists(const const_iterato
     cxx::Expects((this == iter.m_list) && "iterator of other list can't be used");
     return isInvalidIterator(iter);
 }
-
-template <typename T, uint64_t Capacity>
-inline void list<T, Capacity>::errorMessage(const char* source, const char* msg) noexcept
-{
-    std::cerr << source << " ::: " << msg << std::endl;
-}
-
 
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -16,6 +16,7 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 #define IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 
 namespace iox
@@ -189,11 +190,9 @@ PosixCallEvaluator<ReturnType>::evaluate() const&& noexcept
 
     if (!m_details.hasSilentErrno)
     {
-        auto flags = std::cerr.flags();
-        std::cerr << m_details.file << ":" << std::dec << m_details.line << " { " << m_details.callingFunction << " -> "
-                  << m_details.posixFunctionName << " }  :::  [ " << std::dec << m_details.result.errnum << " ]  "
-                  << m_details.result.getHumanReadableErrnum() << std::endl;
-        std::cerr.setf(flags);
+        IOX_LOG(ERROR) << m_details.file << ":" << m_details.line << " { " << m_details.callingFunction << " -> "
+                       << m_details.posixFunctionName << " }  :::  [ " << m_details.result.errnum << " ]  "
+                       << m_details.result.getHumanReadableErrnum();
     }
 
     return iox::cxx::error<PosixCallResult<ReturnType>>(m_details.result);

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -18,6 +18,8 @@
 #define IOX_HOOFS_UNITS_DURATION_HPP
 
 #include "iceoryx_hoofs/cxx/expected.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
+#include "iceoryx_hoofs/log/logstream.hpp"
 #include "iceoryx_platform/time.hpp" // required for QNX
 
 #include <chrono>
@@ -295,6 +297,7 @@ class Duration
     friend constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
+    friend iox::log::LogStream& operator<<(iox::log::LogStream& stream, const Duration t) noexcept;
 
     static constexpr uint32_t SECS_PER_MINUTE{60U};
     static constexpr uint32_t SECS_PER_HOUR{3600U};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,9 +69,9 @@ constexpr Duration operator"" _d(unsigned long long int value) noexcept;
 ///   using namespace units::duration_literals;
 ///   auto someDays = 2 * 7_d + 5_ns;
 ///   auto someSeconds = 42_s + 500_ms;
-///   std::cout << someDays << std::endl;
-///   std::cout << someDays.nanoSeconds<uint64_t>() << " ns" << std::endl;
-///   std::cout << someSeconds.milliSeconds<int64_t>() << " ms" << std::endl;
+///   IOX_LOG(INFO) << someDays;
+///   IOX_LOG(INFO) << someDays.nanoSeconds<uint64_t>() << " ns";
+///   IOX_LOG(INFO) << someSeconds.milliSeconds<int64_t>() << " ms";
 /// @endcode
 class Duration
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -88,14 +88,14 @@ struct PosixCallDetails
 ///             .ignoreErrnos(ETIMEDOUT) // can be a comma separated list of errnos
 ///             .evaluate()
 ///             .and_then([](auto & result){
-///                 std::cout << result.value << std::endl; // return value of sem_timedwait
-///                 std::cout << result.errno << std::endl; // errno which was set by sem_timedwait
-///                 std::cout << result.getHumanReadableErrnum() << std::endl; // get string returned by strerror(errno)
+///                 IOX_LOG(INFO) << result.value; // return value of sem_timedwait
+///                 IOX_LOG(INFO) << result.errno; // errno which was set by sem_timedwait
+///                 IOX_LOG(INFO) << result.getHumanReadableErrnum(); // get string returned by strerror(errno)
 ///             })
 ///             .or_else([](auto & result){
-///                 std::cout << result.value << std::endl; // return value of sem_timedwait
-///                 std::cout << result.errno << std::endl; // errno which was set by sem_timedwait
-///                 std::cout << result.getHumanReadableErrnum() << std::endl; // get string returned by strerror(errno)
+///                 IOX_LOG(INFO) << result.value; // return value of sem_timedwait
+///                 IOX_LOG(INFO) << result.errno; // errno which was set by sem_timedwait
+///                 IOX_LOG(INFO) << result.getHumanReadableErrnum(); // get string returned by strerror(errno)
 ///             })
 ///
 ///        // when your posix call signals failure with one specific return value use

--- a/iceoryx_hoofs/memory/include/iox/unique_ptr.hpp
+++ b/iceoryx_hoofs/memory/include/iox/unique_ptr.hpp
@@ -40,7 +40,7 @@ namespace iox
 ///       });
 ///
 ///       // Data can be accessed through unique_ptr
-///       std::cout << myPtr->myClassMember << std::endl;
+///       IOX_LOG(INFO) << myPtr->myClassMember;
 ///
 ///       // Resetting the unique_ptr, can be performed by calling the move assignment operator
 ///       myPtr = std::move(uniquePtrToAnotherInt);

--- a/iceoryx_hoofs/source/cxx/requires.cpp
+++ b/iceoryx_hoofs/source/cxx/requires.cpp
@@ -17,6 +17,7 @@
 
 #include "iceoryx_hoofs/cxx/requires.hpp"
 #include "iceoryx_hoofs/error_handling/error_handling.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 #include <iostream>
 
@@ -33,8 +34,8 @@ void Require(
 {
     if (!condition)
     {
-        std::cerr << "Condition: " << conditionString << " in " << function << " is violated. (" << file << ":" << line
-                  << ")" << std::endl;
+        IOX_LOG(ERROR) << "Condition: " << conditionString << " in " << function << " is violated. (" << file << ":"
+                       << line << ")";
         errorHandler(HoofsError::EXPECTS_ENSURES_FAILED, ErrorLevel::FATAL);
     }
 }
@@ -50,8 +51,8 @@ void Require(const bool condition,
 {
     if (!condition)
     {
-        std::cerr << "Condition: " << conditionString << " in " << function << " is violated: " << msgString << ". ("
-                  << file << ":" << line << ")" << std::endl;
+        IOX_LOG(ERROR) << "Condition: " << conditionString << " in " << function << " is violated: " << msgString
+                       << ". (" << file << ":" << line << ")";
         errorHandler(HoofsError::EXPECTS_ENSURES_FAILED, ErrorLevel::FATAL);
     }
 }

--- a/iceoryx_hoofs/source/posix_wrapper/access_control.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/access_control.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/access_control.hpp"
 #include "iceoryx_hoofs/cxx/function.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 
 #include <iostream>
@@ -30,7 +31,7 @@ bool AccessController::writePermissionsToFile(const int32_t fileDescriptor) cons
 {
     if (m_permissions.empty())
     {
-        std::cerr << "Error: No ACL entries defined." << std::endl;
+        IOX_LOG(ERROR) << "Error: No ACL entries defined.";
         return false;
     }
 
@@ -38,7 +39,7 @@ bool AccessController::writePermissionsToFile(const int32_t fileDescriptor) cons
 
     if (maybeWorkingACL.has_error())
     {
-        std::cerr << "Error: Creating ACL failed." << std::endl;
+        IOX_LOG(ERROR) << "Error: Creating ACL failed.";
         return false;
     }
 
@@ -64,7 +65,7 @@ bool AccessController::writePermissionsToFile(const int32_t fileDescriptor) cons
 
     if (aclCheckCall.has_error())
     {
-        std::cerr << "Error: Invalid ACL, cannot write to file." << std::endl;
+        IOX_LOG(ERROR) << "Error: Invalid ACL, cannot write to file.";
         return false;
     }
 
@@ -72,7 +73,7 @@ bool AccessController::writePermissionsToFile(const int32_t fileDescriptor) cons
     auto aclSetFdCall = posixCall(acl_set_fd)(fileDescriptor, workingACL.get()).successReturnValue(0).evaluate();
     if (aclSetFdCall.has_error())
     {
-        std::cerr << "Error: Could not set file ACL." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not set file ACL.";
         return false;
     }
 
@@ -106,7 +107,7 @@ bool AccessController::addUserPermission(const Permission permission, const Posi
 {
     if (name.empty())
     {
-        std::cerr << "Error: specific users must have an explicit name." << std::endl;
+        IOX_LOG(ERROR) << "Error: specific users must have an explicit name.";
         return false;
     }
 
@@ -123,7 +124,7 @@ bool AccessController::addGroupPermission(const Permission permission, const Pos
 {
     if (name.empty())
     {
-        std::cerr << "Error: specific groups must have an explicit name." << std::endl;
+        IOX_LOG(ERROR) << "Error: specific groups must have an explicit name.";
         return false;
     }
 
@@ -142,7 +143,7 @@ bool AccessController::addPermissionEntry(const Category category,
 {
     if (m_permissions.size() >= m_permissions.capacity())
     {
-        std::cerr << "Error: Number of allowed permission entries exceeded." << std::endl;
+        IOX_LOG(ERROR) << "Error: Number of allowed permission entries exceeded.";
         return false;
     }
 
@@ -152,7 +153,7 @@ bool AccessController::addPermissionEntry(const Category category,
     {
         if (!posix::PosixUser::getUserName(id).has_value())
         {
-            std::cerr << "Error: No such user" << std::endl;
+            IOX_LOG(ERROR) << "Error: No such user";
             return false;
         }
 
@@ -163,7 +164,7 @@ bool AccessController::addPermissionEntry(const Category category,
     {
         if (!posix::PosixGroup::getGroupName(id).has_value())
         {
-            std::cerr << "Error: No such group" << std::endl;
+            IOX_LOG(ERROR) << "Error: No such group";
             return false;
         }
 
@@ -189,7 +190,7 @@ bool AccessController::createACLEntry(const acl_t ACL, const PermissionEntry& en
 
     if (aclCreateEntryCall.has_error())
     {
-        std::cerr << "Error: Could not create new ACL entry." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not create new ACL entry.";
         return false;
     }
 
@@ -199,7 +200,7 @@ bool AccessController::createACLEntry(const acl_t ACL, const PermissionEntry& en
 
     if (aclSetTagTypeCall.has_error())
     {
-        std::cerr << "Error: Could not add tag type to ACL entry." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not add tag type to ACL entry.";
         return false;
     }
 
@@ -213,7 +214,7 @@ bool AccessController::createACLEntry(const acl_t ACL, const PermissionEntry& en
 
         if (aclSetQualifierCall.has_error())
         {
-            std::cerr << "Error: Could not set ACL qualifier of user " << entry.m_id << std::endl;
+            IOX_LOG(ERROR) << "Error: Could not set ACL qualifier of user " << entry.m_id;
             return false;
         }
 
@@ -226,7 +227,7 @@ bool AccessController::createACLEntry(const acl_t ACL, const PermissionEntry& en
 
         if (aclSetQualifierCall.has_error())
         {
-            std::cerr << "Error: Could not set ACL qualifier of group " << entry.m_id << std::endl;
+            IOX_LOG(ERROR) << "Error: Could not set ACL qualifier of group " << entry.m_id;
             return false;
         }
         break;
@@ -243,7 +244,7 @@ bool AccessController::createACLEntry(const acl_t ACL, const PermissionEntry& en
 
     if (aclGetPermsetCall.has_error())
     {
-        std::cerr << "Error: Could not obtain ACL permission set of new ACL entry." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not obtain ACL permission set of new ACL entry.";
         return false;
     }
 
@@ -282,7 +283,7 @@ bool AccessController::addAclPermission(acl_permset_t permset, acl_perm_t perm) 
 
     if (aclAddPermCall.has_error())
     {
-        std::cerr << "Error: Could not add permission to ACL permission set." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not add permission to ACL permission set.";
         return false;
     }
     return true;

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/grp.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
@@ -45,7 +46,7 @@ PosixGroup::PosixGroup(const PosixGroup::groupName_t& name) noexcept
     }
     else
     {
-        std::cerr << "Error: Group name not found" << std::endl;
+        IOX_LOG(ERROR) << "Error: Group name not found";
         m_id = std::numeric_limits<uint32_t>::max();
     }
 }
@@ -66,7 +67,7 @@ cxx::optional<gid_t> PosixGroup::getGroupID(const PosixGroup::groupName_t& name)
 
     if (getgrnamCall.has_error())
     {
-        std::cerr << "Error: Could not find group '" << name << "'." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not find group '" << name << "'.";
         return cxx::nullopt_t();
     }
 
@@ -79,7 +80,7 @@ cxx::optional<PosixGroup::groupName_t> PosixGroup::getGroupName(gid_t id) noexce
 
     if (getgrgidCall.has_error())
     {
-        std::cerr << "Error: Could not find group with id '" << id << "'." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not find group with id '" << id << "'.";
         return cxx::nullopt_t();
     }
 
@@ -113,7 +114,7 @@ cxx::optional<uid_t> PosixUser::getUserID(const userName_t& name) noexcept
 
     if (getpwnamCall.has_error())
     {
-        std::cerr << "Error: Could not find user '" << name << "'." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not find user '" << name << "'.";
         return cxx::nullopt_t();
     }
     return cxx::make_optional<uid_t>(getpwnamCall->value->pw_uid);
@@ -125,7 +126,7 @@ cxx::optional<PosixUser::userName_t> PosixUser::getUserName(uid_t id) noexcept
 
     if (getpwuidCall.has_error())
     {
-        std::cerr << "Error: Could not find user with id'" << id << "'." << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not find user with id'" << id << "'.";
         return cxx::nullopt_t();
     }
     return cxx::make_optional<userName_t>(userName_t(iox::cxx::TruncateToCapacity, getpwuidCall->value->pw_name));
@@ -142,7 +143,7 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
     auto getpwnamCall = posixCall(getpwnam)(userName->c_str()).failureReturnValue(nullptr).evaluate();
     if (getpwnamCall.has_error())
     {
-        std::cerr << "Error: getpwnam call failed" << std::endl;
+        IOX_LOG(ERROR) << "Error: getpwnam call failed";
         return groupVector_t();
     }
 
@@ -155,13 +156,13 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
                                 .evaluate();
     if (getgrouplistCall.has_error())
     {
-        std::cerr << "Error: Could not obtain group list" << std::endl;
+        IOX_LOG(ERROR) << "Error: Could not obtain group list";
         return groupVector_t();
     }
 
     if (numGroups == -1)
     {
-        std::cerr << "Error: List with negative size returned" << std::endl;
+        IOX_LOG(ERROR) << "Error: List with negative size returned";
         return groupVector_t();
     }
 
@@ -189,7 +190,7 @@ PosixUser::PosixUser(const PosixUser::userName_t& name) noexcept
     }
     else
     {
-        std::cerr << "Error: User name not found" << std::endl;
+        IOX_LOG(ERROR) << "Error: User name not found";
         m_id = std::numeric_limits<uint32_t>::max();
     }
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/cxx/helplets.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
 
 #include <iostream>
@@ -59,9 +60,9 @@ void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcep
     }
     else
     {
-        std::cerr << "Trying to allocate additional " << size << " bytes in the shared memory of capacity " << m_length
-                  << " when there are already " << alignedPosition << " aligned bytes in use." << std::endl;
-        std::cerr << "Only " << m_length - alignedPosition << " bytes left." << std::endl;
+        IOX_LOG(ERROR) << "Trying to allocate additional " << size << " bytes in the shared memory of capacity "
+                       << m_length << " when there are already " << alignedPosition << " aligned bytes in use.";
+        IOX_LOG(ERROR) << "Only " << m_length - alignedPosition << " bytes left.";
 
         cxx::Expects(false && "Not enough space left in shared memory");
     }

--- a/iceoryx_hoofs/source/posix_wrapper/signal_handler.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/signal_handler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ void SignalGuard::restorePreviousAction() noexcept
         posixCall(sigaction)(static_cast<int>(m_signal), &m_previousAction, nullptr)
             .successReturnValue(0)
             .evaluate()
-            .or_else([](auto&) { std::cerr << "Unable to restore the previous signal handling state!" << std::endl; });
+            .or_else([](auto&) { IOX_LOG(ERROR) << "Unable to restore the previous signal handling state!"; });
     }
 }
 

--- a/iceoryx_hoofs/source/posix_wrapper/system_configuration.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/system_configuration.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 #include "iceoryx_hoofs/internal/posix_wrapper/system_configuration.hpp"
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 
 namespace iox
@@ -32,8 +33,7 @@ uint64_t pageSize() noexcept
                                      .failureReturnValue(-1)
                                      .evaluate()
                                      .or_else([](auto& r) {
-                                         std::cerr << "This should never happen: " << r.getHumanReadableErrnum()
-                                                   << std::endl;
+                                         IOX_LOG(ERROR) << "This should never happen: " << r.getHumanReadableErrnum();
                                          cxx::Ensures(false && "Internal logic error");
                                      })
                                      .value()

--- a/iceoryx_hoofs/source/units/duration.cpp
+++ b/iceoryx_hoofs/source/units/duration.cpp
@@ -75,5 +75,11 @@ std::ostream& operator<<(std::ostream& stream, const units::Duration& t) noexcep
     return stream;
 }
 
+iox::log::LogStream& operator<<(iox::log::LogStream& stream, const Duration t) noexcept
+{
+    stream << t.m_seconds << "s " << t.m_nanoseconds << "ns";
+    return stream;
+}
+
 } // namespace units
 } // namespace iox

--- a/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_algorithm.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,15 +30,9 @@ class algorithm_test : public Test
   public:
     void SetUp() override
     {
-        testing::internal::CaptureStderr();
     }
     void TearDown() override
     {
-        std::string output = testing::internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 };
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_convert.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,15 +31,9 @@ class convert_test : public Test
   public:
     void SetUp() override
     {
-        internal::CaptureStderr();
     }
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 };
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_expected.cpp
@@ -585,7 +585,7 @@ TEST_F(expected_test, AccessingErrorOfLValueErrorOnlyExpectedWhichContainsValueL
     auto sut = expected<TestError>::create_value();
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ sut.get_error(); }, ""); // ERROR: Trying to access an error but a value is stored
 }
 
 TEST_F(expected_test, AccessingErrorOfConstLValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -594,7 +594,7 @@ TEST_F(expected_test, AccessingErrorOfConstLValueErrorOnlyExpectedWhichContainsV
     const auto sut = expected<TestError>::create_value();
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ sut.get_error(); }, ""); // ERROR: Trying to access an error but a value is stored
 }
 
 TEST_F(expected_test, AccessingErrorOfRValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -603,7 +603,7 @@ TEST_F(expected_test, AccessingErrorOfRValueErrorOnlyExpectedWhichContainsValueL
     auto sut = expected<TestError>::create_value();
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ std::move(sut).get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ std::move(sut).get_error(); }, ""); // ERROR: Trying to access an error but a value is stored
 }
 
 TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithArrowOpLeadsToErrorHandlerCall)
@@ -612,7 +612,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithArrowO
     auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithArrowOpLeadsToErrorHandlerCall)
@@ -621,7 +621,7 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithA
     const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ IOX_DISCARD_RESULT(sut->m_a); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithDerefOpLeadsToErrorHandlerCall)
@@ -630,7 +630,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithDerefO
     auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ *sut; }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ *sut; }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithDerefOpLeadsToErrorHandlerCall)
@@ -639,7 +639,7 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithD
     const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ *sut; }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ *sut; }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
@@ -648,7 +648,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorLeadsToErr
     auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.value(); }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ sut.value(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
@@ -657,9 +657,8 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorLeads
     const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.value(); }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ sut.value(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
-
 
 TEST_F(expected_test, AccessingValueOfRValueExpectedWhichContainsErrorLeadsToErrorHandlerCall)
 {
@@ -667,7 +666,7 @@ TEST_F(expected_test, AccessingValueOfRValueExpectedWhichContainsErrorLeadsToErr
     auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ std::move(sut).value(); }, "Trying to access a value but an error is stored");
+    EXPECT_DEATH({ std::move(sut).value(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingErrorOfLValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -677,7 +676,7 @@ TEST_F(expected_test, AccessingErrorOfLValueExpectedWhichContainsValueLeadsToErr
     auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ sut.get_error(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -687,7 +686,7 @@ TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeads
     const auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ sut.get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ sut.get_error(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -697,7 +696,7 @@ TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErr
     auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, cppcoreguidelines-avoid-goto, hicpp-avoid-goto, hicpp-vararg)
-    EXPECT_DEATH({ std::move(sut).get_error(); }, "Trying to access an error but a value is stored");
+    EXPECT_DEATH({ std::move(sut).get_error(); }, ""); // ERROR: Trying to access a value but an error is stored
 }
 
 TEST_F(expected_test, TwoErrorOnlyExpectedWithEqualErrorAreEqual)

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,8 +25,6 @@ using namespace iox::cxx;
 
 namespace
 {
-using std::cout;
-using std::endl;
 
 constexpr uint64_t Bytes = 128U;
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function_ref.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function_ref.cpp
@@ -168,7 +168,7 @@ TEST_F(function_refDeathTest, CallMovedFromLeadsToTermination)
     // NOLINTJUSTIFICATION Use after move is tested here
     // NOLINTBEGIN(bugprone-use-after-move, hicpp-invalid-access-moved, cppcoreguidelines-pro-type-vararg,
     // cppcoreguidelines-avoid-goto)
-    EXPECT_DEATH(sut1(), "Empty function_ref invoked");
+    EXPECT_DEATH(sut1(), ""); // ERROR: Empty function_ref invoked
     // NOLINTEND(bugprone-use-after-move, hicpp-invalid-access-moved, cppcoreguidelines-pro-type-vararg,
     // cppcoreguidelines-avoid-goto)
 }

--- a/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_list.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 
 #include "iceoryx_hoofs/cxx/attributes.hpp"
 #include "iceoryx_hoofs/cxx/list.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "test.hpp"
 
 
@@ -154,7 +155,7 @@ int64_t iteratorTraitReturnDoubleValue(IterType iter)
 // reason: the warning is already addressed with the internal handling, which shall be tested here
 bool dummyFunc(bool whatever)
 {
-    std::cerr << "Never get here - ever " << whatever << std::endl;
+    IOX_LOG(ERROR) << "Never get here - ever " << whatever;
     return whatever;
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_cxx_serialization.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_serialization.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,15 +27,9 @@ class Serialization_test : public Test
   public:
     void SetUp() override
     {
-        internal::CaptureStderr();
     }
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 };
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_string.cpp
@@ -3311,7 +3311,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaAtFails)
     ::testing::Test::RecordProperty("TEST_ID", "89817818-f05a-4ceb-8663-9727d227048c");
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ this->testSubject.at(0U); }, "Out of bounds access!");
+    EXPECT_DEATH({ this->testSubject.at(0U); }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaAtFails)
@@ -3321,7 +3321,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaAtFails)
     constexpr auto STRINGCAP = MyString().capacity();
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ this->testSubject.at(STRINGCAP); }, "Out of bounds access!");
+    EXPECT_DEATH({ this->testSubject.at(STRINGCAP); }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessFirstPositionOfNonEmptyStringViaAtReturnsCorrectCharacter)
@@ -3356,7 +3356,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaConstAtFails)
     const string<STRINGCAP> sut;
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ sut.at(0U); }, "Out of bounds access!");
+    EXPECT_DEATH({ sut.at(0U); }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstAtFails)
@@ -3367,7 +3367,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstAtFails)
     const string<STRINGCAP> sut;
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ sut.at(STRINGCAP); }, "Out of bounds access");
+    EXPECT_DEATH({ sut.at(STRINGCAP); }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaConstAtReturnsCorrectCharacter)
@@ -3397,7 +3397,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaSubscriptOperatorFail
     ::testing::Test::RecordProperty("TEST_ID", "95ced457-1aec-47e9-a496-0197ea3f4600");
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ this->testSubject[0U]; }, "Out of bounds access!");
+    EXPECT_DEATH({ this->testSubject[0U]; }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaSubscriptOperatorFails)
@@ -3407,7 +3407,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaSubscriptOperatorFails)
     constexpr auto STRINGCAP = MyString().capacity();
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ this->testSubject[STRINGCAP]; }, "Out of bounds access!");
+    EXPECT_DEATH({ this->testSubject[STRINGCAP]; }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaSubscriptOperatorReturnsCorrectCharacter)
@@ -3442,7 +3442,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOfEmptyStringViaConstSubscriptOperato
     const string<STRINGCAP> sut;
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ sut[0U]; }, "Out of bounds access!");
+    EXPECT_DEATH({ sut[0U]; }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstSubscriptOperatorFails)
@@ -3453,7 +3453,7 @@ TYPED_TEST(stringTyped_test, AccessPositionOutOfBoundsViaConstSubscriptOperatorF
     const string<STRINGCAP> sut;
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg, hicpp-avoid-goto, cert-err33-c)
-    EXPECT_DEATH({ sut[STRINGCAP]; }, "Out of bounds access!");
+    EXPECT_DEATH({ sut[STRINGCAP]; }, ""); // ERROR: Out of bounds access !
 }
 
 TYPED_TEST(stringTyped_test, AccessFirstPositionOfNotEmptyStringViaConstSubscriptOperatorReturnsCorrectCharacter)

--- a/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_variant.cpp
@@ -28,7 +28,6 @@ class variant_Test : public Test
   public:
     void SetUp() override
     {
-        internal::CaptureStderr();
         DoubleDelete::dtorCalls = 0;
         DoubleDelete::ctorCalls = 0;
         DTorTest::dtorWasCalled = false;
@@ -36,11 +35,6 @@ class variant_Test : public Test
 
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     class ComplexClass

--- a/iceoryx_hoofs/test/moduletests/test_logging.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_logging.cpp
@@ -61,8 +61,11 @@ void testLogLevelThreshold(const iox::log::LogLevel loggerLogLevel)
         if (logEntryLogLevel.value <= loggerLogLevel)
         {
             ASSERT_THAT(iox::testing::TestingLogger::getNumberOfLogMessages(), Eq(1U));
-            auto logMessage = iox::testing::TestingLogger::getLogMessages().back();
-            EXPECT_THAT(logMessage.find(logEntryLogLevel.string), Ne(std::string::npos));
+            iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+                logEntryLogLevel.value, [&](const auto& logMessages) {
+                    const auto& logMessage = logMessages.back();
+                    EXPECT_THAT(logMessage.find(logEntryLogLevel.string), Ne(std::string::npos));
+                });
         }
         else
         {

--- a/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ class AccessController_test : public ::testing::Test
   public:
     void SetUp() override
     {
-        ::testing::internal::CaptureStderr();
         m_fileStream = fopen(TestFileName, "w");
         m_fileDescriptor = fileno(m_fileStream);
     }
@@ -44,12 +43,6 @@ class AccessController_test : public ::testing::Test
     {
         IOX_DISCARD_RESULT(fclose(m_fileStream));
         IOX_DISCARD_RESULT(std::remove(TestFileName));
-
-        std::string output = ::testing::internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     iox::posix::AccessController m_accessController;

--- a/iceoryx_hoofs/test/moduletests/test_posix_access_rights.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_access_rights.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,24 +41,17 @@ class PosixAccessRights_test : public Test
             .failureReturnValue(-1)
             .evaluate()
             .or_else([](auto& r) {
-                std::cerr << "system call failed with error: " << r.getHumanReadableErrnum();
+                IOX_LOG(ERROR) << "system call failed with error: " << r.getHumanReadableErrnum();
                 std::terminate();
             });
-
-        internal::CaptureStderr();
     }
 
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
         if (std::remove(TestFileName.c_str()) != 0)
         {
-            std::cerr << "Failed to remove temporary file '" << TestFileName
-                      << "'. You'll have to remove it by yourself.";
+            IOX_LOG(ERROR) << "Failed to remove temporary file '" << TestFileName
+                           << "'. You'll have to remove it by yourself.";
         }
     }
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_allocator.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "test.hpp"
 
 namespace
@@ -77,7 +78,6 @@ TEST_F(Allocator_Test, allocateTooMuchSingleElement)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9deed5c0-19d8-4469-a5c3-f185d4d881f1");
     iox::posix::Allocator sut(memory, memorySize);
-    std::set_terminate([]() { std::cout << "", std::abort(); });
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
     // hiccpp-vararg)
@@ -94,8 +94,6 @@ TEST_F(Allocator_Test, allocateTooMuchMultipleElement)
     {
         sut.allocate(32, 1);
     }
-
-    std::set_terminate([]() { std::cout << "", std::abort(); });
 
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
@@ -143,8 +141,6 @@ TEST_F(Allocator_Test, allocateAfterFinalizeAllocation)
     AllocatorAccess sut(memory, memorySize);
     sut.allocate(5, MEMORY_ALIGNMENT);
     sut.finalizeAllocation();
-
-    std::set_terminate([]() { std::cout << "", std::abort(); });
 
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -70,11 +70,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_GoodCase)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_BadCase)
@@ -96,11 +93,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_BadCase)
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_GoodCase)
@@ -119,11 +113,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_GoodCase)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_BadCase)
@@ -145,11 +136,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_BadCase)
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_GoodCase)
@@ -169,11 +157,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_Good
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadCase)
@@ -196,11 +181,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadC
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_GoodCase)
@@ -220,11 +202,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_Good
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadCase)
@@ -247,11 +226,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadC
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
@@ -271,11 +247,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails)
@@ -295,11 +268,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSucceeds)
@@ -319,11 +289,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSuc
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucceeds)
@@ -343,11 +310,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucc
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsFirst)
@@ -369,11 +333,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsMiddle)
@@ -395,11 +356,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsLast)
@@ -421,11 +379,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
@@ -447,11 +402,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage)
@@ -471,11 +423,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintErrorMessage)
@@ -495,11 +444,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintErrorMess
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsErrorMessage)
@@ -519,11 +465,8 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsError
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintErrorMessage)
@@ -543,11 +486,8 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintE
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPrintsErrorMessage)
@@ -569,11 +509,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPri
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNotPrintErrorMessage)
@@ -595,11 +532,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNo
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingOfIgnoredErrnoDoesNotPrintErrorMessage)
@@ -620,11 +554,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfIgnoredErrnoDoesNotPrintErrorMessag
         })
         .or_else([&](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingOfNotIgnoredErrnoDoesNotPrintErrorMessage)
@@ -645,11 +576,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfNotIgnoredErrnoDoesNotPrintErrorMes
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)
@@ -667,11 +595,8 @@ TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
     EXPECT_THAT(eintrRepetition, Eq(0));
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 
@@ -690,11 +615,8 @@ TEST_F(PosixCall_test, FunctionReturnsEINTRTooOftenResultsInFailure)
         });
 
     EXPECT_THAT(eintrRepetition, Eq(1));
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsFirst)
@@ -713,11 +635,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsCenter)
@@ -736,11 +655,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsLast)
@@ -759,11 +675,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsNotPresent)
@@ -782,11 +695,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsFirst)
@@ -805,11 +715,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsCenter)
@@ -828,11 +735,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsLast)
@@ -851,11 +755,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsNotPresent)
@@ -874,11 +775,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_GoodCase)
@@ -896,11 +794,8 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
         })
         .or_else([&](auto&) { EXPECT_TRUE(false); });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_EQ(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_EQ(logMessages.size(), 0); });
 }
 
 TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_BadCase)
@@ -918,9 +813,6 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
             EXPECT_THAT(r.errnum, Eq(RETURN_VALUE));
         });
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_GT(logMessages.size(), 0);
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [](const auto& logMessages) { ASSERT_GT(logMessages.size(), 0); });
 }

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -15,7 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iceoryx_hoofs/testing/testing_logger.hpp"
 #include "test.hpp"
+#include <gtest/gtest.h>
 
 using namespace ::testing;
 
@@ -55,7 +57,6 @@ class PosixCall_test : public Test
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_GoodCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a01759f9-bd81-4223-9313-91f2c12acd2c");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 1;
     constexpr int ERRNO_VALUE = 2;
@@ -69,13 +70,16 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_GoodCase)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_BadCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "aea9317e-1bf8-47bd-bc6c-971439f93a43");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 3;
     constexpr int ERRNO_VALUE = 4;
@@ -92,13 +96,16 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_BadCase)
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_GoodCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ee9814a8-b646-4a8c-b1ba-5923c5331a7a");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 5;
     constexpr int ERRNO_VALUE = 6;
@@ -112,13 +119,16 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_GoodCase)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_BadCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "de9ec4b8-72ac-43c2-a3a2-962571c8039d");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 7;
     constexpr int ERRNO_VALUE = 8;
@@ -135,13 +145,16 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_BadCase)
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_GoodCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4cf87f69-d694-423a-98bf-d5658758f7f0");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 9;
     constexpr int ERRNO_VALUE = 10;
@@ -156,13 +169,16 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_Good
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "29cd753e-9b89-43dd-a754-d9bde42d7ff3");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 11;
     constexpr int ERRNO_VALUE = 12;
@@ -180,13 +196,16 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadC
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_GoodCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f9cc178d-9d74-4458-8cc7-5086b2359511");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 13;
     constexpr int ERRNO_VALUE = 14;
@@ -201,13 +220,16 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_Good
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7d872f26-b303-4f01-817d-857e5ee2353a");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 15;
     constexpr int ERRNO_VALUE = 16;
@@ -225,13 +247,16 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadC
     // we expect an error message via stderr to the console, details are not
     // verified since it depends on the target and where the source code is
     // stored
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "382eeb72-03a8-480f-8fe1-51e749370d44");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 17;
     constexpr int ERRNO_VALUE = 18;
@@ -246,13 +271,16 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a1f11d1b-7eb4-4a61-b977-ec0813a55fe1");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 19;
     constexpr int ERRNO_VALUE = 20;
@@ -267,13 +295,16 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSucceeds)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f6937559-185e-481d-9186-4c332cafd700");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 21;
     constexpr int ERRNO_VALUE = 22;
@@ -288,13 +319,16 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSuc
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucceeds)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3e9817ef-ad3a-4c73-94bc-1032448972e3");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 23;
     constexpr int ERRNO_VALUE = 24;
@@ -309,13 +343,16 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucc
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsFirst)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fbf80e39-2f7c-4eff-9bd2-079526f83059");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 117;
     constexpr int ERRNO_VALUE = 118;
@@ -332,13 +369,16 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsMiddle)
 {
     ::testing::Test::RecordProperty("TEST_ID", "06eba974-df54-44ff-accb-e0d4e3a64895");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 217;
     constexpr int ERRNO_VALUE = 218;
@@ -355,13 +395,16 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIsLast)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5c3e55ad-5665-47be-ba01-3c7096075858");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 317;
     constexpr int ERRNO_VALUE = 318;
@@ -378,13 +421,16 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "83f52825-fd6c-457c-859f-d3cccd8800bd");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 417;
     constexpr int ERRNO_VALUE = 418;
@@ -401,13 +447,16 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f7447e69-44bd-45ba-9dda-4c90107fc73e");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 111;
     constexpr int ERRNO_VALUE = 112;
@@ -422,13 +471,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bc7bc0f5-8d31-4254-a61e-6a5c43ab87ee");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 113;
     constexpr int ERRNO_VALUE = 114;
@@ -443,13 +495,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintErrorMess
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "207f2148-f0f1-464b-bf64-0f8a820a5b70");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 115;
     constexpr int ERRNO_VALUE = 116;
@@ -464,13 +519,16 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsError
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1f26ada9-ba40-4a6f-a572-c911dff36ebb");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 117;
     constexpr int ERRNO_VALUE = 118;
@@ -485,13 +543,16 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintE
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPrintsErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "49e41c5c-9a95-47c8-a522-245a3885003b");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 119;
     constexpr int ERRNO_VALUE = 120;
@@ -508,13 +569,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPri
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNotPrintErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0624a93c-8589-44e2-94f5-ba284486f220");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 121;
     constexpr int ERRNO_VALUE = 122;
@@ -531,13 +595,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNo
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingOfIgnoredErrnoDoesNotPrintErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3292eff4-6f91-4a84-a9ba-05e77b63a5f0");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 123;
     constexpr int ERRNO_VALUE = 124;
@@ -553,13 +620,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfIgnoredErrnoDoesNotPrintErrorMessag
         })
         .or_else([&](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, SuppressErrnoLoggingOfNotIgnoredErrnoDoesNotPrintErrorMessage)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9d8142b9-f993-46a2-ba45-2f103d3c6ee8");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 123;
     constexpr int ERRNO_VALUE = 124;
@@ -575,13 +645,16 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfNotIgnoredErrnoDoesNotPrintErrorMes
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c613542f-dead-409e-9630-f05486faa8f3");
-    internal::CaptureStderr();
 
     eintrRepetition = iox::posix::POSIX_CALL_EINTR_REPETITIONS;
     iox::posix::posixCall(testEintr)()
@@ -594,14 +667,17 @@ TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
     EXPECT_THAT(eintrRepetition, Eq(0));
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 
 TEST_F(PosixCall_test, FunctionReturnsEINTRTooOftenResultsInFailure)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a63b36d3-bccc-4d5c-9fad-502dd6f163f1");
-    internal::CaptureStderr();
 
     eintrRepetition = iox::posix::POSIX_CALL_EINTR_REPETITIONS + 1;
     iox::posix::posixCall(testEintr)()
@@ -614,13 +690,16 @@ TEST_F(PosixCall_test, FunctionReturnsEINTRTooOftenResultsInFailure)
         });
 
     EXPECT_THAT(eintrRepetition, Eq(1));
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsFirst)
 {
     ::testing::Test::RecordProperty("TEST_ID", "776689ef-8289-44f0-a509-a195dae025c0");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 25;
     constexpr int ERRNO_VALUE = 26;
@@ -634,13 +713,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsCenter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1b45e355-f809-4214-b227-18aa0c1585c5");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 27;
     constexpr int ERRNO_VALUE = 28;
@@ -654,13 +736,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsLast)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0de42576-bb17-4596-9e91-e80f6bf2bdb5");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 29;
     constexpr int ERRNO_VALUE = 30;
@@ -674,13 +759,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodValueIsNotPresent)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f8d0036f-8f99-467a-8d74-f8e736296e80");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 31;
     constexpr int ERRNO_VALUE = 32;
@@ -694,13 +782,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsFirst)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d3000e92-5585-43d1-a857-085df9b3e890");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 33;
     constexpr int ERRNO_VALUE = 34;
@@ -714,13 +805,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsCenter)
 {
     ::testing::Test::RecordProperty("TEST_ID", "280f24d2-22b2-4904-bab0-79dbcff0aad2");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 35;
     constexpr int ERRNO_VALUE = 36;
@@ -734,13 +828,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsLast)
 {
     ::testing::Test::RecordProperty("TEST_ID", "21f34570-8d2f-45d1-aa9f-4c74bcdd7296");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 37;
     constexpr int ERRNO_VALUE = 38;
@@ -754,13 +851,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
             EXPECT_THAT(r.errnum, Eq(ERRNO_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailureValueIsNotPresent)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a8c6d31d-2214-447f-9d13-c60497641cc1");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 39;
     constexpr int ERRNO_VALUE = 40;
@@ -774,13 +874,16 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
         })
         .or_else([](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_GoodCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b2dc8737-703d-4a85-a370-1c6e53f845a0");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 0;
 
@@ -793,13 +896,16 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
         })
         .or_else([&](auto&) { EXPECT_TRUE(false); });
 
-    EXPECT_TRUE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_EQ(logMessages.size(), 0);
+    }
 }
 
 TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInReturnValue_BadCase)
 {
     ::testing::Test::RecordProperty("TEST_ID", "ae8aa873-d5f0-4301-8325-506c14a49393");
-    internal::CaptureStderr();
 
     constexpr int RETURN_VALUE = 42;
 
@@ -812,5 +918,9 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
             EXPECT_THAT(r.errnum, Eq(RETURN_VALUE));
         });
 
-    EXPECT_FALSE(internal::GetCapturedStderr().empty());
+    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
+    {
+        auto logMessages = iox::testing::TestingLogger::getLogMessages();
+        ASSERT_GT(logMessages.size(), 0);
+    }
 }

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
@@ -36,18 +36,12 @@ class SharedMemory_Test : public Test
   public:
     void SetUp() override
     {
-        testing::internal::CaptureStderr();
         auto result = iox::posix::SharedMemory::unlinkIfExist(SUT_SHM_NAME);
         ASSERT_FALSE(result.has_error());
     }
 
     void TearDown() override
     {
-        std::string output = testing::internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays) test only

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -29,30 +29,20 @@ class SharedMemoryObject_Test : public Test
   public:
     void SetUp() override
     {
-        internal::CaptureStderr();
     }
 
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     static void PerformDeathTest(const std::function<void()>& deathTest)
     {
-        std::set_terminate([]() { std::cout << "", std::abort(); });
-
-        internal::GetCapturedStderr();
         // @todo iox-#1613 remove EXPECT_DEATH
         // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
         // hiccpp-vararg)
         EXPECT_DEATH({ deathTest(); }, ".*");
         // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
         // hiccpp-vararg)
-        internal::CaptureStderr();
     }
 };
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,18 +40,12 @@ class SignalHandler_test : public Test
 
     void SetUp() override
     {
-        internal::CaptureStderr();
         signalOfCallback1 = INVALID_SIGNAL;
         signalOfCallback2 = INVALID_SIGNAL;
     }
 
     void TearDown() override
     {
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     static void signalHandler1(int s)

--- a/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_relative_pointer.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/memory/relative_pointer.hpp"
-
 #include "test.hpp"
 
 #include <cstdint>
@@ -37,7 +36,6 @@ class RelativePointer_test : public Test
   public:
     void SetUp() override
     {
-        internal::CaptureStderr();
         memset(
             static_cast<void*>(memoryPartition), memoryPatternValue, NUMBER_OF_MEMORY_PARTITIONS * SHARED_MEMORY_SIZE);
         ++memoryPatternValue;
@@ -46,11 +44,6 @@ class RelativePointer_test : public Test
     void TearDown() override
     {
         UntypedRelativePointer::unregisterAll();
-        std::string output = internal::GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     uint8_t* partitionPtr(uint32_t partition)

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -17,6 +17,8 @@
 
 #include "iceoryx_hoofs/internal/units/duration.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
+#include "iceoryx_hoofs/testing/testing_logger.hpp"
 #include "test.hpp"
 #include <ctime>
 #include <iostream>
@@ -2154,6 +2156,37 @@ TEST(Duration_test, StreamingOperator)
 
     std::clog.rdbuf(clogBuffer);
 }
+
+TEST(Duration_test, LogStreamingOperator)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "2ce98e19-17be-47fa-b5e7-f4d9dacd0855");
+
+    iox::testing::Logger_Mock loggerMock{};
+
+    {
+        IOX_LOGSTREAM_MOCK(loggerMock) << 0_s;
+    }
+    ASSERT_THAT(loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(loggerMock.logs[0].message, StrEq("0s 0ns"));
+    loggerMock.logs.clear();
+
+    {
+        const auto lessThanOneSecond = 42_ns;
+        IOX_LOGSTREAM_MOCK(loggerMock) << lessThanOneSecond;
+    }
+    ASSERT_THAT(loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(loggerMock.logs[0].message, StrEq("0s 42ns"));
+    loggerMock.logs.clear();
+
+    {
+        const auto moreThanOneSecond = 13_s + 73_ms + 37_us + 42_ns;
+        IOX_LOGSTREAM_MOCK(loggerMock) << moreThanOneSecond;
+    }
+    ASSERT_THAT(loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(loggerMock.logs[0].message, StrEq("13s 73037042ns"));
+    loggerMock.logs.clear();
+}
+
 
 // END ARITHMETIC TESTS
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -2133,7 +2133,7 @@ TEST(Duration_test, MultiplyDurationWithDoubleResultsInSaturationDueToNanosecond
     EXPECT_THAT(DURATION * MULTIPLICATOR, Eq(DurationAccessor::max()));
 }
 
-TEST(Duration_test, StreamingOperator)
+TEST(Duration_test, StdStreamingOperator)
 {
     ::testing::Test::RecordProperty("TEST_ID", "526d6cf3-b3df-44ce-8668-a0a170c94919");
     std::stringstream capture;

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -57,7 +57,6 @@ class UnixDomainSocket_test : public Test
             goodName, IpcChannelSide::SERVER, UnixDomainSocket::MAX_MESSAGE_SIZE, MaxMsgNumber);
         ASSERT_THAT(serverResult.has_error(), Eq(false));
         server = std::move(serverResult.value());
-        CaptureStderr();
 
         auto clientResult = UnixDomainSocket::create(
             goodName, IpcChannelSide::CLIENT, UnixDomainSocket::MAX_MESSAGE_SIZE, MaxMsgNumber);
@@ -67,11 +66,6 @@ class UnixDomainSocket_test : public Test
 
     void TearDown() override
     {
-        std::string output = GetCapturedStderr();
-        if (Test::HasFailure())
-        {
-            std::cout << output << std::endl;
-        }
     }
 
     static bool createTestSocket(const UnixDomainSocket::UdsName_t& name)
@@ -98,12 +92,12 @@ class UnixDomainSocket_test : public Test
                     .failureReturnValue(ERROR_CODE)
                     .evaluate()
                     .or_else([&](auto&) {
-                        std::cerr << "unable to bind socket\n";
+                        IOX_LOG(ERROR) << "unable to bind socket";
                         socketCreationSuccess = false;
                     });
             })
             .or_else([&](auto&) {
-                std::cerr << "unable to create socket\n";
+                IOX_LOG(ERROR) << "unable to create socket";
                 socketCreationSuccess = false;
             });
         return socketCreationSuccess;

--- a/iceoryx_hoofs/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
+++ b/iceoryx_hoofs/test/stresstests/benchmark_optional_and_expected/benchmark.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 - 2021 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,6 +53,7 @@ void PerformBenchmark(Return (&f)(), const char* functionName, const iox::units:
     keepRunning = false;
     t.join();
 
+    // Not using iceoryx logger due to width requirements
     std::cout << std::setw(16) << compiler << " [ " << duration << " ] " << std::setw(15) << numberOfCalls << " : "
               << functionName << std::endl;
 }

--- a/iceoryx_hoofs/test/stresstests/sofi/test_stress_sofi.cpp
+++ b/iceoryx_hoofs/test/stresstests/sofi/test_stress_sofi.cpp
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/concurrent/sofi.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 #include "iceoryx_hoofs/testing/test.hpp"
 
@@ -56,7 +57,7 @@ class SoFiStress : public Test
         auto retVal = pthread_setaffinity_np(nativeHandle, sizeof(cpu_set_t), &cpuset);
         if (retVal != 0)
         {
-            std::cout << "Error calling pthread_setaffinity_np: " << retVal << "; errno: " << errno << std::endl;
+            IOX_LOG(ERROR) << "Error calling pthread_setaffinity_np: " << retVal << "; errno: " << errno;
             return false;
         }
 #else
@@ -194,8 +195,8 @@ TEST_F(SoFiStress, SimultaneouslyPushAndPopOnEmptySoFi)
         << "There should be at least 4 times as many trys to pop as actual pops!";
     EXPECT_THAT(pushCounter, Eq(popCounter)) << "Push and Pop Counter should be Equal after the Test!";
 
-    std::cout << "try pop counter: " << tryPopCounter << std::endl;
-    std::cout << "pop counter    : " << pushCounter << std::endl;
+    IOX_LOG(INFO) << "try pop counter: " << tryPopCounter;
+    IOX_LOG(INFO) << "pop counter    : " << pushCounter;
 }
 
 /// @brief This tests a fast pusher and slow popper.
@@ -392,8 +393,8 @@ TEST_F(SoFiStress, PopFromContinuouslyOverflowingSoFi)
     EXPECT_THAT(pushCounter / 4, Gt(popCounter)) << "There should be at least 4 times as many pushes as pops!";
     EXPECT_THAT(pushCounter, Eq(dataCounter)) << "Push and Data Counter should be Equal after the Test!";
 
-    std::cout << "push counter: " << pushCounter << std::endl;
-    std::cout << "pop counter : " << popCounter << std::endl;
+    IOX_LOG(INFO) << "push counter: " << pushCounter;
+    IOX_LOG(INFO) << "pop counter : " << popCounter;
 }
 
 /// @brief This tests a fast pusher and fast popper.
@@ -540,7 +541,7 @@ TEST_F(SoFiStress, PushAndPopFromNonOverflowingNonEmptySoFi)
     EXPECT_THAT(pushCounter / 1000, Gt(STRESS_TIME.count())) << "There should be at least 1000 pushes per millisecond!";
     EXPECT_THAT(pushCounter, Eq(popCounter.load())) << "Push and Pop Counter should be Equal after the Test!";
 
-    std::cout << "push & pop counter: " << pushCounter << std::endl;
+    IOX_LOG(INFO) << "push & pop counter: " << pushCounter.load();
 }
 
 int main(int argc, char* argv[])

--- a/iceoryx_hoofs/test/stresstests/test_lockfree_queue_stresstest.cpp
+++ b/iceoryx_hoofs/test/stresstests/test_lockfree_queue_stresstest.cpp
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/testing/test.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 
 #include "iceoryx_hoofs/concurrent/lockfree_queue.hpp"
 using namespace ::testing;
@@ -46,7 +47,7 @@ struct Data
 
     void print() const
     {
-        std::cout << "data id " << id << " count " << count << std::endl;
+        IOX_LOG(INFO) << "data id " << id << " count " << count;
     }
 };
 
@@ -198,13 +199,13 @@ bool checkTwoConsumerResult(std::list<Data>& consumed1,
 
         if (!isStrictlyMonotonous(filtered1) || !isStrictlyMonotonous(filtered2))
         {
-            std::cout << "id " << id << " not strictly monotonous" << std::endl;
+            IOX_LOG(INFO) << "id " << id << " not strictly monotonous";
             return false;
         }
 
         if (!isComplete(filtered1, filtered2, expectedFinalCount))
         {
-            std::cout << "id " << id << " incomplete" << std::endl;
+            IOX_LOG(INFO) << "id " << id << " incomplete";
             return false;
         }
     }
@@ -336,16 +337,10 @@ class LockFreeQueueStressTest : public ::testing::Test
 
     void SetUp()
     {
-        // internal::CaptureStdout();
     }
 
     void TearDown()
     {
-        if (Test::HasFailure())
-        {
-            // std::string output = internal::GetCapturedStdout();
-            // std::cout << output << std::endl;
-        }
     }
 
     using Queue = T;

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/testing_logger.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/testing_logger.hpp
@@ -34,12 +34,11 @@ namespace testing
 /// also be used to check for the occurrence on specific log messages, e.g. when a function is expected to log an error.
 /// @code
 /// callToFunctionWhichLogsAnError();
-/// if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-/// {
-///     auto logMessages = iox::testing::TestingLogger::getLogMessages();
+/// iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(iox::log::LogLevel::ERROR, [](const auto&
+/// logMessages){
 ///     ASSERT_THAT(logMessages.size(), Eq(1U));
 ///     EXPECT_THAT(logMessages[0], HasSubstr(expectedOutput));
-/// }
+/// });
 /// @endcode
 class TestingLogger : public log::TestingLoggerBase
 {
@@ -82,10 +81,10 @@ class TestingLogger : public log::TestingLoggerBase
     /// @note This can be used in tests which check for a specific log output
     static uint64_t getNumberOfLogMessages() noexcept;
 
-    /// @brief Access to the cached log messages
-    /// @return a vector of strings with all caches log messages
-    /// @note This can be used in tests which check for a specific log output
-    static std::vector<std::string> getLogMessages() noexcept;
+    /// @brief Runs the provided checker function for the collected log messages
+    /// @note This can be used in tests to verify the collected log messages
+    static void checkLogMessageIfLogLevelIsSupported(iox::log::LogLevel logLevel,
+                                                     const std::function<void(const std::vector<std::string>&)>& check);
 
     /// @brief Checks if the the LogLevel is above the minimal supported LogLevel compiled into the binary
     /// @param[in] logLevel is the log level to check if it is supported
@@ -100,6 +99,7 @@ class TestingLogger : public log::TestingLoggerBase
     TestingLogger() noexcept = default;
 
     void flush() noexcept override;
+    static std::vector<std::string> getLogMessages() noexcept;
 
     struct LoggerData
     {

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/watch_dog.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/watch_dog.hpp
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_TESTUTILS_WATCH_DOG_HPP
 
 #include "iceoryx_hoofs/internal/units/duration.hpp"
+#include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
 
 #include <functional>
@@ -68,8 +69,8 @@ class Watchdog
                 .and_then([&](auto& result) {
                     if (result == iox::posix::SemaphoreWaitState::TIMEOUT)
                     {
-                        std::cerr << "Watchdog observed no reaction after " << m_timeToWait << ". Taking measures!"
-                                  << std::endl;
+                        std::cerr << "Watchdog observed no reaction after " << m_timeToWait.toSeconds()
+                                  << "s. Taking measures!" << std::endl;
                         if (actionOnFailure)
                         {
                             actionOnFailure();

--- a/iceoryx_hoofs/testing/testing_logger.cpp
+++ b/iceoryx_hoofs/testing/testing_logger.cpp
@@ -82,11 +82,15 @@ uint64_t TestingLogger::getNumberOfLogMessages() noexcept
     return logger.m_loggerData->buffer.size();
 }
 
-std::vector<std::string> TestingLogger::getLogMessages() noexcept
+void TestingLogger::checkLogMessageIfLogLevelIsSupported(
+    iox::log::LogLevel logLevel, const std::function<void(const std::vector<std::string>&)>& check)
 {
-    auto& logger = dynamic_cast<TestingLogger&>(log::Logger::get());
-    return logger.m_loggerData->buffer;
+    if (doesLoggerSupportLogLevel(logLevel))
+    {
+        check(getLogMessages());
+    }
 }
+
 
 void TestingLogger::flush() noexcept
 {
@@ -100,6 +104,12 @@ void TestingLogger::flush() noexcept
     }
 
     Base::assumeFlushed();
+}
+
+std::vector<std::string> TestingLogger::getLogMessages() noexcept
+{
+    auto& logger = dynamic_cast<TestingLogger&>(log::Logger::get());
+    return logger.m_loggerData->buffer;
 }
 
 void LogPrinter::OnTestStart(const ::testing::TestInfo&)

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
@@ -223,12 +223,11 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorWithEmptyConfigSetRunVariableToFal
 
     EXPECT_FALSE(roudi.getVariableRun());
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_THAT(logMessages.size(), Eq(1U));
-        EXPECT_THAT(logMessages[0], HasSubstr(expectedOutput));
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [&](const auto& logMessages) {
+            ASSERT_THAT(logMessages.size(), Eq(1U));
+            EXPECT_THAT(logMessages[0], HasSubstr(expectedOutput));
+        });
 }
 
 TEST_F(IceoryxRoudiApp_test, VerifyConstructorUsingConfigWithSegmentWithoutMemPoolSetRunVariableToFalse)
@@ -256,11 +255,10 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorUsingConfigWithSegmentWithoutMemPo
 
     EXPECT_FALSE(roudi.getVariableRun());
 
-    if (iox::testing::TestingLogger::doesLoggerSupportLogLevel(iox::log::LogLevel::ERROR))
-    {
-        auto logMessages = iox::testing::TestingLogger::getLogMessages();
-        ASSERT_THAT(logMessages.size(), Eq(1U));
-        EXPECT_THAT(logMessages[0], HasSubstr(expectedOutput));
-    }
+    iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
+        iox::log::LogLevel::ERROR, [&](const auto& logMessages) {
+            ASSERT_THAT(logMessages.size(), Eq(1U));
+            EXPECT_THAT(logMessages[0], HasSubstr(expectedOutput));
+        });
 }
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Replaces use of `std::cout`, `std::cerr` and `std::clog` in almost all locations within `iceoryx_hoofs`.
Exceptions:

1. [test_unit_duration.cpp](https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp#L2134) - use of `std::clog` is required to test the std streaming operator
2. [testing_logger.cpp](https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_hoofs/testing/testing_logger.cpp#L26) - use of `std::cout` is required for testing the logger
3. [benchmark_optional_and_expected/benchmark.hpp](https://github.com/eclipse-iceoryx/iceoryx/blob/master/iceoryx_hoofs/test/stresstests/benchmark_optional_and_expected/benchmark.hpp#L39) - the iceoryx logger does not support `std::setw` so it cannot be dropped in here and additionally its use would not bring any additional value

Additionally, added a streaming operator for `iox::units::Duration` so it can be used with the iceoryx logger.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1756 
