### PR TITLE
iox-1732 implement bump allocator

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -31,6 +31,7 @@
 - Support user defined platforms with cmake switch `-DIOX_PLATFORM_PATH` [\#1619](https://github.com/eclipse-iceoryx/iceoryx/issues/1619)
 - Add equality and inequality operators for `iox::variant` and `iox::expected` [\#1751](https://github.com/eclipse-iceoryx/iceoryx/issues/1751)
 - Implement UninitializedArray [\#1614](https://github.com/eclipse-iceoryx/iceoryx/issues/1614)
+- Implement BumpAllocator [\#1732](https://github.com/eclipse-iceoryx/iceoryx/issues/1732)
 
 **Bugfixes:**
 
@@ -106,6 +107,7 @@
 - Change return type of `cxx::variant::emplace_at_index` and `emplace` to void [\#1394](https://github.com/eclipse-iceoryx/iceoryx/issues/1394)
 - Replace uses of `std::cout`, `std::cerr` with the iceoryx logger [\#1756](https://github.com/eclipse-iceoryx/iceoryx/issues/1756)
 - Move `IOX_NO_DISCARD`, `IOX_FALLTHROUGH` and `IOX_MAYBE_UNUSED` to `iceoryx_platform` [\#1726](https://github.com/eclipse-iceoryx/iceoryx/issues/1726)
+- Move `cxx::static_storage` from `iceoryx_hoofs` to `iceoryx_dust` [\#1732](https://github.com/eclipse-iceoryx/iceoryx/issues/1732)
 
 **Workflow:**
 
@@ -808,3 +810,14 @@
     iox::UninitializedArray<T, Capacity> myAlignedArray;
 
     ```
+
+42. Move `static_storage` from `iceoryx_hoofs` to `iceoryx_dust`
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
+
+    // after
+    #include "iceoryx_dust/internal/cxx/static_storage.hpp"
+    ```
+

--- a/iceoryx_binding_c/test/moduletests/test_client.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_client.cpp
@@ -103,10 +103,10 @@ class iox_client_test : public Test
 
     static constexpr uint64_t MANAGEMENT_MEMORY_SIZE = 1024 * 1024;
     char managementMemory[MANAGEMENT_MEMORY_SIZE];
-    iox::posix::Allocator mgmtAllocator{managementMemory, MANAGEMENT_MEMORY_SIZE};
+    iox::BumpAllocator mgmtAllocator{managementMemory, MANAGEMENT_MEMORY_SIZE};
     static constexpr uint64_t DATA_MEMORY_SIZE = 1024 * 1024;
     char dataMemory[DATA_MEMORY_SIZE];
-    iox::posix::Allocator dataAllocator{dataMemory, DATA_MEMORY_SIZE};
+    iox::BumpAllocator dataAllocator{dataMemory, DATA_MEMORY_SIZE};
     iox::mepoo::MemoryManager memoryManager;
     iox::mepoo::MePooConfig memoryConfig;
 

--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -198,7 +198,7 @@ class iox_listener_test : public Test
     static constexpr uint32_t CHUNK_SIZE = 128U;
     static constexpr uint64_t MEMORY_SIZE = 1024U * 1024U * 100U;
     uint8_t m_memory[MEMORY_SIZE];
-    Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;
     MemoryManager m_memoryManager;
 

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -102,7 +102,7 @@ class iox_notification_info_test : public Test
     static constexpr uint32_t CHUNK_SIZE = 128U;
     static constexpr size_t MEMORY_SIZE = 1024 * 1024 * 100;
     uint8_t m_memory[MEMORY_SIZE];
-    Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;
     MemoryManager m_memoryManager;
     SubscriberOptions m_subscriberOptions{MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, 0U};

--- a/iceoryx_binding_c/test/moduletests/test_publisher.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_publisher.cpp
@@ -106,7 +106,7 @@ class iox_pub_test : public Test
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
                                       iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
 
-    Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;
     MemoryManager m_memoryManager;
 

--- a/iceoryx_binding_c/test/moduletests/test_server.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_server.cpp
@@ -96,10 +96,10 @@ class iox_server_test : public Test
 
     static constexpr uint64_t MANAGEMENT_MEMORY_SIZE = 1024 * 1024;
     char managementMemory[MANAGEMENT_MEMORY_SIZE];
-    iox::posix::Allocator mgmtAllocator{managementMemory, MANAGEMENT_MEMORY_SIZE};
+    iox::BumpAllocator mgmtAllocator{managementMemory, MANAGEMENT_MEMORY_SIZE};
     static constexpr uint64_t DATA_MEMORY_SIZE = 1024 * 1024;
     char dataMemory[DATA_MEMORY_SIZE];
-    iox::posix::Allocator dataAllocator{dataMemory, DATA_MEMORY_SIZE};
+    iox::BumpAllocator dataAllocator{dataMemory, DATA_MEMORY_SIZE};
     iox::mepoo::MemoryManager memoryManager;
     iox::mepoo::MePooConfig memoryConfig;
 

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -102,7 +102,7 @@ class iox_sub_test : public Test
     static constexpr uint32_t NUM_CHUNKS_IN_POOL = MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY + 2U;
     static constexpr uint32_t CHUNK_SIZE = 128U;
 
-    Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;
     MemoryManager m_memoryManager;
 

--- a/iceoryx_dust/README.md
+++ b/iceoryx_dust/README.md
@@ -16,3 +16,4 @@ grouped together in categories or namespace, depending on where or how they are 
 |`SignalWatcher`        | Batteries included signal handling with polling and optional blocking wait for `SIGINT` and `SIGTERM`.                  |
 |`NamedPipe`            | Shared memory based ipc channel. Mainly a `UnixDomainSocket` replacement on Windows.                                    |
 |`relocatable_ptr`      |                                                                                                                         |
+|`static_storage`       | Untyped aligned static storage.                                                                                         |

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.hpp
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_STATIC_STORAGE_HPP
-#define IOX_HOOFS_STATIC_STORAGE_HPP
+#ifndef IOX_DUST_STATIC_STORAGE_HPP
+#define IOX_DUST_STATIC_STORAGE_HPP
 
 #include <cstdint>
 #include <cstring>
@@ -109,5 +109,5 @@ class static_storage final
 } // namespace cxx
 } // namespace iox
 
-#include "iceoryx_hoofs/internal/cxx/static_storage.inl"
-#endif // IOX_HOOFS_STATIC_STORAGE_HPP
+#include "iceoryx_dust/internal/cxx/static_storage.inl"
+#endif // IOX_DUST_STATIC_STORAGE_HPP

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.hpp
@@ -98,7 +98,7 @@ class static_storage final
     static constexpr uint64_t allocation_size() noexcept;
 
   private:
-    /// @NOLINTJUSTIFICATION @todo iox-#1732 will be refactored with BumpAllocator
+    /// AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the static_storage
     /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     alignas(Align) uint8_t m_bytes[Capacity];
     void* m_ptr{nullptr};

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.inl
@@ -14,10 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef IOX_HOOFS_CXX_STATIC_STORAGE_INL
-#define IOX_HOOFS_CXX_STATIC_STORAGE_INL
+#ifndef IOX_DUST_CXX_STATIC_STORAGE_INL
+#define IOX_DUST_CXX_STATIC_STORAGE_INL
 
-#include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
+#include "iceoryx_dust/internal/cxx/static_storage.hpp"
 
 namespace iox
 {
@@ -113,4 +113,4 @@ constexpr uint64_t static_storage<Capacity, Align>::allocation_size() noexcept
 } // namespace iox
 
 
-#endif // IOX_HOOFS_STATIC_STORAGE_INL
+#endif // IOX_DUST_STATIC_STORAGE_INL

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/static_storage.inl
@@ -26,7 +26,7 @@ namespace cxx
 template <uint64_t Capacity, uint64_t Align>
 constexpr uint64_t static_storage<Capacity, Align>::align_mismatch(uint64_t align, uint64_t requiredAlign) noexcept
 {
-    const auto r = align % requiredAlign;
+    const uint64_t r = align % requiredAlign;
 
     // If r != 0 we are not aligned with requiredAlign and need to add r to an align
     // aligned address to be aligned with requiredAlign.

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -110,7 +110,7 @@ NamedPipe::NamedPipe(const IpcChannelName_t& name,
     auto allocationResult = m_sharedMemory->allocate(sizeof(NamedPipeData), alignof(NamedPipeData));
     if (allocationResult.has_error())
     {
-        std::cerr << "Unable to allocate for named pipe \"" << name << "\"" << std::endl;
+        std::cerr << "Unable to allocate memory for named pipe \"" << name << "\"" << std::endl;
         m_isInitialized = false;
         m_errorValue = IpcChannelError::MEMORY_ALLOCATION_FAILED;
         return;

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -107,7 +107,15 @@ NamedPipe::NamedPipe(const IpcChannelName_t& name,
         return;
     }
 
-    m_data = static_cast<NamedPipeData*>(m_sharedMemory->allocate(sizeof(NamedPipeData), alignof(NamedPipeData)));
+    auto allocationResult = m_sharedMemory->allocate(sizeof(NamedPipeData), alignof(NamedPipeData));
+    if (allocationResult.has_error())
+    {
+        std::cerr << "Unable to allocate for named pipe \"" << name << "\"" << std::endl;
+        m_isInitialized = false;
+        m_errorValue = IpcChannelError::MEMORY_ALLOCATION_FAILED;
+        return;
+    }
+    m_data = static_cast<NamedPipeData*>(allocationResult.value());
 
     m_isInitialized = true;
     if (m_sharedMemory->hasOwnership())

--- a/iceoryx_dust/test/moduletests/test_static_storage.cpp
+++ b/iceoryx_dust/test/moduletests/test_static_storage.cpp
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
+#include "iceoryx_dust/internal/cxx/static_storage.hpp"
 #include "test.hpp"
 
 #include <iostream>
@@ -245,6 +245,5 @@ TEST(static_storage_test, AllocationSizeReturnsMoreThanSizeIfTypeIsNotAlignedWit
     constexpr auto size = static_storage<17, storageAlign>::allocation_size<Data>();
     EXPECT_EQ(size, sizeof(Data) + typeAlign - storageAlign);
 }
-
 
 } // namespace

--- a/iceoryx_hoofs/BUILD.bazel
+++ b/iceoryx_hoofs/BUILD.bazel
@@ -33,6 +33,7 @@ cc_library(
         "source/**/*.cpp",
         "vocabulary/source/**/*.cpp",
         "source/**/*.hpp",
+        "memory/source/*.cpp",
     ]),
     hdrs = glob(["include/**"]) + glob(["legacy/**"]) + glob(["memory/**"]) + glob(["container/**"]) + glob(["vocabulary/**"]) + [
         ":iceoryx_hoofs_deployment_hpp",

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -80,7 +80,6 @@ iox_add_library(
         source/posix_wrapper/scheduler.cpp
         source/posix_wrapper/semaphore_interface.cpp
         source/posix_wrapper/shared_memory_object.cpp
-        source/posix_wrapper/shared_memory_object/allocator.cpp
         source/posix_wrapper/shared_memory_object/memory_map.cpp
         source/posix_wrapper/shared_memory_object/shared_memory.cpp
         source/posix_wrapper/signal_handler.cpp
@@ -91,6 +90,7 @@ iox_add_library(
         source/posix_wrapper/unix_domain_socket.cpp
         source/memory/relative_pointer_data.cpp
         source/units/duration.cpp
+        memory/source/bump_allocator.cpp
 )
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/iceoryx_hoofs_deployment.hpp.in"

--- a/iceoryx_hoofs/README.md
+++ b/iceoryx_hoofs/README.md
@@ -32,8 +32,8 @@ The module structure is a logical grouping. It is replicated for `concurrent` an
 |`RelativePointer`                   |          | Pointer which can be stored in shared memory                                                                                                                                                                             |
 |`ScopeGuard`                        |          | This is an abstraction of the C++ RAII idiom. Sometimes you have constructs where you would like to perform a certain task on creation and then again when they are getting out of scope, this is where `ScopeGuard` comes in. It is like a `std::lock_guard` or a `std::shared_ptr` but more generic. |
 |`scoped_static`                     |          | Helper function to limit lifetime of static or global variables to a scope                                                                                                                                               |
-|`static_storage`                    | i        | Untyped aligned static storage.                                                                                                                                                                                          |
 |`shared_memory_object/Allocator`    | i        | Helper class for the `SharedMemoryObject`.                                                                                                                                                                               |
+|`BumpAllocator`                     | i        | Implementation of a bump allocator                                                                                                                                                                                       |
 
 ### Container (container)
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/function.hpp
@@ -17,7 +17,6 @@
 #ifndef IOX_HOOFS_FUNCTION_HPP
 #define IOX_HOOFS_FUNCTION_HPP
 
-#include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
 #include "iceoryx_hoofs/internal/cxx/storable_function.hpp"
 
 namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_STORABLE_FUNCTION_HPP
 
 #include "iceoryx_hoofs/cxx/type_traits.hpp"
+#include "iceoryx_hoofs/iceoryx_hoofs_types.hpp"
 #include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
 
 #include <iostream>
@@ -155,7 +156,9 @@ class storable_function<Capacity, signature<ReturnType, Args...>> final
   private:
     operations m_operations; // operations depending on type-erased callable (copy, move, destroy)
 
-    StorageType m_storage;                              // storage for the callable
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the storable_function
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays, hicpp-avoid-c-arrays)
+    byte_t m_storage[Capacity];                         // storage for the callable
     void* m_callable{nullptr};                          // pointer to stored type-erased callable
     ReturnType (*m_invoker)(void*, Args&&...){nullptr}; // indirection to invoke the stored callable,
                                                         // nullptr if no callable is stored

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -193,6 +193,9 @@ class storable_function<Capacity, signature<ReturnType, Args...>> final
     // m_invoker is initialized with this function and has to work with functors as well
     // (functors may change due to invocation)
     static ReturnType invokeFreeFunction(void* callable, Args&&... args) noexcept;
+
+    template <typename T>
+    static constexpr void* safeAlign(byte_t* startAddress);
 };
 
 /// @brief swap two storable functions

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.hpp
@@ -19,7 +19,6 @@
 
 #include "iceoryx_hoofs/cxx/type_traits.hpp"
 #include "iceoryx_hoofs/iceoryx_hoofs_types.hpp"
-#include "iceoryx_hoofs/internal/cxx/static_storage.hpp"
 
 #include <iostream>
 #include <utility>
@@ -49,7 +48,6 @@ template <uint64_t Capacity, typename ReturnType, typename... Args>
 class storable_function<Capacity, signature<ReturnType, Args...>> final
 {
   public:
-    using StorageType = static_storage<Capacity>;
     using signature_t = signature<ReturnType, Args...>;
 
     /// @brief construct from functor (including lambdas)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -169,6 +169,7 @@ inline void swap(storable_function<Capacity, T>& f, storable_function<Capacity, 
 template <typename T>
 void* allocate(byte_t* startAddress)
 {
+    // static_assert: startAddress + size < Capacity
     uint64_t alignedPosition = cxx::align(reinterpret_cast<uint64_t>(startAddress), alignof(T));
     return reinterpret_cast<void*>(alignedPosition);
 }

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -26,6 +26,7 @@ namespace iox
 namespace cxx
 {
 // AXIVION Next Construct AutosarC++19_03-A12.6.1: members are initialized in body before read access
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 template <typename Functor, typename>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(const Functor& functor) noexcept
@@ -35,9 +36,10 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_fun
 
 // AXIVION Next Construct AutosarC++19_03-A12.1.5: constructor delegation is not feasible here due
 // to lack of sufficient common initialization
-// AXIVION Next Construct AutosarC++19_03-A12.6.1: members are default initialized
 // AXIVION Next Construct AutosarC++19_03-M5.2.6: the converted pointer is only used
 // as its original function pointer type after reconversion (type erasure)
+// AXIVION Next Construct AutosarC++19_03-A12.6.1: members are default initialized
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(
     ReturnType (*function)(Args...)) noexcept
@@ -56,6 +58,7 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_fun
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1: members are default initialized
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 template <typename T, typename>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(
@@ -69,6 +72,7 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_fun
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1: members are default initialized
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 template <typename T, typename>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(const T& object,
@@ -83,6 +87,7 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_fun
 }
 
 // AXIVION Next Construct AutosarC++19_03-A12.6.1: m_storage is default initialized
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(
     const storable_function& other) noexcept
@@ -92,9 +97,10 @@ inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_fun
     m_operations.copy(other, *this);
 }
 
-// AXIVION Next Construct AutosarC++19_03-A12.6.1: m_storage is default initialized
 // AXIVION Next Construct AutosarC++19_03-A12.8.4: we copy only the operation pointer table
 // (required) and will perform a move with its type erased move function
+// AXIVION Next Construct AutosarC++19_03-A12.6.1: m_storage is default initialized
+// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <uint64_t Capacity, typename ReturnType, typename... Args>
 inline storable_function<Capacity, signature<ReturnType, Args...>>::storable_function(
     storable_function&& other) noexcept
@@ -169,11 +175,13 @@ inline void swap(storable_function<Capacity, T>& f, storable_function<Capacity, 
 template <typename T>
 void* allocate(byte_t* startAddress, uint64_t Capacity)
 {
-    // static_assert: startAddress + size < Capacity
-    uint64_t alignedPosition = cxx::align(reinterpret_cast<uint64_t>(startAddress), alignof(T));
+    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr) required for low level pointer alignment
+    uint64_t alignment = alignof(T);
+    uint64_t alignedPosition = cxx::align(reinterpret_cast<uint64_t>(startAddress), alignment);
     cxx::Expects(alignedPosition + sizeof(T) - reinterpret_cast<uint64_t>(startAddress) < Capacity
                  && "type does not fit into storage");
     return reinterpret_cast<void*>(alignedPosition);
+    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast, performance-no-int-to-ptr) required for low level pointer alignment
 }
 
 template <uint64_t Capacity, typename ReturnType, typename... Args>
@@ -204,6 +212,7 @@ inline void storable_function<Capacity, signature<ReturnType, Args...>>::copy(co
     const auto obj = static_cast<CallableType*>(src.m_callable);
     cxx::Expects(obj != nullptr); // should not happen unless src is incorrectly used after move
 
+    // NOLINTNEXTLINE(clang-analyzer-core.NonNullParamChecker) checked two lines above
     new (dest.m_callable) CallableType(*obj);
     dest.m_invoker = src.m_invoker;
 }
@@ -215,13 +224,13 @@ template <typename CallableType>
 inline void storable_function<Capacity, signature<ReturnType, Args...>>::move(storable_function& src,
                                                                               storable_function& dest) noexcept
 {
-    //  m_callable = static_cast<void*>(align(reinterpret_cast<uint64_t>(m_storage), alignof(CallableType)));
     dest.m_callable = allocate<CallableType>(dest.m_storage, Capacity);
 
     // AXIVION Next Construct AutosarC++19_03-M5.2.8: type erasure - conversion to compatible type
     const auto obj = static_cast<CallableType*>(src.m_callable);
     cxx::Expects(obj != nullptr); // should not happen unless src is incorrectly used after move
 
+    // NOLINTNEXTLINE(clang-analyzer-core.NonNullParamChecker) checked two lines above
     new (dest.m_callable) CallableType(std::move(*obj));
     dest.m_invoker = src.m_invoker;
     src.m_operations.destroy(src);
@@ -272,9 +281,10 @@ inline ReturnType storable_function<Capacity, signature<ReturnType, Args...>>::i
                                                                                       Args&&... args) noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A18.9.2: we use idiomatic perfect forwarding
+    // AXIVION Next Construct AutosarC++19_03-M5.2.8: type erasure - conversion to compatible type
     // AXIVION Next Construct AutosarC++19_03-A5.3.2: callable is guaranteed not to be nullptr
     // when invoke is called (it is private and only used for type erasure)
-    // AXIVION Next Construct AutosarC++19_03-M5.2.8: type erasure - conversion to compatible type
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage) see justification above
     return (*static_cast<CallableType*>(callable))(std::forward<Args>(args)...);
 }
 
@@ -301,7 +311,6 @@ template <uint64_t Capacity, typename ReturnType, typename... Args>
 template <typename T>
 inline constexpr uint64_t storable_function<Capacity, signature<ReturnType, Args...>>::required_storage_size() noexcept
 {
-    // return StorageType::template allocation_size<T>();
     return sizeof(T) + alignof(T);
 }
 
@@ -309,7 +318,7 @@ template <uint64_t Capacity, typename ReturnType, typename... Args>
 template <typename T>
 inline constexpr bool storable_function<Capacity, signature<ReturnType, Args...>>::is_storable() noexcept
 {
-    return (required_storage_size<T>() <= StorageType::capacity()) && is_invocable_r<ReturnType, T, Args...>::value;
+    return (required_storage_size<T>() <= Capacity) && is_invocable_r<ReturnType, T, Args...>::value;
 }
 
 template <uint64_t Capacity, typename ReturnType, typename... Args>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/storable_function.inl
@@ -173,7 +173,6 @@ void* allocate(byte_t* startAddress, uint64_t Capacity)
     uint64_t alignedPosition = cxx::align(reinterpret_cast<uint64_t>(startAddress), alignof(T));
     cxx::Expects(alignedPosition + sizeof(T) - reinterpret_cast<uint64_t>(startAddress) < Capacity
                  && "type does not fit into storage");
-    // cxx::Expects(alignedPosition + sizeof(T) < Capacity && "type does not fit into storage");
     return reinterpret_cast<void*>(alignedPosition);
 }
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021, 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ enum class IpcChannelError : uint8_t
     INVALID_FILE_DESCRIPTOR,
     I_O_ERROR,
     CONNECTION_RESET_BY_PEER,
+    MEMORY_ALLOCATION_FAILED,
     UNDEFINED
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -103,6 +103,7 @@ class SharedMemoryObject
     SharedMemory m_sharedMemory;
     MemoryMap m_memoryMap;
     BumpAllocator m_allocator;
+    bool m_allocationFinalized{false};
 };
 
 class SharedMemoryObjectBuilder

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -40,6 +40,14 @@ enum class SharedMemoryObjectError
     INTERNAL_LOGIC_FAILURE,
 };
 
+enum class SharedMemoryAllocationError
+{
+    REQUESTED_MEMORY_AFTER_FINALIZED_ALLOCATION,
+    NOT_ENOUGH_MEMORY,
+    REQUESTED_ZERO_SIZED_MEMORY
+
+};
+
 class SharedMemoryObjectBuilder;
 
 /// @brief Creates a shared memory segment and maps it into the process space.
@@ -60,10 +68,10 @@ class SharedMemoryObject
     ///        alignment
     /// @param[in] size the size of the memory inside the shared memory
     /// @param[in] alignment the alignment of the memory
-    /// @return pointer to a memory address with the requested size and alignment.
-    ///         if finalizeAllocation was called before or not enough memory is available
-    ///         allocate will call the errorHandler via cxx::Expects
-    void* allocate(const uint64_t size, const uint64_t alignment) noexcept;
+    /// @return an expected containing a pointer to a memory address with the requested size and alignment on success,
+    /// an expected containing SharedMemoryAllocationError if finalizeAllocation was called before or not enough memory
+    /// is available
+    cxx::expected<void*, SharedMemoryAllocationError> allocate(const uint64_t size, const uint64_t alignment) noexcept;
 
     /// @brief After this call the user cannot allocate memory inside the SharedMemoryObject
     ///        anymore. This ensures that memory is only allocated in the startup phase.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -19,10 +19,10 @@
 
 #include "iceoryx_hoofs/cxx/filesystem.hpp"
 #include "iceoryx_hoofs/design_pattern/builder.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
 #include "iceoryx_platform/stat.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iox/optional.hpp"
 
 #include <cstdint>
@@ -70,7 +70,7 @@ class SharedMemoryObject
     void finalizeAllocation() noexcept;
 
     /// @brief Returns the reference to the underlying allocator
-    Allocator& getAllocator() noexcept;
+    BumpAllocator& getBumpAllocator() noexcept;
 
     /// @brief Returns start- or base-address of the shared memory.
     const void* getBaseAddress() const noexcept;
@@ -94,7 +94,7 @@ class SharedMemoryObject
   private:
     SharedMemoryObject(SharedMemory&& sharedMemory,
                        MemoryMap&& memoryMap,
-                       Allocator&& allocator,
+                       BumpAllocator&& allocator,
                        const uint64_t memorySizeInBytes) noexcept;
 
   private:
@@ -102,7 +102,7 @@ class SharedMemoryObject
 
     SharedMemory m_sharedMemory;
     MemoryMap m_memoryMap;
-    Allocator m_allocator;
+    BumpAllocator m_allocator;
 };
 
 class SharedMemoryObjectBuilder

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -27,7 +27,8 @@ namespace iox
 
 enum class BumpAllocatorError
 {
-    OUT_OF_MEMORY
+    OUT_OF_MEMORY,
+    REQUESTED_ZERO_SIZED_MEMORY
 };
 
 class BumpAllocator
@@ -47,8 +48,8 @@ class BumpAllocator
     /// @brief allocates on the memory supplied with the ctor
     /// @param[in] size of the memory to allocate, must be greater than 0
     /// @param[in] alignment of the memory to allocate
-    /// @return returns an expected containing a pointer to the allocated memory if memory is available, otherwise
-    /// BumpAllocatorError::OUT_OF_MEMORY
+    /// @return returns an expected containing a pointer to the memory if allocation was successful, otherwise
+    /// BumpAllocatorError
     cxx::expected<void*, BumpAllocatorError> allocate(const uint64_t size, const uint64_t alignment) noexcept;
 
     /// @brief mark the memory as unused
@@ -57,7 +58,7 @@ class BumpAllocator
   private:
     cxx::byte_t* m_startAddress{nullptr};
     uint64_t m_length{0U};
-    uint64_t m_currentPosition = 0U;
+    uint64_t m_currentPosition{0U};
 };
 } // namespace iox
 

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -17,16 +17,18 @@
 #ifndef IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
 #define IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
 
