### PR TITLE
iox-1955 use posix compliant calls to set nonblocking flags

### DIFF
--- a/iceoryx_examples/iceperf/uds.cpp
+++ b/iceoryx_examples/iceperf/uds.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_examples/iceperf/uds.cpp
+++ b/iceoryx_examples/iceperf/uds.cpp
@@ -93,7 +93,7 @@ void UDS::initFollower() noexcept
 void UDS::init() noexcept
 {
     // init subscriber
-    iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM | SOCK_NONBLOCK, 0)
+    iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0)
         .failureReturnValue(ERROR_CODE)
         .evaluate()
         .and_then([this](auto& r) { m_sockfdSubscriber = r.value; })
@@ -101,6 +101,28 @@ void UDS::init() noexcept
             std::cout << "socket error " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
         });
+
+    auto setNonBlocking = [&](int fd) {
+        int fdFlags{0};
+        iox::posix::posixCall(iox_fcntl2)(fd, F_GETFL)
+            .failureReturnValue(ERROR_CODE)
+            .evaluate()
+            .and_then([&](auto& r) { fdFlags = r.value; })
+            .or_else([](auto& r) {
+                std::cout << "error getting socket flags: " << r.getHumanReadableErrnum() << std::endl;
+                exit(1);
+            });
+
+        iox::posix::posixCall(iox_fcntl3)(fd, F_SETFL, fdFlags | O_NONBLOCK)
+            .failureReturnValue(ERROR_CODE)
+            .evaluate()
+            .or_else([](auto& r) {
+                std::cout << "error setting socket O_NONBLOCK flag: " << r.getHumanReadableErrnum() << std::endl;
+                exit(1);
+            });
+    };
+
+    setNonBlocking(m_sockfdSubscriber);
 
     iox::posix::posixCall(iox_bind)(
         m_sockfdSubscriber, reinterpret_cast<struct sockaddr*>(&m_sockAddrSubscriber), sizeof(m_sockAddrSubscriber))
@@ -112,7 +134,7 @@ void UDS::init() noexcept
         });
 
     // init publisher
-    iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM | SOCK_NONBLOCK, 0)
+    iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0)
         .failureReturnValue(ERROR_CODE)
         .evaluate()
         .and_then([this](auto& r) { m_sockfdPublisher = r.value; })
@@ -120,6 +142,8 @@ void UDS::init() noexcept
             std::cout << "socket error " << r.getHumanReadableErrnum() << std::endl;
             exit(1);
         });
+
+    setNonBlocking(m_sockfdPublisher);
 }
 
 void UDS::waitForLeader() noexcept

--- a/iceoryx_platform/linux/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/linux/include/iceoryx_platform/fcntl.hpp
@@ -21,4 +21,7 @@
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 
+int iox_fcntl2(int fd, int cmd);
+int iox_fcntl3(int fd, int cmd, int flags);
+
 #endif // IOX_HOOFS_LINUX_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/linux/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/linux/include/iceoryx_platform/fcntl.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/linux/source/fnctl.cpp
+++ b/iceoryx_platform/linux/source/fnctl.cpp
@@ -21,3 +21,13 @@ int iox_open(const char* pathname, int flags, mode_t mode)
 {
     return open(pathname, flags, mode);
 }
+
+int iox_fcntl2(int fd, int cmd)
+{
+    return fcntl(fd, cmd);
+}
+
+int iox_fcntl3(int fd, int cmd, int flags)
+{
+    return fcntl(fd, cmd, flags);
+}

--- a/iceoryx_platform/linux/source/fnctl.cpp
+++ b/iceoryx_platform/linux/source/fnctl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/mac/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/mac/include/iceoryx_platform/fcntl.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/mac/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/mac/include/iceoryx_platform/fcntl.hpp
@@ -21,4 +21,7 @@
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 
+int iox_fcntl2(int fd, int cmd);
+int iox_fcntl3(int fd, int cmd, int flags);
+
 #endif // IOX_HOOFS_MAC_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/mac/source/fnctl.cpp
