### PR TITLE
iox-#1969 rework constructors for expected

### DIFF
--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -475,6 +475,22 @@ TEST_F(expected_test, ErrorTypeOnlyMoveAssignmentLeadsToMovedSource)
     EXPECT_FALSE(sutDestination.get_error().m_moved);
     EXPECT_EQ(sutDestination.get_error().m_a, A);
     EXPECT_EQ(sutDestination.get_error().m_b, B);
+}
+
+TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidErrorOnlySut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "91a8ad7f-4843-4bd9-a56b-0561ae6b56cb");
+    expected<TestError> sut{in_place};
+    ASSERT_THAT(sut.has_error(), Eq(false));
+}
+
+TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidSut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3a527c62-aaea-44ae-9b99-027c19d032b5");
+    constexpr int VALUE = 42;
+    expected<int, TestError> sut{in_place, VALUE};
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
 TEST_F(expected_test, CreateFromEmptySuccessTypeLeadsToValidSut)

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,6 +98,13 @@ inline expected<ValueType, ErrorType>::expected(error<ErrorType>&& errorValue) n
 template <typename ValueType, typename ErrorType>
 inline expected<ValueType, ErrorType>::expected(expected<ValueType, ErrorType>&& rhs) noexcept
     : m_store{std::move(rhs.m_store)}
+{
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename... Targs>
+inline expected<ValueType, ErrorType>::expected(in_place_t, Targs&&... args) noexcept
+    : m_store(in_place_index<VALUE_INDEX>(), std::forward<Targs>(args)...)
 {
 }
 
@@ -265,6 +272,11 @@ inline expected<ErrorType>::expected(const success<void>) noexcept
 }
 
 template <typename ErrorType>
+inline expected<ErrorType>::expected(in_place_t) noexcept
+{
+}
+
+template <typename ErrorType>
 inline expected<ErrorType>::expected(expected<ErrorType>&& rhs) noexcept
     : m_store(std::move(rhs.m_store))
 {
@@ -292,6 +304,7 @@ inline expected<ErrorType>::expected(error<ErrorType>&& errorValue) noexcept
     : m_store(in_place_index<ERROR_INDEX>(), std::move(errorValue.value))
 {
 }
+
 // AXIVION DISABLE STYLE AutosarC++19_03-A16.0.1: Required for Windows due to MSVC deficiencies
 #if defined(_WIN32)
 template <typename ErrorType>

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2019 - 2020 by Robert Bosch GmbH. All rights reserved.
-// Copyright (c) 2020 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2020 - 2023 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -195,6 +195,11 @@ class IOX_NO_DISCARD expected<ErrorType> final : public FunctionalInterface<expe
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(const success<void>) noexcept;
 
+    /// @brief Creates an expected which is signaling success. This mirrors the c'tor for the 'expected' with a
+    /// 'ValueType'.
+    /// @param[in] in_place_t compile time variable to distinguish between constructors with certain behavior
+    explicit expected(in_place_t) noexcept;
+
     /// @brief  constructs an expected which is signaling an error and stores the
     ///         error value provided by errorValue
     /// @param[in] errorValue error value which will be stored in the expected
@@ -276,6 +281,14 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     /// @note The move c'tor does not explicitly invalidate the moved-from object but relies on the move c'tor of
     /// ValueType or ErrorType to correctly invalidate the stored object
     expected(expected&& rhs) noexcept;
+
+    /// @brief Creates an expected which is signaling success and perfectly forwards
+    ///        the args to the constructor of ValueType
+    /// @tparam Targs is the template parameter pack for the perfectly forwarded arguments
+    /// @param[in] in_place_t compile time variable to distinguish between constructors with certain behavior
+    /// @param[in] args... arguments which will be forwarded to the 'ValueType' constructor
+    template <typename... Targs>
+    explicit expected(in_place_t, Targs&&... args) noexcept;
 
     /// @brief calls the destructor of the success value or error value - depending on what
     ///         is stored in the expected


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds the `in_place_t` direct constructors for the `expected` to better align with the `std::expected`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1969
