### PR TITLE
iox-#1835 fixed spelling error in mutex log error msg

### DIFF
--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -126,7 +126,7 @@ struct MutexAttributes
                 IOX_LOG(ERROR) << "The used mutex priority is not supported by the platform";
                 return cxx::error<MutexCreationError>(MutexCreationError::USED_PRIORITY_UNSUPPORTED_BY_PLATFORM);
             case EPERM:
-                IOX_LOG(ERROR) << "Unsufficient permissions to set mutex priorities";
+                IOX_LOG(ERROR) << "Insufficient permissions to set mutex priorities";
                 return cxx::error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
             default:
                 IOX_LOG(ERROR)
@@ -148,7 +148,7 @@ struct MutexAttributes
             switch (result.get_error().errnum)
             {
             case EPERM:
-                IOX_LOG(ERROR) << "Unsufficient permissions to set the mutex priority ceiling.";
+                IOX_LOG(ERROR) << "Insufficient permissions to set the mutex priority ceiling.";
                 return cxx::error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
             case ENOSYS:
                 IOX_LOG(ERROR) << "The platform does not support mutex priority ceiling.";
@@ -203,7 +203,7 @@ cxx::expected<MutexCreationError> initializeMutex(pthread_mutex_t* const handle,
             IOX_LOG(ERROR) << "Not enough memory to initialize mutex.";
             return cxx::error<MutexCreationError>(MutexCreationError::INSUFFICIENT_MEMORY);
         case EPERM:
-            IOX_LOG(ERROR) << "Unsufficient permissions to create mutex.";
+            IOX_LOG(ERROR) << "Insufficient permissions to create mutex.";
             return cxx::error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
         default:
             IOX_LOG(ERROR)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1835 