+#include "iceoryx_hoofs/cxx/expected.hpp"
 #include "iceoryx_hoofs/iceoryx_hoofs_types.hpp"
 
 #include <cstdint>
 
 namespace iox
 {
-namespace posix
+
+enum class BumpAllocatorError
 {
-class SharedMemoryObject;
-}
+    OUT_OF_MEMORY
+};
 
 class BumpAllocator
 {
@@ -43,24 +45,19 @@ class BumpAllocator
     ~BumpAllocator() noexcept = default;
 
     /// @brief allocates on the memory supplied with the ctor
-    /// @param[in] size of the memory to allocate
+    /// @param[in] size of the memory to allocate, must be greater than 0
     /// @param[in] alignment of the memory to allocate
-    /// @note May terminate if out of memory or finalizeAllocation() was called before
-    void* allocate(const uint64_t size, const uint64_t alignment) noexcept;
+    /// @return returns an expected containing a pointer to the allocated memory if memory is available, otherwise
+    /// BumpAllocatorError::OUT_OF_MEMORY
+    cxx::expected<void*, BumpAllocatorError> allocate(const uint64_t size, const uint64_t alignment) noexcept;
 
     /// @brief mark the memory as unused
     void deallocate() noexcept;
-
-  protected:
-    friend class posix::SharedMemoryObject;
-    // make free function; destructive move? - then we would not be able to deallocate and allocate again afterwards
-    void finalizeAllocation() noexcept;
 
   private:
     cxx::byte_t* m_startAddress{nullptr};
     uint64_t m_length{0U};
     uint64_t m_currentPosition = 0U;
-    bool m_allocationFinalized = false;
 };
 } // namespace iox
 

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_ALLOCATOR_HPP
-#define IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_ALLOCATOR_HPP
+#ifndef IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
+#define IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
 
 #include <cstdint>
 namespace iox
