### PR TITLE
iox-#1892 Ensure the NonZeroedBuffer does not zero its elements

### DIFF
--- a/iceoryx_hoofs/container/include/iox/uninitialized_array.hpp
+++ b/iceoryx_hoofs/container/include/iox/uninitialized_array.hpp
@@ -77,7 +77,9 @@ class UninitializedArray final
     using iterator = ElementType*;
     using const_iterator = const ElementType*;
 
-    constexpr UninitializedArray() noexcept = default;
+    // The (empty) user-defined constructor is required.
+    // Use of "= default" leads to value-initialization of class members.
+    constexpr UninitializedArray() noexcept {};
     UninitializedArray(const UninitializedArray&) = delete;
     UninitializedArray(UninitializedArray&&) = delete;
     UninitializedArray& operator=(const UninitializedArray&) = delete;

--- a/iceoryx_hoofs/test/moduletests/test_container_uninitialized_array.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_container_uninitialized_array.cpp
@@ -149,6 +149,8 @@ TEST(UninitializedArrayTest, AllElementsInitializedWithZeroWhenBufferSetToZeroed
     for (auto& e : buffer)
     {
         new (&e) uint32_t(std::numeric_limits<uint32_t>::max());
+        // Access `e` to prevent the compiler from optimizing away the loop
+        EXPECT_EQ(e, std::numeric_limits<uint32_t>::max());
     }
 
     new (&buffer) UninitializedArray<uint32_t, CAPACITY, iox::ZeroedBuffer>();
@@ -156,6 +158,31 @@ TEST(UninitializedArrayTest, AllElementsInitializedWithZeroWhenBufferSetToZeroed
     for (auto& e : buffer)
     {
         EXPECT_EQ(e, 0);
+    }
+}
+
+TEST(UninitializedArrayTest, AllElementsAreNotZeroedWhenBufferSetToNonZeroedBuffer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "35666437-6ee5-4940-b053-e82d8e312a11");
+    constexpr uint64_t CAPACITY{32};
+    UninitializedArray<uint32_t, CAPACITY, iox::ZeroedBuffer> buffer;
+    for (auto& e : buffer)
+    {
+        new (&e) uint32_t(std::numeric_limits<uint32_t>::max());
+        // Access `e` to prevent the compiler from optimizing away the loop
+        EXPECT_EQ(e, std::numeric_limits<uint32_t>::max());
+    }
+
+    new (&buffer) UninitializedArray<uint32_t, CAPACITY, iox::NonZeroedBuffer>();
+
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays) : explicitly required for test
+    uint32_t result[CAPACITY];
+    memcpy(&result, &buffer, CAPACITY * sizeof(uint32_t));
+
+    for (uint64_t i = 0; i < CAPACITY; i++)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index) : false positive, is integer constexpr
+        EXPECT_EQ(result[i], std::numeric_limits<uint32_t>::max());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Jeff Ithier <jeff.ithier@apex.ai>

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Providing a user-default (empty) constructor prevents value-initialization of the buffer.
See: https://stackoverflow.com/a/2418195

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1892 