### PR TITLE
iox-#1394 Fix axivion warnings in duration class

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -334,8 +334,7 @@ class Duration
 
   private:
     template <typename T>
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
-    static constexpr unsigned long long int positiveValueOrClampToZero(const T value) noexcept;
+    static constexpr uint64_t positiveValueOrClampToZero(const T value) noexcept;
 
     template <typename T>
     constexpr Duration fromFloatingPointSeconds(const T floatingPointSeconds) const noexcept;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -373,6 +373,48 @@ constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
+/// @brief Equal to operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept;
+
+/// @brief Not equal to operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration not equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept;
+
+/// @brief Less than operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is less than rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept;
+
+/// @brief Greater than operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is greater than rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept;
+
+/// @brief Less than or equal to operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is less than or equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept;
+
+/// @brief Greater than or equal to operator
+/// @param[in] lhs is the left hand side of the comparison
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is greater than or equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept;
+
 } // namespace units
 } // namespace iox
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -188,18 +188,14 @@ class Duration
     // END CONSTRUCTORS AND ASSIGNMENT
 
     // BEGIN COMPARISON
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    // AXIVION DISABLE STYLE AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     friend constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION ENABLE STYLE AutosarC++19_03-A8.4.7
     // END COMPARISON
 
     // BEGIN ARITHMETIC
@@ -308,7 +304,7 @@ class Duration
     // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int value) noexcept;
 
-    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+    // AXIVION Next Construct AutosarC++19_03-A8.4.7 : Argument is larger than two words
     template <typename T>
     friend constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
@@ -369,65 +365,9 @@ class Duration
 /// @param[in] rhs is the multiplicant
 /// @return a new Duration object
 /// @attention Since negative durations are not allowed, the duration will be clamped to 0
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+// AXIVION Next Construct AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 template <typename T>
 constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