@@ -23,24 +23,26 @@ namespace iox
 namespace posix
 {
 class SharedMemoryObject;
+}
 
-class Allocator
+class BumpAllocator
 {
     using byte_t = uint8_t;
 
 
   public:
+    // remove:
     static constexpr uint64_t MEMORY_ALIGNMENT = 8U;
     /// @brief A bump allocator for the memory provided in the ctor arguments
     /// @param[in] startAddress of the memory this allocator manages
     /// @param[in] length of the memory this allocator manages
-    Allocator(void* const startAddress, const uint64_t length) noexcept;
+    BumpAllocator(void* const startAddress, const uint64_t length) noexcept;
 
-    Allocator(const Allocator&) = delete;
-    Allocator(Allocator&&) noexcept = default;
-    Allocator& operator=(const Allocator&) noexcept = delete;
-    Allocator& operator=(Allocator&&) noexcept = default;
-    ~Allocator() noexcept = default;
+    BumpAllocator(const BumpAllocator&) = delete;
+    BumpAllocator(BumpAllocator&&) noexcept = default;
+    BumpAllocator& operator=(const BumpAllocator&) noexcept = delete;
+    BumpAllocator& operator=(BumpAllocator&&) noexcept = default;
+    ~BumpAllocator() noexcept = default;
 
     /// @brief allocates on the memory supplied with the ctor
     /// @param[in] size of the memory to allocate
@@ -49,7 +51,8 @@ class Allocator
     void* allocate(const uint64_t size, const uint64_t alignment) noexcept;
 
   protected:
-    friend class SharedMemoryObject;
+    friend class posix::SharedMemoryObject;
+    // make free function; destructive move?
     void finalizeAllocation() noexcept;
 
   private:
@@ -58,7 +61,6 @@ class Allocator
     uint64_t m_currentPosition = 0U;
     bool m_allocationFinalized = false;
 };
-} // namespace posix
 } // namespace iox
 
-#endif // IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_ALLOCATOR_HPP
+#endif // IOX_HOOFS_POSIX_MEMORY_BUMP_ALLOCATOR_HPP

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -48,9 +48,12 @@ class BumpAllocator
     /// @note May terminate if out of memory or finalizeAllocation() was called before
     void* allocate(const uint64_t size, const uint64_t alignment) noexcept;
 
+    /// @brief mark the memory as unused
+    void deallocate() noexcept;
+
   protected:
     friend class posix::SharedMemoryObject;
-    // make free function; destructive move?
+    // make free function; destructive move? - then we would not be able to deallocate and allocate again afterwards
     void finalizeAllocation() noexcept;
 
   private:

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -49,7 +49,7 @@ class BumpAllocator
     /// @brief allocates on the memory supplied with the ctor
     /// @param[in] size of the memory to allocate, must be greater than 0
     /// @param[in] alignment of the memory to allocate
-    /// @return returns an expected containing a pointer to the memory if allocation was successful, otherwise
+    /// @return an expected containing a pointer to the memory if allocation was successful, otherwise
     /// BumpAllocatorError
     cxx::expected<void*, BumpAllocatorError> allocate(const uint64_t size, const uint64_t alignment) noexcept;
 

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -17,7 +17,10 @@
 #ifndef IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
 #define IOX_HOOFS_MEMORY_BUMP_ALLOCATOR_HPP
 
+#include "iceoryx_hoofs/iceoryx_hoofs_types.hpp"
+
 #include <cstdint>
