### PR TITLE
iox-1394 Fix AUTOSAR violations in functional_interface

### DIFF
--- a/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/cxx/functional_interface.hpp
@@ -58,8 +58,8 @@ struct HasGetErrorMethod<Derived, cxx::void_t<decltype(std::declval<Derived>().g
 void print_expect_message(const char* message) noexcept;
 
 template <typename Derived>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
-// not deleted.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define
+// a destructor, hence the move operations are not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
@@ -77,8 +77,8 @@ struct Expect
 };
 
 template <typename Derived, typename ValueType>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
-// not deleted.
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define
+// a destructor, hence the move operations are not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
@@ -121,7 +121,7 @@ struct ExpectWithValue
 };
 
 template <typename Derived, typename ValueType>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
@@ -151,7 +151,7 @@ struct ValueOr
 };
 
 template <typename Derived, typename ValueType>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
@@ -203,7 +203,7 @@ struct AndThenWithValue
 };
 
 template <typename Derived>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
@@ -241,7 +241,7 @@ struct AndThen
 };
 
 template <typename Derived, typename ErrorType>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
@@ -293,7 +293,7 @@ struct OrElseWithValue
 };
 
 template <typename Derived>
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.
@@ -339,7 +339,7 @@ template <typename Derived, typename ValueType, typename ErrorType>
 // with a default implementation. But they dont come with the downside of an explicit user-side
 // forward implementation.
 //
-// not required since a default'ed destructor does not define a destructor, hence the move operations are
+// AXIVION Next Construct AutosarC++19_03-A12.0.1 : not required since a default'ed destructor does not define a destructor, hence the move operations are
 // not deleted.
 // the only adaptation is that the dtor is protected to prohibit the user deleting the child type by
 // explicitly calling the destructor of the base type.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/functional_interface.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/functional_interface.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2022 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ inline void Expect<Derived>::expect(const StringType& msg) const noexcept
     static_assert(is_char_array<StringType>::value || is_cxx_string<StringType>::value,
                   "Only char arrays and iox::cxx::strings are allowed as message type.");
 
-    const auto& derivedThis{*static_cast<const Derived*>(this)};
+    const auto& derivedThis = *static_cast<const Derived*>(this);
 
     if (!derivedThis)
     {
@@ -51,7 +51,7 @@ inline ValueType& ExpectWithValue<Derived, ValueType>::expect(const StringType& 
     static_assert(is_char_array<StringType>::value || is_cxx_string<StringType>::value,
                   "Only char arrays and iox::cxx::strings are allowed as message type.");
 
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (!derivedThis)
     {
@@ -95,11 +95,13 @@ inline const ValueType&& ExpectWithValue<Derived, ValueType>::expect(const Strin
 /////////////////
 // BEGIN value_or
 /////////////////
+
+// AXIVION Next Construct AutosarC++19_03-A13.3.1 : overload is invoked only on const lvalues
 template <typename Derived, typename ValueType>
 template <typename U>
 inline ValueType ValueOr<Derived, ValueType>::value_or(U&& alternative) const& noexcept
 {
-    const auto& derivedThis{*static_cast<const Derived*>(this)};
+    const auto& derivedThis = *static_cast<const Derived*>(this);
 
     if (!derivedThis)
     {
@@ -109,11 +111,12 @@ inline ValueType ValueOr<Derived, ValueType>::value_or(U&& alternative) const& n
     return derivedThis.value();
 }
 
+// AXIVION Next Construct AutosarC++19_03-A13.3.1 : overload is invoked only on rvalues
 template <typename Derived, typename ValueType>
 template <typename U>
 inline ValueType ValueOr<Derived, ValueType>::value_or(U&& alternative) && noexcept
 {
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (!derivedThis)
     {
@@ -134,11 +137,11 @@ inline Derived& AndThenWithValue<Derived, ValueType>::and_then(const Functor& ca
     static_assert(cxx::is_invocable<Functor, ValueType&>::value,
                   "Only callables with a signature of void(ValueType&) are allowed!");
 
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (derivedThis)
     {
-        auto callback = static_cast<and_then_callback_t>(callable);
+        const auto callback = static_cast<and_then_callback_t>(callable);
         callback(derivedThis.value());
     }
 
@@ -159,11 +162,11 @@ inline const Derived& AndThenWithValue<Derived, ValueType>::and_then(const Funct
     static_assert(cxx::is_invocable<Functor, const ValueType&>::value,
                   "Only callables with a signature of void(const ValueType&) are allowed!");
 
-    const auto& derivedThis{*static_cast<const Derived*>(this)};
+    const auto& derivedThis = *static_cast<const Derived*>(this);
 
     if (derivedThis)
     {
-        auto callback = static_cast<const_and_then_callback_t>(callable);
+        const auto callback = static_cast<const_and_then_callback_t>(callable);
         callback(derivedThis.value());
     }
 
@@ -180,7 +183,7 @@ inline const Derived&& AndThenWithValue<Derived, ValueType>::and_then(const Func
 template <typename Derived>
 inline Derived& AndThen<Derived>::and_then(const and_then_callback_t& callable) & noexcept
 {
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (derivedThis)
     {
@@ -227,11 +230,11 @@ inline Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor& call
     static_assert(cxx::is_invocable<Functor, ErrorType&>::value,
                   "Only callables with a signature of void(ErrorType&) are allowed!");
 
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (!derivedThis)
     {
-        auto callback = static_cast<or_else_callback_t>(callable);
+        const auto callback = static_cast<or_else_callback_t>(callable);
         callback(derivedThis.get_error());
     }
 
@@ -252,7 +255,7 @@ inline const Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor
     static_assert(cxx::is_invocable<Functor, ErrorType&>::value,
                   "Only callables with a signature of void(const ErrorType&) are allowed!");
 
-    const auto& derivedThis{*static_cast<const Derived*>(this)};
+    const auto& derivedThis = *static_cast<const Derived*>(this);
 
     if (!derivedThis)
     {
@@ -273,7 +276,7 @@ inline const Derived&& OrElseWithValue<Derived, ErrorType>::or_else(const Functo
 template <typename Derived>
 inline Derived& OrElse<Derived>::or_else(const or_else_callback_t& callable) & noexcept
 {
-    auto& derivedThis{*static_cast<Derived*>(this)};
+    auto& derivedThis = *static_cast<Derived*>(this);
 
     if (!derivedThis)
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes AUTOSAR violations in `functional_interface` and suppresses some rules.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1394 (partially)
