### PR TITLE
iox-1855 Return in `WaitSet::wait` if data was send before `WaitSet::attachState`

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -63,6 +63,7 @@
 - Avoid UB when accessing `iox::expected` [\#1750](https://github.com/eclipse-iceoryx/iceoryx/issues/1750)
 - Fix double move in `vector::emplace` [\#1823](https://github.com/eclipse-iceoryx/iceoryx/issues/1823)
 - Default roudi_config.toml path is not used [\#1826](https://github.com/eclipse-iceoryx/iceoryx/issues/1826)
+- `WaitSet::wait` returns if data was send before `WaitSet::attachState(.., State::HAS_{DATA, REQUEST, RESPONSE})` [\#1855](https://github.com/eclipse-iceoryx/iceoryx/issues/1855)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
@@ -233,6 +233,12 @@ WaitSet<Capacity>::attachState(T& stateOrigin,
                 stateOrigin,
                 TriggerHandle(*m_conditionVariableDataPtr, {*this, &WaitSet::removeTrigger}, uniqueId),
                 stateType);
+
+            auto& trigger = m_triggerArray[uniqueId];
+            if (trigger->isStateConditionSatisfied())
+            {
+                ConditionNotifier(*m_conditionVariableDataPtr, uniqueId).notify();
+            }
         });
 }
 
@@ -259,6 +265,12 @@ inline expected<WaitSetError> WaitSet<Capacity>::attachState(
         .and_then([&](auto& uniqueId) {
             NotificationAttorney::enableState(
                 stateOrigin, TriggerHandle(*m_conditionVariableDataPtr, {*this, &WaitSet::removeTrigger}, uniqueId));
+
+            auto& trigger = m_triggerArray[uniqueId];
+            if (trigger->isStateConditionSatisfied())
+            {
+                ConditionNotifier(*m_conditionVariableDataPtr, uniqueId).notify();
+            }
         });
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
@@ -1761,4 +1761,30 @@ TEST_F(WaitSet_test, TimedWaitUnblocksAfterMarkForDestructionCall)
     t.join();
 }
 
+TEST_F(WaitSet_test, WaitSetReturnsIfStateTriggeredBeforeAttachingWithEventType)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "407dc160-a50c-45b3-84bc-92a5f186fc14");
+    m_simpleEvents[0U].m_autoResetTrigger = false;
+    m_simpleEvents[0U].trigger();
+
+    ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0U], SimpleState1::STATE1).has_error());
+
+    auto triggerVector = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+}
+
+TEST_F(WaitSet_test, WaitSetReturnsIfStateTriggeredBeforeAttachingWithEventId)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5753de85-7b34-4024-bd50-938c8885d269");
+    m_simpleEvents[0U].m_autoResetTrigger = false;
+    m_simpleEvents[0U].trigger();
+
+    ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0U], 0U).has_error());
+
+    auto triggerVector = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+}
+
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
@@ -1787,4 +1787,41 @@ TEST_F(WaitSet_test, WaitSetReturnsIfStateTriggeredBeforeAttachingWithEventId)
     EXPECT_TRUE(triggerVector[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
 }
 
+TEST_F(WaitSet_test, WaitSetReturnsAgainIfStateTriggeredBeforeAttachingWithEventType)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c86d2592-e8e5-4acc-b468-0a82be82fe7c");
+    m_simpleEvents[0U].m_autoResetTrigger = false;
+    m_simpleEvents[0U].trigger();
+
+    ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0U], SimpleState1::STATE1).has_error());
+
+    auto triggerVector1 = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector1.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector1[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+
+    // Waiting for another time should lead to the same result
+    auto triggerVector2 = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector2.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector2[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+}
+
+TEST_F(WaitSet_test, WaitSetReturnsAgainIfStateTriggeredBeforeAttachingWithEventId)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b07c9e09-f497-4bfa-9403-633d15363f5e");
+    m_simpleEvents[0U].m_autoResetTrigger = false;
+    m_simpleEvents[0U].trigger();
+
+    ASSERT_FALSE(m_sut->attachState(m_simpleEvents[0U], 0U).has_error());
+
+    auto triggerVector1 = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector1.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector1[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+
+    // Waiting for another time should lead to the same result
+    auto triggerVector2 = m_sut->timedWait(iox::units::Duration::fromSeconds(1337));
+    ASSERT_THAT(triggerVector2.size(), Eq(1U));
+    EXPECT_TRUE(triggerVector2[0U]->doesOriginateFrom(&m_simpleEvents[0U]));
+}
+
+
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] ~~All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`~~
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* After attaching a state to the `WaitSet`, `isStateConditionSatisfied()` is called to see whether the state condition is still fulfilled, if so the `ConditionNotifier` is triggered
   * This allows the usage in ROS 2's rmw where `rmw_wait` attaches all wait-able entities just before waiting on every run (see https://github.com/ros2/rmw_iceoryx/pull/84)

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1855