+
 namespace iox
 {
 namespace posix
@@ -27,12 +30,7 @@ class SharedMemoryObject;
 
 class BumpAllocator
 {
-    using byte_t = uint8_t;
-
-
   public:
-    // remove:
-    static constexpr uint64_t MEMORY_ALIGNMENT = 8U;
     /// @brief A bump allocator for the memory provided in the ctor arguments
     /// @param[in] startAddress of the memory this allocator manages
     /// @param[in] length of the memory this allocator manages
@@ -56,7 +54,7 @@ class BumpAllocator
     void finalizeAllocation() noexcept;
 
   private:
-    byte_t* m_startAddress{nullptr};
+    cxx::byte_t* m_startAddress{nullptr};
     uint64_t m_length{0U};
     uint64_t m_currentPosition = 0U;
     bool m_allocationFinalized = false;

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -31,10 +31,11 @@ enum class BumpAllocatorError
     REQUESTED_ZERO_SIZED_MEMORY
 };
 
+/// @brief A bump allocator for the memory provided in the ctor arguments
 class BumpAllocator
 {
   public:
-    /// @brief A bump allocator for the memory provided in the ctor arguments
+    /// @brief c'tor
     /// @param[in] startAddress of the memory this allocator manages
     /// @param[in] length of the memory this allocator manages
     BumpAllocator(void* const startAddress, const uint64_t length) noexcept;

--- a/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
+++ b/iceoryx_hoofs/memory/include/iox/bump_allocator.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -39,6 +39,8 @@ void* BumpAllocator::allocate(const uint64_t size, const uint64_t alignment) noe
     cxx::Expects(
         !m_allocationFinalized
         && "allocate() call after finalizeAllocation()! You are not allowed to acquire shared memory chunks anymore");
+    // return a nullptr instead of terminate? Then this could be checked in SharedMemoryObject and the log messages
+    // could be printed there...
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     uint64_t currentAddress = reinterpret_cast<uint64_t>(m_startAddress) + m_currentPosition;
@@ -70,6 +72,12 @@ void* BumpAllocator::allocate(const uint64_t size, const uint64_t alignment) noe
 void BumpAllocator::finalizeAllocation() noexcept
 {
     m_allocationFinalized = true;
+}
+
+void BumpAllocator::deallocate() noexcept
+{
+    m_currentPosition = 0;
+    m_allocationFinalized = false;
 }
 
 } // namespace iox

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -47,12 +47,12 @@ cxx::expected<void*, BumpAllocatorError> BumpAllocator::allocate(const uint64_t 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     alignedPosition -= reinterpret_cast<uint64_t>(m_startAddress);
 
-    cxx::byte_t* l_returnValue = nullptr;
+    cxx::byte_t* allocation = nullptr;
 
     if (m_length >= alignedPosition + size)
     {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic) low-level memory management
-        l_returnValue = m_startAddress + alignedPosition;
+        allocation = m_startAddress + alignedPosition;
         m_currentPosition = alignedPosition + size;
     }
     else
@@ -63,7 +63,7 @@ cxx::expected<void*, BumpAllocatorError> BumpAllocator::allocate(const uint64_t 
         return cxx::error<BumpAllocatorError>(BumpAllocatorError::OUT_OF_MEMORY);
     }
 
-    return cxx::success<void*>(l_returnValue);
+    return cxx::success<void*>(allocation);
 }
 
 void BumpAllocator::deallocate() noexcept

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -24,9 +24,8 @@
 
 namespace iox
 {
-constexpr uint64_t BumpAllocator::MEMORY_ALIGNMENT;
 BumpAllocator::BumpAllocator(void* const startAddress, const uint64_t length) noexcept
-    : m_startAddress(static_cast<byte_t*>(startAddress))
+    : m_startAddress(static_cast<cxx::byte_t*>(startAddress))
     , m_length(length)
 {
 }
@@ -48,7 +47,7 @@ void* BumpAllocator::allocate(const uint64_t size, const uint64_t alignment) noe
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     alignedPosition -= reinterpret_cast<uint64_t>(m_startAddress);
 
-    byte_t* l_returnValue = nullptr;
+    cxx::byte_t* l_returnValue = nullptr;
 
     if (m_length >= alignedPosition + size)
     {

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -34,7 +34,11 @@ BumpAllocator::BumpAllocator(void* const startAddress, const uint64_t length) no
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 cxx::expected<void*, BumpAllocatorError> BumpAllocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
 {
-    cxx::ExpectsWithMsg(size > 0, "Cannot allocate memory of size 0");
+    if (size == 0)
+    {
+        IOX_LOG(WARN) << "Cannot allocate memory of size 0.";
+        return cxx::error<BumpAllocatorError>(BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY);
+    }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for low level pointer alignment
     uint64_t currentAddress = reinterpret_cast<uint64_t>(m_startAddress) + m_currentPosition;

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iceoryx_hoofs/cxx/helplets.hpp"
 #include "iceoryx_hoofs/log/logging.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
@@ -24,10 +24,8 @@
 
 namespace iox
 {
-namespace posix
-{
-constexpr uint64_t Allocator::MEMORY_ALIGNMENT;
-Allocator::Allocator(void* const startAddress, const uint64_t length) noexcept
+constexpr uint64_t BumpAllocator::MEMORY_ALIGNMENT;
+BumpAllocator::BumpAllocator(void* const startAddress, const uint64_t length) noexcept
     : m_startAddress(static_cast<byte_t*>(startAddress))
     , m_length(length)
 {
@@ -35,7 +33,7 @@ Allocator::Allocator(void* const startAddress, const uint64_t length) noexcept
 
 // NOLINTJUSTIFICATION allocation interface requires size and alignment as integral types
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
+void* BumpAllocator::allocate(const uint64_t size, const uint64_t alignment) noexcept
 {
     cxx::Expects(size > 0);
 
@@ -70,10 +68,9 @@ void* Allocator::allocate(const uint64_t size, const uint64_t alignment) noexcep
     return static_cast<void*>(l_returnValue);
 }
 
-void Allocator::finalizeAllocation() noexcept
+void BumpAllocator::finalizeAllocation() noexcept
 {
     m_allocationFinalized = true;
 }
 
-} // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -176,8 +176,7 @@ cxx::expected<void*, SharedMemoryAllocationError> SharedMemoryObject::allocate(c
     }
     if (m_allocationFinalized)
     {
-        IOX_LOG(WARN) << "allocate() call after finalizeAllocation()! You are not allowed to acquire shared memory "
-                         "chunks anymore.";
+        IOX_LOG(WARN) << "allocate() call after finalizeAllocation()! Could not acquire shared memory chunk.";
         return cxx::error<SharedMemoryAllocationError>(
             SharedMemoryAllocationError::REQUESTED_MEMORY_AFTER_FINALIZED_ALLOCATION);
     }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -109,7 +109,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         return error<SharedMemoryObjectError>(SharedMemoryObjectError::MAPPING_SHARED_MEMORY_FAILED);
     }
 
-    Allocator allocator(memoryMap->getBaseAddress(), m_memorySizeInBytes);
+    BumpAllocator allocator(memoryMap->getBaseAddress(), m_memorySizeInBytes);
 
     if (sharedMemory->hasOwnership())
     {
@@ -157,7 +157,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
 
 SharedMemoryObject::SharedMemoryObject(SharedMemory&& sharedMemory,
                                        MemoryMap&& memoryMap,
-                                       Allocator&& allocator,
+                                       BumpAllocator&& allocator,
                                        const uint64_t memorySizeInBytes) noexcept
     : m_memorySizeInBytes(memorySizeInBytes)
     , m_sharedMemory(std::move(sharedMemory))
@@ -176,7 +176,7 @@ void SharedMemoryObject::finalizeAllocation() noexcept
     m_allocator.finalizeAllocation();
 }
 
-Allocator& SharedMemoryObject::getAllocator() noexcept
+BumpAllocator& SharedMemoryObject::getBumpAllocator() noexcept
 {
     return m_allocator;
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -556,7 +556,7 @@ TEST_F(function_test, CallWithRValueReferenceArgumentsWorks)
     Arg arg(initial);
 
     auto lambda = [](Arg&& a) { return a.value + 1; };
-    iox::cxx::function<int32_t(Arg&&), 128> sut(lambda);
+    iox::cxx::function<int32_t(Arg &&), 128> sut(lambda);
 
     auto result = sut(std::move(arg));
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -258,8 +258,8 @@ TEST_F(function_test, FunctionStateIsIndependentOfSource)
 
     // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) low-level memory management for testing purpose
     void* memory = malloc(MEMORY_SIZE);
-    iox::BumpAllocator storage(memory, MEMORY_SIZE);
-    auto allocationResult = storage.allocate(sizeof(Functor), alignof(Functor));
+    iox::BumpAllocator allocator(memory, MEMORY_SIZE);
+    auto allocationResult = allocator.allocate(sizeof(Functor), alignof(Functor));
     ASSERT_FALSE(allocationResult.has_error());
 
     auto* p = static_cast<Functor*>(allocationResult.value());
@@ -556,7 +556,7 @@ TEST_F(function_test, CallWithRValueReferenceArgumentsWorks)
     Arg arg(initial);
 
     auto lambda = [](Arg&& a) { return a.value + 1; };
-    iox::cxx::function<int32_t(Arg &&), 128> sut(lambda);
+    iox::cxx::function<int32_t(Arg&&), 128> sut(lambda);
 
     auto result = sut(std::move(arg));
 

--- a/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cxx_function.cpp
@@ -15,6 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/cxx/function.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 #include <functional>
@@ -252,9 +253,16 @@ TEST_F(function_test, ConstructionFromAnotherFunctionIsCallable)
 TEST_F(function_test, FunctionStateIsIndependentOfSource)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8302046f-cd6a-4527-aca6-3e6408f87a6b");
-    constexpr uint32_t INITIAL_STATE = 73U;
-    static_storage<1024U> storage;
-    auto* p = storage.allocate<Functor>();
+    constexpr uint32_t INITIAL_STATE = 73;
+    constexpr uint32_t MEMORY_SIZE = 1024;
+
+    // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) low-level memory management for testing purpose
+    void* memory = malloc(MEMORY_SIZE);
+    iox::BumpAllocator storage(memory, MEMORY_SIZE);
+    auto allocationResult = storage.allocate(sizeof(Functor), alignof(Functor));
+    ASSERT_FALSE(allocationResult.has_error());
+
+    auto* p = static_cast<Functor*>(allocationResult.value());
     p = new (p) Functor(INITIAL_STATE);
 
     // call the dtor in any case (even if the test fails due to ASSERT)
@@ -270,7 +278,8 @@ TEST_F(function_test, FunctionStateIsIndependentOfSource)
     EXPECT_EQ(sut(1U), functor(1U));
 
     guard.reset(); // call the deleter
-    storage.clear();
+    // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) low-level memory management for testing purpose
+    free(memory);
 
     EXPECT_EQ(sut(1U), INITIAL_STATE + 2U);
 }

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -149,4 +149,42 @@ TEST_F(BumpAllocator_Test, allocateAfterFinalizeAllocation)
     // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
     // hiccpp-vararg)
 }
+
+TEST_F(BumpAllocator_Test, allocateAfterDeallocateWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "");
+    iox::BumpAllocator sut(memory, memorySize);
+    sut.allocate(memorySize, 1);
+
+    sut.deallocate();
+
+    int* bla = static_cast<int*>(sut.allocate(memorySize, 1));
+    *bla = 1990;
+    EXPECT_THAT(*bla, Eq(1990));
+}
+
+TEST_F(BumpAllocator_Test, allocateAfterFinalizeAllocationAndDeallocateWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "");
+    class AllocatorAccess : iox::BumpAllocator
+    {
+      public:
+        AllocatorAccess(void* const startAddress, const uint64_t length)
+            : iox::BumpAllocator(startAddress, length)
+        {
+        }
+        using iox::BumpAllocator::allocate;
+        using iox::BumpAllocator::deallocate;
+        using iox::BumpAllocator::finalizeAllocation;
+    };
+    AllocatorAccess sut(memory, memorySize);
+    sut.allocate(memorySize, 1);
+    sut.finalizeAllocation();
+
+    sut.deallocate();
+
+    int* bla = static_cast<int*>(sut.allocate(memorySize, 1));
+    *bla = 32;
+    EXPECT_THAT(*bla, Eq(32));
+}
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -121,12 +121,9 @@ TEST_F(BumpAllocator_Test, allocateElementOfSizeZero)
     ::testing::Test::RecordProperty("TEST_ID", "17caa50c-94bf-4a1d-a1ec-dfda563caa0b");
     iox::BumpAllocator sut(memory, memorySize);
 
-    // @todo iox-#1613 remove EXPECT_DEATH
-    // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg)
-    EXPECT_DEATH(IOX_DISCARD_RESULT(sut.allocate(0, MEMORY_ALIGNMENT)), ".*");
-    // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-    // hiccpp-vararg)
+    auto allocationResult = sut.allocate(0, MEMORY_ALIGNMENT);
+    ASSERT_TRUE(allocationResult.has_error());
+    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY));
 }
 
 TEST_F(BumpAllocator_Test, allocateAfterDeallocateWorks)

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 #include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
+#include <limits>
+
 namespace
 {
 using namespace testing;
@@ -28,7 +30,8 @@ class BumpAllocator_Test : public Test
     void SetUp() override
     {
         // NOLINTNEXTLINE(hicpp-no-malloc, cppcoreguidelines-no-malloc) required to test allocation
-        memory = malloc(memorySize);
+        memory = malloc(MEMORY_SIZE);
+        ASSERT_THAT(memory, Ne(nullptr));
     }
 
     void TearDown() override
@@ -38,63 +41,39 @@ class BumpAllocator_Test : public Test
     }
 
     static constexpr uint64_t MEMORY_ALIGNMENT{8};
+    static constexpr uint64_t MEMORY_SIZE{10016};
 
     void* memory{nullptr};
-    size_t memorySize = 10016;
 };
 
-TEST_F(BumpAllocator_Test, allocateOneSmallElement)
+TEST_F(BumpAllocator_Test, AllocateFailsWithZeroSize)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "f689e95c-5743-4370-93f0-8a23b909c75a");
-    iox::BumpAllocator sut(memory, memorySize);
-    auto allocationResult = sut.allocate(sizeof(int), MEMORY_ALIGNMENT);
-    ASSERT_FALSE(allocationResult.has_error());
-    int* bla = static_cast<int*>(allocationResult.value());
-    *bla = 123;
-    EXPECT_THAT(*bla, Eq(123));
+    ::testing::Test::RecordProperty("TEST_ID", "17caa50c-94bf-4a1d-a1ec-dfda563caa0b");
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+
+    auto allocationResult = sut.allocate(0, MEMORY_ALIGNMENT);
+    ASSERT_TRUE(allocationResult.has_error());
+    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY));
 }
 
-TEST_F(BumpAllocator_Test, allocateEverythingWithSingleElement)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "f2e1085b-08fe-4b08-b022-0385b5a53fca");
-    iox::BumpAllocator sut(memory, memorySize);
-    auto allocationResult = sut.allocate(memorySize, 1);
-    ASSERT_FALSE(allocationResult.has_error());
-    int* bla = static_cast<int*>(allocationResult.value());
-    *bla = 123;
-    EXPECT_THAT(*bla, Eq(123));
-}
-
-TEST_F(BumpAllocator_Test, allocateEverythingWithMultipleElements)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "21d0fa61-54f9-41a0-8e53-e3448784497b");
-    iox::BumpAllocator sut(memory, memorySize);
-    for (size_t i = 0; i < memorySize; i += 32)
-    {
-        auto allocationResult = sut.allocate(32, 1);
-        ASSERT_FALSE(allocationResult.has_error());
-        auto* bla = static_cast<size_t*>(allocationResult.value());
-        *bla = i;
-        EXPECT_THAT(*bla, Eq(i));
-    }
-}
-
-TEST_F(BumpAllocator_Test, allocateTooMuchSingleElement)
+TEST_F(BumpAllocator_Test, OverallocationFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9deed5c0-19d8-4469-a5c3-f185d4d881f1");
-    iox::BumpAllocator sut(memory, memorySize);
-    auto allocationResult = sut.allocate(memorySize + 1, MEMORY_ALIGNMENT);
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+
+    auto allocationResult = sut.allocate(MEMORY_SIZE + 1, MEMORY_ALIGNMENT);
     ASSERT_TRUE(allocationResult.has_error());
     EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
 }
 
-TEST_F(BumpAllocator_Test, allocateTooMuchMultipleElement)
+TEST_F(BumpAllocator_Test, OverallocationAfterMultipleCallsFails)
 {
     ::testing::Test::RecordProperty("TEST_ID", "435151e8-cc34-41ce-8115-5c179716a60a");
-    iox::BumpAllocator sut(memory, memorySize);
-    for (size_t i = 0; i < memorySize; i += 32)
+    constexpr uint64_t MEMORY_CHUNK_SIZE{32};
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+    for (uint64_t i{0}; i < MEMORY_SIZE; i += MEMORY_CHUNK_SIZE)
     {
-        ASSERT_FALSE(sut.allocate(32, 1).has_error());
+        ASSERT_FALSE(sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_ALIGNMENT).has_error());
     }
 
     auto allocationResult = sut.allocate(1, MEMORY_ALIGNMENT);
@@ -102,41 +81,118 @@ TEST_F(BumpAllocator_Test, allocateTooMuchMultipleElement)
     EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
 }
 
-TEST_F(BumpAllocator_Test, allocateAndAlignment)
+TEST_F(BumpAllocator_Test, AllocationIsCorrectlyAligned)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4252ddcc-05d4-499f-ad7c-30bffb420e08");
-    iox::BumpAllocator sut(memory, memorySize);
-    auto allocationResult = sut.allocate(5, MEMORY_ALIGNMENT);
-    ASSERT_FALSE(allocationResult.has_error());
-    auto* bla = static_cast<uint8_t*>(allocationResult.value());
+    constexpr uint64_t MEMORY_CHUNK_SIZE{sizeof(int)};
+    constexpr uint64_t MEMORY_CHUNK_ALIGNMENT{alignof(int)};
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
 