-
-/// @brief Equal to operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration equal to rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return (lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds == rhs.m_nanoseconds);
-}
-
-/// @brief Not equal to operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration not equal to rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-/// @brief Less than operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is less than rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return (lhs.m_seconds < rhs.m_seconds)
-           || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds < rhs.m_nanoseconds));
-}
-
-/// @brief Greater than operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is greater than rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return (lhs.m_seconds > rhs.m_seconds)
-           || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds > rhs.m_nanoseconds));
-}
-
-/// @brief Less than or equal to operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is less than or equal to rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return !(lhs > rhs);
-}
-
-/// @brief Greater than or equal to operator
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is greater than or equal to rhs
-// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
-constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept
-{
-    return !(lhs < rhs);
-}
 
 /// @brief stream operator for the Duration class
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -289,20 +289,15 @@ class Duration
 
     // END CONVERSION
 
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
+    // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _us(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _s(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _m(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _h(unsigned long long int value) noexcept;
-    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int value) noexcept;
+    // AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
 
     // AXIVION Next Construct AutosarC++19_03-A8.4.7 : Argument is larger than two words
     template <typename T>

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -43,24 +43,31 @@ class Duration;
 namespace duration_literals
 {
 /// @brief Constructs a new Duration object from nanoseconds
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _ns(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from microseconds
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _us(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from milliseconds
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _ms(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from seconds
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _s(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from minutes
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _m(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from hours
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _h(unsigned long long int value) noexcept;
 
 /// @brief Constructs a new Duration object from days
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 constexpr Duration operator"" _d(unsigned long long int value) noexcept;
 } // namespace duration_literals
 
@@ -148,67 +155,51 @@ class Duration
 
     /// @brief Construct a Duration object from timeval
     /// @param[in] value as timeval
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     constexpr explicit Duration(const struct timeval& value) noexcept;
 
     /// @brief Construct a Duration object from timespec
     /// @param[in] value as timespec
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     constexpr explicit Duration(const struct timespec& value) noexcept;
 
     /// @brief Construct a Duration object from itimerspec
     /// @param[in] value as itimerspec
     /// @note only it_interval from the itimerspec is used
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     constexpr explicit Duration(const struct itimerspec& value) noexcept;
 
     /// @brief Construct a Duration object from std::chrono::milliseconds
     /// @param[in] value as milliseconds
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
-    constexpr explicit Duration(const std::chrono::milliseconds& value) noexcept;
+    constexpr explicit Duration(const std::chrono::milliseconds value) noexcept;
 
     /// @brief Construct a Duration object from std::chrono::nanoseconds
     /// @param[in] value as nanoseconds
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
-    constexpr explicit Duration(const std::chrono::nanoseconds& value) noexcept;
+    constexpr explicit Duration(const std::chrono::nanoseconds value) noexcept;
 
     /// @brief Assigns a std::chrono::milliseconds to an duration object
     /// @param[in] rhs is the right hand side of the assignment
     /// @return a reference to the Duration object with the assigned millisecond value
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
-    Duration& operator=(const std::chrono::milliseconds& rhs) noexcept;
+    Duration& operator=(const std::chrono::milliseconds rhs) noexcept;
 
     // END CONSTRUCTORS AND ASSIGNMENT
 
     // BEGIN COMPARISON
-
-    /// @brief Equal to operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration equal to rhs
-    constexpr bool operator==(const Duration& rhs) const noexcept;
-
-    /// @brief Not equal to operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration not equal to rhs
-    constexpr bool operator!=(const Duration& rhs) const noexcept;
-
-    /// @brief Less than operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration is less than rhs
-    constexpr bool operator<(const Duration& rhs) const noexcept;
-
-    /// @brief Less than or equal to operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration is less than or equal to rhs
-    constexpr bool operator<=(const Duration& rhs) const noexcept;
-
-    /// @brief Greater than operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration is greater than rhs
-    constexpr bool operator>(const Duration& rhs) const noexcept;
-
-    /// @brief Greater than or equal to operator
-    /// @param[in] rhs is the right hand side of the comparison
-    /// @return true if duration is greater than or equal to rhs
-    constexpr bool operator>=(const Duration& rhs) const noexcept;
-
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+    friend constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept;
     // END COMPARISON
 
     // BEGIN ARITHMETIC
@@ -217,6 +208,7 @@ class Duration
     ///        saturates to Duration::max().
     /// @param[in] rhs is the second summand
     /// @return a new Duration object
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     constexpr Duration operator+(const Duration& rhs) const noexcept;
 
     /// @brief Creates Duration object by subtraction. On underflow duration
@@ -224,6 +216,7 @@ class Duration
     /// @param[in] rhs is the subtrahend
     /// @return a new Duration object
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     constexpr Duration operator-(const Duration& rhs) const noexcept;
 
     /// @brief Creates Duration object by multiplication.
@@ -276,7 +269,7 @@ class Duration
     constexpr uint64_t toDays() const noexcept;
 
     /// @brief converts duration in a timespec c struct
-    struct timespec timespec(const TimeSpecReference& reference = TimeSpecReference::None) const noexcept;
+    struct timespec timespec(const TimeSpecReference reference = TimeSpecReference::None) const noexcept;
 
     /// @brief converts duration in a timeval c struct
     ///     timeval::tv_sec = seconds since the Epoch (01.01.1970)
@@ -285,17 +278,26 @@ class Duration
 
     // END CONVERSION
 
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _ns(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _us(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _ms(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _s(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _m(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _h(unsigned long long int value) noexcept;
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     friend constexpr Duration duration_literals::operator"" _d(unsigned long long int value) noexcept;
 
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     template <typename T>
     friend constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     friend std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
     friend iox::log::LogStream& operator<<(iox::log::LogStream& stream, const Duration t) noexcept;
 
@@ -326,6 +328,7 @@ class Duration
 
   private:
     template <typename T>
+    // AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
     static constexpr unsigned long long int positiveValueOrClampToZero(const T value) noexcept;
 
     template <typename T>
@@ -351,10 +354,68 @@ class Duration
 /// @param[in] rhs is the multiplicant
 /// @return a new Duration object
 /// @attention Since negative durations are not allowed, the duration will be clamped to 0
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 template <typename T>
 constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept;
 
+/// @brief Equal to operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return (lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds == rhs.m_nanoseconds);
+}
+
+/// @brief Not equal to operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration not equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+
+/// @brief Less than operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is less than rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return (lhs.m_seconds < rhs.m_seconds)
+           || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds < rhs.m_nanoseconds));
+}
+
+/// @brief Greater than operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is greater than rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return (lhs.m_seconds > rhs.m_seconds)
+           || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds > rhs.m_nanoseconds));
+}
+
+/// @brief Less than or equal to operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is less than or equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return !(lhs > rhs);
+}
+
+/// @brief Greater than or equal to operator
+/// @param[in] rhs is the right hand side of the comparison
+/// @return true if duration is greater than or equal to rhs
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
+constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept
+{
+    return !(lhs < rhs);
+}
+
 /// @brief stream operator for the Duration class
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 std::ostream& operator<<(std::ostream& stream, const Duration& t) noexcept;
 
 } // namespace units

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.hpp
@@ -211,6 +211,13 @@ class Duration
     // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
     constexpr Duration operator+(const Duration& rhs) const noexcept;
 
+    /// @brief Creates Duration object by addition. On overflow duration
+    ///        saturates to Duration::max().
+    /// @param[in] rhs is the second summand
+    /// @return a new Duration object
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+    constexpr Duration& operator+=(const Duration& rhs) noexcept;
+
     /// @brief Creates Duration object by subtraction. On underflow duration
     ///        saturates to Duration::zero().
     /// @param[in] rhs is the subtrahend
@@ -218,6 +225,14 @@ class Duration
     /// @attention Since negative durations are not allowed, the duration will be clamped to 0
     // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
     constexpr Duration operator-(const Duration& rhs) const noexcept;
+
+    /// @brief Creates Duration object by subtraction. On underflow duration
+    ///        saturates to Duration::zero().
+    /// @param[in] rhs is the subtrahend
+    /// @return a new Duration object
+    /// @attention Since negative durations are not allowed, the duration will be clamped to 0
+    // AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+    constexpr Duration& operator-=(const Duration& rhs) noexcept;
 
     /// @brief Creates Duration object by multiplication.
     /// @tparam T is an arithmetic type for the multiplicator

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -61,10 +61,8 @@ inline constexpr Duration Duration::zero() noexcept
     return Duration{0U, 0U};
 }
 
