### PR TITLE
iox-1612 make lossy std string conversion more visible

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -372,7 +372,7 @@
     iox::cxx::isValidPathToFile(..);
     iox::cxx::isValidPathToDirectory(..);
     iox::cxx::doesEndWithPathSeparator(..);
-    
+
     // after
     #include "iceoryx_hoofs/cxx/filesystem.hpp"
     iox::cxx::isValidPathEntry(..);
@@ -994,7 +994,7 @@
 
     std::string myStdString("foo");
     // std::string to iox::string
-    iox::string<3> myIoxString = iox::into<iox::string<3>>(myStdString);
+    iox::string<3> myIoxString = iox::into<iox::lossy<iox::string<3>>>(myStdString);
     // iox::string to std::string
     std::string myConvertedIoxString = iox::into<std::string>(myIoxString);
     ```

--- a/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
@@ -17,7 +17,6 @@
 #define IOX_DUST_STD_STRING_SUPPORT_HPP
 
 #include "iox/into.hpp"
-#include "iox/optional.hpp"
 #include "iox/string.hpp"
 
 #include <string>
@@ -34,12 +33,6 @@ template <uint64_t N>
 struct FromImpl<std::string, string<N>>
 {
     static string<N> fromImpl(const std::string& value) noexcept;
-};
-
-template <uint64_t N>
-struct FromImpl<std::string, optional<string<N>>>
-{
-    static optional<string<N>> fromImpl(const std::string& value) noexcept;
 };
 
 template <uint64_t N>

--- a/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2022 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/cxx/std_string_support.hpp
@@ -17,6 +17,7 @@
 #define IOX_DUST_STD_STRING_SUPPORT_HPP
 
 #include "iox/into.hpp"
+#include "iox/optional.hpp"
 #include "iox/string.hpp"
 
 #include <string>
@@ -31,6 +32,18 @@ struct FromImpl<string<N>, std::string>
 
 template <uint64_t N>
 struct FromImpl<std::string, string<N>>
+{
+    static string<N> fromImpl(const std::string& value) noexcept;
+};
+
+template <uint64_t N>
+struct FromImpl<std::string, optional<string<N>>>
+{
+    static optional<string<N>> fromImpl(const std::string& value) noexcept;
+};
+
+template <uint64_t N>
+struct FromImpl<std::string, lossy<string<N>>>
 {
     static string<N> fromImpl(const std::string& value) noexcept;
 };

--- a/iceoryx_dust/include/iceoryx_dust/internal/cli/option_manager.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cli/option_manager.inl
@@ -62,7 +62,7 @@ inline T OptionManager::defineOption(T& referenceToMember,
 {
     constexpr bool IS_NO_SWITCH = false;
     m_optionSet.addOption(OptionWithDetails{
-        {shortName, IS_NO_SWITCH, name, into<Argument_t>(cxx::convert::toString(defaultArgumentValue))},
+        {shortName, IS_NO_SWITCH, name, into<lossy<Argument_t>>(cxx::convert::toString(defaultArgumentValue))},
         description,
         optionType,
         {cxx::TypeInfo<T>::NAME}});

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
@@ -27,9 +27,16 @@ inline std::string FromImpl<string<N>, std::string>::fromImpl(const string<N>& v
 }
 
 template <uint64_t N>
-inline string<N> FromImpl<std::string, string<N>>::fromImpl(const std::string& value) noexcept
+inline string<N> FromImpl<std::string, string<N>>::fromImpl(const std::string&) noexcept
 {
-    return string<N>(TruncateToCapacity, value.c_str(), value.size());
+    static_assert(cxx::always_false_v<std::string> && cxx::always_false_v<string<N>>, "\n \
+        The conversion from 'std::string' to 'iox::sring<N>' is potentially lossy!\n \
+        This happens when the size of source string exceeds the capacity of the destination string!\n \
+        Please use either: \n \
+          - 'iox::into<iox::optional<iox::string<N>>>' which returns a 'iox::optional<iox::string<N>>'\n \
+            with a 'nullopt' if the size of the source string exceeds the capacity of the destination string\n \
+          - 'iox::into<iox::lossy<iox::string<N>>>' which returns a 'iox::string<N>' and truncates the\n \
+            source string if its size exceeds the capacity of the destination string");
 }
 
 template <uint64_t N>

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2022 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
@@ -31,6 +31,23 @@ inline string<N> FromImpl<std::string, string<N>>::fromImpl(const std::string& v
 {
     return string<N>(TruncateToCapacity, value.c_str(), value.size());
 }
+
+template <uint64_t N>
+inline optional<string<N>> FromImpl<std::string, optional<string<N>>>::fromImpl(const std::string& value) noexcept
+{
+    const auto stringLength = value.size();
+    if (stringLength <= N)
+    {
+        return string<N>(TruncateToCapacity, value.c_str(), stringLength);
+    }
+    return nullopt;
+}
+
+template <uint64_t N>
+inline string<N> FromImpl<std::string, lossy<string<N>>>::fromImpl(const std::string& value) noexcept
+{
+    return string<N>(TruncateToCapacity, value.c_str(), value.size());
+}
 } // namespace iox
 
 #endif // IOX_DUST_STD_STRING_SUPPORT_INL

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/std_string_support.inl
@@ -32,22 +32,8 @@ inline string<N> FromImpl<std::string, string<N>>::fromImpl(const std::string&) 
     static_assert(cxx::always_false_v<std::string> && cxx::always_false_v<string<N>>, "\n \
         The conversion from 'std::string' to 'iox::sring<N>' is potentially lossy!\n \
         This happens when the size of source string exceeds the capacity of the destination string!\n \
-        Please use either: \n \
-          - 'iox::into<iox::optional<iox::string<N>>>' which returns a 'iox::optional<iox::string<N>>'\n \
-            with a 'nullopt' if the size of the source string exceeds the capacity of the destination string\n \
-          - 'iox::into<iox::lossy<iox::string<N>>>' which returns a 'iox::string<N>' and truncates the\n \
+        Please use 'iox::into<iox::lossy<iox::string<N>>>' which returns a 'iox::string<N>' and truncates the\n \
             source string if its size exceeds the capacity of the destination string");
-}
-
-template <uint64_t N>
-inline optional<string<N>> FromImpl<std::string, optional<string<N>>>::fromImpl(const std::string& value) noexcept
-{
-    const auto stringLength = value.size();
-    if (stringLength <= N)
-    {
-        return string<N>(TruncateToCapacity, value.c_str(), stringLength);
-    }
-    return nullopt;
 }
 
 template <uint64_t N>

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -221,7 +221,7 @@ expected<IpcChannelError> NamedPipe::trySend(const std::string& message) const n
 
     if (*result)
     {
-        IOX_DISCARD_RESULT(m_data->messages.push(into<Message_t>(message)));
+        IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
         cxx::Expects(!m_data->receiveSemaphore().post().has_error());
         return success<>();
     }
@@ -241,7 +241,7 @@ expected<IpcChannelError> NamedPipe::send(const std::string& message) const noex
     }
 
     cxx::Expects(!m_data->sendSemaphore().wait().has_error());
-    IOX_DISCARD_RESULT(m_data->messages.push(into<Message_t>(message)));
+    IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
     cxx::Expects(!m_data->receiveSemaphore().post().has_error());
 
     return success<>();
@@ -265,7 +265,7 @@ expected<IpcChannelError> NamedPipe::timedSend(const std::string& message,
 
     if (*result == SemaphoreWaitState::NO_TIMEOUT)
     {
-        IOX_DISCARD_RESULT(m_data->messages.push(into<Message_t>(message)));
+        IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
         cxx::Expects(!m_data->receiveSemaphore().post().has_error());
         return success<>();
     }

--- a/iceoryx_dust/test/moduletests/test_cli_command_line_parser.cpp
+++ b/iceoryx_dust/test/moduletests/test_cli_command_line_parser.cpp
@@ -91,15 +91,15 @@ void FailureTest(const std::vector<std::string>& options,
         OptionDefinition optionSet("", [&] { wasErrorHandlerCalled = true; });
         for (const auto& o : optionsToRegister)
         {
-            optionSet.addOptional(o[0], iox::into<OptionName_t>(o), "", "int", "0");
+            optionSet.addOptional(o[0], iox::into<iox::lossy<OptionName_t>>(o), "", "int", "0");
         }
         for (const auto& s : switchesToRegister)
         {
-            optionSet.addSwitch(s[0], iox::into<OptionName_t>(s), "");
+            optionSet.addSwitch(s[0], iox::into<iox::lossy<OptionName_t>>(s), "");
         }
         for (const auto& r : requiredValuesToRegister)
         {
-            optionSet.addRequired(r[0], iox::into<OptionName_t>(r), "", "int");
+            optionSet.addRequired(r[0], iox::into<iox::lossy<OptionName_t>>(r), "", "int");
         }
 
         IOX_DISCARD_RESULT(parseCommandLineArguments(optionSet, args.argc, args.argv, 1U));
@@ -893,15 +893,16 @@ Arguments SuccessTest(const std::vector<std::string>& options,
         OptionDefinition optionSet("");
         for (const auto& o : optionsToRegister)
         {
-            optionSet.addOptional(o[0], iox::into<OptionName_t>(o), "", "int", CommandLineParser_test::defaultValue);
+            optionSet.addOptional(
+                o[0], iox::into<iox::lossy<OptionName_t>>(o), "", "int", CommandLineParser_test::defaultValue);
         }
         for (const auto& s : switchesToRegister)
         {
-            optionSet.addSwitch(s[0], iox::into<OptionName_t>(s), "");
+            optionSet.addSwitch(s[0], iox::into<iox::lossy<OptionName_t>>(s), "");
         }
         for (const auto& r : requiredValuesToRegister)
         {
-            optionSet.addRequired(r[0], iox::into<OptionName_t>(r), "", "int");
+            optionSet.addRequired(r[0], iox::into<iox::lossy<OptionName_t>>(r), "", "int");
         }
 
         {

--- a/iceoryx_dust/test/moduletests/test_cxx_string_conversion.cpp
+++ b/iceoryx_dust/test/moduletests/test_cxx_string_conversion.cpp
@@ -43,7 +43,7 @@ TYPED_TEST(StdString_test, STDStringToStringConvConstrWithSize0ResultsInSize0)
     using MyString = typename TestFixture::stringType;
     constexpr auto STRINGCAP = MyString::capacity();
     std::string testString;
-    string<STRINGCAP> fuu = into<MyString>(testString);
+    string<STRINGCAP> fuu = into<lossy<MyString>>(testString);
     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.size(), Eq(0U));
     EXPECT_THAT(fuu.c_str(), StrEq(""));
@@ -55,7 +55,7 @@ TYPED_TEST(StdString_test, STDStringToStringConvConstrWithSizeSmallerCapaResults
     using MyString = typename TestFixture::stringType;
     constexpr auto STRINGCAP = MyString::capacity();
     std::string testString(STRINGCAP - 1U, 'M');
-    string<STRINGCAP> fuu = into<MyString>(testString);
+    string<STRINGCAP> fuu = into<lossy<MyString>>(testString);
     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.size(), Eq(STRINGCAP - 1U));
     EXPECT_THAT(fuu.c_str(), Eq(testString));
@@ -67,7 +67,7 @@ TYPED_TEST(StdString_test, STDStringToStringConvConstrWithSizeCapaResultsInSizeC
     using MyString = typename TestFixture::stringType;
     constexpr auto STRINGCAP = MyString::capacity();
     std::string testString(STRINGCAP, 'M');
-    string<STRINGCAP> fuu = into<MyString>(testString);
+    string<STRINGCAP> fuu = into<lossy<MyString>>(testString);
     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.size(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.c_str(), Eq(testString));
@@ -79,7 +79,7 @@ TYPED_TEST(StdString_test, STDStringToStringConvConstrWithSizeGreaterCapaResults
     using MyString = typename TestFixture::stringType;
     constexpr auto STRINGCAP = MyString::capacity();
     std::string testString(STRINGCAP + 1U, 'M');
-    string<STRINGCAP> fuu = into<MyString>(testString);
+    string<STRINGCAP> fuu = into<lossy<MyString>>(testString);
     EXPECT_THAT(fuu.capacity(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.size(), Eq(STRINGCAP));
     EXPECT_THAT(fuu.c_str(), Eq(testString.substr(0U, STRINGCAP)));

--- a/iceoryx_hoofs/utility/include/iox/detail/into.inl
+++ b/iceoryx_hoofs/utility/include/iox/detail/into.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/utility/include/iox/detail/into.inl
+++ b/iceoryx_hoofs/utility/include/iox/detail/into.inl
@@ -23,22 +23,25 @@
 namespace iox
 {
 template <typename SourceType, typename DestinationType>
-inline constexpr DestinationType from(const SourceType value)
+inline constexpr typename detail::extract_into_type<DestinationType>::type_t from(const SourceType value)
 {
     return FromImpl<SourceType, DestinationType>::fromImpl(value);
 }
 
-
 template <typename SourceType, typename DestinationType>
-inline DestinationType FromImpl<SourceType, DestinationType>::fromImpl(const SourceType&)
+inline auto FromImpl<SourceType, DestinationType>::fromImpl(const SourceType&)
 {
-    static_assert(cxx::always_false_v<SourceType> && cxx::always_false_v<DestinationType>,
-                  "Conversion for the specified types is not implemented!\
-    Please specialize 'template <typename SourceType, typename DestinationType> constexpr DestinationType FromImpl::fromImpl(const SourceType&) noexcept'!");
+    static_assert(cxx::always_false_v<SourceType> && cxx::always_false_v<DestinationType>, "\n \
+        Conversion for the specified types is not implemented!\n \
+        Please specialize 'FromImpl::fromImpl'!\n \
+        -------------------------------------------------------------------------\n \
+        template <typename SourceType, typename DestinationType>\n \
+        constexpr DestinationType FromImpl::fromImpl(const SourceType&) noexcept;\n \
+        -------------------------------------------------------------------------");
 }
 
 template <typename DestinationType, typename SourceType>
-inline constexpr DestinationType into(const SourceType value)
+inline constexpr typename detail::extract_into_type<DestinationType>::type_t into(const SourceType value)
 {
     return from<SourceType, DestinationType>(value);
 }

--- a/iceoryx_hoofs/utility/include/iox/into.hpp
+++ b/iceoryx_hoofs/utility/include/iox/into.hpp
@@ -19,6 +19,27 @@
 
 namespace iox
 {
+
+template <typename D>
+struct lossy
+{
+};
+namespace detail
+{
+template <typename T>
+struct extract_into_type
+{
+    using type_t = T;
+};
+
+
+template <typename T>
+struct extract_into_type<lossy<T>>
+{
+    using type_t = T;
+};
+} // namespace detail
+
 /// @brief Converts a value of type SourceType to a corresponding value of type DestinationType. This function needs to
 /// be specialized by the user for the types to be converted.
 /// @code
@@ -60,13 +81,14 @@ namespace iox
 /// @param[in] value of type SourceType to convert to DestinationType
 /// @return converted value of SourceType to corresponding value of DestinationType
 template <typename SourceType, typename DestinationType>
-constexpr DestinationType from(const SourceType value);
+constexpr typename detail::extract_into_type<DestinationType>::type_t from(const SourceType value);
+
 
 // Using a struct as impl, as free functions do not support partially specialized templates
 template <typename SourceType, typename DestinationType>
 struct FromImpl
 {
-    static DestinationType fromImpl(const SourceType& value);
+    static auto fromImpl(const SourceType& value);
 };
 
 /// @brief Converts a value of type SourceType to a corresponding value of type DestinationType. This is a convenience
@@ -80,7 +102,7 @@ struct FromImpl
 /// @param[in] value of type SourceType to convert to DestinationType
 /// @return converted value of SourceType to corresponding value of DestinationType
 template <typename DestinationType, typename SourceType>
-constexpr DestinationType into(const SourceType value);
+constexpr typename detail::extract_into_type<DestinationType>::type_t into(const SourceType value);
 
 } // namespace iox
 

--- a/iceoryx_hoofs/utility/include/iox/into.hpp
+++ b/iceoryx_hoofs/utility/include/iox/into.hpp
@@ -28,8 +28,8 @@ struct lossy
 
 namespace detail
 {
-/// @brief Helper struct to get the actual destination type 'T' for `into` with an additional indirection like
-/// `into<lossy<T>>`
+/// @brief Helper struct to get the actual destination type 'T' for 'into' with an additional indirection like
+/// 'into<lossy<T>>'
 template <typename T>
 struct extract_into_type
 {
@@ -51,9 +51,9 @@ struct extract_into_type<lossy<T>>
 /// instead either one or both of:
 ///   - 'Destination from<Source, lossy<Destination>>(...)'
 ///   - 'optional<Destination> from<Source, optional<Destination>>(...)'
-/// The `Destination from<Source, Destination>(...)` implementation should have a 'static_assert' with a hint of the
+/// The 'Destination from<Source, Destination>(...)' implementation should have a 'static_assert' with a hint of the
 /// reason, e.g. lossy conversion and a hint to use 'Destination into<lossy<Destination>>(...)' or
-/// `optional<Destination> into<optional<Destination>>(...)`. The `std_string_support.hpp` can be used as a source of
+/// 'optional<Destination> into<optional<Destination>>(...)'. The 'std_string_support.hpp' can be used as a source of
 /// inspiration for an implementation and error message.
 /// @code
 /// enum class LowLevel
@@ -105,8 +105,8 @@ struct FromImpl
 };
 
 /// @brief Converts a value of type SourceType to a corresponding value of type DestinationType. This is a convenience
-/// function which is automatically available when `from` is implemented. This function shall therefore not be
-/// specialized but always the `from` function.
+/// function which is automatically available when 'from' is implemented. This function shall therefore not be
+/// specialized but always the 'from' function.
 /// @code
 /// Bar b = iox::into<Bar>(Foo::ENUM_VALUE);
 /// @endcode

--- a/iceoryx_hoofs/utility/include/iox/into.hpp
+++ b/iceoryx_hoofs/utility/include/iox/into.hpp
@@ -20,19 +20,23 @@
 namespace iox
 {
 
+/// @brief Helper struct to indicate a lossy conversion, e.g. from an unbounded type into a bounded type
 template <typename D>
 struct lossy
 {
 };
+
 namespace detail
 {
+/// @brief Helper struct to get the actual destination type 'T' for `into` with an additional indirection like
+/// `into<lossy<T>>`
 template <typename T>
 struct extract_into_type
 {
     using type_t = T;
 };
 
-
+/// @brief Helper struct to get the actual destination type 'T' for 'into<lossy<T>>'
 template <typename T>
 struct extract_into_type<lossy<T>>
 {
@@ -41,7 +45,16 @@ struct extract_into_type<lossy<T>>
 } // namespace detail
 
 /// @brief Converts a value of type SourceType to a corresponding value of type DestinationType. This function needs to
-/// be specialized by the user for the types to be converted.
+/// be specialized by the user for the types to be converted. If a partial specialization is needed, please have a look
+/// at 'FromImpl'.
+/// @note If the conversion is potentially lossy 'Destination from<Source, Destination>(...)' should not be used but
+/// instead either one or both of:
+///   - 'Destination from<Source, lossy<Destination>>(...)'
+///   - 'optional<Destination> from<Source, optional<Destination>>(...)'
+/// The `Destination from<Source, Destination>(...)` implementation should have a 'static_assert' with a hint of the
+/// reason, e.g. lossy conversion and a hint to use 'Destination into<lossy<Destination>>(...)' or
+/// `optional<Destination> into<optional<Destination>>(...)`. The `std_string_support.hpp` can be used as a source of
+/// inspiration for an implementation and error message.
 /// @code
 /// enum class LowLevel
 /// {

--- a/iceoryx_hoofs/utility/include/iox/into.hpp
+++ b/iceoryx_hoofs/utility/include/iox/into.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
@@ -78,9 +78,9 @@ iox::config::TomlGatewayConfigParser::parse(const roudi::ConfigFilePathString_t&
         auto serviceName = service->get_as<std::string>(GATEWAY_CONFIG_SERVICE_NAME);
         auto instance = service->get_as<std::string>(GATEWAY_CONFIG_SERVICE_INSTANCE_NAME);
         auto event = service->get_as<std::string>(GATEWAY_CONFIG_SERVICE_EVENT_NAME);
-        entry.m_serviceDescription = iox::capro::ServiceDescription(into<iox::capro::IdString_t>(*serviceName),
-                                                                    into<iox::capro::IdString_t>(*instance),
-                                                                    into<iox::capro::IdString_t>(*event));
+        entry.m_serviceDescription = iox::capro::ServiceDescription(into<lossy<iox::capro::IdString_t>>(*serviceName),
+                                                                    into<lossy<iox::capro::IdString_t>>(*instance),
+                                                                    into<lossy<iox::capro::IdString_t>>(*event));
         config.m_configuredServices.push_back(entry);
     }
 

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -173,7 +173,7 @@ void RouDi::processRuntimeMessages() noexcept
         if (roudiIpcInterface.timedReceive(m_runtimeMessagesThreadTimeout, message))
         {
             auto cmd = runtime::stringToIpcMessageType(message.getElementAtIndex(0).c_str());
-            RuntimeName_t runtimeName{into<RuntimeName_t>(message.getElementAtIndex(1))};
+            RuntimeName_t runtimeName{into<lossy<RuntimeName_t>>(message.getElementAtIndex(1))};
 
             processMessage(message, cmd, runtimeName);
         }
@@ -388,9 +388,11 @@ void RouDi::processMessage(const runtime::IpcMessage& message,
         }
         else
         {
-            capro::Interfaces interface = StringToCaProInterface(into<capro::IdString_t>(message.getElementAtIndex(2)));
+            capro::Interfaces interface =
+                StringToCaProInterface(into<lossy<capro::IdString_t>>(message.getElementAtIndex(2)));
 
-            m_prcMgr->addInterfaceForProcess(runtimeName, interface, into<NodeName_t>(message.getElementAtIndex(3)));
+            m_prcMgr->addInterfaceForProcess(
+                runtimeName, interface, into<lossy<NodeName_t>>(message.getElementAtIndex(3)));
         }
         break;
     }

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
@@ -34,6 +34,8 @@ using ::testing::_;
 
 // ======================================== Helpers ======================================== //
 
+using iox::into;
+using iox::lossy;
 using iox::capro::IdString_t;
 
 // We do not need real channel terminals to test the base class.
@@ -148,9 +150,9 @@ TEST_F(GatewayGenericTest, HandlesMaxmimumChannelCapacity)
     for (auto i = 0U; i < iox::MAX_CHANNEL_NUMBER; i++)
     {
         auto result = sut->addChannel(
-            iox::capro::ServiceDescription(iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i)),
-                                           iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i)),
-                                           iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i))),
+            iox::capro::ServiceDescription(into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i)),
+                                           into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i)),
+                                           into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i))),
             StubbedIceoryxTerminal::Options());
         EXPECT_EQ(false, result.has_error());
     }
@@ -168,9 +170,9 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenExceedingMaximumChannelCapaicity)
     for (auto i = 0U; i < iox::MAX_CHANNEL_NUMBER; i++)
     {
         auto result = sut->addChannel(
-            iox::capro::ServiceDescription(iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i)),
-                                           iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i)),
-                                           iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i))),
+            iox::capro::ServiceDescription(into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i)),
+                                           into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i)),
+                                           into<lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i))),
             StubbedIceoryxTerminal::Options());
         EXPECT_EQ(false, result.has_error());
     }

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -369,7 +369,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, ParseValidConfigFileWithMaximumAllowedN
     for (auto configuredService : config.m_configuredServices)
     {
         std::string stringentry = "validservice" + std::to_string(count);
-        auto convertedStringentry = iox::into<iox::capro::IdString_t>(stringentry);
+        auto convertedStringentry = iox::into<iox::lossy<iox::capro::IdString_t>>(stringentry);
         EXPECT_EQ(configuredService.m_serviceDescription.getServiceIDString(), convertedStringentry);
         EXPECT_EQ(configuredService.m_serviceDescription.getInstanceIDString(), convertedStringentry);
         EXPECT_EQ(configuredService.m_serviceDescription.getEventIDString(), convertedStringentry);

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -136,7 +136,7 @@ TEST_F(PoshRuntime_test, MaxAppNameLength)
     ::testing::Test::RecordProperty("TEST_ID", "dfdf3ce1-c7d4-4c57-94ea-6ed9479371e3");
     std::string maxValidName(iox::MAX_RUNTIME_NAME_LENGTH, 's');
 
-    auto& runtime = PoshRuntime::initRuntime(iox::into<iox::RuntimeName_t>(maxValidName));
+    auto& runtime = PoshRuntime::initRuntime(into<lossy<RuntimeName_t>>(maxValidName));
 
     EXPECT_THAT(maxValidName, StrEq(runtime.getInstanceName().c_str()));
 }
@@ -322,17 +322,17 @@ TEST_F(PoshRuntime_test, getMiddlewarePublisherPublisherlistOverflow)
     for (; i < (iox::MAX_PUBLISHERS - iox::NUMBER_OF_INTERNAL_PUBLISHERS); ++i)
     {
         auto publisherPort = m_runtime->getMiddlewarePublisher(
-            iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+            iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
         ASSERT_NE(nullptr, publisherPort);
     }
     EXPECT_FALSE(publisherlistOverflowDetected);
 
     auto publisherPort = m_runtime->getMiddlewarePublisher(
-        iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+        iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
     EXPECT_EQ(nullptr, publisherPort);
     EXPECT_TRUE(publisherlistOverflowDetected);
 }
@@ -556,17 +556,17 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberSubscriberlistOverflow)
     for (; i < iox::MAX_SUBSCRIBERS; ++i)
     {
         auto subscriberPort = m_runtime->getMiddlewareSubscriber(
-            iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+            iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
         ASSERT_NE(nullptr, subscriberPort);
     }
     EXPECT_FALSE(subscriberlistOverflowDetected);
 
     auto subscriberPort = m_runtime->getMiddlewareSubscriber(
-        iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+        iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
 
     EXPECT_EQ(nullptr, subscriberPort);
     EXPECT_TRUE(subscriberlistOverflowDetected);
@@ -719,17 +719,17 @@ TEST_F(PoshRuntime_test, GetMiddlewareClientWhenMaxClientsAreUsedResultsInClient
     for (; i < iox::MAX_CLIENTS; ++i)
     {
         auto clientPort = m_runtime->getMiddlewareClient(
-            iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+            iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
         ASSERT_THAT(clientPort, Ne(nullptr));
     }
     EXPECT_FALSE(clientOverflowDetected);
 
     auto clientPort = m_runtime->getMiddlewareClient(
-        iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+        iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
     EXPECT_THAT(clientPort, Eq(nullptr));
     EXPECT_TRUE(clientOverflowDetected);
 }
@@ -830,17 +830,17 @@ TEST_F(PoshRuntime_test, GetMiddlewareServerWhenMaxServerAreUsedResultsInServerl
     for (; i < iox::MAX_SERVERS; ++i)
     {
         auto serverPort = m_runtime->getMiddlewareServer(
-            iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                           iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+            iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                           into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
         ASSERT_THAT(serverPort, Ne(nullptr));
     }
     EXPECT_FALSE(serverOverflowDetected);
 
     auto serverPort = m_runtime->getMiddlewareServer(
-        iox::capro::ServiceDescription(iox::into<iox::RuntimeName_t>(convert::toString(i)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 1U)),
-                                       iox::into<iox::RuntimeName_t>(convert::toString(i + 2U))));
+        iox::capro::ServiceDescription(into<lossy<RuntimeName_t>>(convert::toString(i)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 1U)),
+                                       into<lossy<RuntimeName_t>>(convert::toString(i + 2U))));
     EXPECT_THAT(serverPort, Eq(nullptr));
     EXPECT_TRUE(serverOverflowDetected);
 }

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -21,6 +21,9 @@
 
 namespace iox_test_roudi_portmanager
 {
+using iox::into;
+using iox::lossy;
+
 PublisherOptions createTestPubOptions()
 {
     return PublisherOptions{0U, iox::NodeName_t("node"), true, iox::popo::ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA};
@@ -596,10 +599,10 @@ TEST_F(PortManager_test, DeleteInterfacePortfromMaximumNumberAndAddOneIsSuccessf
         unsigned int testi = 0;
         auto newProcessName = runtimeName + iox::cxx::convert::toString(testi);
         // this is done because there is no removeInterfaceData method in the PortManager class
-        m_portManager->deletePortsOfProcess(iox::into<iox::RuntimeName_t>(newProcessName));
+        m_portManager->deletePortsOfProcess(into<lossy<iox::RuntimeName_t>>(newProcessName));
 
         auto interfacePort = m_portManager->acquireInterfacePortData(iox::capro::Interfaces::INTERNAL,
-                                                                     iox::into<iox::RuntimeName_t>(newProcessName));
+                                                                     into<lossy<iox::RuntimeName_t>>(newProcessName));
         EXPECT_NE(interfacePort, nullptr);
     }
 }
@@ -655,10 +658,10 @@ TEST_F(PortManager_test, DeleteConditionVariablePortfromMaximumNumberAndAddOneIs
         unsigned int testi = 0;
         auto newProcessName = runtimeName + iox::cxx::convert::toString(testi);
         // this is done because there is no removeConditionVariableData method in the PortManager class
-        m_portManager->deletePortsOfProcess(iox::into<iox::RuntimeName_t>(newProcessName));
+        m_portManager->deletePortsOfProcess(into<lossy<iox::RuntimeName_t>>(newProcessName));
 
         auto conditionVariableResult =
-            m_portManager->acquireConditionVariableData(iox::into<iox::RuntimeName_t>(newProcessName));
+            m_portManager->acquireConditionVariableData(into<lossy<iox::RuntimeName_t>>(newProcessName));
         EXPECT_FALSE(conditionVariableResult.has_error());
     }
 }
@@ -726,8 +729,8 @@ TEST_F(PortManager_test, DeleteNodePortfromMaximumNumberandAddOneIsSuccessful)
 
     // delete one and add one NodeData should be possible now
     unsigned int i = 0U;
-    iox::RuntimeName_t newProcessName = iox::into<RuntimeName_t>(runtimeName + iox::cxx::convert::toString(i));
-    iox::NodeName_t newNodeName = iox::into<RuntimeName_t>(nodeName + iox::cxx::convert::toString(i));
+    iox::RuntimeName_t newProcessName = into<lossy<RuntimeName_t>>(runtimeName + iox::cxx::convert::toString(i));
+    iox::NodeName_t newNodeName = into<lossy<RuntimeName_t>>(nodeName + iox::cxx::convert::toString(i));
     // this is done because there is no removeNodeData method in the PortManager class
     m_portManager->deletePortsOfProcess(newProcessName);
 
@@ -768,7 +771,7 @@ TEST_F(PortManager_test, UnblockRouDiShutdownMakesAllPublisherStopOffer)
     for (unsigned int i = 0; i < iox::MAX_PUBLISHERS; i++)
     {
         auto servideDescription = getUniqueSD();
-        auto publisherRuntimeName = iox::into<iox::RuntimeName_t>("pub_" + std::to_string(i));
+        auto publisherRuntimeName = into<lossy<iox::RuntimeName_t>>("pub_" + std::to_string(i));
         auto publisherPortDataResult = m_portManager->acquirePublisherPortData(servideDescription,
                                                                                publisherOptions,
                                                                                publisherRuntimeName,

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
@@ -133,9 +133,9 @@ class PortManager_test : public Test
                 }
             }
         }
-        return {iox::into<iox::capro::IdString_t>(convert::toString(m_sIdCounter)),
-                iox::into<iox::capro::IdString_t>(convert::toString(m_eventIdCounter)),
-                iox::into<iox::capro::IdString_t>(convert::toString(m_instIdCounter))};
+        return {into<lossy<IdString_t>>(convert::toString(m_sIdCounter)),
+                into<lossy<IdString_t>>(convert::toString(m_eventIdCounter)),
+                into<lossy<IdString_t>>(convert::toString(m_instIdCounter))};
     }
 
     void acquireMaxNumberOfInterfaces(
@@ -146,7 +146,7 @@ class PortManager_test : public Test
         {
             auto newProcessName = runtimeName + iox::cxx::convert::toString(i);
             auto interfacePort = m_portManager->acquireInterfacePortData(iox::capro::Interfaces::INTERNAL,
-                                                                         iox::into<iox::RuntimeName_t>(newProcessName));
+                                                                         into<lossy<RuntimeName_t>>(newProcessName));
             ASSERT_NE(interfacePort, nullptr);
             if (f)
             {
@@ -162,7 +162,7 @@ class PortManager_test : public Test
         for (unsigned int i = 0; i < iox::MAX_NUMBER_OF_CONDITION_VARIABLES; i++)
         {
             auto newProcessName = runtimeName + iox::cxx::convert::toString(i);
-            auto condVar = m_portManager->acquireConditionVariableData(iox::into<iox::RuntimeName_t>(newProcessName));
+            auto condVar = m_portManager->acquireConditionVariableData(into<lossy<RuntimeName_t>>(newProcessName));
             ASSERT_FALSE(condVar.has_error());
             if (f)
             {
@@ -180,8 +180,8 @@ class PortManager_test : public Test
         {
             auto newProcessName = runtimeName + iox::cxx::convert::toString(i);
             auto newNodeName = nodeName + iox::cxx::convert::toString(i);
-            auto node = m_portManager->acquireNodeData(iox::into<RuntimeName_t>(newProcessName),
-                                                       iox::into<NodeName_t>(newNodeName));
+            auto node = m_portManager->acquireNodeData(into<lossy<RuntimeName_t>>(newProcessName),
+                                                       into<lossy<NodeName_t>>(newNodeName));
             ASSERT_FALSE(node.has_error());
             if (f)
             {

--- a/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portpool.cpp
@@ -45,9 +45,9 @@ class PortPool_test : public Test
         for (uint32_t i = 0; i < numberOfClientPortsToAdd; ++i)
         {
             std::string service = "service" + cxx::convert::toString(i);
-            auto serviceId = iox::into<IdString_t>(service);
+            auto serviceId = into<lossy<IdString_t>>(service);
             ServiceDescription sd{serviceId, "instance", "event"};
-            RuntimeName_t runtimeName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+            RuntimeName_t runtimeName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
             auto clientPortResult = sut.addClientPort(sd, &m_memoryManager, runtimeName, m_clientOptions, m_memoryInfo);
             if (clientPortResult.has_error())
@@ -68,9 +68,9 @@ class PortPool_test : public Test
         for (uint32_t i = 0; i < numberOfServerPortsToAdd; ++i)
         {
             std::string service = "service" + cxx::convert::toString(i);
-            auto serviceId = iox::into<IdString_t>(service);
+            auto serviceId = into<lossy<IdString_t>>(service);
             ServiceDescription sd{serviceId, "instance", "event"};
-            RuntimeName_t runtimeName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+            RuntimeName_t runtimeName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
             auto serverPortResult = sut.addServerPort(sd, &m_memoryManager, runtimeName, m_serverOptions, m_memoryInfo);
             if (serverPortResult.has_error())
@@ -221,7 +221,7 @@ TEST_F(PortPool_test, AddPublisherPortWithMaxCapacityIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "3328692a-77a7-42d4-8ec2-154e1e89f8cd");
     for (uint32_t i = 0U; i < MAX_PUBLISHERS; ++i)
     {
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
         auto publisherPort = sut.addPublisherPort(
             m_serviceDescription, &m_memoryManager, applicationName, m_publisherOptions, m_memoryInfo);
@@ -242,10 +242,10 @@ TEST_F(PortPool_test, AddPublisherPortWhenPublisherListOverflowsReturnsError)
     auto addPublisherPort = [&](const uint32_t i) -> bool {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
         return sut
-            .addPublisherPort({iox::into<IdString_t>(service), iox::into<IdString_t>(instance), "foo"},
+            .addPublisherPort({into<lossy<IdString_t>>(service), into<lossy<IdString_t>>(instance), "foo"},
                               &m_memoryManager,
                               applicationName,
                               m_publisherOptions)
@@ -300,9 +300,9 @@ TEST_F(PortPool_test, GetPublisherPortDataListCompletelyFilledSuccessfully)
     {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
-        ASSERT_FALSE(sut.addPublisherPort({iox::into<IdString_t>(service), iox::into<IdString_t>(instance), "foo"},
+        ASSERT_FALSE(sut.addPublisherPort({into<lossy<IdString_t>>(service), into<lossy<IdString_t>>(instance), "foo"},
                                           &m_memoryManager,
                                           applicationName,
                                           m_publisherOptions)
@@ -352,7 +352,7 @@ TEST_F(PortPool_test, AddSubscriberPortToMaxCapacityIsSuccessful)
     {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
 
         auto subscriberPort =
@@ -374,11 +374,11 @@ TEST_F(PortPool_test, AddSubscriberPortWhenSubscriberListOverflowsReturnsError)
     auto addSubscriberPort = [&](const uint32_t i) -> bool {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
 
         auto publisherPort =
-            sut.addSubscriberPort({iox::into<IdString_t>(service), iox::into<IdString_t>(instance), "foo"},
+            sut.addSubscriberPort({into<lossy<IdString_t>>(service), into<lossy<IdString_t>>(instance), "foo"},
                                   applicationName,
                                   m_subscriberOptions);
         return publisherPort.has_error();
@@ -427,10 +427,10 @@ TEST_F(PortPool_test, GetSubscriberPortDataListCompletelyFilledIsSuccessful)
     {
         std::string service = "service" + cxx::convert::toString(i);
         std::string instance = "instance" + cxx::convert::toString(i);
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
 
         auto publisherPort =
-            sut.addSubscriberPort({iox::into<IdString_t>(service), iox::into<IdString_t>(instance), "foo"},
+            sut.addSubscriberPort({into<lossy<IdString_t>>(service), into<lossy<IdString_t>>(instance), "foo"},
                                   applicationName,
                                   m_subscriberOptions);
         EXPECT_FALSE(publisherPort.has_error());
@@ -737,7 +737,7 @@ TEST_F(PortPool_test, GetInterfacePortDataListCompletelyFilledIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "460703f9-72d8-4b72-9c3a-761be22e6c9a");
     for (uint32_t i = 0U; i < MAX_INTERFACE_NUMBER; ++i)
     {
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
         ASSERT_FALSE(sut.addInterfacePort(applicationName, Interfaces::INTERNAL).has_error());
     }
     auto interfacePortDataList = sut.getInterfacePortDataList();
@@ -824,7 +824,7 @@ TEST_F(PortPool_test, GetConditionVariableDataListCompletelyFilledIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "42c58990-4dbe-485f-bbf6-7430cc878118");
     for (uint32_t i = 0U; i < MAX_NUMBER_OF_CONDITION_VARIABLES; ++i)
     {
-        RuntimeName_t applicationName = iox::into<RuntimeName_t>("AppName" + cxx::convert::toString(i));
+        RuntimeName_t applicationName = into<lossy<RuntimeName_t>>("AppName" + cxx::convert::toString(i));
         ASSERT_FALSE(sut.addConditionVariableData(applicationName).has_error());
     }
     auto condtionalVariableData = sut.getConditionVariableDataList();

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -184,7 +184,7 @@ TYPED_TEST(ServiceRegistry_test, AddMaximumNumberOfServiceDescriptionsWorks)
     for (uint64_t i = 0U; i < CAPACITY; i++)
     {
         services.push_back(iox::capro::ServiceDescription(
-            "Foo", "Bar", iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i))));
+            "Foo", "Bar", iox::into<iox::lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i))));
     }
 
     for (auto& service : services)
@@ -202,7 +202,7 @@ TYPED_TEST(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFa
     for (uint64_t i = 0U; i < CAPACITY; i++)
     {
         services.push_back(iox::capro::ServiceDescription(
-            "Foo", "Bar", iox::into<iox::capro::IdString_t>(iox::cxx::convert::toString(i))));
+            "Foo", "Bar", iox::into<iox::lossy<iox::capro::IdString_t>>(iox::cxx::convert::toString(i))));
     }
 
     for (auto& service : services)
@@ -598,7 +598,7 @@ TYPED_TEST(ServiceRegistry_test, SearchInFullRegistryWorks)
 
     constexpr auto CAP = string_t::capacity();
 
-    string_t fixedId = iox::into<string_t>(std::string(CAP, '0'));
+    string_t fixedId = iox::into<iox::lossy<string_t>>(std::string(CAP, '0'));
 
     ServiceDescription lastAdded;
     do


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR makes the potentially lossy conversion from a `std::string` into a fixed size `iox::string` more visible to the user.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1612 