-    allocationResult = sut.allocate(5, MEMORY_ALIGNMENT);
+    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
     ASSERT_FALSE(allocationResult.has_error());
-    auto* bla2 = static_cast<uint8_t*>(allocationResult.value());
-    EXPECT_THAT(bla2 - bla, Eq(8U));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+    auto p = reinterpret_cast<uintptr_t>(allocationResult.value());
+    EXPECT_THAT(p % MEMORY_CHUNK_ALIGNMENT, Eq(0));
+
+    allocationResult = sut.allocate(2 * MEMORY_CHUNK_SIZE, 2 * MEMORY_CHUNK_ALIGNMENT);
+    ASSERT_FALSE(allocationResult.has_error());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+    p = reinterpret_cast<uintptr_t>(allocationResult.value());
+    EXPECT_THAT(p % (2 * MEMORY_CHUNK_ALIGNMENT), Eq(0));
 }
 
-TEST_F(BumpAllocator_Test, allocateElementOfSizeZero)
+TEST_F(BumpAllocator_Test, AllocateSmallMemoryChunkAndStoreDataWorks)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "17caa50c-94bf-4a1d-a1ec-dfda563caa0b");
-    iox::BumpAllocator sut(memory, memorySize);
+    ::testing::Test::RecordProperty("TEST_ID", "f689e95c-5743-4370-93f0-8a23b909c75a");
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+    auto allocationResult = sut.allocate(sizeof(int), alignof(int));
+    ASSERT_FALSE(allocationResult.has_error());
 
-    auto allocationResult = sut.allocate(0, MEMORY_ALIGNMENT);
-    ASSERT_TRUE(allocationResult.has_error());
-    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY));
+    int* bla = static_cast<int*>(allocationResult.value());
+    *bla = std::numeric_limits<int>::min();
+    EXPECT_THAT(*bla, Eq(std::numeric_limits<int>::min()));
 }
 
-TEST_F(BumpAllocator_Test, allocateAfterDeallocateWorks)
+TEST_F(BumpAllocator_Test, AllocateCompleteMemoryAndStoreDataWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "f2e1085b-08fe-4b08-b022-0385b5a53fca");
+    iox::BumpAllocator sut(memory, sizeof(int));
+    auto allocationResult = sut.allocate(sizeof(int), alignof(int));
+    ASSERT_FALSE(allocationResult.has_error());
+
+    int* bla = static_cast<int*>(allocationResult.value());
+    *bla = std::numeric_limits<int>::max();
+    EXPECT_THAT(*bla, Eq(std::numeric_limits<int>::max()));
+}
+
+TEST_F(BumpAllocator_Test, AllocateCompleteMemoryWithEquallySizedChunksWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "21d0fa61-54f9-41a0-8e53-e3448784497b");
+    constexpr uint64_t MEMORY_CHUNK_SIZE{32};
+    constexpr uint64_t MEMORY_CHUNK_ALIGNMENT{32};
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+
+    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+    ASSERT_FALSE(allocationResult.has_error());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+    auto p0 = reinterpret_cast<uintptr_t>(allocationResult.value());
+
+    for (uint64_t i{MEMORY_CHUNK_SIZE}; i < MEMORY_SIZE; i += MEMORY_CHUNK_SIZE)
+    {
+        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+        ASSERT_FALSE(allocationResult.has_error());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+        auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());
+        EXPECT_THAT(p1 - p0, Eq(MEMORY_CHUNK_SIZE));
+        p0 = p1;
+    }
+}
+
+TEST_F(BumpAllocator_Test, AllocateCompleteMemoryWithDifferentSizedChunksWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c8079bb7-1de6-45a6-92af-a50aa59d7481");
+    constexpr uint64_t MEMORY_CHUNK_SIZE{64};
+    constexpr uint64_t MEMORY_CHUNK_ALIGNMENT{64};
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+
+    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+    ASSERT_FALSE(allocationResult.has_error());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+    auto p0 = reinterpret_cast<uintptr_t>(allocationResult.value());
+
+    for (uint64_t i{MEMORY_CHUNK_SIZE}; i < MEMORY_SIZE - MEMORY_CHUNK_SIZE; i += MEMORY_CHUNK_SIZE)
+    {
+        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+        ASSERT_FALSE(allocationResult.has_error());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+        auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());
+        EXPECT_THAT(p1 - p0, Eq(MEMORY_CHUNK_SIZE));
+        p0 = p1;
+    }
+
+    allocationResult = sut.allocate(MEMORY_CHUNK_SIZE / 2, MEMORY_CHUNK_ALIGNMENT / 2);
+    ASSERT_FALSE(allocationResult.has_error());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
+    auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());
+    EXPECT_THAT(p1 - p0, Eq(MEMORY_CHUNK_SIZE));
+}
+
+TEST_F(BumpAllocator_Test, AllocateAfterDeallocateWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "323fc1af-481f-4732-b7d3-fa32da389cef");
-    iox::BumpAllocator sut(memory, memorySize);
-    ASSERT_FALSE(sut.allocate(memorySize, 1).has_error());
+    iox::BumpAllocator sut(memory, MEMORY_SIZE);
+    auto allocationResult = sut.allocate(sizeof(int), alignof(int));
+    ASSERT_FALSE(allocationResult.has_error());
+    int* bla = static_cast<int*>(allocationResult.value());
+    *bla = std::numeric_limits<int>::max();
 
     sut.deallocate();
 
-    auto allocationResult = sut.allocate(memorySize, 1);
+    allocationResult = sut.allocate(sizeof(int), alignof(int));
     ASSERT_FALSE(allocationResult.has_error());
-    int* bla = static_cast<int*>(allocationResult.value());
+    bla = static_cast<int*>(allocationResult.value());
+    EXPECT_THAT(bla, Eq(memory));
+
     *bla = 1990;
     EXPECT_THAT(*bla, Eq(1990));
 }

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -124,7 +124,7 @@ TEST_F(BumpAllocator_Test, allocateElementOfSizeZero)
     // @todo iox-#1613 remove EXPECT_DEATH
     // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
     // hiccpp-vararg)
-    EXPECT_DEATH(sut.allocate(0, MEMORY_ALIGNMENT), ".*");
+    EXPECT_DEATH(IOX_DISCARD_RESULT(sut.allocate(0, MEMORY_ALIGNMENT)), ".*");
     // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
     // hiccpp-vararg)
 }

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -129,17 +129,16 @@ TEST_F(BumpAllocator_Test, AllocateCompleteMemoryWithEquallySizedChunksWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "21d0fa61-54f9-41a0-8e53-e3448784497b");
     constexpr uint64_t MEMORY_CHUNK_SIZE{32};
-    constexpr uint64_t MEMORY_CHUNK_ALIGNMENT{32};
     iox::BumpAllocator sut(memory, MEMORY_SIZE);
 
-    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_ALIGNMENT);
     ASSERT_FALSE(allocationResult.has_error());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
     auto p0 = reinterpret_cast<uintptr_t>(allocationResult.value());
 
     for (uint64_t i{MEMORY_CHUNK_SIZE}; i < MEMORY_SIZE; i += MEMORY_CHUNK_SIZE)
     {
-        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_ALIGNMENT);
         ASSERT_FALSE(allocationResult.has_error());
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
         auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());
@@ -152,17 +151,16 @@ TEST_F(BumpAllocator_Test, AllocateCompleteMemoryWithDifferentSizedChunksWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c8079bb7-1de6-45a6-92af-a50aa59d7481");
     constexpr uint64_t MEMORY_CHUNK_SIZE{64};
-    constexpr uint64_t MEMORY_CHUNK_ALIGNMENT{64};
     iox::BumpAllocator sut(memory, MEMORY_SIZE);
 
-    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+    auto allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_ALIGNMENT);
     ASSERT_FALSE(allocationResult.has_error());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
     auto p0 = reinterpret_cast<uintptr_t>(allocationResult.value());
 
     for (uint64_t i{MEMORY_CHUNK_SIZE}; i < MEMORY_SIZE - MEMORY_CHUNK_SIZE; i += MEMORY_CHUNK_SIZE)
     {
-        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_CHUNK_ALIGNMENT);
+        allocationResult = sut.allocate(MEMORY_CHUNK_SIZE, MEMORY_ALIGNMENT);
         ASSERT_FALSE(allocationResult.has_error());
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
         auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());
@@ -170,7 +168,7 @@ TEST_F(BumpAllocator_Test, AllocateCompleteMemoryWithDifferentSizedChunksWorks)
         p0 = p1;
     }
 
-    allocationResult = sut.allocate(MEMORY_CHUNK_SIZE / 2, MEMORY_CHUNK_ALIGNMENT / 2);
+    allocationResult = sut.allocate(MEMORY_CHUNK_SIZE / 2, MEMORY_ALIGNMENT);
     ASSERT_FALSE(allocationResult.has_error());
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) required for testing
     auto p1 = reinterpret_cast<uintptr_t>(allocationResult.value());

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -37,6 +37,9 @@ class SharedMemoryObject_Test : public Test
 
     static void PerformDeathTest(const std::function<void()>& deathTest)
     {
+        std::set_terminate([]() { std::cout << "", std::abort(); });
+
+        internal::GetCapturedStderr();
         // @todo iox-#1613 remove EXPECT_DEATH
         // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
         // hiccpp-vararg)

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -44,6 +44,8 @@ class SharedMemoryObject_Test : public Test
         // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
         // hiccpp-vararg)
     }
+
+    static constexpr uint64_t MEMORY_ALIGNMENT{8};
 };
 
 TEST_F(SharedMemoryObject_Test, CTorWithValidArguments)
@@ -141,7 +143,7 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchMemoryInSharedMemoryWithOneChunk)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
 
-    PerformDeathTest([&] { sut->allocate(cxx::align(memorySize, BumpAllocator::MEMORY_ALIGNMENT) + 1, 1); });
+    PerformDeathTest([&] { sut->allocate(cxx::align(memorySize, MEMORY_ALIGNMENT) + 1, 1); });
 }
 
 TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
@@ -158,7 +160,7 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
 
-    for (uint64_t i = 0; i < cxx::align(memorySize, BumpAllocator::MEMORY_ALIGNMENT); ++i)
+    for (uint64_t i = 0; i < cxx::align(memorySize, MEMORY_ALIGNMENT); ++i)
     {
         void* test = sut->allocate(1, 1);
         ASSERT_THAT(test, Ne(nullptr));

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -89,7 +89,9 @@ TEST_F(SharedMemoryObject_Test, AllocateMemoryInSharedMemoryAndReadIt)
                    .create();
 
     ASSERT_THAT(sut.has_error(), Eq(false));
-    int* test = static_cast<int*>(sut->allocate(sizeof(int), 1));
+    auto result = sut->allocate(sizeof(int), 1);
+    ASSERT_THAT(result.has_error(), Eq(false));
+    int* test = static_cast<int*>(result.value());
     ASSERT_THAT(test, Ne(nullptr));
     *test = 123;
     EXPECT_THAT(*test, Eq(123));
@@ -107,8 +109,9 @@ TEST_F(SharedMemoryObject_Test, AllocateWholeSharedMemoryWithOneChunk)
                    .create();
 
     ASSERT_THAT(sut.has_error(), Eq(false));
-    void* test = sut->allocate(8, 1);
-    ASSERT_THAT(test, Ne(nullptr));
+    auto result = sut->allocate(8, 1);
+    ASSERT_THAT(result.has_error(), Eq(false));
+    ASSERT_THAT(result.value(), Ne(nullptr));
 }
 
 TEST_F(SharedMemoryObject_Test, AllocateWholeSharedMemoryWithMultipleChunks)
@@ -126,8 +129,9 @@ TEST_F(SharedMemoryObject_Test, AllocateWholeSharedMemoryWithMultipleChunks)
 
     for (uint64_t i = 0; i < 8; ++i)
     {
-        void* test = sut->allocate(1, 1);
-        ASSERT_THAT(test, Ne(nullptr));
+        auto result = sut->allocate(1, 1);
+        ASSERT_THAT(result.has_error(), Eq(false));
+        ASSERT_THAT(result.value(), Ne(nullptr));
     }
 }
 