-// AXIVION Next Construct AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined
-// literals is enforced by the standard
 template <typename T>
-inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value) noexcept
+inline constexpr uint64_t Duration::positiveValueOrClampToZero(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
@@ -75,7 +73,7 @@ inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(con
         return 0U;
     }
 
-    return static_cast<unsigned long long int>(value);
+    return static_cast<uint64_t>(value);
 }
 
 template <typename T>
@@ -110,9 +108,7 @@ inline constexpr Duration Duration::fromSeconds(const T value) noexcept
     const auto clampedValue = positiveValueOrClampToZero(value);
     constexpr Duration::Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Duration::Seconds_t>::max()};
 
-    // AXIVION Next Construct AutosarC++19_03-M0.1.2, AutosarC++19_03-M0.1.9,
-    // FaultDetection-DeadBranches : False positive, whether this is a dead branch is platforms
-    // dependent.
+    // AXIVION Next Construct AutosarC++19_03-M0.1.2, AutosarC++19_03-M0.1.9: False positive, platform-dependent
     if (clampedValue > MAX_SECONDS_BEFORE_OVERFLOW)
     {
         return Duration::max();

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -60,8 +60,8 @@ inline constexpr Duration Duration::zero() noexcept
     return Duration{0U, 0U};
 }
 
-template <typename T>
-inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value) noexcept
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
+template <typename T> inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
@@ -160,17 +160,17 @@ inline constexpr Duration::Duration(const struct itimerspec& value) noexcept
 {
 }
 
-inline constexpr Duration::Duration(const std::chrono::milliseconds& value) noexcept
+inline constexpr Duration::Duration(const std::chrono::milliseconds value) noexcept
     : Duration(Duration::fromMilliseconds(value.count()))
 {
 }
 
-inline constexpr Duration::Duration(const std::chrono::nanoseconds& value) noexcept
+inline constexpr Duration::Duration(const std::chrono::nanoseconds value) noexcept
     : Duration(Duration::fromNanoseconds(value.count()))
 {
 }
 
-inline Duration& Duration::operator=(const std::chrono::milliseconds& rhs) noexcept
+inline Duration& Duration::operator=(const std::chrono::milliseconds rhs) noexcept
 {
     *this = Duration(rhs);
     return *this;
@@ -253,36 +253,6 @@ inline constexpr struct timeval Duration::timeval() const noexcept
         return {std::numeric_limits<SEC_TYPE>::max(), MICROSECS_PER_SEC - 1U};
     }
     return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / NANOSECS_PER_MICROSEC)};
-}
-
-inline constexpr bool Duration::operator==(const Duration& rhs) const noexcept
-{
-    return (m_seconds == rhs.m_seconds) && (m_nanoseconds == rhs.m_nanoseconds);
-}
-
-inline constexpr bool Duration::operator!=(const Duration& rhs) const noexcept
-{
-    return !(*this == rhs);
-}
-
-inline constexpr bool Duration::operator<(const Duration& rhs) const noexcept
-{
-    return (m_seconds < rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds < rhs.m_nanoseconds));
-}
-
-inline constexpr bool Duration::operator<=(const Duration& rhs) const noexcept
-{
-    return !(*this > rhs);
-}
-
-inline constexpr bool Duration::operator>(const Duration& rhs) const noexcept
-{
-    return (m_seconds > rhs.m_seconds) || ((m_seconds == rhs.m_seconds) && (m_nanoseconds > rhs.m_nanoseconds));
-}
-
-inline constexpr bool Duration::operator>=(const Duration& rhs) const noexcept
-{
-    return !(*this < rhs);
 }
 
 inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcept
