### PR TITLE
iox-#1394 Address re-introduced AUTOSAR warnings

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/scoped_static.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/scoped_static.inl
@@ -27,7 +27,7 @@ template <typename T, typename... CTorArgs>
 inline ScopeGuard makeScopedStatic(T& memory, CTorArgs&&... ctorArgs) noexcept
 {
     memory.emplace(std::forward<CTorArgs>(ctorArgs)...);
-    return ScopeGuard([&memory] { memory.reset(); });
+    return ScopeGuard([&memory]() { memory.reset(); });
 }
 } // namespace cxx
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/memory/relative_pointer_data.hpp
@@ -75,7 +75,7 @@ class RelativePointerData
     /// @note offset in bits for storing and reading the id
     static constexpr uint64_t ID_BIT_SIZE{16U};
     /// @note internal representation of a nullptr
-    static constexpr offset_t LOGICAL_NULLPTR{NULL_POINTER_OFFSET << ID_BIT_SIZE | NULL_POINTER_ID};
+    static constexpr offset_t LOGICAL_NULLPTR{(NULL_POINTER_OFFSET << ID_BIT_SIZE) | NULL_POINTER_ID};
     uint64_t m_idAndOffset{LOGICAL_NULLPTR};
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/memory/relative_pointer.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/memory/relative_pointer.inl
@@ -44,9 +44,9 @@ inline RelativePointer<T>::RelativePointer(const offset_t offset, const segment_
 
 template <typename T>
 inline RelativePointer<T>::RelativePointer(ptr_t const ptr) noexcept
-    : RelativePointer([this, ptr]() -> RelativePointer {
-        segment_id_t id{this->searchId(ptr)};
-        offset_t offset{this->getOffset(id, ptr)};
+    : RelativePointer([this, ptr]() noexcept -> RelativePointer {
+        const segment_id_t id{this->searchId(ptr)};
+        const offset_t offset{this->getOffset(id, ptr)};
         return RelativePointer{offset, id};
     }())
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] ~~Tests follow the [best practice for testing][testing]~~
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Address re-introduced AUTOSAR warnings in `scoped_static.inl`, `relative_pointer_data.hpp` and `relative_pointer.inl`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partly)