@@ -146,7 +150,9 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchMemoryInSharedMemoryWithOneChunk)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
 
-    PerformDeathTest([&] { sut->allocate(cxx::align(memorySize, MEMORY_ALIGNMENT) + 1, 1); });
+    auto result = sut->allocate(cxx::align(memorySize, MEMORY_ALIGNMENT) + 1, 1);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(result.get_error(), Eq(posix::SharedMemoryAllocationError::NOT_ENOUGH_MEMORY));
 }
 
 TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
@@ -165,11 +171,14 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
 
     for (uint64_t i = 0; i < cxx::align(memorySize, MEMORY_ALIGNMENT); ++i)
     {
-        void* test = sut->allocate(1, 1);
-        ASSERT_THAT(test, Ne(nullptr));
+        auto result = sut->allocate(1, 1);
+        ASSERT_THAT(result.has_error(), Eq(false));
+        ASSERT_THAT(result.value(), Ne(nullptr));
     }
 
-    PerformDeathTest([&] { sut->allocate(1, 1); });
+    auto result = sut->allocate(1, 1);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(result.get_error(), Eq(posix::SharedMemoryAllocationError::NOT_ENOUGH_MEMORY));
 }
 
 TEST_F(SharedMemoryObject_Test, AllocateAfterFinalizeAllocation)
@@ -185,7 +194,29 @@ TEST_F(SharedMemoryObject_Test, AllocateAfterFinalizeAllocation)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
     sut->finalizeAllocation();
-    PerformDeathTest([&] { sut->allocate(2, 1); });
+
+    auto result = sut->allocate(2, 1);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(result.get_error(),
+                Eq(posix::SharedMemoryAllocationError::REQUESTED_MEMORY_AFTER_FINALIZED_ALLOCATION));
+}
+
+TEST_F(SharedMemoryObject_Test, AllocateFailsWithZeroSize)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cf7f6692-1b64-4926-8326-0628ec483231");
+    auto sut = iox::posix::SharedMemoryObjectBuilder()
+                   .name("shmAllocate")
+                   .memorySizeInBytes(8)
+                   .accessMode(iox::posix::AccessMode::READ_WRITE)
+                   .openMode(iox::posix::OpenMode::PURGE_AND_CREATE)
+                   .permissions(cxx::perms::owner_all)
+                   .create();
+
+    ASSERT_THAT(sut.has_error(), Eq(false));
+
+    auto result = sut->allocate(0, 1);
+    ASSERT_TRUE(result.has_error());
+    EXPECT_THAT(result.get_error(), Eq(posix::SharedMemoryAllocationError::REQUESTED_ZERO_SIZED_MEMORY));
 }
 
 TEST_F(SharedMemoryObject_Test, OpeningSharedMemoryAndReadMultipleContents)
@@ -203,9 +234,14 @@ TEST_F(SharedMemoryObject_Test, OpeningSharedMemoryAndReadMultipleContents)
 
     ASSERT_THAT(shmMemory.has_error(), Eq(false));
 
-    int* test = static_cast<int*>(shmMemory->allocate(sizeof(int), 1));
+    auto result = shmMemory->allocate(sizeof(int), 1);
+    ASSERT_THAT(result.has_error(), Eq(false));
+    int* test = static_cast<int*>(result.value());
     *test = 4557;
-    int* test2 = static_cast<int*>(shmMemory->allocate(sizeof(int), 1));
+
+    result = shmMemory->allocate(sizeof(int), 1);
+    ASSERT_THAT(result.has_error(), Eq(false));
+    int* test2 = static_cast<int*>(result.value());
     *test2 = 8912;
 
 
@@ -217,8 +253,13 @@ TEST_F(SharedMemoryObject_Test, OpeningSharedMemoryAndReadMultipleContents)
                    .permissions(cxx::perms::owner_all)
                    .create();
 
-    int* sutValue1 = static_cast<int*>(sut->allocate(sizeof(int), 1));
-    int* sutValue2 = static_cast<int*>(sut->allocate(sizeof(int), 1));
+    result = sut->allocate(sizeof(int), 1);
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    int* sutValue1 = static_cast<int*>(result.value());
+
+    result = sut->allocate(sizeof(int), 1);
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    int* sutValue2 = static_cast<int*>(result.value());
 
     EXPECT_THAT(*sutValue1, Eq(4557));
     EXPECT_THAT(*sutValue2, Eq(8912));

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -35,19 +35,6 @@ class SharedMemoryObject_Test : public Test
     {
     }
 
-    static void PerformDeathTest(const std::function<void()>& deathTest)
-    {
-        std::set_terminate([]() { std::cout << "", std::abort(); });
-
-        internal::GetCapturedStderr();
-        // @todo iox-#1613 remove EXPECT_DEATH
-        // NOLINTBEGIN(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-        // hiccpp-vararg)
-        EXPECT_DEATH({ deathTest(); }, ".*");
-        // NOLINTEND(hicpp-avoid-goto, cppcoreguidelines-avoid-goto, cert-err33-c, cppcoreguidelines-pro-type-vararg,
-        // hiccpp-vararg)
-    }
-
     static constexpr uint64_t MEMORY_ALIGNMENT{8};
 };
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -141,7 +141,7 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchMemoryInSharedMemoryWithOneChunk)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
 
-    PerformDeathTest([&] { sut->allocate(cxx::align(memorySize, posix::Allocator::MEMORY_ALIGNMENT) + 1, 1); });
+    PerformDeathTest([&] { sut->allocate(cxx::align(memorySize, BumpAllocator::MEMORY_ALIGNMENT) + 1, 1); });
 }
 
 TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
@@ -158,7 +158,7 @@ TEST_F(SharedMemoryObject_Test, AllocateTooMuchSharedMemoryWithMultipleChunks)
 
     ASSERT_THAT(sut.has_error(), Eq(false));
 
-    for (uint64_t i = 0; i < cxx::align(memorySize, posix::Allocator::MEMORY_ALIGNMENT); ++i)
+    for (uint64_t i = 0; i < cxx::align(memorySize, BumpAllocator::MEMORY_ALIGNMENT); ++i)
     {
         void* test = sut->allocate(1, 1);
         ASSERT_THAT(test, Ne(nullptr));

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -52,8 +52,8 @@ class MemPool
 
     MemPool(const cxx::greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkSize,
             const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-            BumpAllocator& managementAllocator,
-            BumpAllocator& chunkMemoryAllocator) noexcept;
+            iox::BumpAllocator& managementAllocator,
+            iox::BumpAllocator& chunkMemoryAllocator) noexcept;
 
     MemPool(const MemPool&) = delete;
     MemPool(MemPool&&) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -19,9 +19,9 @@
 
 #include "iceoryx_hoofs/cxx/helplets.hpp"
 #include "iceoryx_hoofs/internal/concurrent/loffli.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/memory/relative_pointer.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
+#include "iox/bump_allocator.hpp"
 
 #include <atomic>
 #include <cstdint>
@@ -52,8 +52,8 @@ class MemPool
 
     MemPool(const cxx::greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkSize,
             const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-            posix::Allocator& managementAllocator,
-            posix::Allocator& chunkMemoryAllocator) noexcept;
+            BumpAllocator& managementAllocator,
+            BumpAllocator& chunkMemoryAllocator) noexcept;
 
     MemPool(const MemPool&) = delete;
     MemPool(MemPool&&) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/memory_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/memory_manager.hpp
@@ -23,6 +23,7 @@
 #include "iceoryx_posh/internal/mepoo/mem_pool.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/mepoo/chunk_settings.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iox/expected.hpp"
 
 #include <cstdint>
@@ -62,8 +63,8 @@ class MemoryManager
     ~MemoryManager() noexcept = default;
 
     void configureMemoryManager(const MePooConfig& mePooConfig,
-                                posix::Allocator& managementAllocator,
-                                posix::Allocator& chunkMemoryAllocator) noexcept;
+                                BumpAllocator& managementAllocator,
+                                BumpAllocator& chunkMemoryAllocator) noexcept;
 
     /// @brief Obtains a chunk from the mempools
     /// @param[in] chunkSettings for the requested chunk
@@ -82,11 +83,11 @@ class MemoryManager
     static uint32_t sizeWithChunkHeaderStruct(const MaxChunkPayloadSize_t size) noexcept;
 
     void printMemPoolVector(log::LogStream& log) const noexcept;