@@ -478,36 +448,43 @@ inline constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept
 
 namespace duration_literals
 {
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _ns(unsigned long long int value) noexcept
 {
     return Duration::fromNanoseconds(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _us(unsigned long long int value) noexcept
 {
     return Duration::fromMicroseconds(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _ms(unsigned long long int value) noexcept
 {
     return Duration::fromMilliseconds(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _s(unsigned long long int value) noexcept
 {
     return Duration::fromSeconds(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _m(unsigned long long int value) noexcept
 {
     return Duration::fromMinutes(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _h(unsigned long long int value) noexcept
 {
     return Duration::fromHours(value);
 }
 
+// AXIVION Next Line AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
 inline constexpr Duration operator"" _d(unsigned long long int value) noexcept
 {
     return Duration::fromDays(value);

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -482,30 +482,18 @@ inline constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept
 }
 
 
-/// @brief Equal to operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration equal to rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator==(const Duration& lhs, const Duration& rhs) noexcept
 {
     return (lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds == rhs.m_nanoseconds);
 }
 
-/// @brief Not equal to operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration not equal to rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator!=(const Duration& lhs, const Duration& rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
-/// @brief Less than operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is less than rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept
 {
@@ -513,10 +501,6 @@ constexpr bool operator<(const Duration& lhs, const Duration& rhs) noexcept
            || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds < rhs.m_nanoseconds));
 }
 
-/// @brief Greater than operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is greater than rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept
 {
@@ -524,20 +508,12 @@ constexpr bool operator>(const Duration& lhs, const Duration& rhs) noexcept
            || ((lhs.m_seconds == rhs.m_seconds) && (lhs.m_nanoseconds > rhs.m_nanoseconds));
 }
 
-/// @brief Less than or equal to operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is less than or equal to rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator<=(const Duration& lhs, const Duration& rhs) noexcept
 {
     return !(lhs > rhs);
 }
 
-/// @brief Greater than or equal to operator
-/// @param[in] lhs is the left hand side of the comparison
-/// @param[in] rhs is the right hand side of the comparison
-/// @return true if duration is greater than or equal to rhs
 // AXIVION Next Line AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 constexpr bool operator>=(const Duration& lhs, const Duration& rhs) noexcept
 {

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/units/duration.inl
@@ -31,8 +31,9 @@ inline constexpr Duration::Duration(const Seconds_t seconds, const Nanoseconds_t
 {
     if (nanoseconds >= NANOSECS_PER_SEC)
     {
-        auto additionalSeconds = nanoseconds / NANOSECS_PER_SEC;
-        if (std::numeric_limits<Seconds_t>::max() - additionalSeconds < m_seconds)
+        const Seconds_t additionalSeconds{static_cast<Seconds_t>(nanoseconds)
+                                          / static_cast<Seconds_t>(NANOSECS_PER_SEC)};
+        if ((std::numeric_limits<Seconds_t>::max() - additionalSeconds) < m_seconds)
         {
             m_seconds = std::numeric_limits<Seconds_t>::max();
             m_nanoseconds = NANOSECS_PER_SEC - 1U;
@@ -61,10 +62,12 @@ inline constexpr Duration Duration::zero() noexcept
 }
 
 // AXIVION Next Construct AutosarC++19_03-A3.9.1 : Use of unsigned long long int in user-defined literals is enforced by the standard
-template <typename T> inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value) noexcept
+template <typename T>
+inline constexpr unsigned long long int Duration::positiveValueOrClampToZero(const T value) noexcept
 {
     static_assert(std::numeric_limits<T>::is_integer, "only integer types are supported");
 
+    // AXIVION Next Construct AutosarC++19_03-A1.4.3 : Value is an arbitrary integer type, not necessarily unsigned
     if (value < 0)
     {
         return 0U;
@@ -84,26 +87,29 @@ inline constexpr Duration Duration::fromNanoseconds(const T value) noexcept
 template <typename T>
 inline constexpr Duration Duration::fromMicroseconds(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
-    auto seconds = static_cast<Duration::Seconds_t>(clampedValue / Duration::MICROSECS_PER_SEC);
-    auto nanoseconds = static_cast<Duration::Nanoseconds_t>((clampedValue % Duration::MICROSECS_PER_SEC)
-                                                            * Duration::NANOSECS_PER_MICROSEC);
+    const auto clampedValue = positiveValueOrClampToZero(value);
+    const auto seconds = static_cast<Duration::Seconds_t>(clampedValue / Duration::MICROSECS_PER_SEC);
+    const auto nanoseconds = static_cast<Duration::Nanoseconds_t>((clampedValue % Duration::MICROSECS_PER_SEC)
+                                                                  * Duration::NANOSECS_PER_MICROSEC);
     return Duration{seconds, nanoseconds};
 }
 template <typename T>
 inline constexpr Duration Duration::fromMilliseconds(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
-    auto seconds = static_cast<Duration::Seconds_t>(clampedValue / Duration::MILLISECS_PER_SEC);
-    auto nanoseconds = static_cast<Duration::Nanoseconds_t>((clampedValue % Duration::MILLISECS_PER_SEC)
-                                                            * Duration::NANOSECS_PER_MILLISEC);
+    const auto clampedValue = positiveValueOrClampToZero(value);
+    const auto seconds = static_cast<Duration::Seconds_t>(clampedValue / Duration::MILLISECS_PER_SEC);
+    const auto nanoseconds = static_cast<Duration::Nanoseconds_t>((clampedValue % Duration::MILLISECS_PER_SEC)
+                                                                  * Duration::NANOSECS_PER_MILLISEC);
     return Duration{seconds, nanoseconds};
 }
 template <typename T>
 inline constexpr Duration Duration::fromSeconds(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
+    const auto clampedValue = positiveValueOrClampToZero(value);
     constexpr Duration::Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<Duration::Seconds_t>::max()};
+
+    // AXIVION Next Construct AutosarC++19_03-A0.1.1 : Not dead code as it is platform dependent
+    // AXIVION Next Construct AutosarC++19_03-M0.1.2, AutosarC++19_03-M0.1.9, FaultDetection-DeadBranches : False positive. Platform dependent.
     if (clampedValue > MAX_SECONDS_BEFORE_OVERFLOW)
     {
         return Duration::max();
@@ -113,7 +119,7 @@ inline constexpr Duration Duration::fromSeconds(const T value) noexcept
 template <typename T>
 inline constexpr Duration Duration::fromMinutes(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
+    const auto clampedValue = positiveValueOrClampToZero(value);
     constexpr uint64_t MAX_MINUTES_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / Duration::SECS_PER_MINUTE};
     if (clampedValue > MAX_MINUTES_BEFORE_OVERFLOW)
     {
@@ -124,7 +130,7 @@ inline constexpr Duration Duration::fromMinutes(const T value) noexcept
 template <typename T>
 inline constexpr Duration Duration::fromHours(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
+    const auto clampedValue = positiveValueOrClampToZero(value);
     constexpr uint64_t MAX_HOURS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / Duration::SECS_PER_HOUR};
     if (clampedValue > MAX_HOURS_BEFORE_OVERFLOW)
     {
@@ -135,7 +141,7 @@ inline constexpr Duration Duration::fromHours(const T value) noexcept
 template <typename T>
 inline constexpr Duration Duration::fromDays(const T value) noexcept
 {
-    auto clampedValue = positiveValueOrClampToZero(value);
+    const auto clampedValue = positiveValueOrClampToZero(value);
     constexpr uint64_t SECS_PER_DAY{static_cast<uint64_t>(Duration::HOURS_PER_DAY * Duration::SECS_PER_HOUR)};
     constexpr uint64_t MAX_DAYS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / SECS_PER_DAY};
     if (clampedValue > MAX_DAYS_BEFORE_OVERFLOW)
@@ -145,16 +151,19 @@ inline constexpr Duration Duration::fromDays(const T value) noexcept
     return Duration{static_cast<Duration::Seconds_t>(clampedValue * SECS_PER_DAY), 0U};
 }
 
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 inline constexpr Duration::Duration(const struct timeval& value) noexcept
     : Duration(static_cast<Seconds_t>(value.tv_sec), static_cast<Nanoseconds_t>(value.tv_usec) * NANOSECS_PER_MICROSEC)
 {
 }
 
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 inline constexpr Duration::Duration(const struct timespec& value) noexcept
     : Duration(static_cast<Seconds_t>(value.tv_sec), static_cast<Nanoseconds_t>(value.tv_nsec))
 {
 }
 
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 inline constexpr Duration::Duration(const struct itimerspec& value) noexcept
     : Duration(value.it_interval)
 {
@@ -178,49 +187,53 @@ inline Duration& Duration::operator=(const std::chrono::milliseconds rhs) noexce
 
 inline constexpr uint64_t Duration::toNanoseconds() const noexcept
 {
-    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / NANOSECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() % NANOSECS_PER_SEC};
-    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
-        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
+    constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max()
+                                                    / static_cast<uint64_t>(NANOSECS_PER_SEC)};
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{
+        static_cast<Nanoseconds_t>(std::numeric_limits<uint64_t>::max() % static_cast<uint64_t>(NANOSECS_PER_SEC))};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{
+        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW)};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
-    return m_seconds * NANOSECS_PER_SEC + m_nanoseconds;
+    return (m_seconds * NANOSECS_PER_SEC) + m_nanoseconds;
 }
 
 inline constexpr uint64_t Duration::toMicroseconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MICROSECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC)
-                                                            * NANOSECS_PER_MICROSEC};
-    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
-        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{
+        static_cast<Nanoseconds_t>(std::numeric_limits<uint64_t>::max() % MICROSECS_PER_SEC) * NANOSECS_PER_MICROSEC};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{
+        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW)};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
-    return m_seconds * MICROSECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MICROSEC;
+    return (m_seconds * MICROSECS_PER_SEC)
+           + (static_cast<Seconds_t>(m_nanoseconds) / static_cast<Seconds_t>(NANOSECS_PER_MICROSEC));
 }
 
 inline constexpr uint64_t Duration::toMilliseconds() const noexcept
 {
     constexpr Seconds_t MAX_SECONDS_BEFORE_OVERFLOW{std::numeric_limits<uint64_t>::max() / MILLISECS_PER_SEC};
-    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC)
-                                                            * NANOSECS_PER_MILLISEC};
-    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW =
-        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW);
+    constexpr Nanoseconds_t MAX_NANOSECONDS_BEFORE_OVERFLOW{
+        static_cast<Nanoseconds_t>(std::numeric_limits<uint64_t>::max() % MILLISECS_PER_SEC) * NANOSECS_PER_MILLISEC};
+    constexpr Duration MAX_DURATION_BEFORE_OVERFLOW{
+        createDuration(MAX_SECONDS_BEFORE_OVERFLOW, MAX_NANOSECONDS_BEFORE_OVERFLOW)};
 
     if (*this > MAX_DURATION_BEFORE_OVERFLOW)
     {
         return std::numeric_limits<uint64_t>::max();
     }
 
-    return m_seconds * MILLISECS_PER_SEC + m_nanoseconds / NANOSECS_PER_MILLISEC;
+    return (m_seconds * MILLISECS_PER_SEC)
+           + (static_cast<Seconds_t>(m_nanoseconds) / static_cast<Seconds_t>(NANOSECS_PER_MILLISEC));
 }
 
 inline constexpr uint64_t Duration::toSeconds() const noexcept
@@ -240,7 +253,7 @@ inline constexpr uint64_t Duration::toHours() const noexcept
 
 inline constexpr uint64_t Duration::toDays() const noexcept
 {
-    return m_seconds / (static_cast<uint64_t>(HOURS_PER_DAY * SECS_PER_HOUR));
+    return m_seconds / static_cast<uint64_t>(HOURS_PER_DAY * SECS_PER_HOUR);
 }
 
 inline constexpr struct timeval Duration::timeval() const noexcept
@@ -252,20 +265,24 @@ inline constexpr struct timeval Duration::timeval() const noexcept
     {
         return {std::numeric_limits<SEC_TYPE>::max(), MICROSECS_PER_SEC - 1U};
     }
+    // AXIVION Next Construct AutosarC++19_03-A5.0.9 : Protected by static assertion
+    // AXIVION Next Construct AutosarC++19_03-M5.0.8 : Protected by static assertion
+    // AXIVION Next Construct AutosarC++19_03-M5.0.9 : Protected by static assertion
     return {static_cast<SEC_TYPE>(m_seconds), static_cast<USEC_TYPE>(m_nanoseconds / NANOSECS_PER_MICROSEC)};
 }
 
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcept
 {
-    auto seconds = m_seconds + rhs.m_seconds;
-    auto nanoseconds = m_nanoseconds + rhs.m_nanoseconds;
+    Seconds_t seconds{m_seconds + rhs.m_seconds};
+    Nanoseconds_t nanoseconds{m_nanoseconds + rhs.m_nanoseconds};
     if (nanoseconds >= NANOSECS_PER_SEC)
     {
         ++seconds;
         nanoseconds -= NANOSECS_PER_SEC;
     }
 
-    auto sum = Duration{seconds, nanoseconds};
+    const Duration sum{seconds, nanoseconds};
     if (sum < *this)
     {
         return Duration::max();
@@ -273,13 +290,23 @@ inline constexpr Duration Duration::operator+(const Duration& rhs) const noexcep
     return sum;
 }
 
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+inline constexpr Duration& Duration::operator+=(const Duration& rhs) noexcept
+{
+    *this = *this + rhs;
+    return *this;
+}
+
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
 inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcept
 {
     if (*this < rhs)
     {
         return Duration::zero();
     }
-    auto seconds = m_seconds - rhs.m_seconds;
+    Seconds_t seconds{m_seconds - rhs.m_seconds};
+    // AXIVION Next Construct AutosarC++19_03-M0.1.9 : Variable IS used
+    // AXIVION Next Construct AutosarC++19_03-A0.1.1 : Variable IS used
     Nanoseconds_t nanoseconds{0U};
     if (m_nanoseconds >= rhs.m_nanoseconds)
     {
@@ -287,10 +314,17 @@ inline constexpr Duration Duration::operator-(const Duration& rhs) const noexcep
     }
     else
     {
-        nanoseconds = NANOSECS_PER_SEC - rhs.m_nanoseconds + m_nanoseconds;
+        nanoseconds = (NANOSECS_PER_SEC - rhs.m_nanoseconds) + m_nanoseconds;
         --seconds;
     }
     return Duration{seconds, nanoseconds};
+}
+
+// AXIVION Next Line AutosarC++19_03-A8.4.7 : Argument is larger than two words
+inline constexpr Duration& Duration::operator-=(const Duration& rhs) noexcept
+{
+    *this = *this - rhs;
+    return *this;
 }
 
 template <typename T>
@@ -303,7 +337,7 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
                   "only integer types with less or equal to size of uint64_t are allowed for multiplication");
     const auto multiplicator = static_cast<Seconds_t>(rhs);
 
-    const auto maxBeforeOverflow = std::numeric_limits<Seconds_t>::max() / multiplicator;
+    const Seconds_t maxBeforeOverflow{std::numeric_limits<Seconds_t>::max() / multiplicator};
 
     // check if the result of the m_seconds multiplication would already overflow
     if (m_seconds > maxBeforeOverflow)
@@ -327,8 +361,8 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
     // multiplicator and another one with the upper 32 bits;
 
     // this is the easy part with the lower 32 bits
-    uint64_t multiplicatorLow = static_cast<uint32_t>(multiplicator);
-    auto durationFromNanosecondsLow = Duration::fromNanoseconds(m_nanoseconds * multiplicatorLow);
+    uint64_t multiplicatorLow{static_cast<uint32_t>(multiplicator)};
+    Duration durationFromNanosecondsLow{Duration::fromNanoseconds(m_nanoseconds * multiplicatorLow)};
 
     // this is the complicated part with the upper 32 bits;
     // the m_nanoseconds are multiplied with the upper 32 bits of the multiplicator shifted by 32 bit to the right, thus
@@ -345,16 +379,16 @@ Duration::multiplyWith(const std::enable_if_t<!std::is_floating_point<T>::value,
     // for the following calculation it is not important to be the least common multiple, any common multiple will do
     constexpr uint64_t LEAST_COMMON_MULTIPLE{8388608000000000};
     constexpr uint64_t NUMBER_OF_BITS_IN_UINT32{32};
-    static_assert(LEAST_COMMON_MULTIPLE % (1ULL << NUMBER_OF_BITS_IN_UINT32) == 0, "invalid multiple");
-    static_assert(LEAST_COMMON_MULTIPLE % NANOSECS_PER_SEC == 0, "invalid multiple");
+    static_assert((LEAST_COMMON_MULTIPLE % (1ULL << NUMBER_OF_BITS_IN_UINT32)) == 0, "invalid multiple");
+    static_assert((LEAST_COMMON_MULTIPLE % NANOSECS_PER_SEC) == 0, "invalid multiple");
 
     constexpr uint64_t ONE_FULL_BLOCK_OF_SECONDS_ONLY{LEAST_COMMON_MULTIPLE >> NUMBER_OF_BITS_IN_UINT32};
     constexpr uint64_t SECONDS_PER_FULL_BLOCK{LEAST_COMMON_MULTIPLE / NANOSECS_PER_SEC};
 
-    uint64_t multiplicatorHigh = static_cast<uint32_t>(multiplicator >> NUMBER_OF_BITS_IN_UINT32);
-    auto nanosecondsFromHigh = m_nanoseconds * multiplicatorHigh;
-    auto fullBlocksOfSecondsOnly = nanosecondsFromHigh / ONE_FULL_BLOCK_OF_SECONDS_ONLY;
-    auto remainingBlockWithFullAndFractionalSeconds = nanosecondsFromHigh % ONE_FULL_BLOCK_OF_SECONDS_ONLY;
+    uint64_t multiplicatorHigh{static_cast<uint32_t>(multiplicator >> NUMBER_OF_BITS_IN_UINT32)};
+    uint64_t nanosecondsFromHigh{m_nanoseconds * multiplicatorHigh};
+    uint64_t fullBlocksOfSecondsOnly{nanosecondsFromHigh / ONE_FULL_BLOCK_OF_SECONDS_ONLY};
+    uint64_t remainingBlockWithFullAndFractionalSeconds{nanosecondsFromHigh % ONE_FULL_BLOCK_OF_SECONDS_ONLY};
 
     auto durationFromNanosecondsHigh =
         Duration{fullBlocksOfSecondsOnly * SECONDS_PER_FULL_BLOCK, 0U}
@@ -373,7 +407,7 @@ inline constexpr bool Duration::wouldCastFromFloatingPointProbablyOverflow(const
     // or the first one which causes an overflow;
     // to be safe, this is handled like causing an overflow which would result in undefined behavior when casting to
     // Seconds_t
-    constexpr From SECONDS_BEFORE_LIKELY_OVERFLOW = static_cast<From>(std::numeric_limits<To>::max());
+    constexpr From SECONDS_BEFORE_LIKELY_OVERFLOW{static_cast<From>(std::numeric_limits<To>::max())};
     return floatingPoint >= SECONDS_BEFORE_LIKELY_OVERFLOW;
 }
 
@@ -388,7 +422,7 @@ inline constexpr Duration Duration::fromFloatingPointSeconds(const T floatingPoi
     }
 
     T secondsFull{0};
-    T secondsFraction = std::modf(floatingPointSeconds, &secondsFull);
+    T secondsFraction{std::modf(floatingPointSeconds, &secondsFull)};
 
     if (wouldCastFromFloatingPointProbablyOverflow<T, Seconds_t>(secondsFull))
     {
@@ -421,7 +455,8 @@ Duration::multiplyWith(const std::enable_if_t<std::is_floating_point<T>::value, 
 
     // the multiplication result of nanoseconds would exceed the value an uint64_t can represent
     // -> convert result to seconds and and calculate duration
-    auto durationFromNanoseconds = fromFloatingPointSeconds<T>(resultNanoseconds /= NANOSECS_PER_SEC);
+    auto floatingPointSeconds = resultNanoseconds / NANOSECS_PER_SEC;
+    auto durationFromNanoseconds = fromFloatingPointSeconds<T>(floatingPointSeconds);
 
     return durationFromSeconds + durationFromNanoseconds;
 }
@@ -431,7 +466,7 @@ inline constexpr Duration Duration::operator*(const T& rhs) const noexcept
 {
     static_assert(std::is_arithmetic<T>::value, "non arithmetic types are not supported for multiplication");
 
-    if (rhs <= static_cast<T>(0) || *this == Duration::zero())
+    if ((rhs <= static_cast<T>(0)) || (*this == Duration::zero()))
     {
         return Duration::zero();
     }
@@ -439,7 +474,7 @@ inline constexpr Duration Duration::operator*(const T& rhs) const noexcept
     return multiplyWith<T>(rhs);
 }
 
-
+// AXIVION Next Construct AutosarC++19_03-A8.4.7 : Each argument is larger than two words
 template <typename T>
 inline constexpr Duration operator*(const T& lhs, const Duration& rhs) noexcept
 {

--- a/iceoryx_hoofs/source/units/duration.cpp
+++ b/iceoryx_hoofs/source/units/duration.cpp
@@ -25,7 +25,7 @@ namespace iox
 {
 namespace units
 {
-struct timespec Duration::timespec(const TimeSpecReference& reference) const noexcept
+struct timespec Duration::timespec(const TimeSpecReference reference) const noexcept
 {
     using SEC_TYPE = decltype(std::declval<struct timespec>().tv_sec);
     using NSEC_TYPE = decltype(std::declval<struct timespec>().tv_nsec);

--- a/iceoryx_hoofs/source/units/duration.cpp
+++ b/iceoryx_hoofs/source/units/duration.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019, 2021 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 -2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -1659,7 +1659,7 @@ TEST(Duration_test, AddAssignSecondsToDurationResultsInSecondsAdditionToLHS)
 
     sut += otherDuration;
 
-    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+    EXPECT_EQ(sut, EXPECTED_DURATION);
 }
 
 TEST(Duration_test, AddAssignNanosecondsToDurationResultsInNanosecondsAdditionToLHS)
@@ -1888,7 +1888,7 @@ TEST(Duration_test, SubtractAssignDurationPastZeroNanosecondsResultsInDecremente
     EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
 
-TEST(Duration_test, SubtractAssignDurationPastZeroResultsInZero)
+TEST(Duration_test, SubtractAssignLargerDurationResultsInZero)
 {
     ::testing::Test::RecordProperty("TEST_ID", "eb2bace9-751c-48bd-82eb-2e5679512503");
 

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 - 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unit_duration.cpp
@@ -1649,6 +1649,68 @@ TEST(Duration_test, AddDurationResultsInSaturationFromSeconds)
     EXPECT_THAT(sut2, Eq(DurationAccessor::max()));
 }
 
+TEST(Duration_test, AddAssignSecondsToDurationResultsInSecondsAdditionToLHS)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c223f8b3-d396-4c45-8c2d-b6b7d7b7f57a");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(3U, 0U);
+    auto sut = createDuration(2U, 0U);
+    auto otherDuration = createDuration(1U, 0U);
+
+    sut += otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, AddAssignNanosecondsToDurationResultsInNanosecondsAdditionToLHS)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a0cd4bcf-59f5-4d84-88e6-0d11d34142a1");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(0U, 100U);
+    auto sut = createDuration(0U, 50U);
+    auto otherDuration = createDuration(0U, 50U);
+
+    sut += otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, AddAssignDurationPastNanosecondBoundaryResultsInSecondIncrementToLHS)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "97ec3b19-31c9-41bb-8a1f-442cfdf5ed66");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(1U, 5U);
+    auto sut = createDuration(0U, NANOSECS_PER_SECOND - 5);
+    auto otherDuration = createDuration(0U, 10U);
+
+    sut += otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+
+TEST(Duration_test, AddAssignDurationResultsInSaturationFromSeconds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "940e6a59-9b1c-4928-8fe1-af290beebb5d");
+    auto sut = createDuration(std::numeric_limits<DurationAccessor::Seconds_t>::max() - 1U, NANOSECS_PER_SECOND - 1U);
+    auto otherDuration = createDuration(2U, 0U);
+
+    sut += otherDuration;
+
+    EXPECT_THAT(sut, Eq(DurationAccessor::max()));
+}
+
+TEST(Duration_test, AddAssignDurationResultsInSaturationFromNanoseconds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c8d972a8-cbb1-41e8-bf72-8d05963f95f7");
+    auto sut = createDuration(std::numeric_limits<DurationAccessor::Seconds_t>::max(), NANOSECS_PER_SECOND - 2U);
+    auto otherDuration = createDuration(0U, 2U);
+
+    sut += otherDuration;
+
+    EXPECT_THAT(sut, Eq(DurationAccessor::max()));
+}
+
 TEST(Duration_test, SubtractDurationDoesNotChangeOriginalObject)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c61d7d6e-4164-4c00-b264-7ed62ad22748");
@@ -1786,6 +1848,59 @@ TEST(Duration_test, SubtractDurationWithSecondsAndNanosecondsCausingReductionOfS
 
     EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
 }
+
+TEST(Duration_test, SubtractAssignSecondsFromDurationResultsInSecondSubtractractionToLHS)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "ab917854-0a97-4529-b408-c51c30b9375f");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(1U, 0U);
+    auto sut = createDuration(2U, 0U);
+    auto otherDuration = createDuration(1U, 0U);
+
+    sut -= otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, SubtractAssignNanosecondsFromDurationResultsInNanosecondSubtractractionToLHS)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b6051fe8-37d5-4225-b1ea-5038b56889ce");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(0U, 50U);
+    auto sut = createDuration(0U, 100U);
+    auto otherDuration = createDuration(0U, 50U);
+
+    sut -= otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, SubtractAssignDurationPastZeroNanosecondsResultsInDecrementedSeconds)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cba9f397-9f25-4e88-9608-0d51eb1e4ccc");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(0U, NANOSECS_PER_SECOND - 2);
+    auto sut = createDuration(1U, 0U);
+    auto otherDuration = createDuration(0U, 2U);
+
+    sut -= otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
+TEST(Duration_test, SubtractAssignDurationPastZeroResultsInZero)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "eb2bace9-751c-48bd-82eb-2e5679512503");
+
+    constexpr Duration EXPECTED_DURATION = createDuration(0U, 0U);
+    auto sut = createDuration(1U, 0U);
+    auto otherDuration = createDuration(2U, 0U);
+
+    sut -= otherDuration;
+
+    EXPECT_THAT(sut, Eq(EXPECTED_DURATION));
+}
+
 
 TEST(Duration_test, MultiplyDurationDoesNotChangeOriginalObject)
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. Fixes warnings for `duration.hpp` and `duration.inl`
3. Adds `operator+=` and `operator-=` operators as required by AUTOSAR guidelines + supporting test cases

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1394
