### PR TITLE
iox-1394 fix AUTOSAR violations in variant_internal

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_internal.hpp
@@ -91,8 +91,10 @@ struct get_type_at_index<N, N, T, Targs...>
     using type = T;
 };
 
-// AXIVION DISABLE STYLE AutosarC++19_03-M5.2.8, AutosarC++19_03-A5.2.4 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design of variant; note that this is an internal class used by variant
-// AXIVION DISABLE STYLE AutosarC++19_03-A18.5.10, FaultDetection-IndirectAssignmentOverflow : destination is aligned to the maximum alignment of Types, see variant.hpp
+// AXIVION DISABLE STYLE AutosarC++19_03-M5.2.8 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design of variant; note that this is an internal class used by variant
+// AXIVION DISABLE STYLE AutosarC++19_03-A5.2.4 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design of variant; note that this is an internal class used by variant
+// AXIVION DISABLE STYLE AutosarC++19_03-A18.5.10 : destination is aligned to the maximum alignment of Types, see variant.hpp
+// AXIVION DISABLE STYLE FaultDetection-IndirectAssignmentOverflow : destination is aligned to the maximum alignment of Types, see variant.hpp
 // AXIVION DISABLE STYLE AutosarC++19_03-A5.3.2 : this is an internal struct used only by variant; all pointer arguments are checked in the variant class before the static functions are called
 // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
 template <uint64_t N, typename T, typename... Targs>
@@ -243,8 +245,10 @@ struct call_at_index<N, T>
 };
 // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
 // AXIVION ENABLE STYLE AutosarC++19_03-A5.3.2
-// AXIVION ENABLE STYLE AutosarC++19_03-A18.5.10, FaultDetection-IndirectAssignmentOverflow
-// AXIVION ENABLE STYLE AutosarC++19_03-M5.2.8, AutosarC++19_03-A5.2.4
+// AXIVION ENABLE STYLE FaultDetection-IndirectAssignmentOverflow
+// AXIVION ENABLE STYLE AutosarC++19_03-A18.5.10
+// AXIVION ENABLE STYLE AutosarC++19_03-A5.2.4
+// AXIVION ENABLE STYLE AutosarC++19_03-M5.2.8
 
 } // namespace internal
 } // namespace cxx


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR rearranges some of the suppressions in `variant_internal.hpp` to really suppress the warnings.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partially)