-    void addMemPool(posix::Allocator& managementAllocator,
-                    posix::Allocator& chunkMemoryAllocator,
+    void addMemPool(BumpAllocator& managementAllocator,
+                    BumpAllocator& chunkMemoryAllocator,
                     const cxx::greater_or_equal<uint32_t, MemPool::CHUNK_MEMORY_ALIGNMENT> chunkPayloadSize,
                     const cxx::greater_or_equal<uint32_t, 1> numberOfChunks) noexcept;
-    void generateChunkManagementPool(posix::Allocator& managementAllocator) noexcept;
+    void generateChunkManagementPool(BumpAllocator& managementAllocator) noexcept;
 
   private:
     bool m_denyAddMemPool{false};

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
@@ -19,11 +19,11 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/access_control.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/mepoo/memory_info.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
+#include "iox/bump_allocator.hpp"
 
 namespace iox
 {
@@ -34,7 +34,7 @@ class MePooSegment
 {
   public:
     MePooSegment(const MePooConfig& mempoolConfig,
-                 posix::Allocator& managementAllocator,
+                 BumpAllocator& managementAllocator,
                  const posix::PosixGroup& readerGroup,
                  const posix::PosixGroup& writerGroup,
                  const iox::mepoo::MemoryInfo& memoryInfo = iox::mepoo::MemoryInfo()) noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -34,7 +34,7 @@ constexpr cxx::perms MePooSegment<SharedMemoryObjectType, MemoryManagerType>::SE
 template <typename SharedMemoryObjectType, typename MemoryManagerType>
 inline MePooSegment<SharedMemoryObjectType, MemoryManagerType>::MePooSegment(
     const MePooConfig& mempoolConfig,
-    posix::Allocator& managementAllocator,
+    BumpAllocator& managementAllocator,
     const posix::PosixGroup& readerGroup,
     const posix::PosixGroup& writerGroup,
     const iox::mepoo::MemoryInfo& memoryInfo) noexcept
@@ -59,7 +59,7 @@ inline MePooSegment<SharedMemoryObjectType, MemoryManagerType>::MePooSegment(
         errorHandler(PoshError::MEPOO__SEGMENT_COULD_NOT_APPLY_POSIX_RIGHTS_TO_SHARED_MEMORY);
     }
 
-    m_memoryManager.configureMemoryManager(mempoolConfig, managementAllocator, m_sharedMemoryObject.getAllocator());
+    m_memoryManager.configureMemoryManager(mempoolConfig, managementAllocator, m_sharedMemoryObject.getBumpAllocator());
     m_sharedMemoryObject.finalizeAllocation();
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
@@ -18,13 +18,13 @@
 #define IOX_POSH_MEPOO_SEGMENT_MANAGER_HPP
 
 #include "iceoryx_hoofs/cxx/vector.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/mepoo_segment.hpp"
 #include "iceoryx_posh/mepoo/segment_config.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iox/optional.hpp"
 #include "iox/string.hpp"
 
@@ -42,7 +42,7 @@ template <typename SegmentType = MePooSegment<>>
 class SegmentManager
 {
   public:
-    SegmentManager(const SegmentConfig& segmentConfig, posix::Allocator* managementAllocator) noexcept;
+    SegmentManager(const SegmentConfig& segmentConfig, BumpAllocator* managementAllocator) noexcept;
     ~SegmentManager() noexcept = default;
 
     SegmentManager(const SegmentManager& rhs) = delete;
@@ -100,7 +100,7 @@ class SegmentManager
     template <typename MemoryManger, typename SegmentManager, typename PublisherPort>
     friend class roudi::MemPoolIntrospection;
 
-    posix::Allocator* m_managementAllocator;
+    BumpAllocator* m_managementAllocator;
     cxx::vector<SegmentType, MAX_SHM_SEGMENTS> m_segmentContainer;
     bool m_createInterfaceEnabled{true};
 };

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
@@ -28,7 +28,7 @@ namespace mepoo
 {
 template <typename SegmentType>
 inline SegmentManager<SegmentType>::SegmentManager(const SegmentConfig& segmentConfig,
-                                                   posix::Allocator* managementAllocator) noexcept
+                                                   BumpAllocator* managementAllocator) noexcept
     : m_managementAllocator(managementAllocator)
 {
     cxx::Expects(segmentConfig.m_sharedMemorySegments.capacity() <= m_segmentContainer.capacity());

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.hpp
@@ -24,6 +24,7 @@
 #include "iceoryx_posh/internal/mepoo/mem_pool.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_pointer.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iox/expected.hpp"
 #include "iox/optional.hpp"
 #include "iox/variant.hpp"
@@ -45,8 +46,8 @@ class TypedMemPool
 {
   public:
     TypedMemPool(const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-                 posix::Allocator& managementAllocator,
-                 posix::Allocator& chunkMemoryAllocator) noexcept;
+                 BumpAllocator& managementAllocator,
+                 BumpAllocator& chunkMemoryAllocator) noexcept;
 
     TypedMemPool(const TypedMemPool&) = delete;
     TypedMemPool(TypedMemPool&&) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
@@ -28,8 +28,8 @@ namespace mepoo
 {
 template <typename T>
 inline TypedMemPool<T>::TypedMemPool(const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-                                     posix::Allocator& managementAllocator,
-                                     posix::Allocator& chunkMemoryAllocator) noexcept
+                                     BumpAllocator& managementAllocator,
+                                     BumpAllocator& chunkMemoryAllocator) noexcept
     : m_memPool(static_cast<uint32_t>(requiredChunkSize()), numberOfChunks, managementAllocator, chunkMemoryAllocator)
     , m_chunkManagementPool(sizeof(ChunkManagement), numberOfChunks, managementAllocator, managementAllocator)
 {

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -41,8 +41,8 @@ constexpr uint64_t MemPool::CHUNK_MEMORY_ALIGNMENT;
 
 MemPool::MemPool(const cxx::greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkSize,
                  const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-                 BumpAllocator& managementAllocator,
-                 BumpAllocator& chunkMemoryAllocator) noexcept
+                 iox::BumpAllocator& managementAllocator,
+                 iox::BumpAllocator& chunkMemoryAllocator) noexcept
     : m_chunkSize(chunkSize)
     , m_numberOfChunks(numberOfChunks)
     , m_minFree(numberOfChunks)

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -49,10 +49,15 @@ MemPool::MemPool(const cxx::greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> c
 {
     if (isMultipleOfAlignment(chunkSize))
     {
-        m_rawMemory = static_cast<uint8_t*>(chunkMemoryAllocator.allocate(
-            static_cast<uint64_t>(m_numberOfChunks) * m_chunkSize, CHUNK_MEMORY_ALIGNMENT));
-        auto memoryLoFFLi =
+        auto allocationResult = chunkMemoryAllocator.allocate(static_cast<uint64_t>(m_numberOfChunks) * m_chunkSize,
+                                                              CHUNK_MEMORY_ALIGNMENT);
+        cxx::Expects(!allocationResult.has_error());
+        m_rawMemory = static_cast<uint8_t*>(allocationResult.value());
+
+        allocationResult =
             managementAllocator.allocate(freeList_t::requiredIndexMemorySize(m_numberOfChunks), CHUNK_MEMORY_ALIGNMENT);
+        cxx::Expects(!allocationResult.has_error());
+        auto* memoryLoFFLi = allocationResult.value();
         m_freeIndices.init(static_cast<concurrent::LoFFLi::Index_t*>(memoryLoFFLi), m_numberOfChunks);
     }
     else

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -41,8 +41,8 @@ constexpr uint64_t MemPool::CHUNK_MEMORY_ALIGNMENT;
 
 MemPool::MemPool(const cxx::greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkSize,
                  const cxx::greater_or_equal<uint32_t, 1> numberOfChunks,
-                 posix::Allocator& managementAllocator,
-                 posix::Allocator& chunkMemoryAllocator) noexcept
+                 BumpAllocator& managementAllocator,
+                 BumpAllocator& chunkMemoryAllocator) noexcept
     : m_chunkSize(chunkSize)
     , m_numberOfChunks(numberOfChunks)
     , m_minFree(numberOfChunks)

--- a/iceoryx_posh/source/mepoo/memory_manager.cpp
+++ b/iceoryx_posh/source/mepoo/memory_manager.cpp
@@ -39,8 +39,8 @@ void MemoryManager::printMemPoolVector(log::LogStream& log) const noexcept
     }
 }
 
-void MemoryManager::addMemPool(posix::Allocator& managementAllocator,
-                               posix::Allocator& chunkMemoryAllocator,
+void MemoryManager::addMemPool(BumpAllocator& managementAllocator,
+                               BumpAllocator& chunkMemoryAllocator,
                                const cxx::greater_or_equal<uint32_t, MemPool::CHUNK_MEMORY_ALIGNMENT> chunkPayloadSize,
                                const cxx::greater_or_equal<uint32_t, 1> numberOfChunks) noexcept
 {
@@ -67,7 +67,7 @@ void MemoryManager::addMemPool(posix::Allocator& managementAllocator,
     m_totalNumberOfChunks += numberOfChunks;
 }
 
-void MemoryManager::generateChunkManagementPool(posix::Allocator& managementAllocator) noexcept
+void MemoryManager::generateChunkManagementPool(BumpAllocator& managementAllocator) noexcept
 {
     m_denyAddMemPool = true;
     uint32_t chunkSize = sizeof(ChunkManagement);
@@ -133,8 +133,8 @@ uint64_t MemoryManager::requiredFullMemorySize(const MePooConfig& mePooConfig) n
 }
 
 void MemoryManager::configureMemoryManager(const MePooConfig& mePooConfig,
-                                           posix::Allocator& managementAllocator,
-                                           posix::Allocator& chunkMemoryAllocator) noexcept
+                                           BumpAllocator& managementAllocator,
+                                           BumpAllocator& chunkMemoryAllocator) noexcept
 {
     for (auto entry : mePooConfig.m_mempoolConfig)
     {

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -98,7 +98,12 @@ expected<MemoryProviderError> MemoryProvider::create() noexcept
 
     for (auto* memoryBlock : m_memoryBlocks)
     {
-        memoryBlock->m_memory = allocator.allocate(memoryBlock->size(), memoryBlock->alignment());
+        auto allocationResult = allocator.allocate(memoryBlock->size(), memoryBlock->alignment());
+        if (allocationResult.has_error())
+        {
+            return cxx::error<MemoryProviderError>(MemoryProviderError::MEMORY_ALLOCATION_FAILED);
+        }
+        memoryBlock->m_memory = allocationResult.value();
     }
 
     return success<void>();

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -17,11 +17,11 @@
 
 #include "iceoryx_posh/roudi/memory/memory_provider.hpp"
 #include "iceoryx_hoofs/cxx/helplets.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/memory/relative_pointer.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"
 #include "iceoryx_posh/roudi/memory/memory_block.hpp"
+#include "iox/bump_allocator.hpp"
 
 namespace iox
 {
@@ -94,7 +94,7 @@ expected<MemoryProviderError> MemoryProvider::create() noexcept
     LogDebug() << "Registered memory segment " << iox::log::hex(m_memory) << " with size " << m_size << " to id "
                << m_segmentId;
 
-    iox::posix::Allocator allocator(m_memory, m_size);
+    iox::BumpAllocator allocator(m_memory, m_size);
 
     for (auto* memoryBlock : m_memoryBlocks)
     {

--- a/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
@@ -20,7 +20,7 @@
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 
 #include "iceoryx_hoofs/cxx/algorithm.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iox/bump_allocator.hpp"
 
 namespace iox
 {
@@ -51,7 +51,7 @@ uint64_t MemPoolCollectionMemoryBlock::alignment() const noexcept
 
 void MemPoolCollectionMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept
 {
-    posix::Allocator allocator(memory, size());
+    BumpAllocator allocator(memory, size());
     auto memoryManager = allocator.allocate(sizeof(mepoo::MemoryManager), alignof(mepoo::MemoryManager));
     m_memoryManager = new (memoryManager) mepoo::MemoryManager;
 

--- a/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
@@ -52,7 +52,9 @@ uint64_t MemPoolCollectionMemoryBlock::alignment() const noexcept
 void MemPoolCollectionMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept
 {
     BumpAllocator allocator(memory, size());
-    auto memoryManager = allocator.allocate(sizeof(mepoo::MemoryManager), alignof(mepoo::MemoryManager));
+    auto allocationResult = allocator.allocate(sizeof(mepoo::MemoryManager), alignof(mepoo::MemoryManager));
+    cxx::Expects(!allocationResult.has_error());
+    auto* memoryManager = allocationResult.value();
     m_memoryManager = new (memoryManager) mepoo::MemoryManager;
 
     m_memoryManager->configureMemoryManager(m_memPoolConfig, allocator, allocator);

--- a/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
@@ -17,7 +17,7 @@
 
 #include "iceoryx_posh/internal/roudi/memory/mempool_segment_manager_memory_block.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iox/bump_allocator.hpp"
 
 namespace iox
 {
@@ -48,7 +48,7 @@ uint64_t MemPoolSegmentManagerMemoryBlock::alignment() const noexcept
 
 void MemPoolSegmentManagerMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept
 {
-    posix::Allocator allocator(memory, size());
+    BumpAllocator allocator(memory, size());
     auto segmentManager = allocator.allocate(sizeof(mepoo::SegmentManager<>), alignof(mepoo::SegmentManager<>));
     m_segmentManager = new (segmentManager) mepoo::SegmentManager<>(m_segmentConfig, &allocator);
 }

--- a/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
@@ -49,7 +49,9 @@ uint64_t MemPoolSegmentManagerMemoryBlock::alignment() const noexcept
 void MemPoolSegmentManagerMemoryBlock::onMemoryAvailable(cxx::not_null<void*> memory) noexcept
 {
     BumpAllocator allocator(memory, size());
-    auto segmentManager = allocator.allocate(sizeof(mepoo::SegmentManager<>), alignof(mepoo::SegmentManager<>));
+    auto allocationResult = allocator.allocate(sizeof(mepoo::SegmentManager<>), alignof(mepoo::SegmentManager<>));
+    cxx::Expects(!allocationResult.has_error());
+    auto* segmentManager = allocationResult.value();
     m_segmentManager = new (segmentManager) mepoo::SegmentManager<>(m_segmentConfig, &allocator);
 }
 

--- a/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
@@ -204,7 +204,7 @@ class ChunkBuildingBlocks_IntegrationTest : public Test
     std::atomic<bool> m_forwarderRun{true};
 
     // Memory objects
-    Allocator m_memoryAllocator{g_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{g_memory, MEMORY_SIZE};
     MePooConfig m_mempoolConfig;
     MemoryManager m_memoryManager;
 

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -108,7 +108,7 @@ class PortUser_IntegrationTest : public Test
     std::atomic<uint64_t> m_publisherRunFinished{0U};
 
     // Memory objects
-    Allocator m_memoryAllocator{g_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{g_memory, MEMORY_SIZE};
     MePooConfig m_mempoolConfig;
     MemoryManager m_memoryManager;
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
@@ -15,10 +15,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 namespace
@@ -35,7 +35,7 @@ class MemoryManager_test : public Test
     void SetUp() override
     {
         rawMemory = malloc(rawMemorySize);
-        allocator = new iox::posix::Allocator(rawMemory, rawMemorySize);
+        allocator = new iox::BumpAllocator(rawMemory, rawMemorySize);
         sut = new iox::mepoo::MemoryManager();
     };
     void TearDown() override
@@ -66,7 +66,7 @@ class MemoryManager_test : public Test
     static constexpr uint32_t CHUNK_SIZE_128{128};
     static constexpr uint32_t CHUNK_SIZE_256{256U};
 
-    iox::posix::Allocator* allocator;
+    iox::BumpAllocator* allocator;
     void* rawMemory;
     size_t rawMemorySize = 1000000;
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_mempool.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_mempool.cpp
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/mem_pool.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 namespace
@@ -45,7 +45,7 @@ class MemPool_test : public Test
 
     alignas(MemPool::CHUNK_MEMORY_ALIGNMENT) uint8_t
         m_rawMemory[NUMBER_OF_CHUNKS * CHUNK_SIZE + LOFFLI_MEMORY_REQUIREMENT];
-    iox::posix::Allocator allocator;
+    iox::BumpAllocator allocator;
 
     MemPool sut;
 };
@@ -54,7 +54,7 @@ TEST_F(MemPool_test, MempoolCtorInitialisesTheObjectWithValuesPassedToTheCtor)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b15b0da5-74e0-481b-87b6-53888b8a9890");
     char memory[8192];
-    iox::posix::Allocator allocator{memory, 8192U};
+    iox::BumpAllocator allocator{memory, 8192U};
 
     iox::mepoo::MemPool sut(CHUNK_SIZE, NUMBER_OF_CHUNKS, allocator, allocator);
 
@@ -68,7 +68,7 @@ TEST_F(MemPool_test, MempoolCtorWhenChunkSizeIsNotAMultipleOfAlignmentReturnErro
 {
     ::testing::Test::RecordProperty("TEST_ID", "ee06090a-8e3c-4df2-b74e-ed50e29b84e6");
     char memory[8192U];
-    iox::posix::Allocator allocator{memory, 100U};
+    iox::BumpAllocator allocator{memory, 100U};
     constexpr uint32_t NOT_ALLIGNED_CHUNKED_SIZE{33U};
 
     iox::optional<iox::PoshError> detectedError;

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
 #include "iceoryx_hoofs/testing/test_definitions.hpp"
 #include "iceoryx_platform/fcntl.hpp"
@@ -24,6 +23,7 @@
 #include "iceoryx_platform/types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/mepoo_segment.hpp"
+#include "iox/bump_allocator.hpp"
 #include "iox/expected.hpp"
 #include "test.hpp"
 
@@ -71,7 +71,7 @@ class MePooSegment_test : public Test
             remove("/tmp/roudi_segment_test");
         }
 
-        iox::posix::Allocator& getAllocator()
+        iox::BumpAllocator& getBumpAllocator()
         {
             return *allocator;
         }
@@ -104,7 +104,7 @@ class MePooSegment_test : public Test
         void* m_baseAddressHint{nullptr};
         static constexpr int MEM_SIZE = 100000;
         char memory[MEM_SIZE];
-        std::shared_ptr<iox::posix::Allocator> allocator{new iox::posix::Allocator(memory, MEM_SIZE)};
+        std::shared_ptr<iox::BumpAllocator> allocator{new iox::BumpAllocator(memory, MEM_SIZE)};
         int filehandle;
         static createFct createVerificator;
     };
@@ -145,7 +145,7 @@ class MePooSegment_test : public Test
 
     static constexpr uint64_t RawMemorySize{20000};
     uint8_t m_rawMemory[RawMemorySize];
-    iox::posix::Allocator m_managementAllocator{iox::posix::Allocator(m_rawMemory, RawMemorySize)};
+    iox::BumpAllocator m_managementAllocator{iox::BumpAllocator(m_rawMemory, RawMemorySize)};
 
     MePooConfig mepooConfig = setupMepooConfig();
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
 #include "iceoryx_hoofs/testing/test_definitions.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
@@ -24,6 +23,7 @@
 #include "iceoryx_posh/internal/mepoo/segment_manager.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_posh/mepoo/segment_config.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 
@@ -37,7 +37,7 @@ class MePooSegmentMock
 {
   public:
     MePooSegmentMock(const MePooConfig& mempoolConfig IOX_MAYBE_UNUSED,
-                     Allocator& managementAllocator IOX_MAYBE_UNUSED,
+                     iox::BumpAllocator& managementAllocator IOX_MAYBE_UNUSED,
                      const PosixGroup& readerGroup IOX_MAYBE_UNUSED,
                      const PosixGroup& writerGroup IOX_MAYBE_UNUSED,
                      const MemoryInfo& memoryInfo IOX_MAYBE_UNUSED) noexcept
@@ -92,7 +92,7 @@ class SegmentManager_test : public Test
 
     static constexpr size_t MEM_SIZE{20000};
     char memory[MEM_SIZE];
-    iox::posix::Allocator allocator{memory, MEM_SIZE};
+    iox::BumpAllocator allocator{memory, MEM_SIZE};
     MePooConfig mepooConfig = getMempoolConfig();
     SegmentConfig segmentConfig = getSegmentConfig();
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_shared_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shared_chunk.cpp
@@ -15,10 +15,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 namespace
@@ -58,7 +58,7 @@ class SharedChunk_Test : public Test
     static constexpr uint32_t USER_PAYLOAD_SIZE{64U};
 
     char memory[4096U];
-    iox::posix::Allocator allocator{memory, 4096U};
+    iox::BumpAllocator allocator{memory, 4096U};
     MemPool mempool{sizeof(ChunkHeader) + USER_PAYLOAD_SIZE, NUMBER_OF_CHUNKS, allocator, allocator};
     MemPool chunkMgmtPool{CHUNK_SIZE, NUMBER_OF_CHUNKS, allocator, allocator};
     void* memoryChunk{mempool.getChunk()};

--- a/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shared_pointer.cpp
@@ -15,10 +15,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_pointer.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 namespace
@@ -139,7 +139,7 @@ class SharedPointer_Test : public Test
     static constexpr uint32_t USER_PAYLOAD_SIZE{64U};
 
     char memory[4096U];
-    iox::posix::Allocator allocator{memory, 4096U};
+    iox::BumpAllocator allocator{memory, 4096U};
     MemPool mempool{sizeof(ChunkHeader) + USER_PAYLOAD_SIZE, 10U, allocator, allocator};
     MemPool chunkMgmtPool{64U, 10U, allocator, allocator};
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
@@ -16,11 +16,11 @@
 
 #include "iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
+#include "iox/bump_allocator.hpp"
 
 #include "test.hpp"
 
@@ -60,7 +60,7 @@ class ShmSafeUnmanagedChunk_test : public Test
     static constexpr uint32_t NUM_CHUNKS_IN_POOL = 100;
     static constexpr uint32_t CHUNK_SIZE = 128;
 
-    iox::posix::Allocator m_memoryAllocator{m_memory.get(), MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory.get(), MEMORY_SIZE};
 };
 
 TEST_F(ShmSafeUnmanagedChunk_test, DefaultConstructedResultsInLogicalNullptr)

--- a/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
@@ -17,7 +17,7 @@
 
 #include "iceoryx_posh/internal/mepoo/typed_mem_pool.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
+#include "iox/bump_allocator.hpp"
 
 #include "test.hpp"
 
@@ -57,7 +57,7 @@ class TypedMemPool_test : public Test
     void TearDown(){};
 
     alignas(MemPool::CHUNK_MEMORY_ALIGNMENT) uint8_t m_rawMemory[NumberOfChunks * ChunkSize + LoFFLiMemoryRequirement];
-    iox::posix::Allocator allocator;
+    iox::BumpAllocator allocator;
 
     TypedMemPool<TestClass> sut;
 };

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
@@ -75,7 +75,7 @@ class ChunkDistributor_test : public Test
     static constexpr uint32_t MAX_NUMBER_QUEUES = 128U;
     static constexpr uint32_t MEMPOOL_CHUNK_COUNT{iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY * 2};
     std::unique_ptr<uint8_t[]> memory{new uint8_t[MEMORY_SIZE]};
-    iox::posix::Allocator allocator{memory.get(), MEMORY_SIZE};
+    iox::BumpAllocator allocator{memory.get(), MEMORY_SIZE};
     MemPool mempool{sizeof(ChunkHeader) + USER_PAYLOAD_SIZE, MEMPOOL_CHUNK_COUNT, allocator, allocator};
     MemPool chunkMgmtPool{128U, MEMPOOL_CHUNK_COUNT, allocator, allocator};
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/internal/mepoo/typed_mem_pool.hpp"
@@ -25,6 +24,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/condition_listener.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
+#include "iox/bump_allocator.hpp"
 
 #include "test.hpp"
 
@@ -63,7 +63,7 @@ class ChunkQueue_testBase
     static constexpr size_t MEGABYTE = 1U << 20U;
     static constexpr size_t MEMORY_SIZE = 4U * MEGABYTE;
     std::unique_ptr<char[]> memory{new char[MEMORY_SIZE]};
-    iox::posix::Allocator allocator{memory.get(), MEMORY_SIZE};
+    iox::BumpAllocator allocator{memory.get(), MEMORY_SIZE};
     MemPool mempool{
         sizeof(ChunkHeader) + USER_PAYLOAD_SIZE, 2U * iox::MAX_SUBSCRIBER_QUEUE_CAPACITY, allocator, allocator};
     MemPool chunkMgmtPool{128U, 2U * iox::MAX_SUBSCRIBER_QUEUE_CAPACITY, allocator, allocator};

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
@@ -26,6 +25,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_posh/testing/mocks/chunk_mock.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 #include <memory>
@@ -79,7 +79,7 @@ class ChunkReceiver_test : public Test
         iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY + iox::MAX_SUBSCRIBER_QUEUE_CAPACITY;
     static constexpr uint32_t CHUNK_SIZE = 128;
 
-    iox::posix::Allocator m_memoryAllocator{m_memory.get(), MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory.get(), MEMORY_SIZE};
     iox::mepoo::MePooConfig m_mempoolconf;
     iox::mepoo::MemoryManager m_memoryManager;
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/cxx/scope_guard.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
@@ -32,6 +31,7 @@
 #include "iceoryx_posh/internal/popo/ports/base_port.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_posh/testing/mocks/chunk_mock.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 #include <memory>
@@ -81,7 +81,7 @@ class ChunkSender_test : public Test
     static constexpr uint32_t USER_HEADER_SIZE = iox::CHUNK_NO_USER_HEADER_SIZE;
     static constexpr uint32_t USER_HEADER_ALIGNMENT = iox::CHUNK_NO_USER_HEADER_ALIGNMENT;
 
-    iox::posix::Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     iox::mepoo::MePooConfig m_mempoolconf;
     iox::mepoo::MemoryManager m_memoryManager;
 

--- a/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
@@ -170,7 +170,7 @@ class ClientPort_test : public Test
     static constexpr uint32_t CHUNK_SIZE = 128U;
     static constexpr size_t MEMORY_SIZE = 1024U * 1024U;
     uint8_t m_memory[MEMORY_SIZE];
-    iox::posix::Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     iox::mepoo::MemoryManager m_memoryManager;
 
     ServiceDescription m_serviceDescription{"hyp", "no", "toad"};

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/cxx/scope_guard.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp"
@@ -26,6 +25,7 @@
 #include "iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp"
 #include "iceoryx_posh/internal/popo/ports/publisher_port_user.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
+#include "iox/bump_allocator.hpp"
 #include "test.hpp"
 
 #include <memory>
@@ -73,7 +73,7 @@ class PublisherPort_test : public Test
 
     using ChunkQueueData_t = iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>;
 
-    iox::posix::Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     iox::mepoo::MePooConfig m_mempoolconf;
     iox::mepoo::MemoryManager m_memoryManager;
 

--- a/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
@@ -185,7 +185,7 @@ class ServerPort_test : public Test
     static constexpr uint32_t CHUNK_SIZE = 128U;
     static constexpr size_t MEMORY_SIZE = 1024U * 1024U;
     uint8_t m_memory[MEMORY_SIZE];
-    iox::posix::Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
+    iox::BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MemoryManager m_memoryManager;
 
     ServiceDescription m_serviceDescription{"hyp", "no", "toad"};

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
@@ -25,7 +25,6 @@
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp"
 #include "iceoryx_posh/popo/subscriber_options.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "test.hpp"

--- a/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
@@ -16,9 +16,9 @@
 
 #include "iceoryx_posh/internal/popo/used_chunk_list.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
+#include "iox/bump_allocator.hpp"
 
 #include "test.hpp"
 
@@ -38,7 +38,7 @@ class UsedChunkList_test : public Test
         MePooConfig mempoolconf;
         mempoolconf.addMemPool({CHUNK_SIZE, NUM_CHUNKS_IN_POOL});
 
-        iox::posix::Allocator memoryAllocator{m_memory.get(), MEMORY_SIZE};
+        iox::BumpAllocator memoryAllocator{m_memory.get(), MEMORY_SIZE};
         memoryManager.configureMemoryManager(mempoolconf, memoryAllocator, memoryAllocator);
     };
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR implements the `BumpAllocator`. Therefor the `Allocator` form the shared memory object directory is moved to `memory`, `deallocate` is implemented and the option to finalize the allocation is moved to the shared memory object. Additionally, the `static_storage` is moved to `iceoryx_dust` and a simple byte array is used in the `storable_function` instead.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1732 
