### PR TITLE
iox-#1934 Alias invoke_result to correct implementation based on C++ version

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -74,6 +74,7 @@
 - Fix potential memory leak in `iox::stack` [\#1893](https://github.com/eclipse-iceoryx/iceoryx/issues/1893)
 - Make `MAX_USER_NAME_LENGTH` and `MAX_GROUP_NAME_LENGTH` platform-dependent [\#1919](https://github.com/eclipse-iceoryx/iceoryx/issues/1919)
 - Fix milliseconds in log timestamps [\#1932](https://github.com/eclipse-iceoryx/iceoryx/issues/1932)
+- Alias `invoke_result` to correct implementation based on C++ version [\#1934](https://github.com/eclipse-iceoryx/iceoryx/issues/1934)
 
 **Refactoring:**
 

--- a/iceoryx_platform/linux/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/linux/include/iceoryx_platform/platform_settings.hpp
@@ -41,8 +41,13 @@ constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
 constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
 constexpr uint64_t MAX_GROUP_NAME_LENGTH = 32;
 
+#if __cplusplus >= 201703L
+template <typename C, typename... Cargs>
+using invoke_result = std::invoke_result<C, Cargs...>;
+#else
 template <typename C, typename... Cargs>
 using invoke_result = std::result_of<C(Cargs...)>;
+#endif
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_platform/mac/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/mac/include/iceoryx_platform/platform_settings.hpp
@@ -42,8 +42,13 @@ constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
 constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
 constexpr uint64_t MAX_GROUP_NAME_LENGTH = 16;
 
+#if __cplusplus >= 201703L
 template <typename C, typename... Cargs>
 using invoke_result = std::invoke_result<C, Cargs...>;
+#else
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
+#endif
 
 } // namespace platform
 } // namespace iox

--- a/iceoryx_platform/qnx/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/qnx/include/iceoryx_platform/platform_settings.hpp
@@ -40,8 +40,13 @@ constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/var/lock/";
 constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
 constexpr uint64_t MAX_GROUP_NAME_LENGTH = 16;
 
+#if __cplusplus >= 201703L
+template <typename C, typename... Cargs>
+using invoke_result = std::invoke_result<C, Cargs...>;
+#else
 template <typename C, typename... Cargs>
 using invoke_result = std::result_of<C(Cargs...)>;
+#endif
 } // namespace platform
 } // namespace iox
 

--- a/iceoryx_platform/unix/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/unix/include/iceoryx_platform/platform_settings.hpp
@@ -41,8 +41,13 @@ constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
 constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
 constexpr uint64_t MAX_GROUP_NAME_LENGTH = 16;
 
+#if __cplusplus >= 201703L
 template <typename C, typename... Cargs>
 using invoke_result = std::invoke_result<C, Cargs...>;
+#else
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
+#endif
 
 } // namespace platform
 } // namespace iox

--- a/iceoryx_platform/win/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/platform_settings.hpp
@@ -43,8 +43,13 @@ constexpr uint64_t IOX_MAX_PATH_LENGTH = 255U;
 constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
 constexpr uint64_t MAX_GROUP_NAME_LENGTH = 16;
 
+#if __cplusplus >= 201703L
 template <typename C, typename... Cargs>
 using invoke_result = std::invoke_result<C, Cargs...>;
+#else
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
+#endif
 
 namespace win32
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. ~~[ ] Tests follow the [best practice for testing][testing]~~
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

`result_of` has been deprecated in C++17 and removed in C++20

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes https://github.com/eclipse-iceoryx/iceoryx/issues/1934