+++ b/iceoryx_platform/mac/source/fnctl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/mac/source/fnctl.cpp
+++ b/iceoryx_platform/mac/source/fnctl.cpp
@@ -20,3 +20,13 @@ int iox_open(const char* pathname, int flags, mode_t mode)
 {
     return open(pathname, flags, mode);
 }
+
+int iox_fcntl2(int fd, int cmd)
+{
+    return fcntl(fd, cmd);
+}
+
+int iox_fcntl3(int fd, int cmd, int flags)
+{
+    return fcntl(fd, cmd, flags);
+}

--- a/iceoryx_platform/qnx/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/qnx/include/iceoryx_platform/fcntl.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/qnx/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/qnx/include/iceoryx_platform/fcntl.hpp
@@ -21,4 +21,7 @@
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 
+int iox_fcntl2(int fd, int cmd);
+int iox_fcntl3(int fd, int cmd, int flags);
+
 #endif // IOX_HOOFS_QNX_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/qnx/source/fnctl.cpp
+++ b/iceoryx_platform/qnx/source/fnctl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/qnx/source/fnctl.cpp
+++ b/iceoryx_platform/qnx/source/fnctl.cpp
@@ -20,3 +20,13 @@ int iox_open(const char* pathname, int flags, mode_t mode)
 {
     return open(pathname, flags, mode);
 }
+
+int iox_fcntl2(int fd, int cmd)
+{
+    return fcntl(fd, cmd);
+}
+
+int iox_fcntl3(int fd, int cmd, int flags)
+{
+    return fcntl(fd, cmd, flags);
+}

--- a/iceoryx_platform/unix/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/unix/include/iceoryx_platform/fcntl.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/unix/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/unix/include/iceoryx_platform/fcntl.hpp
@@ -21,4 +21,7 @@
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 
+int iox_fcntl2(int fd, int cmd);
+int iox_fcntl3(int fd, int cmd, int flags);
+
 #endif // IOX_HOOFS_UNIX_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/unix/source/fnctl.cpp
+++ b/iceoryx_platform/unix/source/fnctl.cpp
@@ -21,3 +21,13 @@ int iox_open(const char* pathname, int flags, mode_t mode)
 {
     return open(pathname, flags, mode);
 }
+
+int iox_fcntl2(int fd, int cmd)
+{
+    return fcntl(fd, cmd);
+}
+
+int iox_fcntl3(int fd, int cmd, int flags)
+{
+    return fcntl(fd, cmd, flags);
+}

--- a/iceoryx_platform/unix/source/fnctl.cpp
+++ b/iceoryx_platform/unix/source/fnctl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
@@ -33,4 +33,7 @@
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 
+int iox_fcntl2(int fd, int cmd);
+int iox_fcntl3(int fd, int cmd, int flags);
+
 #endif // IOX_HOOFS_WIN_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/fcntl.hpp
@@ -31,6 +31,9 @@
 #define O_WRONLY _O_WRONLY
 #define O_NONBLOCK 0x0
 
+#define F_GETFL 3
+#define F_SETFL 4
+
 int iox_open(const char* pathname, int flags, mode_t mode);
 
 int iox_fcntl2(int fd, int cmd);

--- a/iceoryx_platform/win/source/fnctl.cpp
+++ b/iceoryx_platform/win/source/fnctl.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_platform/win/source/fnctl.cpp
+++ b/iceoryx_platform/win/source/fnctl.cpp
@@ -39,3 +39,17 @@ int iox_open(const char* pathname, int flags, mode_t mode)
 
     return HandleTranslator::getInstance().add(handle);
 }
+
+int iox_fcntl2(int, int)
+{
+    fprintf(stderr, "%s is not implemented in windows!\n", __PRETTY_FUNCTION__);
+    errno = ENOSYS;
+    return -1;
+}
+
+int iox_fcntl3(int, int, int)
+{
+    fprintf(stderr, "%s is not implemented in windows!\n", __PRETTY_FUNCTION__);
+    errno = ENOSYS;
+    return -1;
+}


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR replaces `SOCK_NOBLOCK` with `O_NON_BLOCK` via `fcntl`. The iceoryx_platform had to be updated for `fcntl`.

I did not add this bugfix to the release notes since it was not part of any release but only recently introduced.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1955
