### PR TITLE
iox-#1755 flush testing logger on terminate

### DIFF
--- a/iceoryx_hoofs/testing/testing_logger.cpp
+++ b/iceoryx_hoofs/testing/testing_logger.cpp
@@ -117,6 +117,12 @@ void LogPrinter::OnTestStart(const ::testing::TestInfo&)
     dynamic_cast<TestingLogger&>(log::Logger::get()).clearLogBuffer();
     TestingLogger::setLogLevel(log::LogLevel::TRACE);
 
+    std::set_terminate([]() {
+        std::cout << "Terminate called\n" << std::flush;
+        dynamic_cast<TestingLogger&>(log::Logger::get()).printLogBuffer();
+        std::abort();
+    });
+
     /// @todo iox-#1755 register signal handler for sigterm to flush to logger;
     /// there might be tests to register a handler itself and when this is
     /// done at each start of the test only the tests who use their

--- a/iceoryx_hoofs/testing/testing_logger.cpp
+++ b/iceoryx_hoofs/testing/testing_logger.cpp
@@ -123,7 +123,7 @@ std::vector<std::string> TestingLogger::getLogMessages() noexcept
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) global variable is required as jmp target
 jmp_buf exitJmpBuffer;
 
-static void sigsegvHandler(int sig, siginfo_t*, void*)
+static void sigHandler(int sig, siginfo_t*, void*)
 {
     switch (sig)
     {
@@ -162,7 +162,7 @@ void LogPrinter::OnTestStart(const ::testing::TestInfo&)
     sigemptyset(&action.sa_mask);
 
     action.sa_flags = SA_NODEFER;
-    action.sa_sigaction = sigsegvHandler;
+    action.sa_sigaction = sigHandler;
 
     sigaction(SIGSEGV, &action, nullptr);
     sigaction(SIGFPE, &action, nullptr);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

This PR adds some functionality to the testing logger to flush the caches log messages on `std::terminate`, `SIGSEV` and `SIGFPE`.

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1755 
