### PR TITLE
iox-1893 fix memory leak in stack

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -69,6 +69,7 @@
   [\#1821](https://github.com/eclipse-iceoryx/iceoryx/issues/1821)
 - Can not build iceoryx with gcc 9.4 [\#1871](https://github.com/eclipse-iceoryx/iceoryx/issues/1871)
 - Update iceoryx_integrationtest package to use ROS2 Humble [\#1906](https://github.com/eclipse-iceoryx/iceoryx/issues/1906)
+- Fix potential memory leak in `iox::stack` [\#1893](https://github.com/eclipse-iceoryx/iceoryx/issues/1893)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
+++ b/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
@@ -144,10 +144,9 @@ inline optional<T> stack<T, Capacity>::pop() noexcept
         return nullopt;
     }
 
-    // AXIVION Next Construct AutosarC++19_03-A5.2.4 : low level memory management with access to the topmost element on
-    // the untyped buffer; reinterpret_cast is safe since the size and the alignment of each array element is guaranteed
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return *reinterpret_cast<T*>(&m_data[--m_size]);
+    optional<T> element{std::move(m_data[--m_size])};
+    m_data[m_size].~T();
+    return element;
 }
 
 template <typename T, uint64_t Capacity>

--- a/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
+++ b/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
@@ -130,10 +130,7 @@ inline T& stack<T, Capacity>::getUnchecked(const uint64_t index) noexcept
 template <typename T, uint64_t Capacity>
 inline const T& stack<T, Capacity>::getUnchecked(const uint64_t index) const noexcept
 {
-    // AXIVION Next Construct AutosarC++19_03-A5.2.4 : reinterpret_cast is safe since the size and the alignment of each
-    // array element is guaranteed
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    return *reinterpret_cast<const T*>(&m_data[index]);
+    return m_data[index];
 }
 
 template <typename T, uint64_t Capacity>

--- a/iceoryx_hoofs/buffer/include/iox/stack.hpp
+++ b/iceoryx_hoofs/buffer/include/iox/stack.hpp
@@ -18,12 +18,18 @@
 
 #include "iox/algorithm.hpp"
 #include "iox/optional.hpp"
+#include "iox/type_traits.hpp"
 #include "iox/uninitialized_array.hpp"
 
 #include <cstdint>
 
 namespace iox
 {
+
+// Due to 'pop' returning an 'iox::optional'
+template <typename T>
+using is_storable_in_iox_stack_t = typename std::is_move_constructible<T>::type;
+
 // AXIVION Next Construct AutosarC++19_03-A12.1.1 : it is guaranteed that the array elements are initialized before read
 // access
 // AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive since no bit-fields are involved
@@ -34,6 +40,8 @@ template <typename T, uint64_t Capacity>
 class stack final // NOLINT(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 {
   public:
+    static_assert(is_storable_in_iox_stack_t<T>::value, "T has to be move constructible");
+
     stack() noexcept = default;
     stack(const stack& rhs) noexcept;
     stack(stack&& rhs) noexcept;

--- a/iceoryx_hoofs/test/moduletests/test_buffer_stack.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_buffer_stack.cpp
@@ -43,6 +43,7 @@ struct CompareOrder
 class TestClass
 {
   public:
+    static uint32_t cTor;
     static uint32_t copyCTor;
     static uint32_t moveCTor;
     static uint32_t copyAssignment;
@@ -58,6 +59,7 @@ class TestClass
         , m_b(b)
         , m_c(c)
     {
+        cTor++;
     }
 
     TestClass(const TestClass& rhs) noexcept
@@ -115,6 +117,7 @@ class TestClass
     uint32_t m_a = 0, m_b = 0, m_c = 0;
 };
 
+uint32_t TestClass::cTor;
 uint32_t TestClass::copyCTor;
 uint32_t TestClass::moveCTor;
 uint32_t TestClass::copyAssignment;
@@ -141,6 +144,7 @@ class stack_test : public Test
 
     void SetUp() override
     {
+        TestClass::cTor = 0;
         TestClass::copyCTor = 0;
         TestClass::moveCTor = 0;
         TestClass::copyAssignment = 0;
@@ -252,6 +256,34 @@ TEST_F(stack_test, CopyConstructorWorksAndCallsTestClassCopyConstructor)
     EXPECT_THAT(TestClass::copyCTor, Eq(1));
     ASSERT_THAT(testStack.size(), Eq(1));
     EXPECT_THAT(testStack.pop().value(), Eq(TestClass(ELEMENT, ELEMENT, ELEMENT)));
+}
+
+TEST_F(stack_test, CopyCtorWithOneElementLeadsToEqualCtorAndDtorCalls)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "dc44fcdc-ced6-4345-822b-58b9e58baf85");
+    constexpr uint32_t ELEMENT{37};
+    {
+        stack<TestClass, STACK_SIZE> other;
+        other.push(TestClass(ELEMENT, ELEMENT, ELEMENT));
+
+        stack<TestClass, STACK_SIZE> sut(other);
+
+        EXPECT_EQ(other.size(), 1);
+        EXPECT_EQ(sut.size(), 1);
+
+        EXPECT_THAT(TestClass::dTor, Eq(1));
+        EXPECT_THAT(TestClass::copyCTor, Eq(1));
+        EXPECT_THAT(TestClass::moveCTor, Eq(1));
+
+        auto element = sut.pop();
+        ASSERT_TRUE(element.has_value());
+        EXPECT_THAT(other.size(), Eq(1));
+        EXPECT_THAT(sut.size(), Eq(0));
+    }
+    EXPECT_THAT(TestClass::dTor, Eq(5));
+    EXPECT_THAT(TestClass::cTor, Eq(5));
+    EXPECT_THAT(TestClass::copyCTor, Eq(1));
+    EXPECT_THAT(TestClass::moveCTor, Eq(3));
 }
 
 TEST_F(stack_test, CopyConstructorWithEmptyStackWorks)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

* Fix potential memory leak in `iox::stack` by
  * Moving the value out on `pop()`
  * Calling `T::~T` after `pop()` on the moved-from value inside the `iox::stack` 

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1893 
