### PR TITLE
iox-#1036 move creation pattern to dust

### DIFF
--- a/.github/workflows/lint_master.yml
+++ b/.github/workflows/lint_master.yml
@@ -26,7 +26,6 @@ jobs:
     # prevent stuck jobs consuming runners for 3 hours
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    needs: pre-flight-check
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -812,7 +812,22 @@
 
     ```
 
-42. Move `static_storage` from `iceoryx_hoofs` to `iceoryx_dust`
+42. Move multiple classes from `iceoryx_hoofs` to `iceoryx_dust`
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/cxx/forward_list.hpp"
+
+    #include "iceoryx_dust/cxx/forward_list.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/design_pattern/creation.hpp"
+
+    // after
+    #include "iceoryx_dust/design/creation.hpp"
+    ```
 
     ```cpp
     // before
@@ -822,3 +837,50 @@
     #include "iceoryx_dust/internal/cxx/static_storage.hpp"
     ```
 
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/internal/file_reader/file_reader.hpp"
+
+    // after
+    #include "iceoryx_dust/cxx/file_reader.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/internal/objectpool/objectpool.hpp"
+
+    // after
+    #include "iceoryx_dust/cxx/objectpool.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/internal/relocatable_pointer/relocatable_ptr.hpp"
+
+    // after
+    #include "iceoryx_dust/relocatable_pointer/relocatable_ptr.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/posix_wrapper/internal/message_queue.hpp"
+
+    // after
+    #include "iceoryx_dust/posix_wrapper/message_queue.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/posix_wrapper/named_pipe.hpp"
+
+    // after
+    #include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
+    ```
+
+    ```cpp
+    // before
+    #include "iceoryx_hoofs/posix_wrapper/signal_watcher.hpp"
+
+    // after
+    #include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+    ```

--- a/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
@@ -147,4 +147,4 @@ class Creation
 #include "iceoryx_dust/internal/design/creation.inl"
 // NOLINTEND
 
-#endif // IOX_HOOFS_DESIGN_CREATION_HPP
+#endif // IOX_DUST_DESIGN_CREATION_HPP

--- a/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
@@ -14,8 +14,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP
-#define IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP
+#ifndef IOX_DUST_DESIGN_CREATION_HPP
+#define IOX_DUST_DESIGN_CREATION_HPP
 
 // NOLINTJUSTIFICATION iox-#1036 will be replaced by builder pattern
 // NOLINTBEGIN
@@ -144,7 +144,7 @@ class Creation
 
 } // namespace DesignPattern
 
-#include "iceoryx_hoofs/internal/design_pattern/creation.inl"
+#include "iceoryx_dust/internal/design/creation.inl"
 // NOLINTEND
 
-#endif // IOX_HOOFS_DESIGN_PATTERN_CREATION_HPP
+#endif // IOX_HOOFS_DESIGN_CREATION_HPP

--- a/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
@@ -13,8 +13,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_DESIGN_PATTERN_CREATION_INL
-#define IOX_HOOFS_DESIGN_PATTERN_CREATION_INL
+#ifndef IOX_DUST_DESIGN_CREATION_INL
+#define IOX_DUST_DESIGN_CREATION_INL
+
 namespace DesignPattern
 {
 template <typename DerivedClass, typename ErrorType>
@@ -81,4 +82,5 @@ inline iox::expected<ErrorType> Creation<DerivedClass, ErrorType>::placementCrea
 
 
 } // namespace DesignPattern
-#endif
+
+#endif // IOX_DUST_DESIGN_CREATION_INL

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_DUST_POSIX_WRAPPER_MESSAGE_QUEUE_HPP
 #define IOX_DUST_POSIX_WRAPPER_MESSAGE_QUEUE_HPP
 
-#include "iceoryx_hoofs/design_pattern/creation.hpp"
+#include "iceoryx_dust/design/creation.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"
 #include "iceoryx_platform/fcntl.hpp"

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
@@ -16,8 +16,8 @@
 #ifndef IOX_DUST_POSIX_WRAPPER_NAMED_PIPE_HPP
 #define IOX_DUST_POSIX_WRAPPER_NAMED_PIPE_HPP
 
+#include "iceoryx_dust/design/creation.hpp"
 #include "iceoryx_hoofs/concurrent/lockfree_queue.hpp"
-#include "iceoryx_hoofs/design_pattern/creation.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"

--- a/iceoryx_examples/iceperf/mq.hpp
+++ b/iceoryx_examples/iceperf/mq.hpp
@@ -19,7 +19,6 @@
 
 #include "base.hpp"
 
-#include "iceoryx_hoofs/design_pattern/creation.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"
 #include "iceoryx_platform/fcntl.hpp"

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -17,7 +17,6 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_UNIX_DOMAIN_SOCKET_HPP
 #define IOX_HOOFS_POSIX_WRAPPER_UNIX_DOMAIN_SOCKET_HPP
 
-#include "iceoryx_hoofs/design_pattern/creation.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_hoofs/internal/units/duration.hpp"
 #include "iceoryx_platform/fcntl.hpp"
@@ -32,7 +31,7 @@ namespace iox
 namespace posix
 {
 /// @brief Wrapper class for unix domain socket
-class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcChannelError>
+class UnixDomainSocket
 {
   public:
     struct NoPathPrefix_t
@@ -47,8 +46,8 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     using UdsName_t = string<LONGEST_VALID_NAME>;
     using Message_t = string<MAX_MESSAGE_SIZE>;
 
-    /// @brief for calling private constructor in create method
-    friend class DesignPattern::Creation<UnixDomainSocket, IpcChannelError>;
+    using result_t = expected<UnixDomainSocket, IpcChannelError>;
+    using errorType_t = IpcChannelError;
 
     /// @brief default constructor. The result is an invalid UnixDomainSocket object which can be reassigned later by
     /// using the
@@ -61,6 +60,18 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     UnixDomainSocket& operator=(UnixDomainSocket&& other) noexcept;
 
     ~UnixDomainSocket() noexcept;
+
+    /// @brief factory method which guarantees that either a working object is produced
+    ///         or an error value describing the error during construction
+    /// @tparam Targs the argument types which will be forwarded to the ctor
+    /// @param[in] args the argument values which will be forwarded to the ctor
+    /// @return returns an expected which either contains the object in a valid
+    ///         constructed state or an error value stating why the construction failed.
+    template <typename... Targs>
+    static expected<UnixDomainSocket, IpcChannelError> create(Targs&&... args) noexcept;
+
+    /// @brief returns true if the object was constructed successfully, otherwise false
+    bool isInitialized() const noexcept;
 
     /// @brief unlink the provided unix domain socket
     /// @param name of the unix domain socket to unlink
@@ -117,12 +128,29 @@ class UnixDomainSocket : public DesignPattern::Creation<UnixDomainSocket, IpcCha
     static constexpr int32_t ERROR_CODE = -1;
     static constexpr int32_t INVALID_FD = -1;
 
+    bool m_isInitialized{false};
+    IpcChannelError m_errorValue;
+
     UdsName_t m_name;
     IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;
     int32_t m_sockfd{INVALID_FD};
     sockaddr_un m_sockAddr{};
     size_t m_maxMessageSize{MAX_MESSAGE_SIZE};
 };
+
+
+template <typename... Targs>
+expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(Targs&&... args) noexcept
+{
+    UnixDomainSocket newObject{std::forward<Targs>(args)...};
+    if (!newObject.m_isInitialized)
+    {
+        return iox::error<IpcChannelError>(newObject.m_errorValue);
+    }
+
+    return iox::success<UnixDomainSocket>(std::move(newObject));
+}
+
 } // namespace posix
 } // namespace iox
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -52,7 +52,7 @@ class UnixDomainSocket
     /// @brief default constructor. The result is an invalid UnixDomainSocket object which can be reassigned later by
     /// using the
     /// move constructor.
-    UnixDomainSocket() noexcept;
+    UnixDomainSocket() noexcept = default;
 
     UnixDomainSocket(const UnixDomainSocket& other) = delete;
     UnixDomainSocket(UnixDomainSocket&& other) noexcept;
@@ -129,7 +129,7 @@ class UnixDomainSocket
     static constexpr int32_t INVALID_FD = -1;
 
     bool m_isInitialized{false};
-    IpcChannelError m_errorValue;
+    IpcChannelError m_errorValue{IpcChannelError::NOT_INITIALIZED};
 
     UdsName_t m_name;
     IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -122,22 +122,24 @@ UnixDomainSocket& UnixDomainSocket::operator=(UnixDomainSocket&& other) noexcept
                            << "\" in the move constructor/move assignment operator";
         }
 
-        CreationPattern_t::operator=(std::move(other));
-
-        // @todo iox-#1036
-        // NOLINTJUSTIFICATION will be fixed with refactoring in #1036
-        // NOLINTBEGIN(bugprone-use-after-move, hicpp-invalid-access-moved)
+        m_isInitialized = other.m_isInitialized;
+        m_errorValue = other.m_errorValue;
         m_name = std::move(other.m_name);
         m_channelSide = other.m_channelSide;
         m_sockfd = other.m_sockfd;
         m_sockAddr = other.m_sockAddr;
         m_maxMessageSize = other.m_maxMessageSize;
-        // NOLINTEND(bugprone-use-after-move, hicpp-invalid-access-moved)
 
+        other.m_isInitialized = false;
         other.m_sockfd = INVALID_FD;
     }
 
     return *this;
+}
+
+bool UnixDomainSocket::isInitialized() const noexcept
+{
+    return m_isInitialized;
 }
 
 expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const UdsName_t& name) noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -34,12 +34,6 @@ namespace posix
 constexpr uint64_t UnixDomainSocket::MAX_MESSAGE_SIZE;
 constexpr uint64_t UnixDomainSocket::NULL_TERMINATOR_SIZE;
 
-UnixDomainSocket::UnixDomainSocket() noexcept
-{
-    this->m_isInitialized = false;
-    this->m_errorValue = IpcChannelError::NOT_INITIALIZED;
-}
-
 UnixDomainSocket::UnixDomainSocket(UnixDomainSocket&& other) noexcept
 {
     *this = std::move(other);

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_pointer.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_pointer.hpp
@@ -17,7 +17,7 @@
 #ifndef IOX_POSH_MEPOO_SHARED_POINTER_HPP
 #define IOX_POSH_MEPOO_SHARED_POINTER_HPP
 
-#include "iceoryx_hoofs/design_pattern/creation.hpp"
+#include "iceoryx_dust/design/creation.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the `Creation` design pattern to dust and adjusts the `UnixDomainSocket`. The  `UnixDomainSocket` will later on be ported to the `Builder` pattern.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1036 
