### PR TITLE
iox-#1969 align iox expected to std expected and add convenience free functions

### DIFF
--- a/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
+++ b/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
@@ -85,7 +85,7 @@ For more information on how it is used for error handling see
 Assume we have `E` as an error type, then we can create a value
 
 ```cpp
-iox::expected<int, E> result(iox::success<int>(73));
+iox::expected<int, E> result(iox::ok(73));
 ```
 
 and use the value or handle a potential error
@@ -106,7 +106,7 @@ else
 If we need an error value, we set
 
 ```cpp
-result = iox::error<E>(errorCode);
+result = iox::err(errorCode);
 ```
 
 which assumes that `E` can be constructed from an `errorCode`.

--- a/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
+++ b/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
@@ -91,7 +91,7 @@ iox::expected<int, E> result(iox::ok(73));
 and use the value or handle a potential error
 
 ```cpp
-if (!result.has_error())
+if (result.has_value())
 {
     auto value = result.value();
     // do something with the value

--- a/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
+++ b/doc/website/concepts/how-optional-and-error-values-are-returned-in-iceoryx.md
@@ -98,7 +98,7 @@ if (!result.has_error())
 }
 else
 {
-    auto error = result.get_error();
+    auto error = result.error();
     // handle the error
 }
 ```

--- a/doc/website/getting-started/overview.md
+++ b/doc/website/getting-started/overview.md
@@ -41,7 +41,7 @@ Now we can use the publisher to send the data.
 
 ```cpp
 auto result = publisher.loan();
-if(!result.has_error())
+if(result.has_value())
 {
     auto& sample = result.value();
     sample->counter = 30;
@@ -66,7 +66,7 @@ iox::popo::Subscriber<CounterTopic> subscriber({"Group", "Instance", "CounterTop
 ```
 
 Now we can use the subscriber to receive data. For simplicity, we assume that we periodically check for new data. It
-is also possible to explicitly wait for data using the [WaitSet](../../../iceoryx_examples/waitset/README.md) or 
+is also possible to explicitly wait for data using the [WaitSet](../../../iceoryx_examples/waitset/README.md) or
 the [Listener](../../../iceoryx_examples/callbacks/README.md). The code to receive the data is the same, the only difference is the way we wake up before checking for data.
 
 ```cpp
@@ -76,7 +76,7 @@ while (keepRunning)
 
     auto result = subscriber.take();
 
-    if(!result.has_error())
+    if(result.has_value())
     {
         auto& sample = result.value();
         uint32_t counter = sample->counter;

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -1135,3 +1135,12 @@
     // after
     return iox::err(MyCustomError::ERROR_CODE);
     ```
+
+51. `expected::get_error` is deprecated in favour of `expected::error`
+
+    ```cpp
+    // before
+    auto e = exp.get_error();
+
+    // after
+    auto e = exp.error();

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -1101,6 +1101,7 @@
     std::chrono::milliseconds chronoDuration = 1_ms;
     iox::units::Duration ioxDuration{into<iox::units::Duration>(chronoDuration)};
     ```
+
 49. Replace error only `expected<E>` with `void` value type `expected<void, E>`
 
     ```cpp
@@ -1109,4 +1110,28 @@
 
     // after
     iox::expected<void, MyCustomError> foo();
+    ```
+
+50. `iox::success` and `iox::error` are deprecated in favour of `ok` and `err` free functions
+
+    ```cpp
+    // before
+    return iox::success<void>();
+
+    // after
+    return iox::ok();
+
+
+    // before
+    return iox::success<bool>(true);
+
+    // after
+    return iox::ok(true);
+
+
+    // before
+    return iox::error<MyCustomError>(MyCustomError::ERROR_CODE);
+
+    // after
+    return iox::err(MyCustomError::ERROR_CODE);
     ```

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -84,6 +84,7 @@
 - Fix undefined behaviour in `publishCopyOf` and `publishResultOf` [\#1963](https://github.com/eclipse-iceoryx/iceoryx/issues/1963)
 - ServiceDescription `Interfaces` and `INTERFACE_NAMES` do not match [\#1977](https://github.com/eclipse-iceoryx/iceoryx/issues/1977)
 - Implement and test nullptr check in c binding [\#1106](https://github.com/eclipse-iceoryx/iceoryx/issues/1106)
+- Fix `expected<void, Error>` is unusable due to `final` [\#1976](https://github.com/eclipse-iceoryx/iceoryx/issues/1976)
 
 **Refactoring:**
 
@@ -136,6 +137,7 @@
 - Wrap all C calls in posixCall in IntrospectionApp [\#1692](https://github.com/eclipse-iceoryx/iceoryx/issues/1692)
 - Move `std::chrono` dependency to `iceoryx_dust` [\#536](https://github.com/eclipse-iceoryx/iceoryx/issues/536)
 - Move `std::string` dependency from `iox::string` to `std_string_support.hpp` in `iceoryx_dust` [\#1612](https://github.com/eclipse-iceoryx/iceoryx/issues/1612)
+- Better align `iox::expected` with `std::expected` [\#1969](https://github.com/eclipse-iceoryx/iceoryx/issues/1969)
 
 **Workflow:**
 
@@ -1079,23 +1081,32 @@
 47. Renaming `byte_t` to `byte`
 
     ```cpp
-    //before
+    // before
     iox::byte_t m_size;
 
-    //after
+    // after
     iox::byte m_size;
     ```
 
 48. Move conversion methods from `duration.hpp` to `iceoryx_dust`
 
     ```cpp
-    //before
+    // before
     std::chrono::milliseconds chronoDuration = 1_ms;
     iox::units::Duration ioxDuration(chronoDuration);
 
-    //after
+    // after
     #include "iceoryx_dust/cxx/std_chrono_support.hpp"
 
     std::chrono::milliseconds chronoDuration = 1_ms;
     iox::units::Duration ioxDuration{into<iox::units::Duration>(chronoDuration)};
+    ```
+49. Replace error only `expected<E>` with `void` value type `expected<void, E>`
+
+    ```cpp
+    // before
+    iox::expected<MyCustomError> foo();
+
+    // after
+    iox::expected<void, MyCustomError> foo();
     ```

--- a/iceoryx_binding_c/source/c_client.cpp
+++ b/iceoryx_binding_c/source/c_client.cpp
@@ -109,7 +109,7 @@ iox_AllocationResult iox_client_loan_aligned_request(iox_client_t const self,
     auto result = self->loan(payloadSize, payloadAlignment);
     if (result.has_error())
     {
-        return cpp2c::allocationResult(result.get_error());
+        return cpp2c::allocationResult(result.error());
     }
 
     *payload = result.value();
@@ -131,7 +131,7 @@ iox_ClientSendResult iox_client_send(iox_client_t const self, void* const payloa
     auto result = self->send(payload);
     if (result.has_error())
     {
-        return cpp2c::clientSendResult(result.get_error());
+        return cpp2c::clientSendResult(result.error());
     }
 
     return ClientSendResult_SUCCESS;
@@ -163,7 +163,7 @@ iox_ChunkReceiveResult iox_client_take_response(iox_client_t const self, const v
     auto result = self->take();
     if (result.has_error())
     {
-        return cpp2c::chunkReceiveResult(result.get_error());
+        return cpp2c::chunkReceiveResult(result.error());
     }
 
     *payload = result.value();

--- a/iceoryx_binding_c/source/c_listener.cpp
+++ b/iceoryx_binding_c/source/c_listener.cpp
@@ -63,7 +63,7 @@ ENUM iox_ListenerResult iox_listener_attach_subscriber_event(iox_listener_t cons
                           NotificationCallback<cpp2c_Subscriber, popo::internal::NoType_t>{callback, nullptr});
     if (result.has_error())
     {
-        return cpp2c::listenerResult(result.get_error());
+        return cpp2c::listenerResult(result.error());
     }
     return ListenerResult_SUCCESS;
 }
@@ -85,7 +85,7 @@ iox_listener_attach_subscriber_event_with_context_data(iox_listener_t const self
                                     NotificationCallback<cpp2c_Subscriber, void>{callback, contextData});
     if (result.has_error())
     {
-        return cpp2c::listenerResult(result.get_error());
+        return cpp2c::listenerResult(result.error());
     }
     return ListenerResult_SUCCESS;
 }
@@ -102,7 +102,7 @@ ENUM iox_ListenerResult iox_listener_attach_user_trigger_event(iox_listener_t co
         self->attachEvent(*userTrigger, NotificationCallback<UserTrigger, popo::internal::NoType_t>{callback, nullptr});
     if (result.has_error())
     {
-        return cpp2c::listenerResult(result.get_error());
+        return cpp2c::listenerResult(result.error());
     }
     return ListenerResult_SUCCESS;
 }
@@ -125,7 +125,7 @@ ENUM iox_ListenerResult iox_listener_attach_user_trigger_event_with_context_data
     auto result = self->attachEvent(*userTrigger, NotificationCallback<UserTrigger, void>{callback, contextData});
     if (result.has_error())
     {
-        return cpp2c::listenerResult(result.get_error());
+        return cpp2c::listenerResult(result.error());
     }
     return ListenerResult_SUCCESS;
 }
@@ -175,8 +175,7 @@ iox_ListenerResult iox_listener_attach_client_event(iox_listener_t const self,
         *client,
         c2cpp::clientEvent(clientEvent),
         NotificationCallback<std::remove_pointer_t<iox_client_t>, popo::internal::NoType_t>{callback, nullptr});
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 iox_ListenerResult iox_listener_attach_client_event_with_context_data(iox_listener_t const self,
@@ -194,8 +193,7 @@ iox_ListenerResult iox_listener_attach_client_event_with_context_data(iox_listen
         self->attachEvent(*client,
                           c2cpp::clientEvent(clientEvent),
                           NotificationCallback<std::remove_pointer_t<iox_client_t>, void>{callback, contextData});
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 void iox_listener_detach_client_event(iox_listener_t const self,
@@ -222,8 +220,7 @@ iox_ListenerResult iox_listener_attach_server_event(iox_listener_t const self,
         *server,
         c2cpp::serverEvent(serverEvent),
         NotificationCallback<std::remove_pointer_t<iox_server_t>, popo::internal::NoType_t>{callback, nullptr});
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 iox_ListenerResult iox_listener_attach_server_event_with_context_data(iox_listener_t const self,
@@ -241,8 +238,7 @@ iox_ListenerResult iox_listener_attach_server_event_with_context_data(iox_listen
         self->attachEvent(*server,
                           c2cpp::serverEvent(serverEvent),
                           NotificationCallback<std::remove_pointer_t<iox_server_t>, void>{callback, contextData});
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 void iox_listener_detach_server_event(iox_listener_t const self,
@@ -270,8 +266,7 @@ iox_listener_attach_service_discovery_event(iox_listener_t const self,
                           c2cpp::serviceDiscoveryEvent(serviceDiscoveryEvent),
                           NotificationCallback<ServiceDiscovery, popo::internal::NoType_t>{callback, nullptr});
 
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 iox_ListenerResult iox_listener_attach_service_discovery_event_with_context_data(
@@ -290,8 +285,7 @@ iox_ListenerResult iox_listener_attach_service_discovery_event_with_context_data
                                     c2cpp::serviceDiscoveryEvent(serviceDiscoveryEvent),
                                     NotificationCallback<ServiceDiscovery, void>{callback, contextData});
 
-    return (result.has_error()) ? cpp2c::listenerResult(result.get_error())
-                                : iox_ListenerResult::ListenerResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::listenerResult(result.error()) : iox_ListenerResult::ListenerResult_SUCCESS;
 }
 
 void iox_listener_detach_service_discovery_event(iox_listener_t const self,

--- a/iceoryx_binding_c/source/c_publisher.cpp
+++ b/iceoryx_binding_c/source/c_publisher.cpp
@@ -149,7 +149,7 @@ iox_AllocationResult iox_pub_loan_aligned_chunk_with_user_header(iox_pub_t const
                       .and_then([&userPayload](ChunkHeader* h) { *userPayload = h->userPayload(); });
     if (result.has_error())
     {
-        return cpp2c::allocationResult(result.get_error());
+        return cpp2c::allocationResult(result.error());
     }
 
     return AllocationResult_SUCCESS;

--- a/iceoryx_binding_c/source/c_server.cpp
+++ b/iceoryx_binding_c/source/c_server.cpp
@@ -99,7 +99,7 @@ iox_ServerRequestResult iox_server_take_request(iox_server_t const self, const v
     auto result = self->take();
     if (result.has_error())
     {
-        return cpp2c::serverRequestResult(result.get_error());
+        return cpp2c::serverRequestResult(result.error());
     }
     *payload = result.value();
     return ServerRequestResult_SUCCESS;
@@ -135,7 +135,7 @@ iox_AllocationResult iox_server_loan_aligned_response(iox_server_t const self,
     auto result = self->loan(RequestHeader::fromPayload(requestPayload), payloadSize, payloadAlignment);
     if (result.has_error())
     {
-        return cpp2c::allocationResult(result.get_error());
+        return cpp2c::allocationResult(result.error());
     }
 
     *payload = result.value();
@@ -150,7 +150,7 @@ iox_ServerSendResult iox_server_send(iox_server_t const self, void* const payloa
     auto result = self->send(payload);
     if (result.has_error())
     {
-        return cpp2c::serverSendResult(result.get_error());
+        return cpp2c::serverSendResult(result.error());
     }
 
     return ServerSendResult_SUCCESS;

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -158,7 +158,7 @@ iox_ChunkReceiveResult iox_sub_take_chunk(iox_sub_t const self, const void** con
     auto result = SubscriberPortUser(self->m_portData).tryGetChunk();
     if (result.has_error())
     {
-        return cpp2c::chunkReceiveResult(result.get_error());
+        return cpp2c::chunkReceiveResult(result.error());
     }
 
     *userPayload = result.value()->userPayload();

--- a/iceoryx_binding_c/source/c_wait_set.cpp
+++ b/iceoryx_binding_c/source/c_wait_set.cpp
@@ -132,7 +132,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_state(iox_ws_t const self,
     iox::cxx::Expects(subscriber != nullptr);
 
     auto result = self->attachState(*subscriber, c2cpp::subscriberState(subscriberState), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_subscriber_state_with_context_data(iox_ws_t const self,
@@ -151,7 +151,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_state_with_context_data(iox_ws_t cons
 
     auto result =
         self->attachState(*subscriber, c2cpp::subscriberState(subscriberState), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_subscriber_event(iox_ws_t const self,
@@ -164,7 +164,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_event(iox_ws_t const self,
     iox::cxx::Expects(subscriber != nullptr);
 
     auto result = self->attachEvent(*subscriber, c2cpp::subscriberEvent(subscriberEvent), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_subscriber_event_with_context_data(iox_ws_t const self,
@@ -183,7 +183,7 @@ iox_WaitSetResult iox_ws_attach_subscriber_event_with_context_data(iox_ws_t cons
 
     auto result =
         self->attachEvent(*subscriber, c2cpp::subscriberEvent(subscriberEvent), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_user_trigger_event(iox_ws_t const self,
@@ -195,7 +195,7 @@ iox_WaitSetResult iox_ws_attach_user_trigger_event(iox_ws_t const self,
     iox::cxx::Expects(userTrigger != nullptr);
 
     auto result = self->attachEvent(*userTrigger, eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_user_trigger_event_with_context_data(iox_ws_t const self,
@@ -212,7 +212,7 @@ iox_WaitSetResult iox_ws_attach_user_trigger_event_with_context_data(iox_ws_t co
     notificationCallback.m_contextData = contextData;
 
     auto result = self->attachEvent(*userTrigger, eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 void iox_ws_detach_subscriber_event(iox_ws_t const self,
@@ -253,7 +253,7 @@ iox_WaitSetResult iox_ws_attach_client_event(const iox_ws_t self,
     iox::cxx::Expects(client != nullptr);
 
     auto result = self->attachEvent(*client, c2cpp::clientEvent(clientEvent), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_client_event_with_context_data(iox_ws_t const self,
@@ -271,7 +271,7 @@ iox_WaitSetResult iox_ws_attach_client_event_with_context_data(iox_ws_t const se
     notificationCallback.m_contextData = contextData;
 
     auto result = self->attachEvent(*client, c2cpp::clientEvent(clientEvent), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_client_state(const iox_ws_t self,
@@ -284,7 +284,7 @@ iox_WaitSetResult iox_ws_attach_client_state(const iox_ws_t self,
     iox::cxx::Expects(client != nullptr);
 
     auto result = self->attachState(*client, c2cpp::clientState(clientState), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_client_state_with_context_data(iox_ws_t const self,
@@ -302,7 +302,7 @@ iox_WaitSetResult iox_ws_attach_client_state_with_context_data(iox_ws_t const se
     notificationCallback.m_contextData = contextData;
 
     auto result = self->attachState(*client, c2cpp::clientState(clientState), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 void iox_ws_detach_client_event(iox_ws_t const self, iox_client_t const client, const ENUM iox_ClientEvent clientEvent)
@@ -331,7 +331,7 @@ iox_WaitSetResult iox_ws_attach_server_event(const iox_ws_t self,
     iox::cxx::Expects(server != nullptr);
 
     auto result = self->attachEvent(*server, c2cpp::serverEvent(serverEvent), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_server_event_with_context_data(iox_ws_t const self,
@@ -349,7 +349,7 @@ iox_WaitSetResult iox_ws_attach_server_event_with_context_data(iox_ws_t const se
     notificationCallback.m_contextData = contextData;
 
     auto result = self->attachEvent(*server, c2cpp::serverEvent(serverEvent), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_server_state(const iox_ws_t self,
@@ -362,7 +362,7 @@ iox_WaitSetResult iox_ws_attach_server_state(const iox_ws_t self,
     iox::cxx::Expects(server != nullptr);
 
     auto result = self->attachState(*server, c2cpp::serverState(serverState), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult iox_ws_attach_server_state_with_context_data(iox_ws_t const self,
@@ -380,7 +380,7 @@ iox_WaitSetResult iox_ws_attach_server_state_with_context_data(iox_ws_t const se
     notificationCallback.m_contextData = contextData;
 
     auto result = self->attachState(*server, c2cpp::serverState(serverState), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 void iox_ws_detach_server_event(iox_ws_t const self, iox_server_t const server, const ENUM iox_ServerEvent serverEvent)
@@ -410,7 +410,7 @@ iox_WaitSetResult iox_ws_attach_service_discovery_event(const iox_ws_t self,
 
     auto result = self->attachEvent(
         *serviceDiscovery, c2cpp::serviceDiscoveryEvent(serviceDiscoveryEvent), eventId, {callback, nullptr});
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 iox_WaitSetResult
@@ -430,7 +430,7 @@ iox_ws_attach_service_discovery_event_with_context_data(iox_ws_t const self,
 
     auto result = self->attachEvent(
         *serviceDiscovery, c2cpp::serviceDiscoveryEvent(serviceDiscoveryEvent), eventId, notificationCallback);
-    return (result.has_error()) ? cpp2c::waitSetResult(result.get_error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
+    return (result.has_error()) ? cpp2c::waitSetResult(result.error()) : iox_WaitSetResult::WaitSetResult_SUCCESS;
 }
 
 void iox_ws_detach_service_discovery_event(iox_ws_t const self,

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -89,11 +89,11 @@ class iox_notification_info_test : public Test
         constexpr uint32_t USER_PAYLOAD_SIZE{100U};
 
         auto chunkSettingsResult = ChunkSettings::create(USER_PAYLOAD_SIZE, iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = m_memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -92,11 +92,11 @@ class iox_sub_test : public Test
         constexpr uint32_t USER_PAYLOAD_SIZE{100U};
 
         auto chunkSettingsResult = ChunkSettings::create(USER_PAYLOAD_SIZE, iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = m_memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
@@ -77,7 +77,7 @@ namespace DesignPattern
 ///
 ///   // if the system resource is movable
 ///   auto resource = MyResourceAbstraction::Create(123);
-///   if ( resource.has_error() && resource.get_error() == MyResourceAbstractionError::ResourceNotAvailable )
+///   if ( resource.has_error() && resource.error() == MyResourceAbstractionError::ResourceNotAvailable )
 ///     // perform error handling
 ///   else
 ///     // perform some work

--- a/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/design/creation.hpp
@@ -125,7 +125,7 @@ class Creation
     /// @return returns an expected which either contains the object in a valid
     ///         constructed state or an error value stating why the construction failed.
     template <typename... Targs>
-    static iox::expected<ErrorType> placementCreate(void* const memory, Targs&&... args) noexcept;
+    static iox::expected<void, ErrorType> placementCreate(void* const memory, Targs&&... args) noexcept;
 
     Creation() noexcept = default;
     Creation(Creation&& rhs) noexcept;

--- a/iceoryx_dust/include/iceoryx_dust/internal/cli/arguments.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cli/arguments.inl
@@ -31,9 +31,9 @@ inline expected<T, Arguments::Error> Arguments::convertFromString(const Argument
     if (!cxx::convert::fromString(stringValue.c_str(), value))
     {
         std::cout << "\"" << stringValue.c_str() << "\" could not be converted to the requested type" << std::endl;
-        return error<Error>(Error::UNABLE_TO_CONVERT_VALUE);
+        return err(Error::UNABLE_TO_CONVERT_VALUE);
     }
-    return success<T>(value);
+    return ok(value);
 }
 
 template <>
@@ -42,10 +42,10 @@ inline expected<bool, Arguments::Error> Arguments::convertFromString(const Argum
     if (stringValue != "true" && stringValue != "false")
     {
         std::cout << "\"" << stringValue.c_str() << "\" could not be converted to the requested type" << std::endl;
-        return error<Error>(Error::UNABLE_TO_CONVERT_VALUE);
+        return err(Error::UNABLE_TO_CONVERT_VALUE);
     }
 
-    return success<bool>(stringValue == "true");
+    return ok(stringValue == "true");
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ inline expected<T, Arguments::Error> Arguments::get(const OptionName_t& optionNa
         }
     }
 
-    return error<Error>(Error::NO_SUCH_VALUE);
+    return err(Error::NO_SUCH_VALUE);
 }
 } // namespace internal
 } // namespace cli

--- a/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
@@ -64,8 +64,8 @@ Creation<DerivedClass, ErrorType>::verify(DerivedClass&& newObject) noexcept
 
 template <typename DerivedClass, typename ErrorType>
 template <typename... Targs>
-inline iox::expected<ErrorType> Creation<DerivedClass, ErrorType>::placementCreate(void* const memory,
-                                                                                   Targs&&... args) noexcept
+inline iox::expected<void, ErrorType> Creation<DerivedClass, ErrorType>::placementCreate(void* const memory,
+                                                                                         Targs&&... args) noexcept
 {
     auto newClass = static_cast<DerivedClass*>(memory);
     new (newClass) DerivedClass(std::forward<Targs>(args)...);

--- a/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/design/creation.inl
@@ -56,10 +56,10 @@ Creation<DerivedClass, ErrorType>::verify(DerivedClass&& newObject) noexcept
 {
     if (!newObject.m_isInitialized)
     {
-        return iox::error<ErrorType>(newObject.m_errorValue);
+        return iox::err(newObject.m_errorValue);
     }
 
-    return iox::success<DerivedClass>(std::move(newObject));
+    return iox::ok(std::move(newObject));
 }
 
 template <typename DerivedClass, typename ErrorType>
@@ -74,10 +74,10 @@ inline iox::expected<void, ErrorType> Creation<DerivedClass, ErrorType>::placeme
     {
         ErrorType errorValue = newClass->m_errorValue;
         newClass->~DerivedClass();
-        return iox::error<ErrorType>(errorValue);
+        return iox::err(errorValue);
     }
 
-    return iox::success<>();
+    return iox::ok();
 }
 
 

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
@@ -71,7 +71,7 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
 
     /// @brief send a message to queue using std::string.
     /// @return true if sent without errors, false otherwise
-    expected<IpcChannelError> send(const std::string& msg) const noexcept;
+    expected<void, IpcChannelError> send(const std::string& msg) const noexcept;
 
     /// @todo iox-#1693 zero copy receive with receive(iox::string&); iox::string would be the buffer for mq_receive
 
@@ -85,7 +85,7 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
     expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
     /// @brief try to send a message to the queue for a given timeout duration using std::string
-    expected<IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
+    expected<void, IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
 
     static expected<bool, IpcChannelError> isOutdated() noexcept;
 
@@ -97,12 +97,12 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
 
     expected<mqd_t, IpcChannelError> open(const IpcChannelName_t& name, const IpcChannelSide channelSide) noexcept;
 
-    expected<IpcChannelError> close() noexcept;
-    expected<IpcChannelError> unlink() noexcept;
+    expected<void, IpcChannelError> close() noexcept;
+    expected<void, IpcChannelError> unlink() noexcept;
     error<IpcChannelError> createErrorFromErrnum(const int32_t errnum) const noexcept;
     static error<IpcChannelError> createErrorFromErrnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
     static expected<IpcChannelName_t, IpcChannelError> sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
-    expected<IpcChannelError> destroy() noexcept;
+    expected<void, IpcChannelError> destroy() noexcept;
 
   private:
     IpcChannelName_t m_name;

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
@@ -99,8 +99,8 @@ class MessageQueue : public DesignPattern::Creation<MessageQueue, IpcChannelErro
 
     expected<void, IpcChannelError> close() noexcept;
     expected<void, IpcChannelError> unlink() noexcept;
-    error<IpcChannelError> createErrorFromErrnum(const int32_t errnum) const noexcept;
-    static error<IpcChannelError> createErrorFromErrnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
+    IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
+    static IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
     static expected<IpcChannelName_t, IpcChannelError> sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
     expected<void, IpcChannelError> destroy() noexcept;
 

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
@@ -72,19 +72,20 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
 
     /// @brief tries to send a message via the named pipe. if the pipe is full IpcChannelError::TIMEOUT is returned
     /// @return on failure an error which describes the failure
-    expected<IpcChannelError> trySend(const std::string& message) const noexcept;
+    expected<void, IpcChannelError> trySend(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe. if the pipe is full this call is blocking until the message could be
     ///        delivered
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<IpcChannelError> send(const std::string& message) const noexcept;
+    expected<void, IpcChannelError> send(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe.
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @param[in] timeout the timeout on how long this method should retry to send the message
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<IpcChannelError> timedSend(const std::string& message, const units::Duration& timeout) const noexcept;
+    expected<void, IpcChannelError> timedSend(const std::string& message,
+                                              const units::Duration& timeout) const noexcept;
 
     /// @brief tries to receive a message via the named pipe. if the pipe is empty IpcChannelError::TIMEOUT is returned
     /// @return on success a string containing the message, otherwise an error which describes the failure
@@ -119,7 +120,7 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
 
     /// @brief destroys an initialized named pipe.
     /// @return is always successful
-    expected<IpcChannelError> destroy() noexcept;
+    expected<void, IpcChannelError> destroy() noexcept;
 
   private:
     optional<SharedMemoryObject> m_sharedMemory;

--- a/iceoryx_dust/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_dust/source/posix_wrapper/message_queue.cpp
@@ -92,7 +92,7 @@ MessageQueue::MessageQueue(const IpcChannelName_t& name,
         else
         {
             this->m_isInitialized = false;
-            this->m_errorValue = openResult.get_error();
+            this->m_errorValue = openResult.error();
         }
     }
 }
@@ -149,7 +149,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(*sanitizedIpcChannelName, mqCall.get_error().errnum));
+        return err(errnoToEnum(*sanitizedIpcChannelName, mqCall.error().errnum));
     }
     return ok(mqCall->errnum != ENOENT);
 }
@@ -190,7 +190,7 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     return ok();
@@ -208,7 +208,7 @@ expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     return ok(std::string(&(message[0])));
@@ -242,7 +242,7 @@ expected<mqd_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     return ok<mqd_t>(mqCall->value);
@@ -254,7 +254,7 @@ expected<void, IpcChannelError> MessageQueue::close() noexcept
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     return ok();
@@ -270,7 +270,7 @@ expected<void, IpcChannelError> MessageQueue::unlink() noexcept
     auto mqCall = posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     return ok();
@@ -291,7 +291,7 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     if (mqCall->errnum == TIMEOUT_ERRNO)
@@ -323,7 +323,7 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
 
     if (mqCall.has_error())
     {
-        return err(errnoToEnum(mqCall.get_error().errnum));
+        return err(errnoToEnum(mqCall.error().errnum));
     }
 
     if (mqCall->errnum == TIMEOUT_ERRNO)

--- a/iceoryx_dust/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_dust/source/posix_wrapper/message_queue.cpp
@@ -138,7 +138,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
     auto sanitizedIpcChannelName = sanitizeIpcChannelName(name);
     if (sanitizedIpcChannelName.has_error())
     {
-        return error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
+        return err(IpcChannelError::INVALID_CHANNEL_NAME);
     }
 
 
@@ -149,9 +149,9 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(*sanitizedIpcChannelName, mqCall.get_error().errnum);
+        return err(errnoToEnum(*sanitizedIpcChannelName, mqCall.get_error().errnum));
     }
-    return success<bool>(mqCall->errnum != ENOENT);
+    return ok(mqCall->errnum != ENOENT);
 }
 
 expected<void, IpcChannelError> MessageQueue::destroy() noexcept
@@ -174,7 +174,7 @@ expected<void, IpcChannelError> MessageQueue::destroy() noexcept
 
     m_mqDescriptor = INVALID_DESCRIPTOR;
     m_isInitialized = false;
-    return success<void>();
+    return ok();
 }
 
 expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const noexcept
@@ -182,7 +182,7 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
     const uint64_t messageSize = msg.size() + NULL_TERMINATOR_SIZE;
     if (messageSize > static_cast<uint64_t>(m_attributes.mq_msgsize))
     {
-        return error<IpcChannelError>(IpcChannelError::MESSAGE_TOO_LONG);
+        return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
     auto mqCall =
@@ -190,10 +190,10 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
-    return success<void>();
+    return ok();
 }
 
 expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
@@ -208,10 +208,10 @@ expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
-    return success<std::string>(std::string(&(message[0])));
+    return ok(std::string(&(message[0])));
 }
 
 expected<mqd_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name,
@@ -220,7 +220,7 @@ expected<mqd_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name
     auto sanitizedIpcChannelName = sanitizeIpcChannelName(name);
     if (sanitizedIpcChannelName.has_error())
     {
-        return error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
+        return err(IpcChannelError::INVALID_CHANNEL_NAME);
     }
 
     int32_t openFlags = O_RDWR;
@@ -242,10 +242,10 @@ expected<mqd_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
-    return success<mqd_t>(mqCall->value);
+    return ok<mqd_t>(mqCall->value);
 }
 
 expected<void, IpcChannelError> MessageQueue::close() noexcept
@@ -254,26 +254,26 @@ expected<void, IpcChannelError> MessageQueue::close() noexcept
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
-    return success<void>();
+    return ok();
 }
 
 expected<void, IpcChannelError> MessageQueue::unlink() noexcept
 {
     if (m_channelSide == IpcChannelSide::CLIENT)
     {
-        return success<void>();
+        return ok();
     }
 
     auto mqCall = posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
-    return success<void>();
+    return ok();
 }
 
 expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::Duration& timeout) const noexcept
@@ -291,15 +291,15 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
     if (mqCall->errnum == TIMEOUT_ERRNO)
     {
-        return createErrorFromErrnum(ETIMEDOUT);
+        return err(errnoToEnum(ETIMEDOUT));
     }
 
-    return success<std::string>(std::string(&(message[0])));
+    return ok(std::string(&(message[0])));
 }
 
 expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
@@ -310,7 +310,7 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
     {
         std::cerr << "the message \"" << msg << "\" which should be sent to the message queue \"" << m_name
                   << "\" is too long" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::MESSAGE_TOO_LONG);
+        return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
     timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
@@ -323,70 +323,70 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
 
     if (mqCall.has_error())
     {
-        return createErrorFromErrnum(mqCall.get_error().errnum);
+        return err(errnoToEnum(mqCall.get_error().errnum));
     }
 
     if (mqCall->errnum == TIMEOUT_ERRNO)
     {
-        return createErrorFromErrnum(ETIMEDOUT);
+        return err(errnoToEnum(ETIMEDOUT));
     }
 
-    return success<void>();
+    return ok();
 }
 
 expected<bool, IpcChannelError> MessageQueue::isOutdated() noexcept
 {
-    return success<bool>(false);
+    return ok(false);
 }
 
-error<IpcChannelError> MessageQueue::createErrorFromErrnum(const int32_t errnum) const noexcept
+IpcChannelError MessageQueue::errnoToEnum(const int32_t errnum) const noexcept
 {
-    return createErrorFromErrnum(m_name, errnum);
+    return errnoToEnum(m_name, errnum);
 }
 
-error<IpcChannelError> MessageQueue::createErrorFromErrnum(const IpcChannelName_t& name, const int32_t errnum) noexcept
+IpcChannelError MessageQueue::errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept
 {
     switch (errnum)
     {
     case EACCES:
     {
         std::cerr << "access denied to message queue \"" << name << "\"" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::ACCESS_DENIED);
+        return IpcChannelError::ACCESS_DENIED;
     }
     case EAGAIN:
     {
         std::cerr << "the message queue \"" << name << "\" is full" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::CHANNEL_FULL);
+        return IpcChannelError::CHANNEL_FULL;
     }
     case ETIMEDOUT:
     {
         // no error message needed since this is a normal use case
-        return error<IpcChannelError>(IpcChannelError::TIMEOUT);
+        return IpcChannelError::TIMEOUT;
     }
     case EEXIST:
     {
         std::cerr << "message queue \"" << name << "\" already exists" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::CHANNEL_ALREADY_EXISTS);
+        return IpcChannelError::CHANNEL_ALREADY_EXISTS;
     }
     case EINVAL:
     {
         std::cerr << "provided invalid arguments for message queue \"" << name << "\"" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::INVALID_ARGUMENTS);
+        return IpcChannelError::INVALID_ARGUMENTS;
     }
     case ENOENT:
     {
         // no error message needed since this is a normal use case
-        return error<IpcChannelError>(IpcChannelError::NO_SUCH_CHANNEL);
+        return IpcChannelError::NO_SUCH_CHANNEL;
     }
     case ENAMETOOLONG:
     {
         std::cerr << "message queue name \"" << name << "\" is too long" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
+        return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     default:
     {
         std::cerr << "internal logic error in message queue \"" << name << "\" occurred" << std::endl;
-        return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
+        return IpcChannelError::INTERNAL_LOGIC_ERROR;
     }
     }
 }
@@ -399,16 +399,16 @@ expected<IpcChannelName_t, IpcChannelError> MessageQueue::sanitizeIpcChannelName
     /// See: https://pubs.opengroup.org/onlinepubs/9699919799/functions/mq_open.html
     if (name.empty() || name.size() < SHORTEST_VALID_QUEUE_NAME)
     {
-        return error<IpcChannelError>(IpcChannelError::INVALID_CHANNEL_NAME);
+        return err(IpcChannelError::INVALID_CHANNEL_NAME);
     }
     // name is checked for emptiness, so it's ok to get a first member
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     if (name.c_str()[0] != '/')
     {
-        return success<IpcChannelName_t>(IpcChannelName_t("/").append(iox::TruncateToCapacity, name));
+        return ok(IpcChannelName_t("/").append(iox::TruncateToCapacity, name));
     }
 
-    return success<IpcChannelName_t>(name);
+    return ok(name);
 }
 
 } // namespace posix

--- a/iceoryx_dust/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_dust/source/posix_wrapper/message_queue.cpp
@@ -154,7 +154,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
     return success<bool>(mqCall->errnum != ENOENT);
 }
 
-expected<IpcChannelError> MessageQueue::destroy() noexcept
+expected<void, IpcChannelError> MessageQueue::destroy() noexcept
 {
     if (m_mqDescriptor != INVALID_DESCRIPTOR)
     {
@@ -177,7 +177,7 @@ expected<IpcChannelError> MessageQueue::destroy() noexcept
     return success<void>();
 }
 
-expected<IpcChannelError> MessageQueue::send(const std::string& msg) const noexcept
+expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const noexcept
 {
     const uint64_t messageSize = msg.size() + NULL_TERMINATOR_SIZE;
     if (messageSize > static_cast<uint64_t>(m_attributes.mq_msgsize))
@@ -248,7 +248,7 @@ expected<mqd_t, IpcChannelError> MessageQueue::open(const IpcChannelName_t& name
     return success<mqd_t>(mqCall->value);
 }
 
-expected<IpcChannelError> MessageQueue::close() noexcept
+expected<void, IpcChannelError> MessageQueue::close() noexcept
 {
     auto mqCall = posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
 
@@ -260,7 +260,7 @@ expected<IpcChannelError> MessageQueue::close() noexcept
     return success<void>();
 }
 
-expected<IpcChannelError> MessageQueue::unlink() noexcept
+expected<void, IpcChannelError> MessageQueue::unlink() noexcept
 {
     if (m_channelSide == IpcChannelSide::CLIENT)
     {
@@ -302,7 +302,8 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
     return success<std::string>(std::string(&(message[0])));
 }
 
-expected<IpcChannelError> MessageQueue::timedSend(const std::string& msg, const units::Duration& timeout) const noexcept
+expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
+                                                        const units::Duration& timeout) const noexcept
 {
     const uint64_t messageSize = msg.size() + NULL_TERMINATOR_SIZE;
     if (messageSize > static_cast<uint64_t>(m_attributes.mq_msgsize))

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -195,7 +195,7 @@ expected<void, IpcChannelError> NamedPipe::destroy() noexcept
         m_sharedMemory.reset();
         m_data = nullptr;
     }
-    return success<>();
+    return ok();
 }
 
 expected<bool, IpcChannelError> NamedPipe::unlinkIfExists(const IpcChannelName_t& name) noexcept
@@ -203,22 +203,22 @@ expected<bool, IpcChannelError> NamedPipe::unlinkIfExists(const IpcChannelName_t
     auto result = SharedMemory::unlinkIfExist(convertName(NAMED_PIPE_PREFIX, name));
     if (result.has_error())
     {
-        return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
+        return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
     }
 
-    return success<bool>(*result);
+    return ok(*result);
 }
 
 expected<void, IpcChannelError> NamedPipe::trySend(const std::string& message) const noexcept
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     if (message.size() > MAX_MESSAGE_SIZE)
     {
-        return error<IpcChannelError>(IpcChannelError::MESSAGE_TOO_LONG);
+        return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
     auto result = m_data->sendSemaphore().tryWait();
@@ -228,28 +228,28 @@ expected<void, IpcChannelError> NamedPipe::trySend(const std::string& message) c
     {
         IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
         cxx::Expects(!m_data->receiveSemaphore().post().has_error());
-        return success<>();
+        return ok();
     }
-    return error<IpcChannelError>(IpcChannelError::TIMEOUT);
+    return err(IpcChannelError::TIMEOUT);
 }
 
 expected<void, IpcChannelError> NamedPipe::send(const std::string& message) const noexcept
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     if (message.size() > MAX_MESSAGE_SIZE)
     {
-        return error<IpcChannelError>(IpcChannelError::MESSAGE_TOO_LONG);
+        return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
     cxx::Expects(!m_data->sendSemaphore().wait().has_error());
     IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
     cxx::Expects(!m_data->receiveSemaphore().post().has_error());
 
-    return success<>();
+    return ok();
 }
 
 expected<void, IpcChannelError> NamedPipe::timedSend(const std::string& message,
@@ -257,12 +257,12 @@ expected<void, IpcChannelError> NamedPipe::timedSend(const std::string& message,
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     if (message.size() > MAX_MESSAGE_SIZE)
     {
-        return error<IpcChannelError>(IpcChannelError::MESSAGE_TOO_LONG);
+        return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
     auto result = m_data->sendSemaphore().timedWait(timeout);
@@ -272,16 +272,16 @@ expected<void, IpcChannelError> NamedPipe::timedSend(const std::string& message,
     {
         IOX_DISCARD_RESULT(m_data->messages.push(into<lossy<Message_t>>(message)));
         cxx::Expects(!m_data->receiveSemaphore().post().has_error());
-        return success<>();
+        return ok();
     }
-    return error<IpcChannelError>(IpcChannelError::TIMEOUT);
+    return err(IpcChannelError::TIMEOUT);
 }
 
 expected<std::string, IpcChannelError> NamedPipe::receive() const noexcept
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     cxx::Expects(!m_data->receiveSemaphore().wait().has_error());
@@ -289,16 +289,16 @@ expected<std::string, IpcChannelError> NamedPipe::receive() const noexcept
     if (message.has_value())
     {
         cxx::Expects(!m_data->sendSemaphore().post().has_error());
-        return success<std::string>(message->c_str());
+        return ok<std::string>(message->c_str());
     }
-    return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
+    return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
 }
 
 expected<std::string, IpcChannelError> NamedPipe::tryReceive() const noexcept
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     auto result = m_data->receiveSemaphore().tryWait();
@@ -310,19 +310,19 @@ expected<std::string, IpcChannelError> NamedPipe::tryReceive() const noexcept
         if (message.has_value())
         {
             cxx::Expects(!m_data->sendSemaphore().post().has_error());
-            return success<std::string>(message->c_str());
+            return ok<std::string>(message->c_str());
         }
-        return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
+        return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
     }
 
-    return error<IpcChannelError>(IpcChannelError::TIMEOUT);
+    return err(IpcChannelError::TIMEOUT);
 }
 
 expected<std::string, IpcChannelError> NamedPipe::timedReceive(const units::Duration& timeout) const noexcept
 {
     if (!m_isInitialized)
     {
-        return error<IpcChannelError>(IpcChannelError::NOT_INITIALIZED);
+        return err(IpcChannelError::NOT_INITIALIZED);
     }
 
     auto result = m_data->receiveSemaphore().timedWait(timeout);
@@ -334,11 +334,11 @@ expected<std::string, IpcChannelError> NamedPipe::timedReceive(const units::Dura
         if (message.has_value())
         {
             cxx::Expects(!m_data->sendSemaphore().post().has_error());
-            return success<std::string>(message->c_str());
+            return ok<std::string>(message->c_str());
         }
-        return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
+        return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
     }
-    return error<IpcChannelError>(IpcChannelError::TIMEOUT);
+    return err(IpcChannelError::TIMEOUT);
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init) semaphores are initalized via placementCreate call

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -182,7 +182,7 @@ IpcChannelName_t NamedPipe::convertName(const Prefix& p, const IpcChannelName_t&
     return channelName;
 }
 
-expected<IpcChannelError> NamedPipe::destroy() noexcept
+expected<void, IpcChannelError> NamedPipe::destroy() noexcept
 {
     if (m_isInitialized)
     {
@@ -209,7 +209,7 @@ expected<bool, IpcChannelError> NamedPipe::unlinkIfExists(const IpcChannelName_t
     return success<bool>(*result);
 }
 
-expected<IpcChannelError> NamedPipe::trySend(const std::string& message) const noexcept
+expected<void, IpcChannelError> NamedPipe::trySend(const std::string& message) const noexcept
 {
     if (!m_isInitialized)
     {
@@ -233,7 +233,7 @@ expected<IpcChannelError> NamedPipe::trySend(const std::string& message) const n
     return error<IpcChannelError>(IpcChannelError::TIMEOUT);
 }
 
-expected<IpcChannelError> NamedPipe::send(const std::string& message) const noexcept
+expected<void, IpcChannelError> NamedPipe::send(const std::string& message) const noexcept
 {
     if (!m_isInitialized)
     {
@@ -252,8 +252,8 @@ expected<IpcChannelError> NamedPipe::send(const std::string& message) const noex
     return success<>();
 }
 
-expected<IpcChannelError> NamedPipe::timedSend(const std::string& message,
-                                               const units::Duration& timeout) const noexcept
+expected<void, IpcChannelError> NamedPipe::timedSend(const std::string& message,
+                                                     const units::Duration& timeout) const noexcept
 {
     if (!m_isInitialized)
     {

--- a/iceoryx_dust/test/moduletests/test_cli_command_line_parser.cpp
+++ b/iceoryx_dust/test/moduletests/test_cli_command_line_parser.cpp
@@ -945,7 +945,7 @@ void verifyEntry(const Arguments& options, const OptionName_t& entry, const opti
                 return;
             }
 
-            EXPECT_THAT(result.get_error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
+            EXPECT_THAT(result.error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
         });
 }
 
@@ -972,7 +972,7 @@ void verifyEntry<float>(const Arguments& options, const OptionName_t& entry, con
                 return;
             }
 
-            EXPECT_THAT(result.get_error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
+            EXPECT_THAT(result.error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
         });
 }
 
@@ -999,7 +999,7 @@ void verifyEntry<double>(const Arguments& options, const OptionName_t& entry, co
                 return;
             }
 
-            EXPECT_THAT(result.get_error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
+            EXPECT_THAT(result.error(), Eq(Arguments::Error::UNABLE_TO_CONVERT_VALUE));
         });
 }
 

--- a/iceoryx_examples/ice_access_control/iox_display_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_display_app.cpp
@@ -51,7 +51,7 @@ int main()
         }
         else
         {
-            if (takeResult.get_error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
+            if (takeResult.error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
             {
                 std::cout << "No chunk available." << std::endl;
             }

--- a/iceoryx_examples/ice_access_control/iox_display_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_display_app.cpp
@@ -39,7 +39,7 @@ int main()
     {
         auto takeResult = subscriber.take();
 
-        if (!takeResult.has_error())
+        if (takeResult.has_value())
         {
             publisher.loan().and_then([&](auto& sample) {
                 sample->x = 2 * takeResult.value()->x;

--- a/iceoryx_examples/ice_access_control/iox_radar_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_radar_app.cpp
@@ -49,7 +49,7 @@ int main()
         }
         else
         {
-            auto error = loanResult.get_error();
+            auto error = loanResult.error();
             // Do something with error
             std::cerr << "Unable to loan sample, error: " << error << std::endl;
         }

--- a/iceoryx_examples/ice_access_control/iox_radar_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_radar_app.cpp
@@ -38,7 +38,7 @@ int main()
 
         // Retrieve a sample from shared memory
         auto loanResult = publisher.loan();
-        if (!loanResult.has_error())
+        if (loanResult.has_value())
         {
             auto& sample = loanResult.value();
             // Sample can be held until ready to publish

--- a/iceoryx_examples/ice_access_control/roudi_main_static_segments.cpp
+++ b/iceoryx_examples/ice_access_control/roudi_main_static_segments.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
 
     iox::config::CmdLineParser cmdLineParser;
     auto cmdLineArgs = cmdLineParser.parse(argc, argv);
-    if (cmdLineArgs.has_error() && (cmdLineArgs.get_error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
+    if (cmdLineArgs.has_error() && (cmdLineArgs.error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
     {
         IOX_LOG(FATAL) << "Unable to parse command line arguments!";
         return EXIT_FAILURE;

--- a/iceoryx_examples/icehello/README.md
+++ b/iceoryx_examples/icehello/README.md
@@ -103,7 +103,7 @@ In case an error occurred during loaning, we need to handle it:
 ```cpp
 else
 {
-    auto error = loanResult.get_error();
+    auto error = loanResult.error();
     // Do something with error
     std::cerr << "Unable to loan sample, error code: " << error << std::endl;
 }
@@ -162,7 +162,7 @@ In case an error occurred during taking, we need to handle it:
 
 <!--[geoffrey][iceoryx_examples/icehello/iox_subscriber_helloworld.cpp][error]-->
 ```cpp
-if (takeResult.get_error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
+if (takeResult.error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
 {
     std::cout << "No chunk available." << std::endl;
 }

--- a/iceoryx_examples/icehello/README.md
+++ b/iceoryx_examples/icehello/README.md
@@ -86,7 +86,7 @@ If loaning was successful, we assign the incremented counter to all three values
 
 <!--[geoffrey][iceoryx_examples/icehello/iox_publisher_helloworld.cpp][publish]-->
 ```cpp
-if (!loanResult.has_error())
+if (loanResult.has_value())
 {
     auto& sample = loanResult.value();
     // Sample can be held until ready to publish
@@ -152,7 +152,7 @@ Inside the `while` loop, we take the sample from shared memory and print it if w
 <!--[geoffrey][iceoryx_examples/icehello/iox_subscriber_helloworld.cpp][receive]-->
 ```cpp
 auto takeResult = subscriber.take();
-if (!takeResult.has_error())
+if (takeResult.has_value())
 {
     std::cout << APP_NAME << " got value: " << takeResult.value()->x << std::endl;
 }

--- a/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
@@ -66,7 +66,7 @@ int main()
         //! [error]
         else
         {
-            auto error = loanResult.get_error();
+            auto error = loanResult.error();
             // Do something with error
             std::cerr << "Unable to loan sample, error code: " << error << std::endl;
         }

--- a/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
@@ -53,7 +53,7 @@ int main()
         auto loanResult = publisher.loan();
         //! [loan]
         //! [publish]
-        if (!loanResult.has_error())
+        if (loanResult.has_value())
         {
             auto& sample = loanResult.value();
             // Sample can be held until ready to publish

--- a/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
@@ -40,7 +40,7 @@ int main()
     {
         //! [receive]
         auto takeResult = subscriber.take();
-        if (!takeResult.has_error())
+        if (takeResult.has_value())
         {
             std::cout << APP_NAME << " got value: " << takeResult.value()->x << std::endl;
         }

--- a/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
@@ -48,7 +48,7 @@ int main()
         else
         {
             //! [error]
-            if (takeResult.get_error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
+            if (takeResult.error() == iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE)
             {
                 std::cout << "No chunk available." << std::endl;
             }

--- a/iceoryx_examples/iceperf/roudi_main_static_config.cpp
+++ b/iceoryx_examples/iceperf/roudi_main_static_config.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
     iox::config::CmdLineParserConfigFileOption cmdLineParser;
     auto cmdLineArgs = cmdLineParser.parse(argc, argv);
-    if (cmdLineArgs.has_error() && (cmdLineArgs.get_error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
+    if (cmdLineArgs.has_error() && (cmdLineArgs.error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
     {
         IOX_LOG(FATAL) << "Unable to parse command line arguments!";
         return EXIT_FAILURE;

--- a/iceoryx_hoofs/design/include/iox/detail/functional_interface.inl
+++ b/iceoryx_hoofs/design/include/iox/detail/functional_interface.inl
@@ -231,7 +231,7 @@ inline Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor& call
     if (!derivedThis)
     {
         const auto callback = static_cast<or_else_callback_t>(callable);
-        callback(derivedThis.get_error());
+        callback(derivedThis.error());
     }
 
     return derivedThis;
@@ -256,7 +256,7 @@ inline const Derived& OrElseWithValue<Derived, ErrorType>::or_else(const Functor
     if (!derivedThis)
     {
         auto callback = static_cast<const_or_else_callback_t>(callable);
-        callback(derivedThis.get_error());
+        callback(derivedThis.error());
     }
 
     return derivedThis;

--- a/iceoryx_hoofs/design/include/iox/functional_interface.hpp
+++ b/iceoryx_hoofs/design/include/iox/functional_interface.hpp
@@ -42,7 +42,7 @@ struct HasGetErrorMethod : std::false_type
 };
 
 template <typename Derived>
-struct HasGetErrorMethod<Derived, void_t<decltype(std::declval<Derived>().get_error())>> : std::true_type
+struct HasGetErrorMethod<Derived, void_t<decltype(std::declval<Derived>().error())>> : std::true_type
 {
 };
 
@@ -422,7 +422,7 @@ struct FunctionalInterfaceImpl<Derived, void, ErrorType>
 ///        When the class has a value method the method
 ///          * value_or
 ///        is added and and_then provides a reference in the callback to the underlying value.
-///        When the class has a get_error method the or_else method has a parameter to access
+///        When the class has a error method the or_else method has a parameter to access
 ///        a reference to the underlying error.
 ///
 /// @note When inheriting from this type one does not have to write additional unit tests.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/mutex.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/mutex.hpp
@@ -116,11 +116,11 @@ class mutex
 
     /// @brief Locks the mutex.
     /// @return When it fails it returns an enum describing the error.
-    expected<MutexLockError> lock() noexcept;
+    expected<void, MutexLockError> lock() noexcept;
 
     /// @brief  Unlocks the mutex.
     /// @return When it fails it returns an enum describing the error.
-    expected<MutexUnlockError> unlock() noexcept;
+    expected<void, MutexUnlockError> unlock() noexcept;
 
     /// @brief Tries to lock the mutex.
     /// @return If the lock was acquired MutexTryLock::LOCK_SUCCEEDED will be returned otherwise
@@ -222,7 +222,7 @@ class MutexBuilder
     /// @brief Initializes a provided uninitialized mutex
     /// @param[in] uninitializedMutex the uninitialized mutex which should be initialized
     /// @return On failure MutexError which explains the error
-    expected<MutexCreationError> create(optional<mutex>& uninitializedMutex) noexcept;
+    expected<void, MutexCreationError> create(optional<mutex>& uninitializedMutex) noexcept;
 };
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -184,7 +184,7 @@ PosixCallEvaluator<ReturnType>::evaluate() const&& noexcept
 {
     if (m_details.hasSuccess || m_details.hasIgnoredErrno)
     {
-        return iox::success<PosixCallResult<ReturnType>>(m_details.result);
+        return ok<PosixCallResult<ReturnType>>(m_details.result);
     }
 
     if (!m_details.hasSilentErrno)
@@ -194,7 +194,7 @@ PosixCallEvaluator<ReturnType>::evaluate() const&& noexcept
                        << m_details.result.getHumanReadableErrnum();
     }
 
-    return iox::error<PosixCallResult<ReturnType>>(m_details.result);
+    return err<PosixCallResult<ReturnType>>(m_details.result);
 }
 
 } // namespace posix

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp
@@ -60,12 +60,12 @@ class SemaphoreInterface
     /// @brief Increments the semaphore by one
     /// @return Fails when the value of the semaphore overflows or when the
     ///         semaphore was removed from outside the process
-    expected<SemaphoreError> post() noexcept;
+    expected<void, SemaphoreError> post() noexcept;
 
     /// @brief Decrements the semaphore by one. When the semaphore value is zero
     ///        it blocks until the semaphore value is greater zero
     /// @return Fails when semaphore was removed from outside the process
-    expected<SemaphoreError> wait() noexcept;
+    expected<void, SemaphoreError> wait() noexcept;
 
     /// @brief Tries to decrement the semaphore by one. When the semaphore value is zero
     ///        it returns false otherwise it returns true and decrement the value by one.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -146,10 +146,10 @@ expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(Targs&&... 
     UnixDomainSocket newObject{std::forward<Targs>(args)...};
     if (!newObject.m_isInitialized)
     {
-        return iox::error<IpcChannelError>(newObject.m_errorValue);
+        return err(newObject.m_errorValue);
     }
 
-    return iox::success<UnixDomainSocket>(std::move(newObject));
+    return ok(std::move(newObject));
 }
 
 } // namespace posix

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -88,13 +88,13 @@ class UnixDomainSocket
     /// @brief send a message using std::string.
     /// @param msg to send
     /// @return IpcChannelError if error occured
-    expected<IpcChannelError> send(const std::string& msg) const noexcept;
+    expected<void, IpcChannelError> send(const std::string& msg) const noexcept;
 
     /// @brief try to send a message for a given timeout duration using std::string
     /// @param msg to send
     /// @param timout for the send operation
     /// @return IpcChannelError if error occured
-    expected<IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
+    expected<void, IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
 
     /// @brief receive message using std::string.
     /// @return received message. In case of an error, IpcChannelError is returned and msg is empty.
@@ -117,13 +117,13 @@ class UnixDomainSocket
                      const size_t maxMsgSize = MAX_MESSAGE_SIZE,
                      const uint64_t maxMsgNumber = 10U) noexcept;
 
-    expected<IpcChannelError> destroy() noexcept;
+    expected<void, IpcChannelError> destroy() noexcept;
 
-    expected<IpcChannelError> initalizeSocket() noexcept;
+    expected<void, IpcChannelError> initalizeSocket() noexcept;
 
     IpcChannelError convertErrnoToIpcChannelError(const int32_t errnum) const noexcept;
 
-    expected<IpcChannelError> closeFileDescriptor() noexcept;
+    expected<void, IpcChannelError> closeFileDescriptor() noexcept;
 
   private:
     static constexpr int32_t ERROR_CODE = -1;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/file_lock.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/file_lock.hpp
@@ -106,7 +106,7 @@ class FileLock
     void invalidate() noexcept;
 
     static FileLockError convertErrnoToFileLockError(const int32_t errnum, const FilePath_t& fileLockPath) noexcept;
-    expected<FileLockError> closeFileDescriptor() noexcept;
+    expected<void, FileLockError> closeFileDescriptor() noexcept;
 };
 
 class FileLockBuilder

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/named_semaphore.hpp
@@ -75,7 +75,7 @@ class NamedSemaphoreBuilder
     /// @param[in] uninitializedSemaphore since the semaphore is not movable the user has to provide
     ///            memory to store the semaphore into - packed in an optional
     /// @return an error describing the failure or success
-    expected<SemaphoreError> create(optional<NamedSemaphore>& uninitializedSemaphore) const noexcept;
+    expected<void, SemaphoreError> create(optional<NamedSemaphore>& uninitializedSemaphore) const noexcept;
 };
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
@@ -99,7 +99,8 @@ class ThreadBuilder
     /// @param[in] uninitializedThread is an iox::optional where the thread is stored
     /// @param[in] callable is the callable that is invoked by the thread
     /// @return an error describing the failure or success
-    expected<ThreadError> create(optional<Thread>& uninitializedThread, const Thread::callable_t& callable) noexcept;
+    expected<void, ThreadError> create(optional<Thread>& uninitializedThread,
+                                       const Thread::callable_t& callable) noexcept;
 };
 
 } // namespace posix

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp
@@ -65,7 +65,7 @@ class UnnamedSemaphoreBuilder
     /// @param[in] uninitializedSemaphore since the semaphore is not movable the user has to provide
     ///            memory to store the semaphore into - packed in an optional
     /// @return an error describing the failure or success
-    expected<SemaphoreError> create(optional<UnnamedSemaphore>& uninitializedSemaphore) const noexcept;
+    expected<void, SemaphoreError> create(optional<UnnamedSemaphore>& uninitializedSemaphore) const noexcept;
 };
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/memory/source/bump_allocator.cpp
+++ b/iceoryx_hoofs/memory/source/bump_allocator.cpp
@@ -39,7 +39,7 @@ expected<void*, BumpAllocatorError> BumpAllocator::allocate(const uint64_t size,
     if (size == 0)
     {
         IOX_LOG(WARN) << "Cannot allocate memory of size 0.";
-        return error<BumpAllocatorError>(BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY);
+        return err(BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY);
     }
 
     const uint64_t currentAddress{m_startAddress + m_currentPosition};
@@ -62,10 +62,10 @@ expected<void*, BumpAllocatorError> BumpAllocator::allocate(const uint64_t size,
         IOX_LOG(WARN) << "Trying to allocate additional " << size << " bytes in the memory of capacity " << m_length
                       << " when there are already " << alignedPosition << " aligned bytes in use.\n Only "
                       << m_length - alignedPosition << " bytes left.";
-        return error<BumpAllocatorError>(BumpAllocatorError::OUT_OF_MEMORY);
+        return err(BumpAllocatorError::OUT_OF_MEMORY);
     }
 
-    return success<void*>(allocation);
+    return ok(allocation);
 }
 
 void BumpAllocator::deallocate() noexcept

--- a/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
@@ -27,7 +27,7 @@ inline expected<Ownership, FileStatError> FileManagementInterface<Derived>::get_
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
 
     return ok(Ownership(result->st_uid, result->st_gid));
@@ -40,7 +40,7 @@ inline expected<access_rights, FileStatError> FileManagementInterface<Derived>::
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
 
     // st_mode also contains the file type, since we only would like to acquire the permissions
@@ -57,7 +57,7 @@ FileManagementInterface<Derived>::set_ownership(const Ownership ownership) noexc
     auto result = details::set_owner(derived_this.get_file_handle(), ownership.uid(), ownership.gid());
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
 
     return ok();
@@ -71,7 +71,7 @@ FileManagementInterface<Derived>::set_permissions(const access_rights permission
     auto result = details::set_permissions(derived_this.get_file_handle(), permissions);
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
 
     return ok();
@@ -84,7 +84,7 @@ inline expected<uint64_t, FileStatError> FileManagementInterface<Derived>::get_s
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
 
     return ok(static_cast<uint64_t>(result->st_size));

--- a/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
@@ -51,7 +51,8 @@ inline expected<access_rights, FileStatError> FileManagementInterface<Derived>::
 }
 
 template <typename Derived>
-inline expected<FileSetOwnerError> FileManagementInterface<Derived>::set_ownership(const Ownership ownership) noexcept
+inline expected<void, FileSetOwnerError>
+FileManagementInterface<Derived>::set_ownership(const Ownership ownership) noexcept
 {
     const auto& derived_this = *static_cast<const Derived*>(this);
     auto result = details::set_owner(derived_this.get_file_handle(), ownership.uid(), ownership.gid());
@@ -64,7 +65,7 @@ inline expected<FileSetOwnerError> FileManagementInterface<Derived>::set_ownersh
 }
 
 template <typename Derived>
-inline expected<FileSetPermissionError>
+inline expected<void, FileSetPermissionError>
 FileManagementInterface<Derived>::set_permissions(const access_rights permissions) noexcept
 {
     const auto& derived_this = *static_cast<const Derived*>(this);

--- a/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
@@ -27,10 +27,10 @@ inline expected<Ownership, FileStatError> FileManagementInterface<Derived>::get_
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return iox::error<FileStatError>(result.get_error());
+        return err(result.get_error());
     }
 
-    return iox::success<Ownership>(Ownership(result->st_uid, result->st_gid));
+    return ok(Ownership(result->st_uid, result->st_gid));
 }
 
 template <typename Derived>
@@ -40,14 +40,13 @@ inline expected<access_rights, FileStatError> FileManagementInterface<Derived>::
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return iox::error<FileStatError>(result.get_error());
+        return err(result.get_error());
     }
 
     // st_mode also contains the file type, since we only would like to acquire the permissions
     // we have to remove the file type
     constexpr uint16_t ONLY_FILE_PERMISSIONS = 0777;
-    return iox::success<access_rights>(
-        access_rights(static_cast<access_rights::value_type>(result->st_mode & ONLY_FILE_PERMISSIONS)));
+    return ok(access_rights(static_cast<access_rights::value_type>(result->st_mode & ONLY_FILE_PERMISSIONS)));
 }
 
 template <typename Derived>
@@ -58,10 +57,10 @@ FileManagementInterface<Derived>::set_ownership(const Ownership ownership) noexc
     auto result = details::set_owner(derived_this.get_file_handle(), ownership.uid(), ownership.gid());
     if (result.has_error())
     {
-        return iox::error<FileSetOwnerError>(result.get_error());
+        return err(result.get_error());
     }
 
-    return iox::success<>();
+    return ok();
 }
 
 template <typename Derived>
@@ -72,10 +71,10 @@ FileManagementInterface<Derived>::set_permissions(const access_rights permission
     auto result = details::set_permissions(derived_this.get_file_handle(), permissions);
     if (result.has_error())
     {
-        return iox::error<FileSetPermissionError>(result.get_error());
+        return err(result.get_error());
     }
 
-    return iox::success<>();
+    return ok();
 }
 
 template <typename Derived>
@@ -85,10 +84,10 @@ inline expected<uint64_t, FileStatError> FileManagementInterface<Derived>::get_s
     auto result = details::get_file_status(derived_this.get_file_handle());
     if (result.has_error())
     {
-        return iox::error<FileStatError>(result.get_error());
+        return err(result.get_error());
     }
 
-    return iox::success<uint64_t>(static_cast<uint64_t>(result->st_size));
+    return ok(static_cast<uint64_t>(result->st_size));
 }
 } // namespace iox
 

--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -58,8 +58,8 @@ enum class FileSetPermissionError
 namespace details
 {
 expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept;
-expected<FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept;
-expected<FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept;
+expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept;
+expected<void, FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept;
 } // namespace details
 
 /// @brief Represents the POSIX owners (user and group) of a file.
@@ -118,7 +118,7 @@ struct FileManagementInterface
     /// @brief Sets the owners of the underlying file descriptor.
     /// @param[in] owner the new owners of the file descriptor
     /// @return On failure a 'FileSetOwnerError' describing the error.
-    expected<FileSetOwnerError> set_ownership(const Ownership owner) noexcept;
+    expected<void, FileSetOwnerError> set_ownership(const Ownership owner) noexcept;
 
     /// @brief Returns the permissions of the underlying file descriptor.
     /// @return On failure a 'FileStatError' describing the error otherwise 'access_rights'.
@@ -127,7 +127,7 @@ struct FileManagementInterface
     /// @brief Sets the permissions of the underlying file descriptor.
     /// @param[in] permissions the new permissions of the file descriptor
     /// @return On failure a 'FileSetPermissionError' describing the error.
-    expected<FileSetPermissionError> set_permissions(const access_rights permissions) noexcept;
+    expected<void, FileSetPermissionError> set_permissions(const access_rights permissions) noexcept;
 
     /// @brief Returns the size of the corresponding file.
     /// @return On failure a 'FileStatError' describing the error otherwise the size.

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -29,7 +29,7 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EIO:
             IOX_LOG(ERROR) << "Unable to acquire file status since an io failure occurred while reading.";
@@ -53,7 +53,7 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EPERM:
             IOX_LOG(ERROR) << "Unable to set owner due to insufficient permissions.";
@@ -86,7 +86,7 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EPERM:
             IOX_LOG(ERROR) << "Unable to adjust permissions due to insufficient permissions.";

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -47,7 +47,7 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
     return iox::success<iox_stat>(file_status);
 }
 
-expected<FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept
+expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept
 {
     auto result = posix::posixCall(iox_fchown)(fildes, uid, gid).failureReturnValue(-1).evaluate();
 
@@ -80,7 +80,7 @@ expected<FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const g
     return iox::success<>();
 }
 
-expected<FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept
+expected<void, FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept
 {
     auto result = posix::posixCall(iox_fchmod)(fildes, perms.value()).failureReturnValue(-1).evaluate();
 

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -33,18 +33,18 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
         {
         case EIO:
             IOX_LOG(ERROR) << "Unable to acquire file status since an io failure occurred while reading.";
-            return iox::error<FileStatError>(FileStatError::IoFailure);
+            return err(FileStatError::IoFailure);
         case EOVERFLOW:
             IOX_LOG(ERROR) << "Unable to acquire file status since the file size cannot be represented by the "
                               "corresponding structure.";
-            return iox::error<FileStatError>(FileStatError::FileTooLarge);
+            return err(FileStatError::FileTooLarge);
         default:
             IOX_LOG(ERROR) << "Unable to acquire file status due to an unknown failure";
-            return iox::error<FileStatError>(FileStatError::UnknownError);
+            return err(FileStatError::UnknownError);
         }
     }
 
-    return iox::success<iox_stat>(file_status);
+    return ok(file_status);
 }
 
 expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept
@@ -57,27 +57,27 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
         {
         case EPERM:
             IOX_LOG(ERROR) << "Unable to set owner due to insufficient permissions.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::PermissionDenied);
+            return err(FileSetOwnerError::PermissionDenied);
         case EROFS:
             IOX_LOG(ERROR) << "Unable to set owner since it is a read-only filesystem.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::ReadOnlyFilesystem);
+            return err(FileSetOwnerError::ReadOnlyFilesystem);
         case EINVAL:
             IOX_LOG(ERROR) << "Unable to set owner since the uid " << uid << " or the gid " << gid
                            << " are not supported by the OS implementation.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::InvalidUidOrGid);
+            return err(FileSetOwnerError::InvalidUidOrGid);
         case EIO:
             IOX_LOG(ERROR) << "Unable to set owner due to an IO error.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::IoFailure);
+            return err(FileSetOwnerError::IoFailure);
         case EINTR:
             IOX_LOG(ERROR) << "Unable to set owner since an interrupt was received.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::Interrupt);
+            return err(FileSetOwnerError::Interrupt);
         default:
             IOX_LOG(ERROR) << "Unable to set owner since an unknown error occurred.";
-            return iox::error<FileSetOwnerError>(FileSetOwnerError::UnknownError);
+            return err(FileSetOwnerError::UnknownError);
         }
     }
 
-    return iox::success<>();
+    return ok();
 }
 
 expected<void, FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept
@@ -90,17 +90,17 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
         {
         case EPERM:
             IOX_LOG(ERROR) << "Unable to adjust permissions due to insufficient permissions.";
-            return iox::error<FileSetPermissionError>(FileSetPermissionError::PermissionDenied);
+            return err(FileSetPermissionError::PermissionDenied);
         case EROFS:
             IOX_LOG(ERROR) << "Unable to adjust permissions since it is a read-only filesystem.";
-            return iox::error<FileSetPermissionError>(FileSetPermissionError::ReadOnlyFilesystem);
+            return err(FileSetPermissionError::ReadOnlyFilesystem);
         default:
             IOX_LOG(ERROR) << "Unable to adjust permissions since an unknown error occurred.";
-            return iox::error<FileSetPermissionError>(FileSetPermissionError::UnknownError);
+            return err(FileSetPermissionError::UnknownError);
         }
     }
 
-    return iox::success<>();
+    return ok();
 }
 
 } // namespace details

--- a/iceoryx_hoofs/posix/filesystem/include/iox/file.hpp
+++ b/iceoryx_hoofs/posix/filesystem/include/iox/file.hpp
@@ -164,7 +164,7 @@ class File : public FileManagementInterface<File>
     explicit File(const int file_descriptor, const posix::AccessMode access_mode) noexcept;
     void close_fd() noexcept;
 
-    expected<FileOffsetError> set_offset(const uint64_t offset) const noexcept;
+    expected<void, FileOffsetError> set_offset(const uint64_t offset) const noexcept;
 
   private:
     static constexpr int INVALID_FILE_DESCRIPTOR{-1};

--- a/iceoryx_hoofs/posix/filesystem/source/file.cpp
+++ b/iceoryx_hoofs/posix/filesystem/source/file.cpp
@@ -78,7 +78,7 @@ expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexce
         return ok(std::move(file));
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EACCES:
         IOX_LOG(ERROR) << "Unable to open/create file due to insufficient permissions.";
@@ -117,7 +117,7 @@ expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexce
         IOX_LOG(ERROR) << "Unable to create file since it already exists.";
         return err(FileCreationError::AlreadyExists);
     default:
-        IOX_LOG(ERROR) << "Unable to open/create file since an unknown error occurred (" << result.get_error().errnum
+        IOX_LOG(ERROR) << "Unable to open/create file since an unknown error occurred (" << result.error().errnum
                        << ").";
         return err(FileCreationError::UnknownError);
     }
@@ -169,7 +169,7 @@ void File::close_fd() noexcept
         return;
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EBADF:
         IOX_LOG(FATAL) << "This should never happen! Unable to close file since the file descriptor is invalid.";
@@ -182,7 +182,7 @@ void File::close_fd() noexcept
         break;
     default:
         IOX_LOG(FATAL) << "This should never happen! Unable to close file due to an unknown error ("
-                       << result.get_error().errnum << ").";
+                       << result.error().errnum << ").";
         break;
     }
 
@@ -198,7 +198,7 @@ expected<bool, FileAccessError> File::does_exist(const FilePath& file) noexcept
         return ok(true);
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EACCES:
         IOX_LOG(ERROR) << "Unable to determine if file exists due to insufficient permissions.";
@@ -216,7 +216,7 @@ expected<bool, FileAccessError> File::does_exist(const FilePath& file) noexcept
         return err(FileAccessError::InsufficientKernelMemory);
     default:
         IOX_LOG(ERROR) << "Unable to determine if file exists since an unknown error occurred ("
-                       << result.get_error().errnum << ").";
+                       << result.error().errnum << ").";
         return err(FileAccessError::UnknownError);
     }
 }
@@ -233,7 +233,7 @@ expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
         return ok(true);
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case ENOENT:
         return ok(false);
@@ -261,8 +261,7 @@ expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
         IOX_LOG(ERROR) << "Unable to remove file since it resides on a read-only file system.";
         return err(FileRemoveError::ReadOnlyFilesystem);
     default:
-        IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.get_error().errnum
-                       << ").";
+        IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.error().errnum << ").";
         return err(FileRemoveError::UnknownError);
     }
 }
@@ -285,7 +284,7 @@ expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const no
     }
 
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EINVAL:
         IOX_FALLTHROUGH;
@@ -300,8 +299,7 @@ expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const no
         IOX_LOG(ERROR) << "Unable to set file offset position since seeking is not supported by the file type.";
         return err(FileOffsetError::SeekingNotSupportedByFileType);
     default:
-        IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.get_error().errnum
-                       << ").";
+        IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.error().errnum << ").";
         return err(FileOffsetError::UnknownError);
     }
 }
@@ -333,7 +331,7 @@ File::read_at(const uint64_t offset, uint8_t* const buffer, const uint64_t buffe
         return ok(static_cast<uint64_t>(result->value));
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EAGAIN:
         IOX_LOG(ERROR) << "Unable to read from file since the operation would block.";
@@ -351,8 +349,7 @@ File::read_at(const uint64_t offset, uint8_t* const buffer, const uint64_t buffe
         IOX_LOG(ERROR) << "Unable to read from file since it is a directory.";
         return err(FileReadError::IsDirectory);
     default:
-        IOX_LOG(ERROR) << "Unable to read from file since an unknown error occurred (" << result.get_error().errnum
-                       << ").";
+        IOX_LOG(ERROR) << "Unable to read from file since an unknown error occurred (" << result.error().errnum << ").";
         return err(FileReadError::UnknownError);
     }
 }
@@ -384,7 +381,7 @@ File::write_at(const uint64_t offset, const uint8_t* const buffer, const uint64_
         return ok(static_cast<uint64_t>(result->value));
     }
 
-    switch (result.get_error().errnum)
+    switch (result.error().errnum)
     {
     case EAGAIN:
         IOX_LOG(ERROR) << "Unable to write to file since the operation would block.";
@@ -411,7 +408,7 @@ File::write_at(const uint64_t offset, const uint8_t* const buffer, const uint64_
         IOX_LOG(ERROR) << "Unable to write to file since an IO failure occurred.";
         return err(FileWriteError::IoFailure);
     default:
-        IOX_LOG(ERROR) << "Unable to write to file since an unknown error has occurred (" << result.get_error().errnum
+        IOX_LOG(ERROR) << "Unable to write to file since an unknown error has occurred (" << result.error().errnum
                        << ").";
         return err(FileWriteError::UnknownError);
     }

--- a/iceoryx_hoofs/posix/filesystem/source/file.cpp
+++ b/iceoryx_hoofs/posix/filesystem/source/file.cpp
@@ -32,7 +32,7 @@ expected<File, FileCreationError> FileBuilder::create(const FilePath& name) noex
         {
             IOX_LOG(ERROR) << "Unable to purge and open file \"" << name.as_string()
                            << "\" since the file could not be removed";
-            return iox::error<FileCreationError>(FileCreationError::CannotBePurged);
+            return err(FileCreationError::CannotBePurged);
         }
     }
 
@@ -54,7 +54,7 @@ expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexce
         if (perms.has_error())
         {
             IOX_LOG(ERROR) << "Unable to acquire the permissions of the file.";
-            return iox::error<FileCreationError>(FileCreationError::PermissionDenied);
+            return err(FileCreationError::PermissionDenied);
         }
 
         if (m_access_mode == posix::AccessMode::READ_ONLY || m_access_mode == posix::AccessMode::READ_WRITE)
@@ -62,7 +62,7 @@ expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexce
             if ((perms->value() & perms::owner_read.value()) == 0)
             {
                 IOX_LOG(ERROR) << "Unable to open/create file due to insufficient read permissions.";
-                return iox::error<FileCreationError>(FileCreationError::PermissionDenied);
+                return err(FileCreationError::PermissionDenied);
             }
         }
 
@@ -71,55 +71,55 @@ expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexce
             if ((perms->value() & perms::owner_write.value()) == 0)
             {
                 IOX_LOG(ERROR) << "Unable to open/create file due to insufficient write permissions.";
-                return iox::error<FileCreationError>(FileCreationError::PermissionDenied);
+                return err(FileCreationError::PermissionDenied);
             }
         }
 
-        return iox::success<File>(std::move(file));
+        return ok(std::move(file));
     }
 
     switch (result.get_error().errnum)
     {
     case EACCES:
         IOX_LOG(ERROR) << "Unable to open/create file due to insufficient permissions.";
-        return iox::error<FileCreationError>(FileCreationError::PermissionDenied);
+        return err(FileCreationError::PermissionDenied);
     case EPERM:
         IOX_LOG(ERROR) << "Unable to open/create file due to insufficient permissions.";
-        return iox::error<FileCreationError>(FileCreationError::PermissionDenied);
+        return err(FileCreationError::PermissionDenied);
     case EINTR:
         IOX_LOG(ERROR) << "Unable to open/create file since an interrupt signal was received.";
-        return iox::error<FileCreationError>(FileCreationError::Interrupt);
+        return err(FileCreationError::Interrupt);
     case EISDIR:
         IOX_LOG(ERROR) << "Unable to open/create file since it is actually a directory.";
-        return iox::error<FileCreationError>(FileCreationError::IsDirectory);
+        return err(FileCreationError::IsDirectory);
     case ELOOP:
         IOX_LOG(ERROR) << "Unable to open/create file since too many symbolic links were encountered.";
-        return iox::error<FileCreationError>(FileCreationError::TooManySymbolicLinksEncountered);
+        return err(FileCreationError::TooManySymbolicLinksEncountered);
     case EMFILE:
         IOX_LOG(ERROR) << "Unable to open/create file since the process limit of open file descriptors was reached.";
-        return iox::error<FileCreationError>(FileCreationError::ProcessLimitOfOpenFileDescriptorsReached);
+        return err(FileCreationError::ProcessLimitOfOpenFileDescriptorsReached);
     case ENFILE:
         IOX_LOG(ERROR) << "Unable to open/create file since the system limit of open file descriptors was reached.";
-        return iox::error<FileCreationError>(FileCreationError::SystemLimitOfOpenFileDescriptorsReached);
+        return err(FileCreationError::SystemLimitOfOpenFileDescriptorsReached);
     case ENOENT:
         IOX_LOG(ERROR) << "Unable to open file since the file does not exist.";
-        return iox::error<FileCreationError>(FileCreationError::DoesNotExist);
+        return err(FileCreationError::DoesNotExist);
     case ENOMEM:
         IOX_LOG(ERROR) << "Unable to open/create file due to insufficient memory.";
-        return iox::error<FileCreationError>(FileCreationError::InsufficientMemory);
+        return err(FileCreationError::InsufficientMemory);
     case EOVERFLOW:
         IOX_LOG(ERROR) << "Unable to open/create file since it is too large.";
-        return iox::error<FileCreationError>(FileCreationError::FileTooLarge);
+        return err(FileCreationError::FileTooLarge);
     case ETXTBSY:
         IOX_LOG(ERROR) << "Unable to open/create file since it is currently in use.";
-        return iox::error<FileCreationError>(FileCreationError::CurrentlyInUse);
+        return err(FileCreationError::CurrentlyInUse);
     case EEXIST:
         IOX_LOG(ERROR) << "Unable to create file since it already exists.";
-        return iox::error<FileCreationError>(FileCreationError::AlreadyExists);
+        return err(FileCreationError::AlreadyExists);
     default:
         IOX_LOG(ERROR) << "Unable to open/create file since an unknown error occurred (" << result.get_error().errnum
                        << ").";
-        return iox::error<FileCreationError>(FileCreationError::UnknownError);
+        return err(FileCreationError::UnknownError);
     }
 }
 
@@ -195,29 +195,29 @@ expected<bool, FileAccessError> File::does_exist(const FilePath& file) noexcept
 
     if (!result.has_error())
     {
-        return iox::success<bool>(true);
+        return ok(true);
     }
 
     switch (result.get_error().errnum)
     {
     case EACCES:
         IOX_LOG(ERROR) << "Unable to determine if file exists due to insufficient permissions.";
-        return iox::error<FileAccessError>(FileAccessError::InsufficientPermissions);
+        return err(FileAccessError::InsufficientPermissions);
     case ENOENT:
-        return iox::success<bool>(false);
+        return ok(false);
     case ELOOP:
         IOX_LOG(ERROR) << "Unable to determine if file exists due to too many symbolic links.";
-        return iox::error<FileAccessError>(FileAccessError::TooManySymbolicLinksEncountered);
+        return err(FileAccessError::TooManySymbolicLinksEncountered);
     case EIO:
         IOX_LOG(ERROR) << "Unable to determine if file exists due to an IO failure.";
-        return iox::error<FileAccessError>(FileAccessError::IoFailure);
+        return err(FileAccessError::IoFailure);
     case ENOMEM:
         IOX_LOG(ERROR) << "Unable to determine if file exists due insufficient kernel memory.";
-        return iox::error<FileAccessError>(FileAccessError::InsufficientKernelMemory);
+        return err(FileAccessError::InsufficientKernelMemory);
     default:
         IOX_LOG(ERROR) << "Unable to determine if file exists since an unknown error occurred ("
                        << result.get_error().errnum << ").";
-        return iox::error<FileAccessError>(FileAccessError::UnknownError);
+        return err(FileAccessError::UnknownError);
     }
 }
 
@@ -230,40 +230,40 @@ expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
 
     if (!result.has_error())
     {
-        return iox::success<bool>(true);
+        return ok(true);
     }
 
     switch (result.get_error().errnum)
     {
     case ENOENT:
-        return iox::success<bool>(false);
+        return ok(false);
     case EPERM:
         IOX_FALLTHROUGH;
     case EACCES:
         IOX_LOG(ERROR) << "Unable to remove file due to insufficient permissions.";
-        return iox::error<FileRemoveError>(FileRemoveError::PermissionDenied);
+        return err(FileRemoveError::PermissionDenied);
     case EBUSY:
         IOX_LOG(ERROR) << "Unable to remove file since it is currently in use.";
-        return iox::error<FileRemoveError>(FileRemoveError::CurrentlyInUse);
+        return err(FileRemoveError::CurrentlyInUse);
     case EIO:
         IOX_LOG(ERROR) << "Unable to remove file due to an IO failure.";
-        return iox::error<FileRemoveError>(FileRemoveError::IoFailure);
+        return err(FileRemoveError::IoFailure);
     case ELOOP:
         IOX_LOG(ERROR) << "Unable to remove file due to too many symbolic links.";
-        return iox::error<FileRemoveError>(FileRemoveError::TooManySymbolicLinksEncountered);
+        return err(FileRemoveError::TooManySymbolicLinksEncountered);
     case ENOMEM:
         IOX_LOG(ERROR) << "Unable to remove file due to insufficient kernel memory.";
-        return iox::error<FileRemoveError>(FileRemoveError::InsufficientKernelMemory);
+        return err(FileRemoveError::InsufficientKernelMemory);
     case EISDIR:
         IOX_LOG(ERROR) << "Unable to remove file since it is a directory.";
-        return iox::error<FileRemoveError>(FileRemoveError::IsDirectory);
+        return err(FileRemoveError::IsDirectory);
     case EROFS:
         IOX_LOG(ERROR) << "Unable to remove file since it resides on a read-only file system.";
-        return iox::error<FileRemoveError>(FileRemoveError::ReadOnlyFilesystem);
+        return err(FileRemoveError::ReadOnlyFilesystem);
     default:
         IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.get_error().errnum
                        << ").";
-        return iox::error<FileRemoveError>(FileRemoveError::UnknownError);
+        return err(FileRemoveError::UnknownError);
     }
 }
 
@@ -277,11 +277,11 @@ expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const no
     {
         if (result->value == static_cast<iox_off_t>(offset))
         {
-            return iox::success<>();
+            return ok();
         }
 
         IOX_LOG(ERROR) << "Unable to set file offset position since it set to the wrong offset position.";
-        return iox::error<FileOffsetError>(FileOffsetError::OffsetAtWrongPosition);
+        return err(FileOffsetError::OffsetAtWrongPosition);
     }
 
 
@@ -291,18 +291,18 @@ expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const no
         IOX_FALLTHROUGH;
     case ENXIO:
         IOX_LOG(ERROR) << "Unable to set file offset position since it is beyond the file limits.";
-        return iox::error<FileOffsetError>(FileOffsetError::OffsetBeyondFileLimits);
+        return err(FileOffsetError::OffsetBeyondFileLimits);
     case EOVERFLOW:
         IOX_LOG(ERROR)
             << "Unable to set file offset position since the file is too large and the offset would overflow.";
-        return iox::error<FileOffsetError>(FileOffsetError::FileOffsetOverflow);
+        return err(FileOffsetError::FileOffsetOverflow);
     case ESPIPE:
         IOX_LOG(ERROR) << "Unable to set file offset position since seeking is not supported by the file type.";
-        return iox::error<FileOffsetError>(FileOffsetError::SeekingNotSupportedByFileType);
+        return err(FileOffsetError::SeekingNotSupportedByFileType);
     default:
         IOX_LOG(ERROR) << "Unable to remove file since an unknown error occurred (" << result.get_error().errnum
                        << ").";
-        return iox::error<FileOffsetError>(FileOffsetError::UnknownError);
+        return err(FileOffsetError::UnknownError);
     }
 }
 
@@ -317,43 +317,43 @@ File::read_at(const uint64_t offset, uint8_t* const buffer, const uint64_t buffe
     if (m_access_mode == posix::AccessMode::WRITE_ONLY)
     {
         IOX_LOG(ERROR) << "Unable to read from file since it is opened for writing only.";
-        return iox::error<FileReadError>(FileReadError::NotOpenedForReading);
+        return err(FileReadError::NotOpenedForReading);
     }
 
     if (set_offset(offset).has_error())
     {
         IOX_LOG(ERROR) << "Unable to read from file since the offset could not be set.";
-        return iox::error<FileReadError>(FileReadError::OffsetFailure);
+        return err(FileReadError::OffsetFailure);
     }
 
     auto result = posix::posixCall(iox_read)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
 
     if (!result.has_error())
     {
-        return iox::success<uint64_t>(static_cast<uint64_t>(result->value));
+        return ok(static_cast<uint64_t>(result->value));
     }
 
     switch (result.get_error().errnum)
     {
     case EAGAIN:
         IOX_LOG(ERROR) << "Unable to read from file since the operation would block.";
-        return iox::error<FileReadError>(FileReadError::OperationWouldBlock);
+        return err(FileReadError::OperationWouldBlock);
     case EINTR:
         IOX_LOG(ERROR) << "Unable to read from file since an interrupt signal was received.";
-        return iox::error<FileReadError>(FileReadError::Interrupt);
+        return err(FileReadError::Interrupt);
     case EINVAL:
         IOX_LOG(ERROR) << "Unable to read from file since it is unsuitable for reading.";
-        return iox::error<FileReadError>(FileReadError::FileUnsuitableForReading);
+        return err(FileReadError::FileUnsuitableForReading);
     case EIO:
         IOX_LOG(ERROR) << "Unable to read from file since an IO failure occurred.";
-        return iox::error<FileReadError>(FileReadError::IoFailure);
+        return err(FileReadError::IoFailure);
     case EISDIR:
         IOX_LOG(ERROR) << "Unable to read from file since it is a directory.";
-        return iox::error<FileReadError>(FileReadError::IsDirectory);
+        return err(FileReadError::IsDirectory);
     default:
         IOX_LOG(ERROR) << "Unable to read from file since an unknown error occurred (" << result.get_error().errnum
                        << ").";
-        return iox::error<FileReadError>(FileReadError::UnknownError);
+        return err(FileReadError::UnknownError);
     }
 }
 
@@ -368,52 +368,52 @@ File::write_at(const uint64_t offset, const uint8_t* const buffer, const uint64_
     if (m_access_mode == posix::AccessMode::READ_ONLY)
     {
         IOX_LOG(ERROR) << "Unable to write to file since it is opened for reading only.";
-        return iox::error<FileWriteError>(FileWriteError::NotOpenedForWriting);
+        return err(FileWriteError::NotOpenedForWriting);
     }
 
     if (set_offset(offset).has_error())
     {
         IOX_LOG(ERROR) << "Unable to write to file since the offset could not be set.";
-        return iox::error<FileWriteError>(FileWriteError::OffsetFailure);
+        return err(FileWriteError::OffsetFailure);
     }
 
     auto result = posix::posixCall(iox_write)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
 
     if (!result.has_error())
     {
-        return iox::success<uint64_t>(static_cast<uint64_t>(result->value));
+        return ok(static_cast<uint64_t>(result->value));
     }
 
     switch (result.get_error().errnum)
     {
     case EAGAIN:
         IOX_LOG(ERROR) << "Unable to write to file since the operation would block.";
-        return iox::error<FileWriteError>(FileWriteError::OperationWouldBlock);
+        return err(FileWriteError::OperationWouldBlock);
     case EDQUOT:
         IOX_LOG(ERROR) << "Unable to write to file since the users disk quota has been exhausted.";
-        return iox::error<FileWriteError>(FileWriteError::DiskQuotaExhausted);
+        return err(FileWriteError::DiskQuotaExhausted);
     case EFBIG:
         IOX_LOG(ERROR) << "Unable to write to file since file size exceeds the maximum supported size.";
-        return iox::error<FileWriteError>(FileWriteError::FileSizeExceedsMaximumSupportedSize);
+        return err(FileWriteError::FileSizeExceedsMaximumSupportedSize);
     case EINTR:
         IOX_LOG(ERROR) << "Unable to write to file since an interrupt signal occurred.";
-        return iox::error<FileWriteError>(FileWriteError::Interrupt);
+        return err(FileWriteError::Interrupt);
     case EINVAL:
         IOX_LOG(ERROR) << "Unable to write to file since the file is unsuitable for writing.";
-        return iox::error<FileWriteError>(FileWriteError::FileUnsuitableForWriting);
+        return err(FileWriteError::FileUnsuitableForWriting);
     case ENOSPC:
         IOX_LOG(ERROR) << "Unable to write to file since there is no space left on target.";
-        return iox::error<FileWriteError>(FileWriteError::NoSpaceLeftOnDevice);
+        return err(FileWriteError::NoSpaceLeftOnDevice);
     case EPERM:
         IOX_LOG(ERROR) << "Unable to write to file since the operation was prevented by a file seal.";
-        return iox::error<FileWriteError>(FileWriteError::PreventedByFileSeal);
+        return err(FileWriteError::PreventedByFileSeal);
     case EIO:
         IOX_LOG(ERROR) << "Unable to write to file since an IO failure occurred.";
-        return iox::error<FileWriteError>(FileWriteError::IoFailure);
+        return err(FileWriteError::IoFailure);
     default:
         IOX_LOG(ERROR) << "Unable to write to file since an unknown error has occurred (" << result.get_error().errnum
                        << ").";
-        return iox::error<FileWriteError>(FileWriteError::UnknownError);
+        return err(FileWriteError::UnknownError);
     }
 }
 

--- a/iceoryx_hoofs/posix/filesystem/source/file.cpp
+++ b/iceoryx_hoofs/posix/filesystem/source/file.cpp
@@ -267,7 +267,7 @@ expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
     }
 }
 
-expected<FileOffsetError> File::set_offset(const uint64_t offset) const noexcept
+expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const noexcept
 {
     auto result = posix::posixCall(iox_lseek)(m_file_descriptor, static_cast<iox_off_t>(offset), IOX_SEEK_SET)
                       .failureReturnValue(-1)

--- a/iceoryx_hoofs/source/posix_wrapper/access_control.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/access_control.cpp
@@ -88,7 +88,7 @@ AccessController::createACL(const int32_t numEntries) noexcept
 
     if (aclInitCall.has_error())
     {
-        return error<AccessControllerError>(AccessControllerError::COULD_NOT_ALLOCATE_NEW_ACL);
+        return err(AccessControllerError::COULD_NOT_ALLOCATE_NEW_ACL);
     }
 
     // define how to free the memory (custom deleter for the smart pointer)
@@ -100,7 +100,7 @@ AccessController::createACL(const int32_t numEntries) noexcept
         cxx::Ensures(!aclFreeCall.has_error() && "Could not free ACL memory");
     };
 
-    return success<smartAclPointer_t>(aclInitCall->value, freeACL);
+    return ok<smartAclPointer_t>(aclInitCall->value, freeACL);
 }
 
 bool AccessController::addUserPermission(const Permission permission, const PosixUser::userName_t& name) noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -65,7 +65,7 @@ expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
 
     if (openCall.has_error())
     {
-        return err(FileLock::convertErrnoToFileLockError(openCall.get_error().errnum, fileLockPath));
+        return err(FileLock::convertErrnoToFileLockError(openCall.error().errnum, fileLockPath));
     }
 
     auto fileDescriptor = openCall.value().value;
@@ -83,7 +83,7 @@ expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
         });
 
         //  possible errors in iox_ext_close() are masked and we inform the user about the actual error
-        return err(FileLock::convertErrnoToFileLockError(lockCall.get_error().errnum, fileLockPath));
+        return err(FileLock::convertErrnoToFileLockError(lockCall.error().errnum, fileLockPath));
     }
 
     return ok(FileLock(fileDescriptor, fileLockPath));

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -127,7 +127,7 @@ FileLock::~FileLock() noexcept
     }
 }
 
-expected<FileLockError> FileLock::closeFileDescriptor() noexcept
+expected<void, FileLockError> FileLock::closeFileDescriptor() noexcept
 {
     if (m_fd != INVALID_FD)
     {

--- a/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/file_lock.cpp
@@ -38,13 +38,13 @@ expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
     if (!isValidFileName(m_name))
     {
         IOX_LOG(ERROR) << "Unable to create FileLock since the name \"" << m_name << "\" is not a valid file name.";
-        return error<FileLockError>(FileLockError::INVALID_FILE_NAME);
+        return err(FileLockError::INVALID_FILE_NAME);
     }
 
     if (!isValidPathToDirectory(m_path))
     {
         IOX_LOG(ERROR) << "Unable to create FileLock since the path \"" << m_path << "\" is not a valid path.";
-        return error<FileLockError>(FileLockError::INVALID_PATH);
+        return err(FileLockError::INVALID_PATH);
     }
 
     FileLock::FilePath_t fileLockPath = m_path;
@@ -65,7 +65,7 @@ expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
 
     if (openCall.has_error())
     {
-        return error<FileLockError>(FileLock::convertErrnoToFileLockError(openCall.get_error().errnum, fileLockPath));
+        return err(FileLock::convertErrnoToFileLockError(openCall.get_error().errnum, fileLockPath));
     }
 
     auto fileDescriptor = openCall.value().value;
@@ -83,10 +83,10 @@ expected<FileLock, FileLockError> FileLockBuilder::create() noexcept
         });
 
         //  possible errors in iox_ext_close() are masked and we inform the user about the actual error
-        return error<FileLockError>(FileLock::convertErrnoToFileLockError(lockCall.get_error().errnum, fileLockPath));
+        return err(FileLock::convertErrnoToFileLockError(lockCall.get_error().errnum, fileLockPath));
     }
 
-    return success<FileLock>(FileLock(fileDescriptor, fileLockPath));
+    return ok(FileLock(fileDescriptor, fileLockPath));
 }
 
 FileLock::FileLock(const int32_t fileDescriptor, const FilePath_t& path) noexcept
@@ -156,10 +156,10 @@ expected<void, FileLockError> FileLock::closeFileDescriptor() noexcept
 
         if (cleanupFailed)
         {
-            return error<FileLockError>(FileLockError::INTERNAL_LOGIC_ERROR);
+            return err(FileLockError::INTERNAL_LOGIC_ERROR);
         }
     }
-    return success<>();
+    return ok();
 }
 
 void FileLock::invalidate() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -56,7 +56,7 @@ struct MutexAttributes
         auto result = posixCall(pthread_mutexattr_init)(&*m_attributes).returnValueMatchesErrno().evaluate();
         if (result.has_error())
         {
-            switch (result.get_error().errnum)
+            switch (result.error().errnum)
             {
             case ENOMEM:
                 IOX_LOG(ERROR) << "Not enough memory to initialize required mutex attributes";
@@ -80,7 +80,7 @@ struct MutexAttributes
                 .evaluate();
         if (result.has_error())
         {
-            switch (result.get_error().errnum)
+            switch (result.error().errnum)
             {
             case ENOTSUP:
                 IOX_LOG(ERROR) << "The platform does not support shared mutex (inter process mutex)";
@@ -117,7 +117,7 @@ struct MutexAttributes
                           .evaluate();
         if (result.has_error())
         {
-            switch (result.get_error().errnum)
+            switch (result.error().errnum)
             {
             case ENOSYS:
                 IOX_LOG(ERROR) << "The system does not support mutex priorities";
@@ -145,7 +145,7 @@ struct MutexAttributes
                           .evaluate();
         if (result.has_error())
         {
-            switch (result.get_error().errnum)
+            switch (result.error().errnum)
             {
             case EPERM:
                 IOX_LOG(ERROR) << "Insufficient permissions to set the mutex priority ceiling.";
@@ -194,7 +194,7 @@ expected<void, MutexCreationError> initializeMutex(pthread_mutex_t* const handle
     auto initResult = posixCall(pthread_mutex_init)(handle, attributes).returnValueMatchesErrno().evaluate();
     if (initResult.has_error())
     {
-        switch (initResult.get_error().errnum)
+        switch (initResult.error().errnum)
         {
         case EAGAIN:
             IOX_LOG(ERROR) << "Not enough resources to initialize another mutex.";
@@ -314,7 +314,7 @@ mutex::~mutex() noexcept
 
         if (destroyCall.has_error())
         {
-            switch (destroyCall.get_error().errnum)
+            switch (destroyCall.error().errnum)
             {
             case EBUSY:
                 IOX_LOG(ERROR) << "Tried to remove a locked mutex which failed. The mutex handle is now leaked and "
@@ -347,7 +347,7 @@ expected<void, MutexLockError> mutex::lock() noexcept
     auto result = posixCall(pthread_mutex_lock)(&m_handle).returnValueMatchesErrno().evaluate();
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EINVAL:
             IOX_LOG(ERROR)
@@ -380,7 +380,7 @@ expected<void, MutexUnlockError> mutex::unlock() noexcept
     auto result = posixCall(pthread_mutex_unlock)(&m_handle).returnValueMatchesErrno().evaluate();
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EPERM:
             IOX_LOG(ERROR) << "The mutex is not owned by the current thread. The mutex must be unlocked by the same "
@@ -402,7 +402,7 @@ expected<MutexTryLock, MutexTryLockError> mutex::try_lock() noexcept
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EAGAIN:
             IOX_LOG(ERROR) << "Maximum number of recursive locks exceeded.";

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -60,15 +60,15 @@ struct MutexAttributes
             {
             case ENOMEM:
                 IOX_LOG(ERROR) << "Not enough memory to initialize required mutex attributes";
-                return error<MutexCreationError>(MutexCreationError::INSUFFICIENT_MEMORY);
+                return err(MutexCreationError::INSUFFICIENT_MEMORY);
             default:
                 IOX_LOG(ERROR)
                     << "This should never happen. An unknown error occurred while initializing the mutex attributes.";
-                return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+                return err(MutexCreationError::UNKNOWN_ERROR);
             }
         }
 
-        return success<>();
+        return ok();
     }
 
     expected<void, MutexCreationError> enableIpcSupport(const bool enableIpcSupport) noexcept
@@ -84,16 +84,16 @@ struct MutexAttributes
             {
             case ENOTSUP:
                 IOX_LOG(ERROR) << "The platform does not support shared mutex (inter process mutex)";
-                return error<MutexCreationError>(MutexCreationError::INTER_PROCESS_MUTEX_UNSUPPORTED_BY_PLATFORM);
+                return err(MutexCreationError::INTER_PROCESS_MUTEX_UNSUPPORTED_BY_PLATFORM);
             default:
                 IOX_LOG(ERROR)
                     << "This should never happen. An unknown error occurred while setting up the inter process "
                        "configuration.";
-                return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+                return err(MutexCreationError::UNKNOWN_ERROR);
             }
         }
 
-        return success<>();
+        return ok();
     }
 
     expected<void, MutexCreationError> setType(const MutexType mutexType) noexcept
@@ -104,10 +104,10 @@ struct MutexAttributes
         if (result.has_error())
         {
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while setting up the mutex type.";
-            return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+            return err(MutexCreationError::UNKNOWN_ERROR);
         }
 
-        return success<>();
+        return ok();
     }
 
     expected<void, MutexCreationError> setProtocol(const MutexPriorityInheritance priorityInheritance)
@@ -121,21 +121,21 @@ struct MutexAttributes
             {
             case ENOSYS:
                 IOX_LOG(ERROR) << "The system does not support mutex priorities";
-                return error<MutexCreationError>(MutexCreationError::PRIORITIES_UNSUPPORTED_BY_PLATFORM);
+                return err(MutexCreationError::PRIORITIES_UNSUPPORTED_BY_PLATFORM);
             case ENOTSUP:
                 IOX_LOG(ERROR) << "The used mutex priority is not supported by the platform";
-                return error<MutexCreationError>(MutexCreationError::USED_PRIORITY_UNSUPPORTED_BY_PLATFORM);
+                return err(MutexCreationError::USED_PRIORITY_UNSUPPORTED_BY_PLATFORM);
             case EPERM:
                 IOX_LOG(ERROR) << "Insufficient permissions to set mutex priorities";
-                return error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
+                return err(MutexCreationError::PERMISSION_DENIED);
             default:
                 IOX_LOG(ERROR)
                     << "This should never happen. An unknown error occurred while setting up the mutex priority.";
-                return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+                return err(MutexCreationError::UNKNOWN_ERROR);
             }
         }
 
-        return success<>();
+        return ok();
     }
 
     expected<void, MutexCreationError> setPrioCeiling(const int32_t priorityCeiling) noexcept
@@ -149,10 +149,10 @@ struct MutexAttributes
             {
             case EPERM:
                 IOX_LOG(ERROR) << "Insufficient permissions to set the mutex priority ceiling.";
-                return error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
+                return err(MutexCreationError::PERMISSION_DENIED);
             case ENOSYS:
                 IOX_LOG(ERROR) << "The platform does not support mutex priority ceiling.";
-                return error<MutexCreationError>(MutexCreationError::PRIORITIES_UNSUPPORTED_BY_PLATFORM);
+                return err(MutexCreationError::PRIORITIES_UNSUPPORTED_BY_PLATFORM);
             case EINVAL:
             {
                 auto minimumPriority = getSchedulerPriorityMinimum(Scheduler::FIFO);
@@ -161,12 +161,12 @@ struct MutexAttributes
                 IOX_LOG(ERROR) << "The priority ceiling \"" << priorityCeiling
                                << "\" is not in the valid priority range [ " << minimumPriority << ", "
                                << maximumPriority << "] of the Scheduler::FIFO.";
-                return error<MutexCreationError>(MutexCreationError::INVALID_PRIORITY_CEILING_VALUE);
+                return err(MutexCreationError::INVALID_PRIORITY_CEILING_VALUE);
             }
             }
         }
 
-        return success<>();
+        return ok();
     }
 
     expected<void, MutexCreationError>
@@ -179,10 +179,10 @@ struct MutexAttributes
         {
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while setting up the mutex thread "
                               "termination behavior.";
-            return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+            return err(MutexCreationError::UNKNOWN_ERROR);
         }
 
-        return success<>();
+        return ok();
     }
 
     optional<pthread_mutexattr_t> m_attributes;
@@ -198,22 +198,22 @@ expected<void, MutexCreationError> initializeMutex(pthread_mutex_t* const handle
         {
         case EAGAIN:
             IOX_LOG(ERROR) << "Not enough resources to initialize another mutex.";
-            return error<MutexCreationError>(MutexCreationError::INSUFFICIENT_RESOURCES);
+            return err(MutexCreationError::INSUFFICIENT_RESOURCES);
         case ENOMEM:
             IOX_LOG(ERROR) << "Not enough memory to initialize mutex.";
-            return error<MutexCreationError>(MutexCreationError::INSUFFICIENT_MEMORY);
+            return err(MutexCreationError::INSUFFICIENT_MEMORY);
         case EPERM:
             IOX_LOG(ERROR) << "Insufficient permissions to create mutex.";
-            return error<MutexCreationError>(MutexCreationError::PERMISSION_DENIED);
+            return err(MutexCreationError::PERMISSION_DENIED);
         default:
             IOX_LOG(ERROR)
                 << "This should never happen. An unknown error occurred while initializing the mutex handle. "
                    "This is possible when the handle is an already initialized mutex handle.";
-            return error<MutexCreationError>(MutexCreationError::UNKNOWN_ERROR);
+            return err(MutexCreationError::UNKNOWN_ERROR);
         }
     }
 
-    return success<>();
+    return ok();
 }
 
 expected<void, MutexCreationError> MutexBuilder::create(optional<mutex>& uninitializedMutex) noexcept
@@ -221,7 +221,7 @@ expected<void, MutexCreationError> MutexBuilder::create(optional<mutex>& uniniti
     if (uninitializedMutex.has_value())
     {
         IOX_LOG(ERROR) << "Unable to override an already initialized mutex with a new mutex";
-        return error<MutexCreationError>(MutexCreationError::MUTEX_ALREADY_INITIALIZED);
+        return err(MutexCreationError::MUTEX_ALREADY_INITIALIZED);
     }
 
     MutexAttributes mutexAttributes;
@@ -276,7 +276,7 @@ expected<void, MutexCreationError> MutexBuilder::create(optional<mutex>& uniniti
     }
 
     uninitializedMutex->m_isDestructable = true;
-    return success<>();
+    return ok();
 }
 
 /// @todo iox-#1036 remove this, introduced to keep current API temporarily
@@ -353,26 +353,26 @@ expected<void, MutexLockError> mutex::lock() noexcept
             IOX_LOG(ERROR)
                 << "The mutex has the attribute MutexPriorityInheritance::PROTECT set and the calling threads "
                    "priority is greater than the mutex priority.";
-            return error<MutexLockError>(MutexLockError::PRIORITY_MISMATCH);
+            return err(MutexLockError::PRIORITY_MISMATCH);
         case EAGAIN:
             IOX_LOG(ERROR) << "Maximum number of recursive locks exceeded.";
-            return error<MutexLockError>(MutexLockError::MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED);
+            return err(MutexLockError::MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED);
         case EDEADLK:
             IOX_LOG(ERROR) << "Deadlock in mutex detected.";
-            return error<MutexLockError>(MutexLockError::DEADLOCK_CONDITION);
+            return err(MutexLockError::DEADLOCK_CONDITION);
         case EOWNERDEAD:
             IOX_LOG(ERROR)
                 << "The thread/process which owned the mutex died. The mutex is now in an inconsistent state "
                    "and must be put into a consistent state again with Mutex::make_consistent()";
             this->m_hasInconsistentState = true;
-            return error<MutexLockError>(MutexLockError::LOCK_ACQUIRED_BUT_HAS_INCONSISTENT_STATE_SINCE_OWNER_DIED);
+            return err(MutexLockError::LOCK_ACQUIRED_BUT_HAS_INCONSISTENT_STATE_SINCE_OWNER_DIED);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while locking the mutex. "
                               "This can indicate a either corrupted or non-POSIX compliant system.";
-            return error<MutexLockError>(MutexLockError::UNKNOWN_ERROR);
+            return err(MutexLockError::UNKNOWN_ERROR);
         }
     }
-    return success<>();
+    return ok();
 }
 
 expected<void, MutexUnlockError> mutex::unlock() noexcept
@@ -385,15 +385,15 @@ expected<void, MutexUnlockError> mutex::unlock() noexcept
         case EPERM:
             IOX_LOG(ERROR) << "The mutex is not owned by the current thread. The mutex must be unlocked by the same "
                               "thread it was locked by.";
-            return error<MutexUnlockError>(MutexUnlockError::NOT_OWNED_BY_THREAD);
+            return err(MutexUnlockError::NOT_OWNED_BY_THREAD);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while unlocking the mutex. "
                               "This can indicate a either corrupted or non-POSIX compliant system.";
-            return error<MutexUnlockError>(MutexUnlockError::UNKNOWN_ERROR);
+            return err(MutexUnlockError::UNKNOWN_ERROR);
         }
     }
 
-    return success<>();
+    return ok();
 }
 
 expected<MutexTryLock, MutexTryLockError> mutex::try_lock() noexcept
@@ -406,28 +406,26 @@ expected<MutexTryLock, MutexTryLockError> mutex::try_lock() noexcept
         {
         case EAGAIN:
             IOX_LOG(ERROR) << "Maximum number of recursive locks exceeded.";
-            return error<MutexTryLockError>(MutexTryLockError::MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED);
+            return err(MutexTryLockError::MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED);
         case EINVAL:
             IOX_LOG(ERROR)
                 << "The mutex has the attribute MutexPriorityInheritance::PROTECT set and the calling threads "
                    "priority is greater than the mutex priority.";
-            return error<MutexTryLockError>(MutexTryLockError::PRIORITY_MISMATCH);
+            return err(MutexTryLockError::PRIORITY_MISMATCH);
         case EOWNERDEAD:
             IOX_LOG(ERROR)
                 << "The thread/process which owned the mutex died. The mutex is now in an inconsistent state "
                    "and must be put into a consistent state again with Mutex::make_consistent()";
             this->m_hasInconsistentState = true;
-            return error<MutexTryLockError>(
-                MutexTryLockError::LOCK_ACQUIRED_BUT_HAS_INCONSISTENT_STATE_SINCE_OWNER_DIED);
+            return err(MutexTryLockError::LOCK_ACQUIRED_BUT_HAS_INCONSISTENT_STATE_SINCE_OWNER_DIED);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while trying to lock the mutex. "
                               "This can indicate a either corrupted or non-POSIX compliant system.";
-            return error<MutexTryLockError>(MutexTryLockError::UNKNOWN_ERROR);
+            return err(MutexTryLockError::UNKNOWN_ERROR);
         }
     }
 
-    return (result->errnum == EBUSY) ? success<MutexTryLock>(MutexTryLock::FAILED_TO_ACQUIRE_LOCK)
-                                     : success<MutexTryLock>(MutexTryLock::LOCK_SUCCEEDED);
+    return (result->errnum == EBUSY) ? ok(MutexTryLock::FAILED_TO_ACQUIRE_LOCK) : ok(MutexTryLock::LOCK_SUCCEEDED);
 }
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/mutex.cpp
@@ -50,7 +50,7 @@ struct MutexAttributes
         }
     }
 
-    expected<MutexCreationError> init() noexcept
+    expected<void, MutexCreationError> init() noexcept
     {
         m_attributes.emplace();
         auto result = posixCall(pthread_mutexattr_init)(&*m_attributes).returnValueMatchesErrno().evaluate();
@@ -71,7 +71,7 @@ struct MutexAttributes
         return success<>();
     }
 
-    expected<MutexCreationError> enableIpcSupport(const bool enableIpcSupport) noexcept
+    expected<void, MutexCreationError> enableIpcSupport(const bool enableIpcSupport) noexcept
     {
         auto result =
             posixCall(pthread_mutexattr_setpshared)(
@@ -96,7 +96,7 @@ struct MutexAttributes
         return success<>();
     }
 
-    expected<MutexCreationError> setType(const MutexType mutexType) noexcept
+    expected<void, MutexCreationError> setType(const MutexType mutexType) noexcept
     {
         auto result = posixCall(pthread_mutexattr_settype)(&*m_attributes, static_cast<int>(mutexType))
                           .returnValueMatchesErrno()
@@ -110,7 +110,7 @@ struct MutexAttributes
         return success<>();
     }
 
-    expected<MutexCreationError> setProtocol(const MutexPriorityInheritance priorityInheritance)
+    expected<void, MutexCreationError> setProtocol(const MutexPriorityInheritance priorityInheritance)
     {
         auto result = posixCall(pthread_mutexattr_setprotocol)(&*m_attributes, static_cast<int>(priorityInheritance))
                           .returnValueMatchesErrno()
@@ -138,7 +138,7 @@ struct MutexAttributes
         return success<>();
     }
 
-    expected<MutexCreationError> setPrioCeiling(const int32_t priorityCeiling) noexcept
+    expected<void, MutexCreationError> setPrioCeiling(const int32_t priorityCeiling) noexcept
     {
         auto result = posixCall(pthread_mutexattr_setprioceiling)(&*m_attributes, static_cast<int>(priorityCeiling))
                           .returnValueMatchesErrno()
@@ -169,7 +169,8 @@ struct MutexAttributes
         return success<>();
     }
 
-    expected<MutexCreationError> setThreadTerminationBehavior(const MutexThreadTerminationBehavior behavior) noexcept
+    expected<void, MutexCreationError>
+    setThreadTerminationBehavior(const MutexThreadTerminationBehavior behavior) noexcept
     {
         auto result = posixCall(pthread_mutexattr_setrobust)(&*m_attributes, static_cast<int>(behavior))
                           .returnValueMatchesErrno()
@@ -187,8 +188,8 @@ struct MutexAttributes
     optional<pthread_mutexattr_t> m_attributes;
 };
 
-expected<MutexCreationError> initializeMutex(pthread_mutex_t* const handle,
-                                             const pthread_mutexattr_t* const attributes) noexcept
+expected<void, MutexCreationError> initializeMutex(pthread_mutex_t* const handle,
+                                                   const pthread_mutexattr_t* const attributes) noexcept
 {
     auto initResult = posixCall(pthread_mutex_init)(handle, attributes).returnValueMatchesErrno().evaluate();
     if (initResult.has_error())
@@ -215,7 +216,7 @@ expected<MutexCreationError> initializeMutex(pthread_mutex_t* const handle,
     return success<>();
 }
 
-expected<MutexCreationError> MutexBuilder::create(optional<mutex>& uninitializedMutex) noexcept
+expected<void, MutexCreationError> MutexBuilder::create(optional<mutex>& uninitializedMutex) noexcept
 {
     if (uninitializedMutex.has_value())
     {
@@ -341,7 +342,7 @@ void mutex::make_consistent() noexcept
     }
 }
 
-expected<MutexLockError> mutex::lock() noexcept
+expected<void, MutexLockError> mutex::lock() noexcept
 {
     auto result = posixCall(pthread_mutex_lock)(&m_handle).returnValueMatchesErrno().evaluate();
     if (result.has_error())
@@ -374,7 +375,7 @@ expected<MutexLockError> mutex::lock() noexcept
     return success<>();
 }
 
-expected<MutexUnlockError> mutex::unlock() noexcept
+expected<void, MutexUnlockError> mutex::unlock() noexcept
 {
     auto result = posixCall(pthread_mutex_unlock)(&m_handle).returnValueMatchesErrno().evaluate();
     if (result.has_error())

--- a/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
@@ -37,7 +37,7 @@ static expected<void, SemaphoreError> unlink(const NamedSemaphore::Name_t& name)
                       .evaluate();
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EACCES:
             IOX_LOG(ERROR) << "You don't have permission to remove the semaphore \"" << name << "\"";
@@ -63,7 +63,7 @@ tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EACCES:
             IOX_LOG(ERROR) << "Insufficient permissions to open semaphore \"" << name << "\".";
@@ -116,7 +116,7 @@ static expected<void, SemaphoreError> createSemaphore(optional<NamedSemaphore>& 
 
     if (result.has_error())
     {
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EACCES:
             IOX_LOG(ERROR) << "Insufficient permissions to create semaphore \"" << name << "\".";

--- a/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
@@ -41,14 +41,14 @@ static expected<void, SemaphoreError> unlink(const NamedSemaphore::Name_t& name)
         {
         case EACCES:
             IOX_LOG(ERROR) << "You don't have permission to remove the semaphore \"" << name << "\"";
-            return error<SemaphoreError>(SemaphoreError::PERMISSION_DENIED);
+            return err(SemaphoreError::PERMISSION_DENIED);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while creating the semaphore \""
                            << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::UNDEFINED);
+            return err(SemaphoreError::UNDEFINED);
         }
     }
-    return success<>();
+    return ok();
 }
 
 static expected<bool, SemaphoreError>
@@ -67,22 +67,22 @@ tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const
         {
         case EACCES:
             IOX_LOG(ERROR) << "Insufficient permissions to open semaphore \"" << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::PERMISSION_DENIED);
+            return err(SemaphoreError::PERMISSION_DENIED);
         case EMFILE:
             IOX_LOG(ERROR) << "The per-process limit of file descriptor exceeded while opening the semaphore \"" << name
                            << "\"";
-            return error<SemaphoreError>(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
+            return err(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
         case ENFILE:
             IOX_LOG(ERROR) << "The system wide limit of file descriptor exceeded while opening the semaphore \"" << name
                            << "\"";
-            return error<SemaphoreError>(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
+            return err(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
         case ENOMEM:
             IOX_LOG(ERROR) << "Insufficient memory to open the semaphore \"" << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::OUT_OF_MEMORY);
+            return err(SemaphoreError::OUT_OF_MEMORY);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while opening the semaphore \""
                            << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::UNDEFINED);
+            return err(SemaphoreError::UNDEFINED);
         }
     }
 
@@ -90,10 +90,10 @@ tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const
     {
         constexpr bool HAS_OWNERSHIP = false;
         uninitializedSemaphore.emplace(result.value().value, name, HAS_OWNERSHIP);
-        return success<bool>(true);
+        return ok(true);
     }
 
-    return success<bool>(false);
+    return ok(false);
 }
 
 /// NOLINTJUSTIFICATION used only internally in this file. Furthermore the problem cannot be avoided since
@@ -120,35 +120,35 @@ static expected<void, SemaphoreError> createSemaphore(optional<NamedSemaphore>& 
         {
         case EACCES:
             IOX_LOG(ERROR) << "Insufficient permissions to create semaphore \"" << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::PERMISSION_DENIED);
+            return err(SemaphoreError::PERMISSION_DENIED);
         case EEXIST:
             IOX_LOG(ERROR)
                 << "A semaphore with the name \"" << name
                 << "\" does already exist. This should not happen until there is a race condition when multiple "
                    "instances try to create the same named semaphore concurrently.";
-            return error<SemaphoreError>(SemaphoreError::ALREADY_EXIST);
+            return err(SemaphoreError::ALREADY_EXIST);
         case EMFILE:
             IOX_LOG(ERROR) << "The per-process limit of file descriptor exceeded while creating the semaphore \""
                            << name << "\"";
-            return error<SemaphoreError>(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
+            return err(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
         case ENFILE:
             IOX_LOG(ERROR) << "The system wide limit of file descriptor exceeded while creating the semaphore \""
                            << name << "\"";
-            return error<SemaphoreError>(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
+            return err(SemaphoreError::FILE_DESCRIPTOR_LIMIT_REACHED);
         case ENOMEM:
             IOX_LOG(ERROR) << "Insufficient memory to create the semaphore \"" << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::OUT_OF_MEMORY);
+            return err(SemaphoreError::OUT_OF_MEMORY);
         default:
             IOX_LOG(ERROR) << "This should never happen. An unknown error occurred while creating the semaphore \""
                            << name << "\".";
-            return error<SemaphoreError>(SemaphoreError::UNDEFINED);
+            return err(SemaphoreError::UNDEFINED);
         }
     }
 
     constexpr bool HAS_OWNERSHIP = true;
     uninitializedSemaphore.emplace(result.value().value, name, HAS_OWNERSHIP);
 
-    return success<>();
+    return ok();
 }
 
 expected<void, SemaphoreError>
@@ -160,14 +160,14 @@ NamedSemaphoreBuilder::create(optional<NamedSemaphore>& uninitializedSemaphore) 
     if (!isValidFileName(m_name))
     {
         IOX_LOG(ERROR) << "The name \"" << m_name << "\" is not a valid semaphore name.";
-        return error<SemaphoreError>(SemaphoreError::INVALID_NAME);
+        return err(SemaphoreError::INVALID_NAME);
     }
 
     if (m_initialValue > IOX_SEM_VALUE_MAX)
     {
         IOX_LOG(ERROR) << "The semaphores \"" << m_name << "\" initial value of " << m_initialValue
                        << " exceeds the maximum semaphore value " << IOX_SEM_VALUE_MAX;
-        return error<SemaphoreError>(SemaphoreError::SEMAPHORE_OVERFLOW);
+        return err(SemaphoreError::SEMAPHORE_OVERFLOW);
     }
 
     if (m_openMode == OpenMode::OPEN_EXISTING)
@@ -181,9 +181,9 @@ NamedSemaphoreBuilder::create(optional<NamedSemaphore>& uninitializedSemaphore) 
         if (!result.value())
         {
             IOX_LOG(ERROR) << "Unable to open semaphore since no semaphore with the name \"" << m_name << "\" exists.";
-            return error<SemaphoreError>(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS);
+            return err(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS);
         }
-        return success<>();
+        return ok();
     }
 
     if (m_openMode == OpenMode::OPEN_OR_CREATE)
@@ -196,7 +196,7 @@ NamedSemaphoreBuilder::create(optional<NamedSemaphore>& uninitializedSemaphore) 
 
         if (result.value())
         {
-            return success<>();
+            return ok();
         }
 
         return createSemaphore(uninitializedSemaphore, m_name, m_openMode, m_permissions, m_initialValue);

--- a/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
@@ -29,7 +29,7 @@ static string<NamedSemaphore::Name_t::capacity() + 1> createNameWithSlash(const 
     return nameWithSlash;
 }
 
-static expected<SemaphoreError> unlink(const NamedSemaphore::Name_t& name) noexcept
+static expected<void, SemaphoreError> unlink(const NamedSemaphore::Name_t& name) noexcept
 {
     auto result = posixCall(iox_sem_unlink)(createNameWithSlash(name).c_str())
                       .failureReturnValue(-1)
@@ -101,11 +101,11 @@ tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const
 ///                     before this function and provide the result but this would increase code complexity
 ///                     even further. The cognitive complexity results from the expanded log macro
 /// NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
-static expected<SemaphoreError> createSemaphore(optional<NamedSemaphore>& uninitializedSemaphore,
-                                                const NamedSemaphore::Name_t& name,
-                                                const OpenMode openMode,
-                                                const access_rights permissions,
-                                                const uint32_t initialValue) noexcept
+static expected<void, SemaphoreError> createSemaphore(optional<NamedSemaphore>& uninitializedSemaphore,
+                                                      const NamedSemaphore::Name_t& name,
+                                                      const OpenMode openMode,
+                                                      const access_rights permissions,
+                                                      const uint32_t initialValue) noexcept
 {
     auto result = posixCall(iox_sem_open_ext)(createNameWithSlash(name).c_str(),
                                               convertToOflags(openMode),
@@ -151,7 +151,7 @@ static expected<SemaphoreError> createSemaphore(optional<NamedSemaphore>& uninit
     return success<>();
 }
 
-expected<SemaphoreError>
+expected<void, SemaphoreError>
 // NOLINTJUSTIFICATION the function size is related to the error handling and the cognitive complexity
 // results from the expanded log macro
 // NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -59,7 +59,7 @@ expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::post() noexce
 
     if (result.has_error())
     {
-        return err(errnoToEnum(result.get_error().errnum));
+        return err(errnoToEnum(result.error().errnum));
     }
 
     return ok();
@@ -77,7 +77,7 @@ SemaphoreInterface<SemaphoreChild>::timedWait(const units::Duration& timeout) no
 
     if (result.has_error())
     {
-        return err(errnoToEnum(result.get_error().errnum));
+        return err(errnoToEnum(result.error().errnum));
     }
 
     return ok((result.value().errnum == ETIMEDOUT) ? SemaphoreWaitState::TIMEOUT : SemaphoreWaitState::NO_TIMEOUT);
@@ -90,7 +90,7 @@ expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWait() noe
 
     if (result.has_error())
     {
-        return err(errnoToEnum(result.get_error().errnum));
+        return err(errnoToEnum(result.error().errnum));
     }
 
     return ok(result.value().errnum != EAGAIN);
@@ -103,7 +103,7 @@ expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexce
 
     if (result.has_error())
     {
-        return err(errnoToEnum(result.get_error().errnum));
+        return err(errnoToEnum(result.error().errnum));
     }
 
     return ok();

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -53,7 +53,7 @@ iox_sem_t* SemaphoreInterface<SemaphoreChild>::getHandle() noexcept
 }
 
 template <typename SemaphoreChild>
-expected<SemaphoreError> SemaphoreInterface<SemaphoreChild>::post() noexcept
+expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::post() noexcept
 {
     auto result = posixCall(iox_sem_post)(getHandle()).failureReturnValue(-1).evaluate();
 
@@ -98,7 +98,7 @@ expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWait() noe
 }
 
 template <typename SemaphoreChild>
-expected<SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexcept
+expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexcept
 {
     auto result = posixCall(iox_sem_wait)(getHandle()).failureReturnValue(-1).evaluate();
 

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -26,24 +26,24 @@ namespace posix
 {
 namespace internal
 {
-error<SemaphoreError> createErrorFromErrno(const int32_t errnum) noexcept
+SemaphoreError errnoToEnum(const int32_t errnum) noexcept
 {
     switch (errnum)
     {
     case EINVAL:
         IOX_LOG(ERROR) << "The semaphore handle is no longer valid. This can indicate a corrupted system.";
-        return error<SemaphoreError>(SemaphoreError::INVALID_SEMAPHORE_HANDLE);
+        return SemaphoreError::INVALID_SEMAPHORE_HANDLE;
     case EOVERFLOW:
         IOX_LOG(ERROR) << "Semaphore overflow. The maximum value of " << IOX_SEM_VALUE_MAX << " would be exceeded.";
-        return error<SemaphoreError>(SemaphoreError::SEMAPHORE_OVERFLOW);
+        return SemaphoreError::SEMAPHORE_OVERFLOW;
     case EINTR:
         IOX_LOG(ERROR) << "The semaphore call was interrupted multiple times by the operating system. Abort operation!";
-        return error<SemaphoreError>(SemaphoreError::INTERRUPTED_BY_SIGNAL_HANDLER);
+        return SemaphoreError::INTERRUPTED_BY_SIGNAL_HANDLER;
     default:
         IOX_LOG(ERROR) << "This should never happen. An unknown error occurred.";
         break;
     }
-    return error<SemaphoreError>(SemaphoreError::UNDEFINED);
+    return SemaphoreError::UNDEFINED;
 }
 
 template <typename SemaphoreChild>
@@ -59,10 +59,10 @@ expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::post() noexce
 
     if (result.has_error())
     {
-        return createErrorFromErrno(result.get_error().errnum);
+        return err(errnoToEnum(result.get_error().errnum));
     }
 
-    return success<>();
+    return ok();
 }
 
 template <typename SemaphoreChild>
@@ -77,11 +77,10 @@ SemaphoreInterface<SemaphoreChild>::timedWait(const units::Duration& timeout) no
 
     if (result.has_error())
     {
-        return createErrorFromErrno(result.get_error().errnum);
+        return err(errnoToEnum(result.get_error().errnum));
     }
 
-    return success<SemaphoreWaitState>((result.value().errnum == ETIMEDOUT) ? SemaphoreWaitState::TIMEOUT
-                                                                            : SemaphoreWaitState::NO_TIMEOUT);
+    return ok((result.value().errnum == ETIMEDOUT) ? SemaphoreWaitState::TIMEOUT : SemaphoreWaitState::NO_TIMEOUT);
 }
 
 template <typename SemaphoreChild>
@@ -91,10 +90,10 @@ expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWait() noe
 
     if (result.has_error())
     {
-        return createErrorFromErrno(result.get_error().errnum);
+        return err(errnoToEnum(result.get_error().errnum));
     }
 
-    return success<bool>(result.value().errnum != EAGAIN);
+    return ok(result.value().errnum != EAGAIN);
 }
 
 template <typename SemaphoreChild>
@@ -104,10 +103,10 @@ expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexce
 
     if (result.has_error())
     {
-        return createErrorFromErrno(result.get_error().errnum);
+        return err(errnoToEnum(result.get_error().errnum));
     }
 
-    return success<>();
+    return ok();
 }
 
 template class SemaphoreInterface<UnnamedSemaphore>;

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -90,7 +90,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     {
         printErrorDetails();
         IOX_LOG(ERROR) << "Unable to create SharedMemoryObject since we could not acquire a SharedMemory resource";
-        return error<SharedMemoryObjectError>(SharedMemoryObjectError::SHARED_MEMORY_CREATION_FAILED);
+        return err(SharedMemoryObjectError::SHARED_MEMORY_CREATION_FAILED);
     }
 
     const auto realSizeResult = sharedMemory->get_size();
@@ -99,7 +99,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         printErrorDetails();
         IOX_LOG(ERROR) << "Unable to create SharedMemoryObject since we could not acquire the memory size of the "
                           "underlying object.";
-        return error<SharedMemoryObjectError>(SharedMemoryObjectError::UNABLE_TO_VERIFY_MEMORY_SIZE);
+        return err(SharedMemoryObjectError::UNABLE_TO_VERIFY_MEMORY_SIZE);
     }
 
     const auto realSize = *realSizeResult;
@@ -108,7 +108,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         printErrorDetails();
         IOX_LOG(ERROR) << "Unable to create SharedMemoryObject since a size of " << m_memorySizeInBytes
                        << " was requested but the object has only a size of " << realSize;
-        return error<SharedMemoryObjectError>(SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE);
+        return err(SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE);
     }
 
     auto memoryMap = MemoryMapBuilder()
@@ -124,7 +124,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     {
         printErrorDetails();
         IOX_LOG(ERROR) << "Failed to map created shared memory into process!";
-        return error<SharedMemoryObjectError>(SharedMemoryObjectError::MAPPING_SHARED_MEMORY_FAILED);
+        return err(SharedMemoryObjectError::MAPPING_SHARED_MEMORY_FAILED);
     }
 
     if (sharedMemory->hasOwnership())
@@ -141,7 +141,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
             {
                 printErrorDetails();
                 IOX_LOG(ERROR) << "Failed to temporarily override SIGBUS to safely zero the shared memory";
-                return error<SharedMemoryObjectError>(SharedMemoryObjectError::INTERNAL_LOGIC_FAILURE);
+                return err(SharedMemoryObjectError::INTERNAL_LOGIC_FAILURE);
             }
 
             // NOLINTJUSTIFICATION snprintf required to populate char array so that it can be used signal safe in
@@ -167,7 +167,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
                        << "]";
     }
 
-    return success<SharedMemoryObject>(SharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
+    return ok(SharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
 }
 
 SharedMemoryObject::SharedMemoryObject(SharedMemory&& sharedMemory, MemoryMap&& memoryMap) noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -56,7 +56,7 @@ expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
                    << ", flags = " << std::bitset<FLAGS_BIT_SIZE>(static_cast<uint32_t>(m_flags)).to_string()
                    << ", offset = " << iox::log::hex(m_offset) << " ]";
     std::cerr.setf(flags);
-    return err(MemoryMap::errnoToEnum(result.get_error().errnum));
+    return err(MemoryMap::errnoToEnum(result.error().errnum));
 }
 
 MemoryMap::MemoryMap(void* const baseAddress, const uint64_t length) noexcept
@@ -177,7 +177,7 @@ bool MemoryMap::destroy() noexcept
 
         if (unmapResult.has_error())
         {
-            errnoToEnum(unmapResult.get_error().errnum);
+            errnoToEnum(unmapResult.error().errnum);
             IOX_LOG(ERROR) << "unable to unmap mapped memory [ address = " << iox::log::hex(m_baseAddress)
                            << ", size = " << m_length << " ]";
             return false;

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -45,7 +45,7 @@ expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
 
     if (result)
     {
-        return success<MemoryMap>(MemoryMap(result.value().value, m_length));
+        return ok(MemoryMap(result.value().value, m_length));
     }
 
     constexpr uint64_t FLAGS_BIT_SIZE = 32U;
@@ -56,7 +56,7 @@ expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
                    << ", flags = " << std::bitset<FLAGS_BIT_SIZE>(static_cast<uint32_t>(m_flags)).to_string()
                    << ", offset = " << iox::log::hex(m_offset) << " ]";
     std::cerr.setf(flags);
-    return error<MemoryMapError>(MemoryMap::errnoToEnum(result.get_error().errnum));
+    return err(MemoryMap::errnoToEnum(result.get_error().errnum));
 }
 
 MemoryMap::MemoryMap(void* const baseAddress, const uint64_t length) noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -54,14 +54,14 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     if (m_name.empty())
     {
         IOX_LOG(ERROR) << "No shared memory name specified!";
-        return error<SharedMemoryError>(SharedMemoryError::EMPTY_NAME);
+        return err(SharedMemoryError::EMPTY_NAME);
     }
 
     if (!isValidFileName(m_name))
     {
         IOX_LOG(ERROR) << "Shared memory requires a valid file name (not path) as name and \"" << m_name
                        << "\" is not a valid file name";
-        return error<SharedMemoryError>(SharedMemoryError::INVALID_FILE_NAME);
+        return err(SharedMemoryError::INVALID_FILE_NAME);
     }
 
     auto nameWithLeadingSlash = addLeadingSlash(m_name);
@@ -73,7 +73,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     {
         IOX_LOG(ERROR) << "Cannot create shared-memory file \"" << m_name << "\" in read-only mode. "
                        << "Initializing a new file requires write access";
-        return error<SharedMemoryError>(SharedMemoryError::INCOMPATIBLE_OPEN_AND_ACCESS_MODE);
+        return err(SharedMemoryError::INCOMPATIBLE_OPEN_AND_ACCESS_MODE);
     }
 
     // the mask will be applied to the permissions, therefore we need to set it to 0
@@ -117,7 +117,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
             if (result.has_error())
             {
                 printError();
-                return error<SharedMemoryError>(SharedMemory::errnoToEnum(result.get_error().errnum));
+                return err(SharedMemory::errnoToEnum(result.get_error().errnum));
             }
         }
         sharedMemoryFileHandle = result->value;
@@ -148,11 +148,11 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
                                    << "\". This may be a SharedMemory leak.";
                 });
 
-            return error<SharedMemoryError>(SharedMemory::errnoToEnum(result.get_error().errnum));
+            return err(SharedMemory::errnoToEnum(result.get_error().errnum));
         }
     }
 
-    return success<SharedMemory>(SharedMemory(m_name, sharedMemoryFileHandle, hasOwnership));
+    return ok(SharedMemory(m_name, sharedMemoryFileHandle, hasOwnership));
 }
 
 SharedMemory::SharedMemory(const Name_t& name, const int handle, const bool hasOwnership) noexcept
@@ -226,10 +226,10 @@ expected<bool, SharedMemoryError> SharedMemory::unlinkIfExist(const Name_t& name
 
     if (!result.has_error())
     {
-        return success<bool>(result->errnum != ENOENT);
+        return ok(result->errnum != ENOENT);
     }
 
-    return error<SharedMemoryError>(errnoToEnum(result.get_error().errnum));
+    return err(errnoToEnum(result.get_error().errnum));
 }
 
 bool SharedMemory::unlink() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -224,12 +224,12 @@ expected<bool, SharedMemoryError> SharedMemory::unlinkIfExist(const Name_t& name
                       .ignoreErrnos(ENOENT)
                       .evaluate();
 
-    if (!result.has_error())
+    if (result.has_error())
     {
-        return ok(result->errnum != ENOENT);
+        return err(errnoToEnum(result.error().errnum));
     }
 
-    return err(errnoToEnum(result.error().errnum));
+    return ok(result->errnum != ENOENT);
 }
 
 bool SharedMemory::unlink() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -103,7 +103,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
         {
             // if it was not possible to create the shm exclusively someone else has the
             // ownership and we just try to open it
-            if (m_openMode == OpenMode::OPEN_OR_CREATE && result.get_error().errnum == EEXIST)
+            if (m_openMode == OpenMode::OPEN_OR_CREATE && result.error().errnum == EEXIST)
             {
                 hasOwnership = false;
                 result = posixCall(iox_shm_open)(nameWithLeadingSlash.c_str(),
@@ -117,7 +117,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
             if (result.has_error())
             {
                 printError();
-                return err(SharedMemory::errnoToEnum(result.get_error().errnum));
+                return err(SharedMemory::errnoToEnum(result.error().errnum));
             }
         }
         sharedMemoryFileHandle = result->value;
@@ -148,7 +148,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
                                    << "\". This may be a SharedMemory leak.";
                 });
 
-            return err(SharedMemory::errnoToEnum(result.get_error().errnum));
+            return err(SharedMemory::errnoToEnum(result.error().errnum));
         }
     }
 
@@ -229,7 +229,7 @@ expected<bool, SharedMemoryError> SharedMemory::unlinkIfExist(const Name_t& name
         return ok(result->errnum != ENOENT);
     }
 
-    return err(errnoToEnum(result.get_error().errnum));
+    return err(errnoToEnum(result.error().errnum));
 }
 
 bool SharedMemory::unlink() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/signal_handler.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/signal_handler.cpp
@@ -67,7 +67,7 @@ expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signa
             << "This should never happen! Unable to create an empty sigaction set while registering a signal "
                "handler for the signal ["
             << static_cast<int>(signal) << "]. No signal handler will be registered!";
-        return error<SignalGuardError>(SignalGuardError::INVALID_SIGNAL_ENUM_VALUE);
+        return err(SignalGuardError::INVALID_SIGNAL_ENUM_VALUE);
     }
 
     // system struct, no way to avoid union
@@ -88,10 +88,10 @@ expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signa
         IOX_LOG(ERROR)
             << "This should never happen! An error occurred while registering a signal handler for the signal ["
             << static_cast<int>(signal) << "]. ";
-        return error<SignalGuardError>(SignalGuardError::UNDEFINED_ERROR_IN_SYSTEM_CALL);
+        return err(SignalGuardError::UNDEFINED_ERROR_IN_SYSTEM_CALL);
     }
 
-    return success<SignalGuard>(SignalGuard(signal, previousAction));
+    return ok(SignalGuard(signal, previousAction));
 }
 } // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -67,10 +67,10 @@ expected<void, ThreadError> ThreadBuilder::create(optional<Thread>& uninitialize
     if (!uninitializedThread->m_isThreadConstructed)
     {
         uninitializedThread.reset();
-        return error<ThreadError>(Thread::errnoToEnum(createResult.get_error().errnum));
+        return err(Thread::errnoToEnum(createResult.get_error().errnum));
     }
 
-    return success<>();
+    return ok();
 }
 
 Thread::Thread(const ThreadName_t& name, const callable_t& callable) noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -63,7 +63,7 @@ expected<void, ThreadError> ThreadBuilder::create(optional<Thread>& uninitialize
             &uninitializedThread->m_threadHandle, threadAttributes, Thread::startRoutine, &uninitializedThread.value())
             .successReturnValue(0)
             .evaluate();
-    uninitializedThread->m_isThreadConstructed = !createResult.has_error();
+    uninitializedThread->m_isThreadConstructed = createResult.has_value();
     if (!uninitializedThread->m_isThreadConstructed)
     {
         uninitializedThread.reset();

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -51,8 +51,8 @@ ThreadName_t getThreadName(iox_pthread_t thread) noexcept
     return ThreadName_t(TruncateToCapacity, &tempName[0]);
 }
 
-expected<ThreadError> ThreadBuilder::create(optional<Thread>& uninitializedThread,
-                                            const Thread::callable_t& callable) noexcept
+expected<void, ThreadError> ThreadBuilder::create(optional<Thread>& uninitializedThread,
+                                                  const Thread::callable_t& callable) noexcept
 {
     uninitializedThread.emplace(m_name, callable);
 

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -67,7 +67,7 @@ expected<void, ThreadError> ThreadBuilder::create(optional<Thread>& uninitialize
     if (!uninitializedThread->m_isThreadConstructed)
     {
         uninitializedThread.reset();
-        return err(Thread::errnoToEnum(createResult.get_error().errnum));
+        return err(Thread::errnoToEnum(createResult.error().errnum));
     }
 
     return ok();
@@ -88,7 +88,7 @@ Thread::~Thread() noexcept
         auto joinResult = posixCall(iox_pthread_join)(m_threadHandle, nullptr).successReturnValue(0).evaluate();
         if (joinResult.has_error())
         {
-            switch (joinResult.get_error().errnum)
+            switch (joinResult.error().errnum)
             {
             case EDEADLK:
                 IOX_LOG(ERROR) << "A deadlock was detected when attempting to join the thread.";

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -168,7 +168,7 @@ expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const NoPathPre
     return error<IpcChannelError>(IpcChannelError::INTERNAL_LOGIC_ERROR);
 }
 
-expected<IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
+expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
 {
     if (m_sockfd != INVALID_FD)
     {
@@ -198,7 +198,7 @@ expected<IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
     return success<>();
 }
 
-expected<IpcChannelError> UnixDomainSocket::destroy() noexcept
+expected<void, IpcChannelError> UnixDomainSocket::destroy() noexcept
 {
     if (m_isInitialized)
     {
@@ -208,15 +208,15 @@ expected<IpcChannelError> UnixDomainSocket::destroy() noexcept
     return success<void>();
 }
 
-expected<IpcChannelError> UnixDomainSocket::send(const std::string& msg) const noexcept
+expected<void, IpcChannelError> UnixDomainSocket::send(const std::string& msg) const noexcept
 {
     // we also support timedSend. The setsockopt call sets the timeout for all further sendto calls, so we must set
     // it to 0 to turn the timeout off
     return timedSend(msg, units::Duration::fromSeconds(0ULL));
 }
 
-expected<IpcChannelError> UnixDomainSocket::timedSend(const std::string& msg,
-                                                      const units::Duration& timeout) const noexcept
+expected<void, IpcChannelError> UnixDomainSocket::timedSend(const std::string& msg,
+                                                            const units::Duration& timeout) const noexcept
 {
     if (msg.size() > m_maxMessageSize)
     {
@@ -296,7 +296,7 @@ expected<std::string, IpcChannelError> UnixDomainSocket::timedReceive(const unit
     return success<std::string>(&message[0]);
 }
 
-expected<IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
+expected<void, IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
 {
     // initialize the sockAddr data structure with the provided name
     memset(&m_sockAddr, 0, sizeof(m_sockAddr));

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -160,12 +160,12 @@ expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const NoPathPre
 
     auto unlinkCall = posixCall(unlink)(name.c_str()).failureReturnValue(ERROR_CODE).ignoreErrnos(ENOENT).evaluate();
 
-    if (!unlinkCall.has_error())
+    if (unlinkCall.has_error())
     {
-        // ENOENT is set if this socket is not known
-        return ok(unlinkCall->errnum != ENOENT);
+        return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
     }
-    return err(IpcChannelError::INTERNAL_LOGIC_ERROR);
+    // ENOENT is set if this socket is not known
+    return ok(unlinkCall->errnum != ENOENT);
 }
 
 expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -193,7 +193,7 @@ expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
 
             return ok();
         }
-        return err(convertErrnoToIpcChannelError(closeCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(closeCall.error().errnum));
     }
     return ok();
 }
@@ -237,7 +237,7 @@ expected<void, IpcChannelError> UnixDomainSocket::timedSend(const std::string& m
 
     if (setsockoptCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(setsockoptCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(setsockoptCall.error().errnum));
     }
     auto sendCall = posixCall(iox_sendto)(m_sockfd, msg.c_str(), msg.size() + NULL_TERMINATOR_SIZE, 0, nullptr, 0)
                         .failureReturnValue(ERROR_CODE)
@@ -245,7 +245,7 @@ expected<void, IpcChannelError> UnixDomainSocket::timedSend(const std::string& m
 
     if (sendCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(sendCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(sendCall.error().errnum));
     }
     return ok();
 }
@@ -277,7 +277,7 @@ expected<std::string, IpcChannelError> UnixDomainSocket::timedReceive(const unit
 
     if (setsockoptCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(setsockoptCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(setsockoptCall.error().errnum));
     }
     // NOLINTJUSTIFICATION needed for recvfrom
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
@@ -291,7 +291,7 @@ expected<std::string, IpcChannelError> UnixDomainSocket::timedReceive(const unit
 
     if (recvCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(recvCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(recvCall.error().errnum));
     }
     return ok<std::string>(&message[0]);
 }
@@ -322,7 +322,7 @@ expected<void, IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
 
     if (socketCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(socketCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(socketCall.error().errnum));
     }
 
     if (IpcChannelSide::SERVER == m_channelSide)
@@ -344,7 +344,7 @@ expected<void, IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
             IOX_LOG(ERROR) << "Unable to close socket file descriptor in error related cleanup during initialization.";
         });
         // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
-        return err(convertErrnoToIpcChannelError(bindCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(bindCall.error().errnum));
     }
     // we use a connected socket, this leads to a behavior closer to the message queue (e.g. error if client
     // is created and server not present)
@@ -362,7 +362,7 @@ expected<void, IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
             IOX_LOG(ERROR) << "Unable to close socket file descriptor in error related cleanup during initialization.";
         });
         // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
-        return err(convertErrnoToIpcChannelError(connectCall.get_error().errnum));
+        return err(convertErrnoToIpcChannelError(connectCall.error().errnum));
     }
     return ok();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -45,7 +45,7 @@ UnnamedSemaphoreBuilder::create(optional<UnnamedSemaphore>& uninitializedSemapho
         uninitializedSemaphore.value().m_destroyHandle = false;
         uninitializedSemaphore.reset();
 
-        switch (result.get_error().errnum)
+        switch (result.error().errnum)
         {
         case EINVAL:
             IOX_LOG(ERROR) << "The initial value of " << m_initialValue << " exceeds " << IOX_SEM_VALUE_MAX;
@@ -69,7 +69,7 @@ UnnamedSemaphore::~UnnamedSemaphore() noexcept
         auto result = posixCall(iox_sem_destroy)(getHandle()).failureReturnValue(-1).evaluate();
         if (result.has_error())
         {
-            switch (result.get_error().errnum)
+            switch (result.error().errnum)
             {
             case EINVAL:
                 IOX_LOG(ERROR) << "The semaphore handle was no longer valid. This can indicate a corrupted system.";

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -29,7 +29,7 @@ UnnamedSemaphoreBuilder::create(optional<UnnamedSemaphore>& uninitializedSemapho
     {
         IOX_LOG(ERROR) << "The unnamed semaphore initial value of " << m_initialValue
                        << " exceeds the maximum semaphore value " << IOX_SEM_VALUE_MAX;
-        return error<SemaphoreError>(SemaphoreError::SEMAPHORE_OVERFLOW);
+        return err(SemaphoreError::SEMAPHORE_OVERFLOW);
     }
 
     uninitializedSemaphore.emplace();
@@ -59,7 +59,7 @@ UnnamedSemaphoreBuilder::create(optional<UnnamedSemaphore>& uninitializedSemapho
         }
     }
 
-    return success<>();
+    return ok();
 }
 
 UnnamedSemaphore::~UnnamedSemaphore() noexcept

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -22,7 +22,7 @@ namespace iox
 {
 namespace posix
 {
-expected<SemaphoreError>
+expected<void, SemaphoreError>
 UnnamedSemaphoreBuilder::create(optional<UnnamedSemaphore>& uninitializedSemaphore) const noexcept
 {
     if (m_initialValue > IOX_SEM_VALUE_MAX)

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.cpp
@@ -57,17 +57,17 @@ const GenericValueError::value_t&& GenericValueError::value() const&& noexcept
     return std::move(m_value);
 }
 
-GenericValueError::error_t& GenericValueError::get_error() & noexcept
+GenericValueError::error_t& GenericValueError::error() & noexcept
 {
     return m_error;
 }
 
-const GenericValueError::error_t& GenericValueError::get_error() const& noexcept
+const GenericValueError::error_t& GenericValueError::error() const& noexcept
 {
     return m_error;
 }
 
-GenericValueError::error_t&& GenericValueError::get_error() && noexcept
+GenericValueError::error_t&& GenericValueError::error() && noexcept
 {
     // we must use std::move otherwise m_value is not converted into a rvalue
     // which would lead to a compile failure
@@ -75,7 +75,7 @@ GenericValueError::error_t&& GenericValueError::get_error() && noexcept
     return std::move(m_error);
 }
 
-const GenericValueError::error_t&& GenericValueError::get_error() const&& noexcept
+const GenericValueError::error_t&& GenericValueError::error() const&& noexcept
 {
     // we must use std::move otherwise m_value is not converted into a rvalue
     // which would lead to a compile failure

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
@@ -51,7 +51,7 @@ class FunctionalInterface_test : public testing::Test
 };
 
 /// @brief This types is used for testing the functional interface in the case
-///        of a value and a get_error method
+///        of a value and a error method
 struct GenericValueError : public iox::FunctionalInterface<GenericValueError, int, int>
 {
     using value_t = int;
@@ -69,10 +69,10 @@ struct GenericValueError : public iox::FunctionalInterface<GenericValueError, in
     value_t&& value() && noexcept;
     const value_t&& value() const&& noexcept;
 
-    error_t& get_error() & noexcept;
-    const error_t& get_error() const& noexcept;
-    error_t&& get_error() && noexcept;
-    const error_t&& get_error() const&& noexcept;
+    error_t& error() & noexcept;
+    const error_t& error() const& noexcept;
+    error_t&& error() && noexcept;
+    const error_t&& error() const&& noexcept;
 
     value_t m_value = 0;
     error_t m_error = 0;

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
@@ -51,7 +51,7 @@ class FunctionalInterface_test : public testing::Test
 };
 
 /// @brief This types is used for testing the functional interface in the case
-///        of a value and a error method
+///        of a 'value' and a 'error' method
 struct GenericValueError : public iox::FunctionalInterface<GenericValueError, int, int>
 {
     using value_t = int;

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.cpp
@@ -124,12 +124,12 @@ void ExpectedValueErrorFactory::configureNextTestCase() noexcept
 
 ExpectedValueErrorFactory::Type ExpectedValueErrorFactory::createValidObject() noexcept
 {
-    return iox::success<uint64_t>(usedTestValue);
+    return iox::ok(usedTestValue);
 }
 
 ExpectedValueErrorFactory::Type ExpectedValueErrorFactory::createInvalidObject() noexcept
 {
-    return iox::error<uint64_t>(usedErrorValue);
+    return iox::err(usedErrorValue);
 }
 //////////////////////////////////
 /// END ExpectedValueErrorFactory
@@ -153,12 +153,12 @@ void ExpectedErrorFactory::configureNextTestCase() noexcept
 
 ExpectedErrorFactory::Type ExpectedErrorFactory::createValidObject() noexcept
 {
-    return iox::success<>();
+    return iox::ok();
 }
 
 ExpectedErrorFactory::Type ExpectedErrorFactory::createInvalidObject() noexcept
 {
-    return iox::error<uint64_t>(usedErrorValue);
+    return iox::err(usedErrorValue);
 }
 ////////////////////////////
 /// END ExpectedErrorFactory

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.hpp
@@ -97,7 +97,7 @@ struct ExpectedErrorFactory
 {
     using error_t = uint64_t;
 
-    using Type = iox::expected<error_t>;
+    using Type = iox::expected<void, error_t>;
 
     static constexpr bool EXPECT_AND_THEN_WITH_VALUE = false;
     static constexpr bool EXPECT_OR_ELSE_WITH_VALUE = true;

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_types.hpp
@@ -142,7 +142,7 @@ struct ExpectedErrorFactory
 ///            Another value which can be compared to usedTestValue and is not equal to it
 ///
 ///     Class with error:
-///        A class with a get_error method requires additionally:
+///        A class with a error method requires additionally:
 ///        * using error_t = ;
 ///            Type alias of the error type
 ///

--- a/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_bump_allocator.cpp
@@ -53,7 +53,7 @@ TEST_F(BumpAllocator_Test, AllocateFailsWithZeroSize)
 
     auto allocationResult = sut.allocate(0, MEMORY_ALIGNMENT);
     ASSERT_TRUE(allocationResult.has_error());
-    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY));
+    EXPECT_THAT(allocationResult.error(), Eq(iox::BumpAllocatorError::REQUESTED_ZERO_SIZED_MEMORY));
 }
 
 TEST_F(BumpAllocator_Test, OverallocationFails)
@@ -63,7 +63,7 @@ TEST_F(BumpAllocator_Test, OverallocationFails)
 
     auto allocationResult = sut.allocate(MEMORY_SIZE + 1, MEMORY_ALIGNMENT);
     ASSERT_TRUE(allocationResult.has_error());
-    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
+    EXPECT_THAT(allocationResult.error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
 }
 
 TEST_F(BumpAllocator_Test, OverallocationAfterMultipleCallsFails)
@@ -78,7 +78,7 @@ TEST_F(BumpAllocator_Test, OverallocationAfterMultipleCallsFails)
 
     auto allocationResult = sut.allocate(1, MEMORY_ALIGNMENT);
     ASSERT_TRUE(allocationResult.has_error());
-    EXPECT_THAT(allocationResult.get_error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
+    EXPECT_THAT(allocationResult.error(), Eq(iox::BumpAllocatorError::OUT_OF_MEMORY));
 }
 
 TEST_F(BumpAllocator_Test, AllocationIsCorrectlyAligned)

--- a/iceoryx_hoofs/test/moduletests/test_posix_file.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file.cpp
@@ -115,7 +115,7 @@ TEST_F(File_test, CreatingExclusivelyTwiceFails)
 
     auto sut2 = FileBuilder().open_mode(OpenMode::EXCLUSIVE_CREATE).create(m_sut_file_path);
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileCreationError::AlreadyExists));
+    EXPECT_THAT(sut2.error(), Eq(FileCreationError::AlreadyExists));
 }
 
 TEST_F(File_test, OpeningExistingFileWorks)
@@ -133,7 +133,7 @@ TEST_F(File_test, OpeningNonExistingFileFails)
     auto sut = FileBuilder().open_mode(OpenMode::OPEN_EXISTING).create(m_sut_file_path);
 
     ASSERT_TRUE(sut.has_error());
-    EXPECT_THAT(sut.get_error(), Eq(FileCreationError::DoesNotExist));
+    EXPECT_THAT(sut.error(), Eq(FileCreationError::DoesNotExist));
 }
 
 TEST_F(File_test, OpenOrCreateCreatesNonExistingFile)
@@ -168,7 +168,7 @@ TEST_F(File_test, OpenFileForReadingWithInsufficientPermissionFails)
     auto sut2 =
         FileBuilder().open_mode(OpenMode::OPEN_EXISTING).access_mode(AccessMode::READ_ONLY).create(m_sut_file_path);
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileCreationError::PermissionDenied));
+    EXPECT_THAT(sut2.error(), Eq(FileCreationError::PermissionDenied));
 }
 
 TEST_F(File_test, OpenFileForReadWriteWithInsufficientPermissionFails)
@@ -181,7 +181,7 @@ TEST_F(File_test, OpenFileForReadWriteWithInsufficientPermissionFails)
     auto sut2 =
         FileBuilder().open_mode(OpenMode::OPEN_EXISTING).access_mode(AccessMode::READ_WRITE).create(m_sut_file_path);
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileCreationError::PermissionDenied));
+    EXPECT_THAT(sut2.error(), Eq(FileCreationError::PermissionDenied));
 }
 #endif
 
@@ -250,7 +250,7 @@ TEST_F(File_test, ReadingOfAWriteOnlyFileFails)
     std::array<uint8_t, 8> read_content{0};
     auto read = sut->read(read_content.data(), read_content.size());
     ASSERT_TRUE(read.has_error());
-    EXPECT_THAT(read.get_error(), Eq(FileReadError::NotOpenedForReading));
+    EXPECT_THAT(read.error(), Eq(FileReadError::NotOpenedForReading));
 }
 #endif
 
@@ -364,7 +364,7 @@ TEST_F(File_test, WritingIntoAReadOnlyFileFails)
 
     auto result = sut->write(test_content.data(), test_content.size());
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(FileWriteError::NotOpenedForWriting));
+    EXPECT_THAT(result.error(), Eq(FileWriteError::NotOpenedForWriting));
 }
 #endif
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
@@ -63,7 +63,7 @@ TEST_F(FileLock_test, EmptyNameLeadsToError)
 
     auto sut2 = iox::posix::FileLockBuilder().name("").create();
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileLockError::INVALID_FILE_NAME));
+    EXPECT_THAT(sut2.error(), Eq(FileLockError::INVALID_FILE_NAME));
 }
 
 TEST_F(FileLock_test, InvalidNameLeadsToError)
@@ -72,7 +72,7 @@ TEST_F(FileLock_test, InvalidNameLeadsToError)
 
     auto sut2 = iox::posix::FileLockBuilder().name("///").create();
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileLockError::INVALID_FILE_NAME));
+    EXPECT_THAT(sut2.error(), Eq(FileLockError::INVALID_FILE_NAME));
 }
 
 TEST_F(FileLock_test, InvalidPathLeadsToError)
@@ -81,7 +81,7 @@ TEST_F(FileLock_test, InvalidPathLeadsToError)
 
     auto sut2 = iox::posix::FileLockBuilder().name("woho").path(".....").create();
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileLockError::INVALID_PATH));
+    EXPECT_THAT(sut2.error(), Eq(FileLockError::INVALID_PATH));
 }
 
 TEST_F(FileLock_test, MaxStringWorks)
@@ -117,7 +117,7 @@ TEST_F(FileLock_test, CreatingSameFileLockAgainFails)
     ::testing::Test::RecordProperty("TEST_ID", "ed3af1c8-4a84-4d4f-a267-c4a80481dc42");
     auto sut2 = iox::posix::FileLockBuilder().name(TEST_NAME).create();
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
+    EXPECT_THAT(sut2.error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
 }
 
 TEST_F(FileLock_test, MoveCtorTransfersLock)
@@ -126,7 +126,7 @@ TEST_F(FileLock_test, MoveCtorTransfersLock)
     auto movedSut{std::move(m_sut.value())};
     auto anotherLock = iox::posix::FileLockBuilder().name(TEST_NAME).create();
     ASSERT_TRUE(anotherLock.has_error());
-    EXPECT_THAT(anotherLock.get_error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
+    EXPECT_THAT(anotherLock.error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
 }
 
 TEST_F(FileLock_test, MoveAssignTransfersLock)
@@ -135,7 +135,7 @@ TEST_F(FileLock_test, MoveAssignTransfersLock)
     auto movedSut = std::move(m_sut.value());
     auto anotherLock = iox::posix::FileLockBuilder().name(TEST_NAME).permission(iox::perms::owner_all).create();
     ASSERT_TRUE(anotherLock.has_error());
-    EXPECT_THAT(anotherLock.get_error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
+    EXPECT_THAT(anotherLock.error(), Eq(FileLockError::LOCKED_BY_OTHER_PROCESS));
 }
 } // namespace
 #endif

--- a/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_mutex.cpp
@@ -181,7 +181,7 @@ TEST_F(Mutex_test, MutexWithDeadlockDetectionsFailsOnDeadlock)
     EXPECT_FALSE(sut->lock().has_error());
     auto result = sut->lock();
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(iox::posix::MutexLockError::DEADLOCK_CONDITION));
+    EXPECT_THAT(result.error(), Eq(iox::posix::MutexLockError::DEADLOCK_CONDITION));
 
     EXPECT_FALSE(sut->unlock().has_error());
 }
@@ -198,7 +198,7 @@ TEST_F(Mutex_test, MutexWithDeadlockDetectionsFailsWhenSameThreadTriesToUnlockIt
 
     auto result = sut->unlock();
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(iox::posix::MutexUnlockError::NOT_OWNED_BY_THREAD));
+    EXPECT_THAT(result.error(), Eq(iox::posix::MutexUnlockError::NOT_OWNED_BY_THREAD));
 }
 
 TEST_F(Mutex_test, MutexWithDeadlockDetectionsFailsWhenAnotherThreadTriesToUnlock)
@@ -212,7 +212,7 @@ TEST_F(Mutex_test, MutexWithDeadlockDetectionsFailsWhenAnotherThreadTriesToUnloc
     std::thread t([&] {
         auto result = sut->unlock();
         ASSERT_TRUE(result.has_error());
-        EXPECT_THAT(result.get_error(), Eq(iox::posix::MutexUnlockError::NOT_OWNED_BY_THREAD));
+        EXPECT_THAT(result.error(), Eq(iox::posix::MutexUnlockError::NOT_OWNED_BY_THREAD));
     });
     t.join();
     EXPECT_FALSE(sut->unlock().has_error());
@@ -237,7 +237,7 @@ TEST_F(Mutex_test,
 
     auto result = sut->try_lock();
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(),
+    EXPECT_THAT(result.error(),
                 iox::posix::MutexTryLockError::LOCK_ACQUIRED_BUT_HAS_INCONSISTENT_STATE_SINCE_OWNER_DIED);
     sut->make_consistent();
     EXPECT_FALSE(sut->unlock().has_error());
@@ -272,6 +272,6 @@ TEST_F(Mutex_test, InitializingMutexTwiceResultsInError)
     auto result = iox::posix::MutexBuilder().create(sutRecursive);
 
     ASSERT_THAT(result.has_error(), Eq(true));
-    EXPECT_THAT(result.get_error(), Eq(iox::posix::MutexCreationError::MUTEX_ALREADY_INITIALIZED));
+    EXPECT_THAT(result.error(), Eq(iox::posix::MutexCreationError::MUTEX_ALREADY_INITIALIZED));
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
@@ -134,7 +134,7 @@ TEST_F(NamedSemaphoreTest, OpenNonExistingSemaphoreFails)
         NamedSemaphoreBuilder().name(sutName).openMode(OpenMode::OPEN_EXISTING).permissions(sutPermission).create(sut);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS));
+    EXPECT_THAT(result.error(), Eq(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS));
 }
 
 TEST_F(NamedSemaphoreTest, ExclusiveCreateFailsWhenSemaphoreAlreadyExists)
@@ -156,7 +156,7 @@ TEST_F(NamedSemaphoreTest, ExclusiveCreateFailsWhenSemaphoreAlreadyExists)
                       .create(sut2);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(SemaphoreError::ALREADY_EXIST));
+    EXPECT_THAT(result.error(), Eq(SemaphoreError::ALREADY_EXIST));
 }
 
 TEST_F(NamedSemaphoreTest, SemaphoreWithInvalidNameFails)
@@ -166,7 +166,7 @@ TEST_F(NamedSemaphoreTest, SemaphoreWithInvalidNameFails)
     auto result =
         NamedSemaphoreBuilder().name("///").openMode(OpenMode::PURGE_AND_CREATE).permissions(sutPermission).create(sut);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(SemaphoreError::INVALID_NAME));
+    EXPECT_THAT(result.error(), Eq(SemaphoreError::INVALID_NAME));
 }
 
 TEST_F(NamedSemaphoreTest, OpenOrCreateOpensExistingSemaphoreWithoutDestroyingItInTheDtor)
@@ -229,7 +229,7 @@ TEST_F(NamedSemaphoreTest, OpenOrCreateRemovesSemaphoreWhenItHasTheOwnership)
     // should fail since the previous sut was deleted and had the ownership
     auto result = NamedSemaphoreBuilder().name(sutName).initialValue(0U).openMode(OpenMode::OPEN_EXISTING).create(sut);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS));
+    EXPECT_THAT(result.error(), Eq(SemaphoreError::NO_SEMAPHORE_WITH_THAT_NAME_EXISTS));
 }
 
 TEST_F(NamedSemaphoreTest, WhenOwningSemaphoreIsClosedBeforeOpenedSemaphoreTheOpenedSemaphoreRemainsUsable)

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -121,7 +121,7 @@ TYPED_TEST(SemaphoreInterfaceTest, InitialValueExceedingMaxSupportedValueFails)
     auto result = this->createSutWithInitialValue(INITIAL_VALUE);
 
     ASSERT_THAT(result.has_error(), Eq(true));
-    EXPECT_THAT(result.get_error(), Eq(iox::posix::SemaphoreError::SEMAPHORE_OVERFLOW));
+    EXPECT_THAT(result.error(), Eq(iox::posix::SemaphoreError::SEMAPHORE_OVERFLOW));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, PostWithMaxSemaphoreValueLeadsToOverflow)
@@ -140,7 +140,7 @@ TYPED_TEST(SemaphoreInterfaceTest, PostWithMaxSemaphoreValueLeadsToOverflow)
 
     auto result = this->sut->post();
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(iox::posix::SemaphoreError::SEMAPHORE_OVERFLOW));
+    EXPECT_THAT(result.error(), Eq(iox::posix::SemaphoreError::SEMAPHORE_OVERFLOW));
 }
 
 TYPED_TEST(SemaphoreInterfaceTest, PostIncreasesSemaphoreValue)

--- a/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_semaphore_interface.cpp
@@ -51,7 +51,7 @@ class SemaphoreInterfaceTest : public Test
         ASSERT_TRUE(SutFactory::create(sut, 0U));
     }
 
-    iox::expected<iox::posix::SemaphoreError> createSutWithInitialValue(const uint32_t value)
+    iox::expected<void, iox::posix::SemaphoreError> createSutWithInitialValue(const uint32_t value)
     {
         sut.reset();
         return SutFactory::create(sut, value);
@@ -76,7 +76,7 @@ constexpr iox::units::Duration SemaphoreInterfaceTest<T>::TIMING_TEST_WAIT_TIME;
 struct UnnamedSemaphoreTest
 {
     using SutType = iox::optional<iox::posix::UnnamedSemaphore>;
-    static iox::expected<iox::posix::SemaphoreError> create(SutType& sut, const uint32_t initialValue)
+    static iox::expected<void, iox::posix::SemaphoreError> create(SutType& sut, const uint32_t initialValue)
     {
         return iox::posix::UnnamedSemaphoreBuilder()
             .initialValue(initialValue)
@@ -88,7 +88,7 @@ struct UnnamedSemaphoreTest
 struct NamedSemaphoreTest
 {
     using SutType = iox::optional<iox::posix::NamedSemaphore>;
-    static iox::expected<iox::posix::SemaphoreError> create(SutType& sut, const uint32_t initialValue)
+    static iox::expected<void, iox::posix::SemaphoreError> create(SutType& sut, const uint32_t initialValue)
     {
         return iox::posix::NamedSemaphoreBuilder()
             .initialValue(initialValue)

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
@@ -261,7 +261,7 @@ TEST_F(SharedMemory_Test, OpenFailsWhenCreatingShmInReadOnlyMode)
                    .create();
 
     ASSERT_TRUE(sut.has_error());
-    ASSERT_THAT(sut.get_error(), Eq(SharedMemoryError::INCOMPATIBLE_OPEN_AND_ACCESS_MODE));
+    ASSERT_THAT(sut.error(), Eq(SharedMemoryError::INCOMPATIBLE_OPEN_AND_ACCESS_MODE));
 }
 
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -120,7 +120,7 @@ TEST_F(SharedMemoryObject_Test, OpenFailsWhenActualMemorySizeIsSmallerThanReques
                     .create();
 
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.get_error(), Eq(posix::SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE));
+    EXPECT_THAT(sut2.error(), Eq(posix::SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE));
 }
 
 TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -36,7 +36,7 @@ using namespace iox::posix;
 using namespace iox::units::duration_literals;
 using namespace iox::units;
 
-using sendCall_t = std::function<expected<IpcChannelError>(const std::string&)>;
+using sendCall_t = std::function<expected<void, IpcChannelError>(const std::string&)>;
 using receiveCall_t = std::function<expected<std::string, IpcChannelError>()>;
 
 // NOLINTJUSTIFICATION used only for test purposes

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -129,7 +129,7 @@ TEST_F(UnixDomainSocket_test, UnlinkEmptySocketNameLeadsToInvalidChannelNameErro
     ::testing::Test::RecordProperty("TEST_ID", "bdc1e253-2750-4b07-a528-83ca50246b29");
     auto ret = UnixDomainSocket::unlinkIfExists(UnixDomainSocket::NoPathPrefix, "");
     ASSERT_TRUE(ret.has_error());
-    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+    EXPECT_THAT(ret.error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
 }
 
 TEST_F(UnixDomainSocket_test, UnlinkEmptySocketNameWithPathPrefixLeadsToInvalidChannelNameError)
@@ -137,7 +137,7 @@ TEST_F(UnixDomainSocket_test, UnlinkEmptySocketNameWithPathPrefixLeadsToInvalidC
     ::testing::Test::RecordProperty("TEST_ID", "97793649-ac88-4e73-a0bc-602dca302746");
     auto ret = UnixDomainSocket::unlinkIfExists("");
     ASSERT_TRUE(ret.has_error());
-    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+    EXPECT_THAT(ret.error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
 }
 
 TEST_F(UnixDomainSocket_test, UnlinkTooLongSocketNameWithPathPrefixLeadsToInvalidChannelNameError)
@@ -152,7 +152,7 @@ TEST_F(UnixDomainSocket_test, UnlinkTooLongSocketNameWithPathPrefixLeadsToInvali
     }
     auto ret = UnixDomainSocket::unlinkIfExists(longSocketName);
     ASSERT_TRUE(ret.has_error());
-    EXPECT_THAT(ret.get_error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
+    EXPECT_THAT(ret.error(), Eq(IpcChannelError::INVALID_CHANNEL_NAME));
 }
 
 TEST_F(UnixDomainSocket_test, UnlinkExistingSocketIsSuccessful)
@@ -183,7 +183,7 @@ void sendOnServerLeadsToError(const sendCall_t& send)
     std::string message{"Foo"};
     auto result = send(message);
     EXPECT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
+    EXPECT_THAT(result.error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
 }
 
 TEST_F(UnixDomainSocket_test, TimedSendOnServerLeadsToError)
@@ -375,7 +375,7 @@ void unableToSendTooLongMessage(const sendCall_t& send)
     std::string message(UnixDomainSocket::MAX_MESSAGE_SIZE + 1, 'x');
     auto result = send(message);
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.get_error(), IpcChannelError::MESSAGE_TOO_LONG);
+    EXPECT_EQ(result.error(), IpcChannelError::MESSAGE_TOO_LONG);
 }
 
 TEST_F(UnixDomainSocket_test, UnableToSendTooLongMessageWithSend)
@@ -396,7 +396,7 @@ void receivingOnClientLeadsToError(const receiveCall_t& receive)
 {
     auto result = receive();
     EXPECT_TRUE(result.has_error());
-    ASSERT_THAT(result.get_error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
+    ASSERT_THAT(result.error(), Eq(IpcChannelError::INTERNAL_LOGIC_ERROR));
 }
 
 TEST_F(UnixDomainSocket_test, ReceivingOnClientLeadsToErrorWithReceive)
@@ -421,7 +421,7 @@ TIMING_TEST_F(UnixDomainSocket_test, TimedReceiveBlocks, Repeat(5), [&] {
     TIMING_TEST_EXPECT_TRUE(end - start >= WAIT_IN_MS);
 
     TIMING_TEST_ASSERT_TRUE(msg.has_error());
-    TIMING_TEST_EXPECT_TRUE(msg.get_error() == IpcChannelError::TIMEOUT);
+    TIMING_TEST_EXPECT_TRUE(msg.error() == IpcChannelError::TIMEOUT);
 })
 
 TIMING_TEST_F(UnixDomainSocket_test, TimedReceiveBlocksUntilMessageIsReceived, Repeat(5), [&] {

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -148,6 +148,13 @@ TEST_F(expected_test, CreateWithPODTypeIsSuccessful)
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
+TEST_F(expected_test, CreateWithVoidTypeIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5baee3cb-4f81-4245-b9f9-d733d14d6d4a");
+    auto sut = expected<void, TestError>::create_value();
+    ASSERT_THAT(sut.has_error(), Eq(false));
+}
+
 TEST_F(expected_test, CreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a2d10c89-6fc8-4c08-9e2d-9f61988ebb3f");
@@ -156,10 +163,10 @@ TEST_F(expected_test, CreateWithErrorResultsInError)
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
 
-TEST_F(expected_test, ErrorTypeOnlyConstCreateWithErrorResultsInError)
+TEST_F(expected_test, ConstCreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "581447a6-0705-494b-8159-cf3434080a06");
-    const auto sut = expected<TestError>::create_error(TestError::ERROR2);
+    const auto sut = expected<int, TestError>::create_error(TestError::ERROR2);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
 }
@@ -167,7 +174,7 @@ TEST_F(expected_test, ErrorTypeOnlyConstCreateWithErrorResultsInError)
 TEST_F(expected_test, ErrorTypeOnlyCreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b01b2217-e67a-4bbf-b1a8-95d9b348d66e");
-    auto sut = expected<TestError>::create_error(TestError::ERROR1);
+    auto sut = expected<void, TestError>::create_error(TestError::ERROR1);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
@@ -179,15 +186,6 @@ TEST_F(expected_test, CreateFromConstErrorResultsInError)
     auto sut = expected<int, TestError>(constError);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR3));
-}
-
-TEST_F(expected_test, ErrorTypeOnlyCreateFromConstErrorResultsInError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "e7c3fdd5-7384-4173-85a3-e3127261baa7");
-    auto constError = error<TestError>(TestError::ERROR1);
-    auto sut = expected<TestError>(constError);
-    ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
 
 TEST_F(expected_test, CreateFromConstSuccessResultsInCorrectValue)
@@ -353,7 +351,7 @@ TEST_F(expected_test, BoolOperatorReturnsNoError)
 TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7949f68f-c21c-43f1-ad8d-dc51eeee3257");
-    auto sut = expected<TestError>::create_error(TestError::ERROR1);
+    auto sut = expected<void, TestError>::create_error(TestError::ERROR1);
     ASSERT_THAT(sut.operator bool(), Eq(false));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
@@ -361,7 +359,7 @@ TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsError)
 TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsNoError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4585b1bf-cd6f-44ac-8409-75dc14fa252a");
-    auto sut = expected<TestError>::create_value();
+    auto sut = expected<void, TestError>::create_value();
     ASSERT_THAT(sut.operator bool(), Eq(true));
 }
 
@@ -402,85 +400,10 @@ TEST_F(expected_test, ConstDereferencingOperatorWorks)
     EXPECT_THAT(*sut, Eq(981));
 }
 
-TEST_F(expected_test, ErrorTypeOnlyCreateValueWithoutValueLeadsToValidSut)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "5baee3cb-4f81-4245-b9f9-d733d14d6d4a");
-    auto sut = expected<TestError>::create_value();
-    ASSERT_THAT(sut.has_error(), Eq(false));
-}
-
-TEST_F(expected_test, ErrorTypeOnlyCreateErrorLeadsToError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "e7919fef-e127-4b12-86cb-603457688675");
-    auto sut = expected<TestError>::create_error(TestError::ERROR2);
-    ASSERT_THAT(sut.has_error(), Eq(true));
-    ASSERT_THAT(sut.get_error(), Eq(TestError::ERROR2));
-}
-
-TEST_F(expected_test, ErrorTypeOnlyCreateValueWithoutValueMoveCtorLeadsToNoError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "2b7feb2c-c0bd-4c10-bc0c-d980eec4f0ca");
-    auto sutSource = expected<NonTrivialTestClass>::create_value();
-    auto sutDestination{std::move(sutSource)};
-    // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
-    // NOLINTNEXTLINE(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    EXPECT_FALSE(sutSource.has_error());
-    EXPECT_FALSE(sutDestination.has_error());
-}
-
-TEST_F(expected_test, ErrorTypeOnlyCreateValueWithoutValueMoveAssignmentLeadsToNoError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "75d3f30e-d927-46bf-83a4-fb8361542333");
-    auto sutSource = expected<NonTrivialTestClass>::create_value();
-    auto sutDestination = std::move(sutSource);
-    // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
-    // NOLINTNEXTLINE(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    EXPECT_FALSE(sutSource.has_error());
-    EXPECT_FALSE(sutDestination.has_error());
-}
-
-TEST_F(expected_test, ErrorTypeOnlyMoveCtorLeadsToMovedSource)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "4662a154-7cf6-498d-b6a1-08182037fbc9");
-    constexpr int A{111};
-    constexpr int B{112};
-    auto sutSource = expected<NonTrivialTestClass>::create_error(A, B);
-    auto sutDestination{std::move(sutSource)};
-
-    // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
-    // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_TRUE(sutSource.has_error());
-    EXPECT_TRUE(sutSource.get_error().m_moved);
-    // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_TRUE(sutDestination.has_error());
-    EXPECT_FALSE(sutDestination.get_error().m_moved);
-    EXPECT_EQ(sutDestination.get_error().m_a, A);
-    EXPECT_EQ(sutDestination.get_error().m_b, B);
-}
-
-TEST_F(expected_test, ErrorTypeOnlyMoveAssignmentLeadsToMovedSource)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "117bc7f6-c3d4-4fbb-9af3-9057742f2d2e");
-    constexpr int A{222};
-    constexpr int B{223};
-    auto sutSource = expected<NonTrivialTestClass>::create_error(A, B);
-    auto sutDestination = std::move(sutSource);
-
-    // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
-    // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_TRUE(sutSource.has_error());
-    EXPECT_TRUE(sutSource.get_error().m_moved);
-    // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_TRUE(sutDestination.has_error());
-    EXPECT_FALSE(sutDestination.get_error().m_moved);
-    EXPECT_EQ(sutDestination.get_error().m_a, A);
-    EXPECT_EQ(sutDestination.get_error().m_b, B);
-}
-
-TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidErrorOnlySut)
+TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidVoidValueTypeSut)
 {
     ::testing::Test::RecordProperty("TEST_ID", "91a8ad7f-4843-4bd9-a56b-0561ae6b56cb");
-    expected<TestError> sut{in_place};
+    expected<void, TestError> sut{in_place};
     ASSERT_THAT(sut.has_error(), Eq(false));
 }
 
@@ -493,10 +416,19 @@ TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidSut)
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
+TEST_F(expected_test, CreateFromUnexpectTypeLeadsToValidSutWithError)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "20ddbfc0-2235-46c3-9618-dd75e9d3c699");
+    constexpr TestError ERROR = TestError::ERROR3;
+    expected<int, TestError> sut{unexpect, ERROR};
+    ASSERT_THAT(sut.has_error(), Eq(true));
+    EXPECT_THAT(sut.get_error(), Eq(ERROR));
+}
+
 TEST_F(expected_test, CreateFromEmptySuccessTypeLeadsToValidSut)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0204f08f-fb6d-45bb-aac7-fd14152ab1bf");
-    expected<TestError> sut{success<>()};
+    expected<void, TestError> sut{success<>()};
     ASSERT_THAT(sut.has_error(), Eq(false));
 }
 
@@ -509,23 +441,6 @@ TEST_F(expected_test, CreateFromSuccessTypeLeadsToValidSut)
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
-TEST_F(expected_test, CreateFromErrorConstLeadsToCorrectError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "2b69f337-7994-40f8-aad7-7b6febe8b254");
-    const TestError f = TestError::ERROR1;
-    expected<TestError> sut{error<TestError>(f)};
-    ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
-}
-
-TEST_F(expected_test, ErrorTypeOnlyCreateFromErrorLeadsToCorrectError)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "1c55e8a2-8da3-43bd-858a-b9bd19d71b1f");
-    expected<TestError> sut{error<TestError>(TestError::ERROR2)};
-    ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
-}
-
 TEST_F(expected_test, CreateFromErrorLeadsToCorrectError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cb7e783d-0a79-45ce-9ea7-3b6e28631ceb");
@@ -534,28 +449,28 @@ TEST_F(expected_test, CreateFromErrorLeadsToCorrectError)
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
 }
 
-TEST_F(expected_test, ConvertNonEmptySuccessResultToErrorTypeOnlyResult)
+TEST_F(expected_test, ConvertNonEmptySuccessResultToVoidValueTypeResultIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b14f4aaa-abd0-4b99-84df-d644506712fa");
     constexpr int VALUE = 91823;
     expected<int, TestError> sut{success<int>(VALUE)};
-    expected<TestError> sut2 = sut;
+    expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_error(), Eq(false));
 }
 
-TEST_F(expected_test, ConvertConstNonEmptySuccessResultToErrorTypeOnlyResult)
+TEST_F(expected_test, ConvertConstNonEmptySuccessResultToVoidValueTypeResultIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6ccaf1cf-1b09-4930-ad33-8f961aca4c2e");
     const expected<int, TestError> sut{success<int>(123)};
-    expected<TestError> sut2 = sut;
+    expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_error(), Eq(false));
 }
 
-TEST_F(expected_test, ConvertNonEmptyErrorResultToErrorTypeOnlyResult)
+TEST_F(expected_test, ConvertNonEmptyErrorResultVoidValueTypeResultIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5907d318-cf1a-46f1-9016-07096153d7d9");
     expected<int, TestError> sut{error<TestError>(TestError::ERROR2)};
-    expected<TestError> sut2 = sut;
+    expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_error(), Eq(true));
     EXPECT_THAT(sut2.get_error(), Eq(TestError::ERROR2));
 }
@@ -590,41 +505,13 @@ TEST_F(expected_test, MoveAssignmentIsNotEnforcedInMoveConstructor)
         ASSERT_THAT(destination.has_error(), Eq(false));
     }
 
-    /// same test with the error only expected
+    /// same test with the void value type
     {
-        auto sut = expected<ClassWithMoveCtorAndNoMoveAssignment>::create_error();
+        auto sut = expected<void, ClassWithMoveCtorAndNoMoveAssignment>::create_error();
         /// this should compile, if not then we enforce move assignment hidden in the implementation
-        expected<ClassWithMoveCtorAndNoMoveAssignment> destination{std::move(sut)};
+        expected<void, ClassWithMoveCtorAndNoMoveAssignment> destination{std::move(sut)};
         ASSERT_THAT(destination.has_error(), Eq(true));
     }
-}
-
-TEST_F(expected_test, AccessingErrorOfLValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "da162edf-06b5-47d2-b35f-361d6004a6c4");
-
-    auto sut = expected<TestError>::create_value();
-
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
-}
-
-TEST_F(expected_test, AccessingErrorOfConstLValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "324cab7d-ba04-4ff0-870f-79af993c272f");
-
-    const auto sut = expected<TestError>::create_value();
-
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
-}
-
-TEST_F(expected_test, AccessingErrorOfRValueErrorOnlyExpectedWhichContainsValueLeadsToErrorHandlerCall)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "0a4309e8-d9f3-41a9-9c4b-bdcfda917277");
-
-    auto sut = expected<TestError>::create_value();
-
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { std::move(sut).get_error(); },
-                                              iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
 TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithArrowOpLeadsToErrorHandlerCall)
@@ -723,41 +610,41 @@ TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErr
                                               iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
-TEST_F(expected_test, TwoErrorOnlyExpectedWithEqualErrorAreEqual)
+TEST_F(expected_test, TwoVoidValueTypeExpectedWithEqualErrorAreEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "471b406d-8dd3-4b82-9d46-00c21d257461");
-    auto sut1 = expected<TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestError>::create_error(TestError::ERROR1);
+    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
+    auto sut2 = expected<void, TestError>::create_error(TestError::ERROR1);
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
 }
 
-TEST_F(expected_test, TwoErrorOnlyExpectedWithUnequalErrorAreUnequal)
+TEST_F(expected_test, TwoVoidValueTypeExpectedWithUnequalErrorAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bcc2f9f1-72a1-41ed-ac8a-2f48cdcfbc56");
-    auto sut1 = expected<TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestError>::create_error(TestError::ERROR2);
+    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
+    auto sut2 = expected<void, TestError>::create_error(TestError::ERROR2);
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);
 }
 
-TEST_F(expected_test, TwoErrorOnlyExpectedWithValuesAreEqual)
+TEST_F(expected_test, TwoVoidValueTypeExpectedWithValuesAreEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "75b25c16-fb79-4589-ab0f-bc73bb9fc2bb");
-    auto sut1 = expected<TestError>::create_value();
-    auto sut2 = expected<TestError>::create_value();
+    auto sut1 = expected<void, TestError>::create_value();
+    auto sut2 = expected<void, TestError>::create_value();
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
 }
 
-TEST_F(expected_test, TwoErrorOnlyExpectedWithErrorAndValueAreUnequal)
+TEST_F(expected_test, TwoVoidValueTypeExpectedWithErrorAndValueAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2108715f-e71c-4778-bb64-553996e860b4");
-    auto sut1 = expected<TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestError>::create_value();
+    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
+    auto sut2 = expected<void, TestError>::create_value();
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -325,6 +325,77 @@ TEST_F(expected_test, CreateWithErrorAndMoveAssignmentLeadsToMovedSource)
     EXPECT_EQ(sutDestination.get_error().m_b, B);
 }
 
+TEST_F(expected_test, CreateWithOkFreeFunktionWithVoidValueTypeIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6d582b25-1c7d-4519-837c-55d151b324ff");
+    expected<void, TestError> sut = ok();
+    ASSERT_THAT(sut.has_error(), Eq(false));
+}
+
+TEST_F(expected_test, CreateWithOkFreeFunktionByCopyIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d3c24c27-432d-4a4b-8d55-6e723bc88c46");
+    constexpr int VALUE = 111;
+    expected<int, TestError> sut = ok(VALUE);
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    EXPECT_THAT(sut.value(), Eq(VALUE));
+}
+
+TEST_F(expected_test, CreateWithOkFreeFunktionByMoveIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b1320e1f-3613-4085-8125-fc95d584681c");
+    constexpr int A{44};
+    constexpr int B{55};
+    NonTrivialTestClass value{A, B};
+    expected<NonTrivialTestClass, TestError> sut = ok(std::move(value));
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    EXPECT_THAT(sut.value().m_a, Eq(A));
+    EXPECT_THAT(sut.value().m_b, Eq(B));
+}
+
+TEST_F(expected_test, CreateWithOkFreeFunktionByForwardingIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a3d41181-f4ad-4431-9441-7dfaeb8d6f7f");
+    constexpr int A{44};
+    constexpr int B{55};
+    expected<NonTrivialTestClass, TestError> sut = ok<NonTrivialTestClass>(A, B);
+    ASSERT_THAT(sut.has_error(), Eq(false));
+    EXPECT_THAT(sut.value().m_a, Eq(A));
+    EXPECT_THAT(sut.value().m_b, Eq(B));
+}
+
+TEST_F(expected_test, CreateWithErrFreeFunktionByCopyIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "bb641919-e319-4e9c-af67-e1e8d5dab682");
+    constexpr TestError ERROR = TestError::ERROR1;
+    expected<int, TestError> sut = err(ERROR);
+    ASSERT_THAT(sut.has_error(), Eq(true));
+    EXPECT_THAT(sut.get_error(), Eq(ERROR));
+}
+
+TEST_F(expected_test, CreateWithErrFreeFunktionByMoveIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "f99af97a-16b2-41e6-a808-2d58bfe0fc57");
+    constexpr int A{666};
+    constexpr int B{73};
+    NonTrivialTestClass error{A, B};
+    expected<int, NonTrivialTestClass> sut = err(std::move(error));
+    ASSERT_THAT(sut.has_error(), Eq(true));
+    EXPECT_THAT(sut.get_error().m_a, Eq(A));
+    EXPECT_THAT(sut.get_error().m_b, Eq(B));
+}
+
+TEST_F(expected_test, CreateWithErrFreeFunktionByForwardingIsSuccessful)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "08411afa-e1d3-4a28-9680-f89796f86340");
+    constexpr int A{44};
+    constexpr int B{55};
+    expected<int, NonTrivialTestClass> sut = err<NonTrivialTestClass>(A, B);
+    ASSERT_THAT(sut.has_error(), Eq(true));
+    EXPECT_THAT(sut.get_error().m_a, Eq(A));
+    EXPECT_THAT(sut.get_error().m_b, Eq(B));
+}
+
 TEST_F(expected_test, BoolOperatorReturnsError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f1e30651-a0e9-4c73-b2bf-57f36fc7eddf");

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -160,7 +160,7 @@ TEST_F(expected_test, CreateWithErrorResultsInError)
     ::testing::Test::RecordProperty("TEST_ID", "a2d10c89-6fc8-4c08-9e2d-9f61988ebb3f");
     auto sut = expected<int, TestError>(unexpect, TestError::ERROR1);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR1));
 }
 
 TEST_F(expected_test, ConstCreateWithErrorResultsInError)
@@ -168,7 +168,7 @@ TEST_F(expected_test, ConstCreateWithErrorResultsInError)
     ::testing::Test::RecordProperty("TEST_ID", "581447a6-0705-494b-8159-cf3434080a06");
     const auto sut = expected<int, TestError>(unexpect, TestError::ERROR2);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR2));
 }
 
 TEST_F(expected_test, ErrorTypeOnlyCreateWithErrorResultsInError)
@@ -176,7 +176,7 @@ TEST_F(expected_test, ErrorTypeOnlyCreateWithErrorResultsInError)
     ::testing::Test::RecordProperty("TEST_ID", "b01b2217-e67a-4bbf-b1a8-95d9b348d66e");
     auto sut = expected<void, TestError>(unexpect, TestError::ERROR1);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR1));
 }
 
 TEST_F(expected_test, CreateFromConstErrorResultsInError)
@@ -185,7 +185,7 @@ TEST_F(expected_test, CreateFromConstErrorResultsInError)
     auto constError = error<TestError>(TestError::ERROR3);
     auto sut = expected<int, TestError>(constError);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR3));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR3));
 }
 
 TEST_F(expected_test, CreateFromConstSuccessResultsInCorrectValue)
@@ -215,7 +215,7 @@ TEST_F(expected_test, CreateWithSTLTypeIsSuccessful)
     const std::string ERROR_VALUE = "RedAlert";
     auto sut = expected<int, std::string>(unexpect, ERROR_VALUE);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(ERROR_VALUE));
+    EXPECT_THAT(sut.error(), Eq(ERROR_VALUE));
 }
 
 TEST_F(expected_test, CreateWithComplexErrorResultsInError)
@@ -225,8 +225,8 @@ TEST_F(expected_test, CreateWithComplexErrorResultsInError)
     constexpr int VALUE_B = 212;
     auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
-    EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
+    EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
 }
 
 TEST_F(expected_test, CreateRValueAndGetErrorResultsInCorrectError)
@@ -234,9 +234,30 @@ TEST_F(expected_test, CreateRValueAndGetErrorResultsInCorrectError)
     ::testing::Test::RecordProperty("TEST_ID", "b032400a-cd08-4ae7-af0c-5ae0362b4dc0");
     constexpr int VALUE_A = 131;
     constexpr int VALUE_B = 121;
-    auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B).get_error();
+    auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B).error();
     EXPECT_THAT(sut.m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, CreateConstRValueAndGetErrorResultsInCorrectError)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "936bb9c0-2559-4716-ba03-d5b927fff40f");
+    constexpr int VALUE_A = 131;
+    constexpr int VALUE_B = 121;
+    using SutType = expected<int, TestClass>;
+    auto sut = static_cast<const SutType&&>(SutType(unexpect, VALUE_A, VALUE_B)).error();
+    EXPECT_THAT(sut.m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, CreateLValueAndGetErrorResultsInCorrectError)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a167d79e-9c50-45d8-afb8-5a4cc2f3da1b");
+    constexpr int VALUE_A = 131;
+    constexpr int VALUE_B = 121;
+    auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
+    EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
 }
 
 TEST_F(expected_test, ConstCreateLValueAndGetErrorResultsInCorrectError)
@@ -244,9 +265,9 @@ TEST_F(expected_test, ConstCreateLValueAndGetErrorResultsInCorrectError)
     ::testing::Test::RecordProperty("TEST_ID", "e56063ea-8b7c-4d47-a898-fe609ea3b283");
     constexpr int VALUE_A = 131;
     constexpr int VALUE_B = 121;
-    const auto& sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
-    EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
-    EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
+    const auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
+    EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
 }
 
 TEST_F(expected_test, CreateWithValueAndMoveCtorLeadsToMovedSource)
@@ -279,12 +300,12 @@ TEST_F(expected_test, CreateWithErrorAndMoveCtorLeadsToMovedSource)
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
     // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
     ASSERT_TRUE(sutSource.has_error());
-    EXPECT_TRUE(sutSource.get_error().m_moved);
+    EXPECT_TRUE(sutSource.error().m_moved);
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
     ASSERT_TRUE(sutDestination.has_error());
-    EXPECT_FALSE(sutDestination.get_error().m_moved);
-    EXPECT_EQ(sutDestination.get_error().m_a, A);
-    EXPECT_EQ(sutDestination.get_error().m_b, B);
+    EXPECT_FALSE(sutDestination.error().m_moved);
+    EXPECT_EQ(sutDestination.error().m_a, A);
+    EXPECT_EQ(sutDestination.error().m_b, B);
 }
 
 TEST_F(expected_test, CreateWithValueAndMoveAssignmentLeadsToMovedSource)
@@ -317,12 +338,12 @@ TEST_F(expected_test, CreateWithErrorAndMoveAssignmentLeadsToMovedSource)
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
     // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
     ASSERT_TRUE(sutSource.has_error());
-    EXPECT_TRUE(sutSource.get_error().m_moved);
+    EXPECT_TRUE(sutSource.error().m_moved);
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
     ASSERT_TRUE(sutDestination.has_error());
-    EXPECT_FALSE(sutDestination.get_error().m_moved);
-    EXPECT_EQ(sutDestination.get_error().m_a, A);
-    EXPECT_EQ(sutDestination.get_error().m_b, B);
+    EXPECT_FALSE(sutDestination.error().m_moved);
+    EXPECT_EQ(sutDestination.error().m_a, A);
+    EXPECT_EQ(sutDestination.error().m_b, B);
 }
 
 TEST_F(expected_test, CreateWithOkFreeFunctionWithVoidValueTypeIsSuccessful)
@@ -370,7 +391,7 @@ TEST_F(expected_test, CreateWithErrFreeFunctionByCopyIsSuccessful)
     constexpr TestError ERROR = TestError::ERROR1;
     expected<int, TestError> sut = err(ERROR);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(ERROR));
+    EXPECT_THAT(sut.error(), Eq(ERROR));
 }
 
 TEST_F(expected_test, CreateWithErrFreeFunctionByMoveIsSuccessful)
@@ -381,8 +402,8 @@ TEST_F(expected_test, CreateWithErrFreeFunctionByMoveIsSuccessful)
     NonTrivialTestClass error{A, B};
     expected<int, NonTrivialTestClass> sut = err(std::move(error));
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error().m_a, Eq(A));
-    EXPECT_THAT(sut.get_error().m_b, Eq(B));
+    EXPECT_THAT(sut.error().m_a, Eq(A));
+    EXPECT_THAT(sut.error().m_b, Eq(B));
 }
 
 TEST_F(expected_test, CreateWithErrFreeFunctionByForwardingIsSuccessful)
@@ -392,8 +413,8 @@ TEST_F(expected_test, CreateWithErrFreeFunctionByForwardingIsSuccessful)
     constexpr int B{55};
     expected<int, NonTrivialTestClass> sut = err<NonTrivialTestClass>(A, B);
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error().m_a, Eq(A));
-    EXPECT_THAT(sut.get_error().m_b, Eq(B));
+    EXPECT_THAT(sut.error().m_a, Eq(A));
+    EXPECT_THAT(sut.error().m_b, Eq(B));
 }
 
 TEST_F(expected_test, BoolOperatorReturnsError)
@@ -403,8 +424,8 @@ TEST_F(expected_test, BoolOperatorReturnsError)
     constexpr int VALUE_B = 11;
     expected<int, TestClass> sut = err<TestClass>(VALUE_A, VALUE_B);
     ASSERT_THAT(sut.operator bool(), Eq(false));
-    EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
-    EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
+    EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
 }
 
 TEST_F(expected_test, BoolOperatorReturnsNoError)
@@ -424,7 +445,7 @@ TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsError)
     ::testing::Test::RecordProperty("TEST_ID", "7949f68f-c21c-43f1-ad8d-dc51eeee3257");
     expected<void, TestError> sut = err(TestError::ERROR1);
     ASSERT_THAT(sut.operator bool(), Eq(false));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR1));
 }
 
 TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsNoError)
@@ -509,7 +530,7 @@ TEST_F(expected_test, CreateFromUnexpectTypeLeadsToValidSutWithError)
     constexpr TestError ERROR = TestError::ERROR3;
     expected<int, TestError> sut{unexpect, ERROR};
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(ERROR));
+    EXPECT_THAT(sut.error(), Eq(ERROR));
 }
 
 TEST_F(expected_test, CreateFromEmptySuccessTypeLeadsToValidSut)
@@ -533,7 +554,7 @@ TEST_F(expected_test, CreateFromErrorLeadsToCorrectError)
     ::testing::Test::RecordProperty("TEST_ID", "cb7e783d-0a79-45ce-9ea7-3b6e28631ceb");
     expected<int, TestError> sut{error<TestError>(TestError::ERROR2)};
     ASSERT_THAT(sut.has_error(), Eq(true));
-    EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
+    EXPECT_THAT(sut.error(), Eq(TestError::ERROR2));
 }
 
 TEST_F(expected_test, ConvertNonEmptySuccessResultToVoidValueTypeResultIsSuccessful)
@@ -559,7 +580,7 @@ TEST_F(expected_test, ConvertNonEmptyErrorResultVoidValueTypeResultIsSuccessful)
     expected<int, TestError> sut{error<TestError>(TestError::ERROR2)};
     expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_error(), Eq(true));
-    EXPECT_THAT(sut2.get_error(), Eq(TestError::ERROR2));
+    EXPECT_THAT(sut2.error(), Eq(TestError::ERROR2));
 }
 
 TEST_F(expected_test, ExpectedWithValueConvertsToOptionalWithValue)
@@ -673,7 +694,7 @@ TEST_F(expected_test, AccessingErrorOfLValueExpectedWhichContainsValueLeadsToErr
     constexpr int VALID_VALUE{42};
     expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
+    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
 TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -683,7 +704,7 @@ TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeads
     constexpr int VALID_VALUE{42};
     const expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
+    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
 TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErrorHandlerCall)
@@ -693,8 +714,7 @@ TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErr
     constexpr int VALID_VALUE{42};
     expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
-    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { std::move(sut).get_error(); },
-                                              iox::HoofsError::EXPECTS_ENSURES_FAILED);
+    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { std::move(sut).error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
 TEST_F(expected_test, TwoVoidValueTypeExpectedWithEqualErrorAreEqual)

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -143,7 +143,7 @@ TEST_F(expected_test, CreateWithPODTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5b91db8c-5d2e-44a4-8cac-4ee436b5fe8e");
     constexpr int VALUE = 123;
-    auto sut = expected<int, TestError>::create_value(VALUE);
+    auto sut = expected<int, TestError>(in_place, VALUE);
     ASSERT_THAT(sut.has_error(), Eq(false));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
@@ -151,14 +151,14 @@ TEST_F(expected_test, CreateWithPODTypeIsSuccessful)
 TEST_F(expected_test, CreateWithVoidTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5baee3cb-4f81-4245-b9f9-d733d14d6d4a");
-    auto sut = expected<void, TestError>::create_value();
+    auto sut = expected<void, TestError>(in_place);
     ASSERT_THAT(sut.has_error(), Eq(false));
 }
 
 TEST_F(expected_test, CreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a2d10c89-6fc8-4c08-9e2d-9f61988ebb3f");
-    auto sut = expected<int, TestError>::create_error(TestError::ERROR1);
+    auto sut = expected<int, TestError>(unexpect, TestError::ERROR1);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
@@ -166,7 +166,7 @@ TEST_F(expected_test, CreateWithErrorResultsInError)
 TEST_F(expected_test, ConstCreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "581447a6-0705-494b-8159-cf3434080a06");
-    const auto sut = expected<int, TestError>::create_error(TestError::ERROR2);
+    const auto sut = expected<int, TestError>(unexpect, TestError::ERROR2);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR2));
 }
@@ -174,7 +174,7 @@ TEST_F(expected_test, ConstCreateWithErrorResultsInError)
 TEST_F(expected_test, ErrorTypeOnlyCreateWithErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b01b2217-e67a-4bbf-b1a8-95d9b348d66e");
-    auto sut = expected<void, TestError>::create_error(TestError::ERROR1);
+    auto sut = expected<void, TestError>(unexpect, TestError::ERROR1);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
@@ -203,7 +203,7 @@ TEST_F(expected_test, CreateWithComplexTypeIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "508a39f7-905a-4d9a-a61b-43145e546eca");
     constexpr int VALUE_A = 12;
     constexpr int VALUE_B = 222;
-    auto sut = expected<TestClass, TestError>::create_value(VALUE_A, VALUE_B);
+    auto sut = expected<TestClass, TestError>(in_place, VALUE_A, VALUE_B);
     ASSERT_THAT(sut.has_error(), Eq(false));
     EXPECT_THAT(sut.value().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.value().m_b, Eq(VALUE_B));
@@ -213,7 +213,7 @@ TEST_F(expected_test, CreateWithSTLTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "24fddc69-64ca-4b69-baab-a58293657cac");
     const std::string ERROR_VALUE = "RedAlert";
-    auto sut = expected<int, std::string>::create_error(ERROR_VALUE);
+    auto sut = expected<int, std::string>(unexpect, ERROR_VALUE);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error(), Eq(ERROR_VALUE));
 }
@@ -223,7 +223,7 @@ TEST_F(expected_test, CreateWithComplexErrorResultsInError)
     ::testing::Test::RecordProperty("TEST_ID", "71e6ea31-d6e3-42a0-a63d-4bbd39c7341c");
     constexpr int VALUE_A = 313;
     constexpr int VALUE_B = 212;
-    auto sut = expected<int, TestClass>::create_error(VALUE_A, VALUE_B);
+    auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
@@ -234,7 +234,7 @@ TEST_F(expected_test, CreateRValueAndGetErrorResultsInCorrectError)
     ::testing::Test::RecordProperty("TEST_ID", "b032400a-cd08-4ae7-af0c-5ae0362b4dc0");
     constexpr int VALUE_A = 131;
     constexpr int VALUE_B = 121;
-    auto sut = expected<int, TestClass>::create_error(VALUE_A, VALUE_B).get_error();
+    auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B).get_error();
     EXPECT_THAT(sut.m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.m_b, Eq(VALUE_B));
 }
@@ -244,7 +244,7 @@ TEST_F(expected_test, ConstCreateLValueAndGetErrorResultsInCorrectError)
     ::testing::Test::RecordProperty("TEST_ID", "e56063ea-8b7c-4d47-a898-fe609ea3b283");
     constexpr int VALUE_A = 131;
     constexpr int VALUE_B = 121;
-    const auto& sut = expected<int, TestClass>::create_error(VALUE_A, VALUE_B);
+    const auto& sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
     EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
 }
@@ -254,7 +254,7 @@ TEST_F(expected_test, CreateWithValueAndMoveCtorLeadsToMovedSource)
     ::testing::Test::RecordProperty("TEST_ID", "8da72983-3046-4dde-8de5-5eed89de0ccf");
     constexpr int A{177};
     constexpr int B{188};
-    auto sutSource = expected<NonTrivialTestClass, int>::create_value(A, B);
+    auto sutSource = expected<NonTrivialTestClass, int>(in_place, A, B);
     auto sutDestination{std::move(sutSource)};
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
@@ -273,7 +273,7 @@ TEST_F(expected_test, CreateWithErrorAndMoveCtorLeadsToMovedSource)
     ::testing::Test::RecordProperty("TEST_ID", "d7784813-458b-40f3-b6db-01521e57175e");
     constexpr int A{22};
     constexpr int B{33};
-    auto sutSource = expected<int, NonTrivialTestClass>::create_error(A, B);
+    auto sutSource = expected<int, NonTrivialTestClass>(unexpect, A, B);
     auto sutDestination{std::move(sutSource)};
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
@@ -292,7 +292,7 @@ TEST_F(expected_test, CreateWithValueAndMoveAssignmentLeadsToMovedSource)
     ::testing::Test::RecordProperty("TEST_ID", "eb5f326b-8446-4914-bdca-8d6ba20103fe");
     constexpr int A{73};
     constexpr int B{37};
-    auto sutSource = expected<NonTrivialTestClass, int>::create_value(A, B);
+    auto sutSource = expected<NonTrivialTestClass, int>(in_place, A, B);
     auto sutDestination = std::move(sutSource);
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
@@ -311,7 +311,7 @@ TEST_F(expected_test, CreateWithErrorAndMoveAssignmentLeadsToMovedSource)
     ::testing::Test::RecordProperty("TEST_ID", "ef2a799d-982e-447d-8f93-f7ad63c091e0");
     constexpr int A{44};
     constexpr int B{55};
-    auto sutSource = expected<int, NonTrivialTestClass>::create_error(A, B);
+    auto sutSource = expected<int, NonTrivialTestClass>(unexpect, A, B);
     auto sutDestination = std::move(sutSource);
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
@@ -401,7 +401,7 @@ TEST_F(expected_test, BoolOperatorReturnsError)
     ::testing::Test::RecordProperty("TEST_ID", "f1e30651-a0e9-4c73-b2bf-57f36fc7eddf");
     constexpr int VALUE_A = 55899;
     constexpr int VALUE_B = 11;
-    auto sut = expected<int, TestClass>::create_error(VALUE_A, VALUE_B);
+    expected<int, TestClass> sut = err<TestClass>(VALUE_A, VALUE_B);
     ASSERT_THAT(sut.operator bool(), Eq(false));
     EXPECT_THAT(sut.get_error().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.get_error().m_b, Eq(VALUE_B));
@@ -412,7 +412,7 @@ TEST_F(expected_test, BoolOperatorReturnsNoError)
     ::testing::Test::RecordProperty("TEST_ID", "aec3e2a3-b7ae-4778-ac1d-d52e64b9b2d3");
     constexpr int VALUE_A = 5599;
     constexpr int VALUE_B = 8111;
-    auto sut = expected<TestClass, TestError>::create_value(VALUE_A, VALUE_B);
+    expected<TestClass, TestError> sut = ok<TestClass>(VALUE_A, VALUE_B);
 
     ASSERT_THAT(sut.operator bool(), Eq(true));
     EXPECT_THAT(sut.value().m_a, Eq(VALUE_A));
@@ -422,7 +422,7 @@ TEST_F(expected_test, BoolOperatorReturnsNoError)
 TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7949f68f-c21c-43f1-ad8d-dc51eeee3257");
-    auto sut = expected<void, TestError>::create_error(TestError::ERROR1);
+    expected<void, TestError> sut = err(TestError::ERROR1);
     ASSERT_THAT(sut.operator bool(), Eq(false));
     EXPECT_THAT(sut.get_error(), Eq(TestError::ERROR1));
 }
@@ -430,7 +430,7 @@ TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsError)
 TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsNoError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4585b1bf-cd6f-44ac-8409-75dc14fa252a");
-    auto sut = expected<void, TestError>::create_value();
+    expected<void, TestError> sut = ok();
     ASSERT_THAT(sut.operator bool(), Eq(true));
 }
 
@@ -439,7 +439,7 @@ TEST_F(expected_test, ArrowOperatorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "39898e81-d4ad-4f27-8c45-d29c80114be2");
     constexpr int VALUE_A = 55;
     constexpr int VALUE_B = 81;
-    auto sut = expected<TestClass, TestError>::create_value(VALUE_A, VALUE_B);
+    expected<TestClass, TestError> sut = ok<TestClass>(VALUE_A, VALUE_B);
     ASSERT_THAT(sut.has_error(), Eq(false));
     EXPECT_THAT(sut->gimme(), Eq(VALUE_A + VALUE_B));
 }
@@ -458,7 +458,7 @@ TEST_F(expected_test, DereferencingOperatorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "11ddbd46-3a2f-43cd-a2d2-ebe2ad4019db");
     constexpr int VALUE = 1652;
-    auto sut = expected<int, TestError>::create_value(VALUE);
+    expected<int, TestError> sut = ok(VALUE);
     ASSERT_THAT(sut.has_error(), Eq(false));
     EXPECT_THAT(*sut, Eq(VALUE));
 }
@@ -570,7 +570,7 @@ TEST_F(expected_test, MoveAssignmentIsNotEnforcedInMoveConstructor)
 {
     ::testing::Test::RecordProperty("TEST_ID", "71cd336f-798b-4f08-9ab6-be3c429c1674");
     {
-        auto sut = expected<ClassWithMoveCtorAndNoMoveAssignment, int>::create_value();
+        auto sut = expected<ClassWithMoveCtorAndNoMoveAssignment, int>(in_place);
         /// this should compile, if not then we enforce move assignment hidden in the implementation
         expected<ClassWithMoveCtorAndNoMoveAssignment, int> destination{std::move(sut)};
         ASSERT_THAT(destination.has_error(), Eq(false));
@@ -578,7 +578,7 @@ TEST_F(expected_test, MoveAssignmentIsNotEnforcedInMoveConstructor)
 
     /// same test with the void value type
     {
-        auto sut = expected<void, ClassWithMoveCtorAndNoMoveAssignment>::create_error();
+        auto sut = expected<void, ClassWithMoveCtorAndNoMoveAssignment>(unexpect);
         /// this should compile, if not then we enforce move assignment hidden in the implementation
         expected<void, ClassWithMoveCtorAndNoMoveAssignment> destination{std::move(sut)};
         ASSERT_THAT(destination.has_error(), Eq(true));
@@ -589,7 +589,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithArrowO
 {
     ::testing::Test::RecordProperty("TEST_ID", "1a821c6f-83db-4fe1-8adf-873afa1251a1");
 
-    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { IOX_DISCARD_RESULT(sut->m_a); },
                                               iox::HoofsError::EXPECTS_ENSURES_FAILED);
@@ -599,7 +599,7 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithA
 {
     ::testing::Test::RecordProperty("TEST_ID", "c4f04d7c-9fa3-48f6-a6fd-b8e4e47b7632");
 
-    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    const expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { IOX_DISCARD_RESULT(sut->m_a); },
                                               iox::HoofsError::EXPECTS_ENSURES_FAILED);
@@ -609,7 +609,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorWithDerefO
 {
     ::testing::Test::RecordProperty("TEST_ID", "08ce6a3f-3813-46de-8e1e-3ffe8087521e");
 
-    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { *sut; }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -618,7 +618,7 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorWithD
 {
     ::testing::Test::RecordProperty("TEST_ID", "838dd364-f91f-40a7-9720-2b662a045b1e");
 
-    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    const expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { *sut; }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -627,7 +627,7 @@ TEST_F(expected_test, AccessingValueOfLValueExpectedWhichContainsErrorLeadsToErr
 {
     ::testing::Test::RecordProperty("TEST_ID", "92139583-b8d6-4d83-ae7e-f4109b98d214");
 
-    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.value(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -636,7 +636,7 @@ TEST_F(expected_test, AccessingValueOfConstLValueExpectedWhichContainsErrorLeads
 {
     ::testing::Test::RecordProperty("TEST_ID", "1bcbb835-8b4c-4430-a534-a26573c2380d");
 
-    const auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    const expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.value(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -645,7 +645,7 @@ TEST_F(expected_test, AccessingValueOfRValueExpectedWhichContainsErrorLeadsToErr
 {
     ::testing::Test::RecordProperty("TEST_ID", "32d59b52-81f5-417a-8670-dfb2c54fedfb");
 
-    auto sut = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    expected<TestClass, TestError> sut = err(TestError::ERROR1);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { std::move(sut).value(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -655,7 +655,7 @@ TEST_F(expected_test, AccessingErrorOfLValueExpectedWhichContainsValueLeadsToErr
     ::testing::Test::RecordProperty("TEST_ID", "aee85ead-e066-49fd-99fe-6f1a6045756d");
 
     constexpr int VALID_VALUE{42};
-    auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -665,7 +665,7 @@ TEST_F(expected_test, AccessingErrorOfConstLValueExpectedWhichContainsValueLeads
     ::testing::Test::RecordProperty("TEST_ID", "a49cf02e-b165-4fd6-9c24-65cedc6cddb9");
 
     constexpr int VALID_VALUE{42};
-    const auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    const expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut.get_error(); }, iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
@@ -675,7 +675,7 @@ TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErr
     ::testing::Test::RecordProperty("TEST_ID", "0ea90b5d-1af6-494a-b35c-da103bed2331");
 
     constexpr int VALID_VALUE{42};
-    auto sut = expected<TestClass, TestError>::create_value(VALID_VALUE, VALID_VALUE);
+    expected<TestClass, TestError> sut = ok<TestClass>(VALID_VALUE, VALID_VALUE);
 
     IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { std::move(sut).get_error(); },
                                               iox::HoofsError::EXPECTS_ENSURES_FAILED);
@@ -684,8 +684,8 @@ TEST_F(expected_test, AccessingErrorOfRValueExpectedWhichContainsValueLeadsToErr
 TEST_F(expected_test, TwoVoidValueTypeExpectedWithEqualErrorAreEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "471b406d-8dd3-4b82-9d46-00c21d257461");
-    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<void, TestError>::create_error(TestError::ERROR1);
+    expected<void, TestError> sut1 = err(TestError::ERROR1);
+    expected<void, TestError> sut2 = err(TestError::ERROR1);
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
@@ -694,8 +694,8 @@ TEST_F(expected_test, TwoVoidValueTypeExpectedWithEqualErrorAreEqual)
 TEST_F(expected_test, TwoVoidValueTypeExpectedWithUnequalErrorAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bcc2f9f1-72a1-41ed-ac8a-2f48cdcfbc56");
-    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<void, TestError>::create_error(TestError::ERROR2);
+    expected<void, TestError> sut1 = err(TestError::ERROR1);
+    expected<void, TestError> sut2 = err(TestError::ERROR2);
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);
@@ -704,8 +704,8 @@ TEST_F(expected_test, TwoVoidValueTypeExpectedWithUnequalErrorAreUnequal)
 TEST_F(expected_test, TwoVoidValueTypeExpectedWithValuesAreEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "75b25c16-fb79-4589-ab0f-bc73bb9fc2bb");
-    auto sut1 = expected<void, TestError>::create_value();
-    auto sut2 = expected<void, TestError>::create_value();
+    expected<void, TestError> sut1 = ok();
+    expected<void, TestError> sut2 = ok();
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
@@ -714,8 +714,8 @@ TEST_F(expected_test, TwoVoidValueTypeExpectedWithValuesAreEqual)
 TEST_F(expected_test, TwoVoidValueTypeExpectedWithErrorAndValueAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2108715f-e71c-4778-bb64-553996e860b4");
-    auto sut1 = expected<void, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<void, TestError>::create_value();
+    expected<void, TestError> sut1 = err(TestError::ERROR1);
+    expected<void, TestError> sut2 = ok();
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);
@@ -724,8 +724,8 @@ TEST_F(expected_test, TwoVoidValueTypeExpectedWithErrorAndValueAreUnequal)
 TEST_F(expected_test, TwoExpectedWithEqualErrorAreEqual)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b1a3b106-06f2-4667-ac25-7a9d9689c219");
-    auto sut1 = expected<TestClass, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestClass, TestError>::create_error(TestError::ERROR1);
+    expected<TestClass, TestError> sut1 = err(TestError::ERROR1);
+    expected<TestClass, TestError> sut2 = err(TestError::ERROR1);
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
@@ -734,8 +734,8 @@ TEST_F(expected_test, TwoExpectedWithEqualErrorAreEqual)
 TEST_F(expected_test, TwoExpectedsWithUnequalErrorAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "25250c6b-aa8f-40ad-ace9-2c55ce8eeaa2");
-    auto sut1 = expected<TestClass, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestClass, TestError>::create_error(TestError::ERROR2);
+    expected<TestClass, TestError> sut1 = err(TestError::ERROR1);
+    expected<TestClass, TestError> sut2 = err(TestError::ERROR2);
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);
@@ -746,8 +746,8 @@ TEST_F(expected_test, TwoExpectedWithEqualValueAreEqual)
     ::testing::Test::RecordProperty("TEST_ID", "278c2fd5-2b48-49d1-a8a4-8ca52b99de41");
     constexpr int VAL_1{42};
     constexpr int VAL_2{73};
-    auto sut1 = expected<TestClass, TestError>::create_value(VAL_1, VAL_2);
-    auto sut2 = expected<TestClass, TestError>::create_value(VAL_1, VAL_2);
+    expected<TestClass, TestError> sut1 = ok<TestClass>(VAL_1, VAL_2);
+    expected<TestClass, TestError> sut2 = ok<TestClass>(VAL_1, VAL_2);
 
     EXPECT_TRUE(sut1 == sut2);
     EXPECT_FALSE(sut1 != sut2);
@@ -758,8 +758,8 @@ TEST_F(expected_test, TwoExpectedWithUnequalValueAreUnequal)
     ::testing::Test::RecordProperty("TEST_ID", "5f6a8760-6fdf-4ab8-a7d5-d751390aa672");
     constexpr int VAL_1{42};
     constexpr int VAL_2{73};
-    auto sut1 = expected<TestClass, TestError>::create_value(VAL_1, VAL_1);
-    auto sut2 = expected<TestClass, TestError>::create_value(VAL_2, VAL_2);
+    expected<TestClass, TestError> sut1 = ok<TestClass>(VAL_1, VAL_1);
+    expected<TestClass, TestError> sut2 = ok<TestClass>(VAL_2, VAL_2);
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);
@@ -769,8 +769,8 @@ TEST_F(expected_test, TwoExpectedWithErrorAndValueAreUnequal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "aa912753-09af-46d5-92d5-52cad69795ad");
     constexpr int VAL{42};
-    auto sut1 = expected<TestClass, TestError>::create_error(TestError::ERROR1);
-    auto sut2 = expected<TestClass, TestError>::create_value(VAL, VAL);
+    expected<TestClass, TestError> sut1 = err(TestError::ERROR1);
+    expected<TestClass, TestError> sut2 = ok<TestClass>(VAL, VAL);
 
     EXPECT_FALSE(sut1 == sut2);
     EXPECT_TRUE(sut1 != sut2);

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -182,7 +182,7 @@ TEST_F(expected_test, ErrorTypeOnlyCreateWithErrorResultsInError)
 TEST_F(expected_test, CreateFromConstErrorResultsInError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8e4324ad-f221-4038-91ad-61a1567545dd");
-    auto constError = error<TestError>(TestError::ERROR3);
+    auto constError = err(TestError::ERROR3);
     auto sut = expected<int, TestError>(constError);
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.error(), Eq(TestError::ERROR3));
@@ -192,7 +192,7 @@ TEST_F(expected_test, CreateFromConstSuccessResultsInCorrectValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cb20f217-6617-4c9e-8185-35cbf2bb8f3e");
     constexpr int VALUE = 424242;
-    auto constSuccess = success<int>(VALUE);
+    auto constSuccess = ok(VALUE);
     auto sut = expected<int, TestError>(constSuccess);
     ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
@@ -527,7 +527,7 @@ TEST_F(expected_test, ConstArrowOperatorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "b35a05e9-6dbc-4cfb-94c2-85ca9d214bb4");
     constexpr int VALUE_A = 554;
     constexpr int VALUE_B = 811;
-    const expected<TestClass, TestError> sut(success<TestClass>(TestClass(VALUE_A, VALUE_B)));
+    const expected<TestClass, TestError> sut(ok<TestClass>(VALUE_A, VALUE_B));
     ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut->constGimme(), Eq(VALUE_A + VALUE_B));
 }
@@ -544,7 +544,7 @@ TEST_F(expected_test, DereferencingOperatorWorks)
 TEST_F(expected_test, ConstDereferencingOperatorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f09b9476-a4f6-4f56-9692-3c00146410fd");
-    const expected<int, TestError> sut(success<int>(981));
+    const expected<int, TestError> sut(ok(981));
     ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(*sut, Eq(981));
 }
@@ -577,7 +577,7 @@ TEST_F(expected_test, CreateFromUnexpectTypeLeadsToValidSutWithError)
 TEST_F(expected_test, CreateFromEmptySuccessTypeLeadsToValidSut)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0204f08f-fb6d-45bb-aac7-fd14152ab1bf");
-    expected<void, TestError> sut{success<>()};
+    expected<void, TestError> sut{ok()};
     ASSERT_THAT(sut.has_error(), Eq(false));
 }
 
@@ -585,7 +585,7 @@ TEST_F(expected_test, CreateFromSuccessTypeLeadsToValidSut)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb83b62e-4e17-480b-8425-72181e6dd55d");
     constexpr int VALUE = 55;
-    expected<int, TestError> sut{success<int>(VALUE)};
+    expected<int, TestError> sut{ok(VALUE)};
     ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
@@ -593,7 +593,7 @@ TEST_F(expected_test, CreateFromSuccessTypeLeadsToValidSut)
 TEST_F(expected_test, CreateFromErrorLeadsToCorrectError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cb7e783d-0a79-45ce-9ea7-3b6e28631ceb");
-    expected<int, TestError> sut{error<TestError>(TestError::ERROR2)};
+    expected<int, TestError> sut{err(TestError::ERROR2)};
     ASSERT_THAT(sut.has_error(), Eq(true));
     EXPECT_THAT(sut.error(), Eq(TestError::ERROR2));
 }
@@ -602,7 +602,7 @@ TEST_F(expected_test, ConvertNonEmptySuccessResultToVoidValueTypeResultIsSuccess
 {
     ::testing::Test::RecordProperty("TEST_ID", "b14f4aaa-abd0-4b99-84df-d644506712fa");
     constexpr int VALUE = 91823;
-    expected<int, TestError> sut{success<int>(VALUE)};
+    expected<int, TestError> sut{ok(VALUE)};
     expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_value(), Eq(true));
 }
@@ -610,7 +610,7 @@ TEST_F(expected_test, ConvertNonEmptySuccessResultToVoidValueTypeResultIsSuccess
 TEST_F(expected_test, ConvertConstNonEmptySuccessResultToVoidValueTypeResultIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6ccaf1cf-1b09-4930-ad33-8f961aca4c2e");
-    const expected<int, TestError> sut{success<int>(123)};
+    const expected<int, TestError> sut{ok(123)};
     expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_value(), Eq(true));
 }
@@ -618,7 +618,7 @@ TEST_F(expected_test, ConvertConstNonEmptySuccessResultToVoidValueTypeResultIsSu
 TEST_F(expected_test, ConvertNonEmptyErrorResultVoidValueTypeResultIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5907d318-cf1a-46f1-9016-07096153d7d9");
-    expected<int, TestError> sut{error<TestError>(TestError::ERROR2)};
+    expected<int, TestError> sut{err(TestError::ERROR2)};
     expected<void, TestError> sut2 = sut;
     EXPECT_THAT(sut2.has_error(), Eq(true));
     EXPECT_THAT(sut2.error(), Eq(TestError::ERROR2));
@@ -628,7 +628,7 @@ TEST_F(expected_test, ExpectedWithValueConvertsToOptionalWithValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a877f9bd-5793-437f-8dee-a109aed9f647");
     constexpr int VALUE = 4711;
-    expected<int, TestError> sut{success<int>(VALUE)};
+    expected<int, TestError> sut{ok(VALUE)};
     optional<int> value = sut.to_optional();
 
     ASSERT_THAT(value.has_value(), Eq(true));
@@ -638,7 +638,7 @@ TEST_F(expected_test, ExpectedWithValueConvertsToOptionalWithValue)
 TEST_F(expected_test, ExpectedWithErrorConvertsToOptionalWithoutValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fe161275-8fa2-43c9-86e7-0a20d79eb44f");
-    expected<int, TestError> sut{error<TestError>(TestError::ERROR1)};
+    expected<int, TestError> sut{err(TestError::ERROR1)};
     optional<int> value = sut.to_optional();
 
     ASSERT_THAT(value.has_value(), Eq(false));

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -144,7 +144,7 @@ TEST_F(expected_test, CreateWithPODTypeIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "5b91db8c-5d2e-44a4-8cac-4ee436b5fe8e");
     constexpr int VALUE = 123;
     auto sut = expected<int, TestError>(in_place, VALUE);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
@@ -152,7 +152,7 @@ TEST_F(expected_test, CreateWithVoidTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5baee3cb-4f81-4245-b9f9-d733d14d6d4a");
     auto sut = expected<void, TestError>(in_place);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
 }
 
 TEST_F(expected_test, CreateWithErrorResultsInError)
@@ -194,7 +194,7 @@ TEST_F(expected_test, CreateFromConstSuccessResultsInCorrectValue)
     constexpr int VALUE = 424242;
     auto constSuccess = success<int>(VALUE);
     auto sut = expected<int, TestError>(constSuccess);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
@@ -204,7 +204,7 @@ TEST_F(expected_test, CreateWithComplexTypeIsSuccessful)
     constexpr int VALUE_A = 12;
     constexpr int VALUE_B = 222;
     auto sut = expected<TestClass, TestError>(in_place, VALUE_A, VALUE_B);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.value().m_b, Eq(VALUE_B));
 }
@@ -259,10 +259,10 @@ TEST_F(expected_test, CreateWithValueAndMoveCtorLeadsToMovedSource)
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
     // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_FALSE(sutSource.has_error());
+    ASSERT_TRUE(sutSource.has_value());
     EXPECT_TRUE(sutSource.value().m_moved);
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_FALSE(sutDestination.has_error());
+    ASSERT_TRUE(sutDestination.has_value());
     EXPECT_FALSE(sutDestination.value().m_moved);
     EXPECT_EQ(sutDestination.value().m_a, A);
     EXPECT_EQ(sutDestination.value().m_b, B);
@@ -297,10 +297,10 @@ TEST_F(expected_test, CreateWithValueAndMoveAssignmentLeadsToMovedSource)
 
     // NOLINTJUSTIFICATION we explicitly want to test the defined state of a moved expected
     // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_FALSE(sutSource.has_error());
+    ASSERT_TRUE(sutSource.has_value());
     EXPECT_TRUE(sutSource.value().m_moved);
     // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
-    ASSERT_FALSE(sutDestination.has_error());
+    ASSERT_TRUE(sutDestination.has_value());
     EXPECT_FALSE(sutDestination.value().m_moved);
     EXPECT_EQ(sutDestination.value().m_a, A);
     EXPECT_EQ(sutDestination.value().m_b, B);
@@ -329,7 +329,7 @@ TEST_F(expected_test, CreateWithOkFreeFunctionWithVoidValueTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6d582b25-1c7d-4519-837c-55d151b324ff");
     expected<void, TestError> sut = ok();
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
 }
 
 TEST_F(expected_test, CreateWithOkFreeFunctionByCopyIsSuccessful)
@@ -337,7 +337,7 @@ TEST_F(expected_test, CreateWithOkFreeFunctionByCopyIsSuccessful)
     ::testing::Test::RecordProperty("TEST_ID", "d3c24c27-432d-4a4b-8d55-6e723bc88c46");
     constexpr int VALUE = 111;
     expected<int, TestError> sut = ok(VALUE);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
@@ -348,7 +348,7 @@ TEST_F(expected_test, CreateWithOkFreeFunctionByMoveIsSuccessful)
     constexpr int B{55};
     NonTrivialTestClass value{A, B};
     expected<NonTrivialTestClass, TestError> sut = ok(std::move(value));
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value().m_a, Eq(A));
     EXPECT_THAT(sut.value().m_b, Eq(B));
 }
@@ -359,7 +359,7 @@ TEST_F(expected_test, CreateWithOkFreeFunctionByForwardingIsSuccessful)
     constexpr int A{44};
     constexpr int B{55};
     expected<NonTrivialTestClass, TestError> sut = ok<NonTrivialTestClass>(A, B);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value().m_a, Eq(A));
     EXPECT_THAT(sut.value().m_b, Eq(B));
 }
@@ -434,6 +434,22 @@ TEST_F(expected_test, ErrorTypeOnlyBoolOperatorReturnsNoError)
     ASSERT_THAT(sut.operator bool(), Eq(true));
 }
 
+TEST_F(expected_test, HasValueIsTrueWhenHasErrorIsFalse)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cf339ae0-bc54-4584-bef1-9471eb2d5370");
+    expected<void, TestError> sut = ok();
+    ASSERT_TRUE(sut.has_value());
+    ASSERT_FALSE(sut.has_error());
+}
+
+TEST_F(expected_test, HasValueIsFalseWhenHasErrorIsTrue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "28f6a33a-5264-4507-a6e3-879a297dc1e5");
+    expected<void, TestError> sut = err(TestError::ERROR1);
+    ASSERT_FALSE(sut.has_value());
+    ASSERT_TRUE(sut.has_error());
+}
+
 TEST_F(expected_test, ArrowOperatorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "39898e81-d4ad-4f27-8c45-d29c80114be2");
@@ -450,7 +466,7 @@ TEST_F(expected_test, ConstArrowOperatorWorks)
     constexpr int VALUE_A = 554;
     constexpr int VALUE_B = 811;
     const expected<TestClass, TestError> sut(success<TestClass>(TestClass(VALUE_A, VALUE_B)));
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut->constGimme(), Eq(VALUE_A + VALUE_B));
 }
 
@@ -459,7 +475,7 @@ TEST_F(expected_test, DereferencingOperatorWorks)
     ::testing::Test::RecordProperty("TEST_ID", "11ddbd46-3a2f-43cd-a2d2-ebe2ad4019db");
     constexpr int VALUE = 1652;
     expected<int, TestError> sut = ok(VALUE);
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(*sut, Eq(VALUE));
 }
 
@@ -467,7 +483,7 @@ TEST_F(expected_test, ConstDereferencingOperatorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f09b9476-a4f6-4f56-9692-3c00146410fd");
     const expected<int, TestError> sut(success<int>(981));
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(*sut, Eq(981));
 }
 
@@ -475,7 +491,7 @@ TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidVoidValueTypeSut)
 {
     ::testing::Test::RecordProperty("TEST_ID", "91a8ad7f-4843-4bd9-a56b-0561ae6b56cb");
     expected<void, TestError> sut{in_place};
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
 }
 
 TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidSut)
@@ -483,7 +499,7 @@ TEST_F(expected_test, CreateFromInPlaceTypeLeadsToValidSut)
     ::testing::Test::RecordProperty("TEST_ID", "3a527c62-aaea-44ae-9b99-027c19d032b5");
     constexpr int VALUE = 42;
     expected<int, TestError> sut{in_place, VALUE};
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
@@ -508,7 +524,7 @@ TEST_F(expected_test, CreateFromSuccessTypeLeadsToValidSut)
     ::testing::Test::RecordProperty("TEST_ID", "fb83b62e-4e17-480b-8425-72181e6dd55d");
     constexpr int VALUE = 55;
     expected<int, TestError> sut{success<int>(VALUE)};
-    ASSERT_THAT(sut.has_error(), Eq(false));
+    ASSERT_THAT(sut.has_value(), Eq(true));
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
@@ -526,7 +542,7 @@ TEST_F(expected_test, ConvertNonEmptySuccessResultToVoidValueTypeResultIsSuccess
     constexpr int VALUE = 91823;
     expected<int, TestError> sut{success<int>(VALUE)};
     expected<void, TestError> sut2 = sut;
-    EXPECT_THAT(sut2.has_error(), Eq(false));
+    EXPECT_THAT(sut2.has_value(), Eq(true));
 }
 
 TEST_F(expected_test, ConvertConstNonEmptySuccessResultToVoidValueTypeResultIsSuccessful)
@@ -534,7 +550,7 @@ TEST_F(expected_test, ConvertConstNonEmptySuccessResultToVoidValueTypeResultIsSu
     ::testing::Test::RecordProperty("TEST_ID", "6ccaf1cf-1b09-4930-ad33-8f961aca4c2e");
     const expected<int, TestError> sut{success<int>(123)};
     expected<void, TestError> sut2 = sut;
-    EXPECT_THAT(sut2.has_error(), Eq(false));
+    EXPECT_THAT(sut2.has_value(), Eq(true));
 }
 
 TEST_F(expected_test, ConvertNonEmptyErrorResultVoidValueTypeResultIsSuccessful)
@@ -573,7 +589,7 @@ TEST_F(expected_test, MoveAssignmentIsNotEnforcedInMoveConstructor)
         auto sut = expected<ClassWithMoveCtorAndNoMoveAssignment, int>(in_place);
         /// this should compile, if not then we enforce move assignment hidden in the implementation
         expected<ClassWithMoveCtorAndNoMoveAssignment, int> destination{std::move(sut)};
-        ASSERT_THAT(destination.has_error(), Eq(false));
+        ASSERT_THAT(destination.has_value(), Eq(true));
     }
 
     /// same test with the void value type

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -325,14 +325,14 @@ TEST_F(expected_test, CreateWithErrorAndMoveAssignmentLeadsToMovedSource)
     EXPECT_EQ(sutDestination.get_error().m_b, B);
 }
 
-TEST_F(expected_test, CreateWithOkFreeFunktionWithVoidValueTypeIsSuccessful)
+TEST_F(expected_test, CreateWithOkFreeFunctionWithVoidValueTypeIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6d582b25-1c7d-4519-837c-55d151b324ff");
     expected<void, TestError> sut = ok();
     ASSERT_THAT(sut.has_error(), Eq(false));
 }
 
-TEST_F(expected_test, CreateWithOkFreeFunktionByCopyIsSuccessful)
+TEST_F(expected_test, CreateWithOkFreeFunctionByCopyIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d3c24c27-432d-4a4b-8d55-6e723bc88c46");
     constexpr int VALUE = 111;
@@ -341,7 +341,7 @@ TEST_F(expected_test, CreateWithOkFreeFunktionByCopyIsSuccessful)
     EXPECT_THAT(sut.value(), Eq(VALUE));
 }
 
-TEST_F(expected_test, CreateWithOkFreeFunktionByMoveIsSuccessful)
+TEST_F(expected_test, CreateWithOkFreeFunctionByMoveIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b1320e1f-3613-4085-8125-fc95d584681c");
     constexpr int A{44};
@@ -353,7 +353,7 @@ TEST_F(expected_test, CreateWithOkFreeFunktionByMoveIsSuccessful)
     EXPECT_THAT(sut.value().m_b, Eq(B));
 }
 
-TEST_F(expected_test, CreateWithOkFreeFunktionByForwardingIsSuccessful)
+TEST_F(expected_test, CreateWithOkFreeFunctionByForwardingIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a3d41181-f4ad-4431-9441-7dfaeb8d6f7f");
     constexpr int A{44};
@@ -364,7 +364,7 @@ TEST_F(expected_test, CreateWithOkFreeFunktionByForwardingIsSuccessful)
     EXPECT_THAT(sut.value().m_b, Eq(B));
 }
 
-TEST_F(expected_test, CreateWithErrFreeFunktionByCopyIsSuccessful)
+TEST_F(expected_test, CreateWithErrFreeFunctionByCopyIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bb641919-e319-4e9c-af67-e1e8d5dab682");
     constexpr TestError ERROR = TestError::ERROR1;
@@ -373,7 +373,7 @@ TEST_F(expected_test, CreateWithErrFreeFunktionByCopyIsSuccessful)
     EXPECT_THAT(sut.get_error(), Eq(ERROR));
 }
 
-TEST_F(expected_test, CreateWithErrFreeFunktionByMoveIsSuccessful)
+TEST_F(expected_test, CreateWithErrFreeFunctionByMoveIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f99af97a-16b2-41e6-a808-2d58bfe0fc57");
     constexpr int A{666};
@@ -385,7 +385,7 @@ TEST_F(expected_test, CreateWithErrFreeFunktionByMoveIsSuccessful)
     EXPECT_THAT(sut.get_error().m_b, Eq(B));
 }
 
-TEST_F(expected_test, CreateWithErrFreeFunktionByForwardingIsSuccessful)
+TEST_F(expected_test, CreateWithErrFreeFunctionByForwardingIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "08411afa-e1d3-4a28-9680-f89796f86340");
     constexpr int A{44};

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -242,8 +242,8 @@ TEST_F(expected_test, CreateRValueAndGetErrorResultsInCorrectError)
 TEST_F(expected_test, CreateConstRValueAndGetErrorResultsInCorrectError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "936bb9c0-2559-4716-ba03-d5b927fff40f");
-    constexpr int VALUE_A = 131;
-    constexpr int VALUE_B = 121;
+    constexpr int VALUE_A = 123;
+    constexpr int VALUE_B = 122;
     using SutType = expected<int, TestClass>;
     auto sut = static_cast<const SutType&&>(SutType(unexpect, VALUE_A, VALUE_B)).error();
     EXPECT_THAT(sut.m_a, Eq(VALUE_A));
@@ -253,8 +253,8 @@ TEST_F(expected_test, CreateConstRValueAndGetErrorResultsInCorrectError)
 TEST_F(expected_test, CreateLValueAndGetErrorResultsInCorrectError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a167d79e-9c50-45d8-afb8-5a4cc2f3da1b");
-    constexpr int VALUE_A = 131;
-    constexpr int VALUE_B = 121;
+    constexpr int VALUE_A = 133;
+    constexpr int VALUE_B = 112;
     auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
     EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
@@ -263,11 +263,52 @@ TEST_F(expected_test, CreateLValueAndGetErrorResultsInCorrectError)
 TEST_F(expected_test, ConstCreateLValueAndGetErrorResultsInCorrectError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e56063ea-8b7c-4d47-a898-fe609ea3b283");
-    constexpr int VALUE_A = 131;
-    constexpr int VALUE_B = 121;
+    constexpr int VALUE_A = 112;
+    constexpr int VALUE_B = 211;
     const auto sut = expected<int, TestClass>(unexpect, VALUE_A, VALUE_B);
     EXPECT_THAT(sut.error().m_a, Eq(VALUE_A));
     EXPECT_THAT(sut.error().m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, CreateRValueAndGetValueResultsInCorrectValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "fb5a3954-50de-419a-b29d-635d068fcb84");
+    constexpr int VALUE_A = 141;
+    constexpr int VALUE_B = 131;
+    auto sut = expected<TestClass, TestError>(in_place, VALUE_A, VALUE_B).value();
+    EXPECT_THAT(sut.m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, CreateConstRValueAndGetValueResultsInCorrectValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "4af92b14-3b70-4ddd-8589-991abe3c8571");
+    constexpr int VALUE_A = 144;
+    constexpr int VALUE_B = 113;
+    using SutType = expected<TestClass, TestError>;
+    auto sut = static_cast<const SutType&&>(SutType(in_place, VALUE_A, VALUE_B)).value();
+    EXPECT_THAT(sut.m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, CreateLValueAndGetValueResultsInCorrectValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5adabab2-3329-47bf-bfb7-fe8aa98eacc2");
+    constexpr int VALUE_A = 114;
+    constexpr int VALUE_B = 311;
+    auto sut = expected<TestClass, TestError>(in_place, VALUE_A, VALUE_B);
+    EXPECT_THAT(sut.value().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.value().m_b, Eq(VALUE_B));
+}
+
+TEST_F(expected_test, ConstCreateLValueAndGetValueResultsInCorrectValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "e33c2d23-7914-4ba7-a8ee-37e3c91c4a74");
+    constexpr int VALUE_A = 411;
+    constexpr int VALUE_B = 133;
+    const auto sut = expected<TestClass, TestError>(in_place, VALUE_A, VALUE_B);
+    EXPECT_THAT(sut.value().m_a, Eq(VALUE_A));
+    EXPECT_THAT(sut.value().m_b, Eq(VALUE_B));
 }
 
 TEST_F(expected_test, CreateWithValueAndMoveCtorLeadsToMovedSource)

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_semantic_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_semantic_string.cpp
@@ -343,7 +343,7 @@ TYPED_TEST(SemanticString_test, InitializeWithStringContainingIllegalCharactersF
         auto sut = SutType::create(string<SutType::capacity()>(TruncateToCapacity, value.c_str()));
 
         ASSERT_THAT(sut.has_error(), Eq(true));
-        ASSERT_THAT(sut.get_error(), Eq(SemanticStringError::ContainsInvalidCharacters));
+        ASSERT_THAT(sut.error(), Eq(SemanticStringError::ContainsInvalidCharacters));
     }
 }
 
@@ -357,7 +357,7 @@ TYPED_TEST(SemanticString_test, InitializeWithStringContainingIllegalContentFail
         auto sut = SutType::create(string<SutType::capacity()>(TruncateToCapacity, value.c_str()));
 
         ASSERT_THAT(sut.has_error(), Eq(true));
-        ASSERT_THAT(sut.get_error(), Eq(SemanticStringError::ContainsInvalidContent));
+        ASSERT_THAT(sut.error(), Eq(SemanticStringError::ContainsInvalidContent));
     }
 }
 
@@ -371,7 +371,7 @@ TYPED_TEST(SemanticString_test, InitializeWithTooLongContentFails)
         auto sut = SutType::create(string<SutType::capacity() * 2>(TruncateToCapacity, value.c_str()));
 
         ASSERT_THAT(sut.has_error(), Eq(true));
-        ASSERT_THAT(sut.get_error(), Eq(SemanticStringError::ExceedsMaximumLength));
+        ASSERT_THAT(sut.error(), Eq(SemanticStringError::ExceedsMaximumLength));
     }
 }
 
@@ -413,7 +413,7 @@ TYPED_TEST(SemanticString_test, AppendInvalidCharactersToValidStringFails)
 
             auto result = sut->append(string<SutType::capacity()>(TruncateToCapacity, invalid_value.c_str()));
             ASSERT_TRUE(result.has_error());
-            EXPECT_THAT(result.get_error(), Eq(SemanticStringError::ContainsInvalidCharacters));
+            EXPECT_THAT(result.error(), Eq(SemanticStringError::ContainsInvalidCharacters));
             EXPECT_THAT(sut->size(), value.size());
             EXPECT_THAT(sut->capacity(), Eq(TestValues<SutType>::CAPACITY));
 
@@ -436,7 +436,7 @@ TYPED_TEST(SemanticString_test, GenerateInvalidContentWithAppend)
 
             auto result = sut->append(string<SutType::capacity()>(TruncateToCapacity, invalid_value.c_str()));
             ASSERT_TRUE(result.has_error());
-            EXPECT_THAT(result.get_error(), Eq(SemanticStringError::ContainsInvalidContent));
+            EXPECT_THAT(result.error(), Eq(SemanticStringError::ContainsInvalidContent));
             EXPECT_THAT(sut->size(), value.size());
             EXPECT_THAT(sut->capacity(), Eq(TestValues<SutType>::CAPACITY));
 
@@ -460,7 +460,7 @@ TYPED_TEST(SemanticString_test, GenerateInvalidContentWithInsert)
             auto result = sut->insert(
                 0, string<SutType::capacity()>(TruncateToCapacity, invalid_value.c_str()), invalid_value.size());
             ASSERT_TRUE(result.has_error());
-            EXPECT_THAT(result.get_error(), Eq(SemanticStringError::ContainsInvalidContent));
+            EXPECT_THAT(result.error(), Eq(SemanticStringError::ContainsInvalidContent));
             EXPECT_THAT(sut->size(), value.size());
             EXPECT_THAT(sut->capacity(), Eq(TestValues<SutType>::CAPACITY));
 
@@ -541,7 +541,7 @@ TYPED_TEST(SemanticString_test, InsertInvalidCharactersToValidStringFails)
                                           string<SutType::capacity()>(TruncateToCapacity, add_value.c_str()),
                                           add_value.size());
                 ASSERT_TRUE(result.has_error());
-                EXPECT_THAT(result.get_error(), Eq(SemanticStringError::ContainsInvalidCharacters));
+                EXPECT_THAT(result.error(), Eq(SemanticStringError::ContainsInvalidCharacters));
 
 
                 EXPECT_THAT(sut->size(), value.size());

--- a/iceoryx_hoofs/test/stresstests/benchmark_optional_and_expected/benchmark_optional_and_expected.cpp
+++ b/iceoryx_hoofs/test/stresstests/benchmark_optional_and_expected/benchmark_optional_and_expected.cpp
@@ -137,10 +137,10 @@ iox::expected<uint64_t, uint64_t> complexErrorValueExpectedImpl()
 
     if (mod >= 4)
     {
-        return iox::error<uint64_t>(mod);
+        return iox::err(mod);
     }
 
-    return iox::success<uint64_t>(mod);
+    return iox::ok(mod);
 }
 
 void complexErrorValueExpected()
@@ -190,13 +190,13 @@ iox::expected<T, uint64_t> largeObjectPopExpectedImpl()
 
     if (globalCounter % 3 == 0)
     {
-        return iox::error<uint64_t>(globalCounter);
+        return iox::err(globalCounter);
     }
 
     T returnValue;
     returnValue.value = globalCounter;
 
-    return iox::success<T>(returnValue);
+    return iox::ok(returnValue);
 }
 
 template <typename T>

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -22,67 +22,67 @@
 namespace iox
 {
 template <typename T, typename>
-detail::success<void> ok()
+detail::ok<void> ok()
 {
-    return detail::success<void>{};
+    return detail::ok<void>{};
 }
 
 template <typename T, typename>
-detail::success<T> ok(const T& value)
+detail::ok<T> ok(const T& value)
 {
-    return detail::success<T>{value};
+    return detail::ok<T>{value};
 }
 
 template <typename T, typename, typename>
-detail::success<T> ok(T&& value)
+detail::ok<T> ok(T&& value)
 {
-    return detail::success<T>{std::forward<T>(value)};
+    return detail::ok<T>{std::forward<T>(value)};
 }
 
 template <typename T, typename... Targs, typename>
-detail::success<T> ok(Targs&&... args)
+detail::ok<T> ok(Targs&&... args)
 {
-    return detail::success<T>{std::forward<Targs>(args)...};
+    return detail::ok<T>{std::forward<Targs>(args)...};
 }
 
 template <typename T>
-detail::error<T> err(const T& value)
+detail::err<T> err(const T& value)
 {
-    return detail::error<T>{value};
+    return detail::err<T>{value};
 }
 
 template <typename T, typename>
-detail::error<T> err(T&& value)
+detail::err<T> err(T&& value)
 {
-    return detail::error<T>{std::forward<T>(value)};
+    return detail::err<T>{std::forward<T>(value)};
 }
 
 template <typename T, typename... Targs>
-detail::error<T> err(Targs&&... args)
+detail::err<T> err(Targs&&... args)
 {
-    return detail::error<T>{std::forward<Targs>(args)...};
+    return detail::err<T>{std::forward<Targs>(args)...};
 }
 
 template <typename ValueType, typename ErrorType>
-inline expected<ValueType, ErrorType>::expected(const detail::success<ValueType>& successValue) noexcept
+inline expected<ValueType, ErrorType>::expected(const detail::ok<ValueType>& successValue) noexcept
     : m_store(in_place, successValue.value)
 {
 }
 
 template <typename ValueType, typename ErrorType>
-inline expected<ValueType, ErrorType>::expected(detail::success<ValueType>&& successValue) noexcept
+inline expected<ValueType, ErrorType>::expected(detail::ok<ValueType>&& successValue) noexcept
     : m_store(in_place, std::move(successValue.value))
 {
 }
 
 template <typename ValueType, typename ErrorType>
-inline expected<ValueType, ErrorType>::expected(const detail::error<ErrorType>& errorValue) noexcept
+inline expected<ValueType, ErrorType>::expected(const detail::err<ErrorType>& errorValue) noexcept
     : m_store(unexpect, errorValue.value)
 {
 }
 
 template <typename ValueType, typename ErrorType>
-inline expected<ValueType, ErrorType>::expected(detail::error<ErrorType>&& errorValue) noexcept
+inline expected<ValueType, ErrorType>::expected(detail::err<ErrorType>&& errorValue) noexcept
     : m_store(unexpect, std::move(errorValue.value))
 {
 }

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -46,15 +46,15 @@ detail::ok<T> ok(Targs&&... args)
 }
 
 template <typename T>
-detail::err<T> err(const T& value)
+detail::err<T> err(const T& error)
 {
-    return detail::err<T>{value};
+    return detail::err<T>{error};
 }
 
 template <typename T, typename>
-detail::err<T> err(T&& value)
+detail::err<T> err(T&& error)
 {
-    return detail::err<T>{std::forward<T>(value)};
+    return detail::err<T>{std::forward<T>(error)};
 }
 
 template <typename T, typename... Targs>

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -120,20 +120,6 @@ expected<ValueType, ErrorType>::operator=(expected<ValueType, ErrorType>&& rhs) 
 }
 
 template <typename ValueType, typename ErrorType>
-template <typename... Targs>
-inline expected<ValueType, ErrorType> expected<ValueType, ErrorType>::create_value(Targs&&... args) noexcept
-{
-    return expected{in_place, std::forward<Targs>(args)...};
-}
-
-template <typename ValueType, typename ErrorType>
-template <typename... Targs>
-inline expected<ValueType, ErrorType> expected<ValueType, ErrorType>::create_error(Targs&&... args) noexcept
-{
-    return expected{unexpect, std::forward<Targs>(args)...};
-}
-
-template <typename ValueType, typename ErrorType>
 inline expected<ValueType, ErrorType>::operator bool() const noexcept
 {
     return !has_error();

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -126,6 +126,12 @@ inline expected<ValueType, ErrorType>::operator bool() const noexcept
 }
 
 template <typename ValueType, typename ErrorType>
+inline bool expected<ValueType, ErrorType>::has_value() const noexcept
+{
+    return m_store.has_value();
+}
+
+template <typename ValueType, typename ErrorType>
 inline bool expected<ValueType, ErrorType>::has_error() const noexcept
 {
     return m_store.has_error();

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -122,7 +122,7 @@ expected<ValueType, ErrorType>::operator=(expected<ValueType, ErrorType>&& rhs) 
 template <typename ValueType, typename ErrorType>
 inline expected<ValueType, ErrorType>::operator bool() const noexcept
 {
-    return !has_error();
+    return has_value();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -198,7 +198,7 @@ template <typename ValueType, typename ErrorType>
 template <typename U>
 inline const enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value_checked() const& noexcept
 {
-    cxx::ExpectsWithMsg(!has_error(), "Trying to access a value but an error is stored!");
+    cxx::ExpectsWithMsg(has_value(), "Trying to access a value but an error is stored!");
     return m_store.value_unchecked();
 }
 
@@ -289,7 +289,7 @@ template <typename U>
 inline optional<enable_if_non_void_t<U>> expected<ValueType, ErrorType>::to_optional() const noexcept
 {
     optional<enable_if_non_void_t<U>> returnValue;
-    if (!has_error())
+    if (has_value())
     {
         returnValue.emplace(m_store.value_unchecked());
     }

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -138,24 +138,60 @@ inline bool expected<ValueType, ErrorType>::has_error() const noexcept
 }
 
 template <typename ValueType, typename ErrorType>
+inline ErrorType& expected<ValueType, ErrorType>::error_checked() & noexcept
+{
+    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    return const_cast<ErrorType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->error_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+inline const ErrorType& expected<ValueType, ErrorType>::error_checked() const& noexcept
+{
+    cxx::ExpectsWithMsg(has_error(), "Trying to access an error but a value is stored!");
+    return m_store.error_unchecked();
+}
+
+template <typename ValueType, typename ErrorType>
+inline ErrorType&& expected<ValueType, ErrorType>::error() && noexcept
+{
+    return std::move(error_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+inline const ErrorType&& expected<ValueType, ErrorType>::error() const&& noexcept
+{
+    return std::move(error_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+inline ErrorType& expected<ValueType, ErrorType>::error() & noexcept
+{
+    return error_checked();
+}
+
+template <typename ValueType, typename ErrorType>
+inline const ErrorType& expected<ValueType, ErrorType>::error() const& noexcept
+{
+    return error_checked();
+}
+
+template <typename ValueType, typename ErrorType>
 inline ErrorType&& expected<ValueType, ErrorType>::get_error() && noexcept
 {
-    return std::move(get_error());
+    return std::move(error_checked());
 }
 
 template <typename ValueType, typename ErrorType>
 inline ErrorType& expected<ValueType, ErrorType>::get_error() & noexcept
 {
-    // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return const_cast<ErrorType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->get_error());
+    return error_checked();
 }
 
 template <typename ValueType, typename ErrorType>
 inline const ErrorType& expected<ValueType, ErrorType>::get_error() const& noexcept
 {
-    cxx::ExpectsWithMsg(has_error(), "Trying to access an error but a value is stored!");
-    return m_store.error_unchecked();
+    return error_checked();
 }
 
 template <typename ValueType, typename ErrorType>

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -196,14 +196,7 @@ inline const ErrorType& expected<ValueType, ErrorType>::get_error() const& noexc
 
 template <typename ValueType, typename ErrorType>
 template <typename U>
-inline enable_if_non_void_t<U>&& expected<ValueType, ErrorType>::value() && noexcept
-{
-    return std::move(value());
-}
-
-template <typename ValueType, typename ErrorType>
-template <typename U>
-inline const enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value() const& noexcept
+inline const enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value_checked() const& noexcept
 {
     cxx::ExpectsWithMsg(!has_error(), "Trying to access a value but an error is stored!");
     return m_store.value_unchecked();
@@ -211,18 +204,46 @@ inline const enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value() co
 
 template <typename ValueType, typename ErrorType>
 template <typename U>
-inline enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value() & noexcept
+inline enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value_checked() & noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A5.2.3 : const cast to avoid code duplication
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-    return const_cast<ValueType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->value());
+    return const_cast<ValueType&>(const_cast<const expected<ValueType, ErrorType>*>(this)->value_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename U>
+inline enable_if_non_void_t<U>&& expected<ValueType, ErrorType>::value() && noexcept
+{
+    return std::move(value_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename U>
+inline const enable_if_non_void_t<U>&& expected<ValueType, ErrorType>::value() const&& noexcept
+{
+    return std::move(value_checked());
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename U>
+inline const enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value() const& noexcept
+{
+    return value_checked();
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename U>
+inline enable_if_non_void_t<U>& expected<ValueType, ErrorType>::value() & noexcept
+{
+    return value_checked();
 }
 
 template <typename ValueType, typename ErrorType>
 template <typename U>
 inline enable_if_non_void_t<U>* expected<ValueType, ErrorType>::operator->() noexcept
 {
-    return &value();
+    return &value_checked();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -239,7 +260,7 @@ template <typename ValueType, typename ErrorType>
 template <typename U>
 inline enable_if_non_void_t<U>& expected<ValueType, ErrorType>::operator*() noexcept
 {
-    return value();
+    return value_checked();
 }
 
 template <typename ValueType, typename ErrorType>
@@ -270,7 +291,7 @@ inline optional<enable_if_non_void_t<U>> expected<ValueType, ErrorType>::to_opti
     optional<enable_if_non_void_t<U>> returnValue;
     if (!has_error())
     {
-        returnValue.emplace(value());
+        returnValue.emplace(m_store.value_unchecked());
     }
     return returnValue;
 }

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2023 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_VOCABULARY_EXPECTED_HELPER_HPP
+#define IOX_HOOFS_VOCABULARY_EXPECTED_HELPER_HPP
+
+#include "iox/optional.hpp"
+#include "iox/variant.hpp"
+
+namespace iox
+{
+/// @brief helper struct which is used to call the in-place-construction constructor for error types
+struct unexpect_t
+{
+};
+constexpr unexpect_t unexpect{};
+
+/// @brief forward declaration required for 'compare_expected_value'
+template <typename ValueType, typename ErrorType>
+class expected;
+
+namespace detail
+{
+/// @brief helper class to be able to handle 'void' value type specialization
+template <typename ValueType, typename ErrorType>
+class expected_storage
+{
+  public:
+    expected_storage() noexcept = delete;
+
+    template <typename... Targs>
+    explicit expected_storage(in_place_t, Targs&&... args)
+        : data(in_place_index<VALUE_INDEX>(), std::forward<Targs>(args)...)
+    {
+    }
+
+    template <typename... Targs>
+    explicit expected_storage(unexpect_t, Targs&&... args)
+        : data(in_place_index<ERROR_INDEX>(), std::forward<Targs>(args)...)
+    {
+    }
+
+    bool has_value() const
+    {
+        return data.index() == VALUE_INDEX;
+    }
+
+    bool has_error() const
+    {
+        return data.index() == ERROR_INDEX;
+    }
+
+    ValueType& value_unchecked()
+    {
+        return *data.template get_at_index<VALUE_INDEX>();
+    }
+
+    const ValueType& value_unchecked() const
+    {
+        return *data.template get_at_index<VALUE_INDEX>();
+    }
+
+    ErrorType& error_unchecked()
+    {
+        return *data.template get_at_index<ERROR_INDEX>();
+    }
+
+    const ErrorType& error_unchecked() const
+    {
+        return *data.template get_at_index<ERROR_INDEX>();
+    }
+
+  private:
+    static constexpr uint64_t VALUE_INDEX{0};
+    static constexpr uint64_t ERROR_INDEX{1};
+
+    iox::variant<ValueType, ErrorType> data;
+};
+
+template <typename ErrorType>
+class expected_storage<void, ErrorType>
+{
+  public:
+    expected_storage() noexcept = delete;
+
+    template <typename... Targs>
+    explicit expected_storage(in_place_t, Targs&&...)
+        : data(in_place_index<VALUE_INDEX>(), DUMMY_VALUE)
+    {
+    }
+
+    template <typename... Targs>
+    explicit expected_storage(unexpect_t, Targs&&... args)
+        : data(in_place_index<ERROR_INDEX>(), std::forward<Targs>(args)...)
+    {
+    }
+
+    bool has_value() const
+    {
+        return data.index() == VALUE_INDEX;
+    }
+
+    bool has_error() const
+    {
+        return data.index() == ERROR_INDEX;
+    }
+
+    void value_unchecked() const
+    {
+        // nothing to do
+    }
+
+    ErrorType& error_unchecked()
+    {
+        return *data.template get_at_index<ERROR_INDEX>();
+    }
+
+    const ErrorType& error_unchecked() const
+    {
+        return *data.template get_at_index<ERROR_INDEX>();
+    }
+
+  private:
+    static constexpr uint64_t VALUE_INDEX{0};
+    static constexpr uint64_t ERROR_INDEX{1};
+
+    using DummyValueType = bool;
+    static constexpr DummyValueType DUMMY_VALUE{true};
+
+    iox::variant<DummyValueType, ErrorType> data;
+};
+
+template <typename ErrorType>
+constexpr typename expected_storage<void, ErrorType>::DummyValueType expected_storage<void, ErrorType>::DUMMY_VALUE;
+
+/// @brief helper struct for 'operator==' to be able to handle 'void' value type specialization
+template <typename T, typename E>
+struct compare_expected_value
+{
+    static constexpr bool is_same_value_unchecked(const expected_storage<T, E>& lhs, const expected_storage<T, E>& rhs)
+    {
+        return lhs.value_unchecked() == rhs.value_unchecked();
+    }
+};
+
+template <typename E>
+struct compare_expected_value<void, E>
+{
+    static constexpr bool is_same_value_unchecked(const expected_storage<void, E>&, const expected_storage<void, E>&)
+    {
+        return true;
+    }
+};
+
+} // namespace detail
+} // namespace iox
+
+#endif // IOX_HOOFS_VOCABULARY_EXPECTED_HELPER_HPP

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
@@ -47,25 +47,25 @@ namespace detail
 {
 /// @brief helper struct to create an expected which is signalling success more easily
 template <typename T = void>
-struct success
+struct ok
 {
     // AXIVION Next Construct AutosarC++19_03-A12.1.5 : This is a false positive since there is no fitting constructor
     // available for delegation
-    explicit success(const T& t) noexcept
+    explicit ok(const T& t) noexcept
         : value(t)
     {
     }
 
     // AXIVION Next Construct AutosarC++19_03-A18.9.2 : For universal references std::forward must be used
     template <typename U = T, typename = enable_if_not_lvalue_referece_t<U>>
-    explicit success(T&& t) noexcept
+    explicit ok(T&& t) noexcept
         : value(std::forward<T>(t))
     {
     }
 
-    // AXIVION Next Construct AutosarC++19_03-A15.4.2, FaultDetection-NoexceptViolations : Intentional behavior. 'success' is not intended to be used with a type which throws
+    // AXIVION Next Construct AutosarC++19_03-A15.4.2, FaultDetection-NoexceptViolations : Intentional behavior. 'ok' is not intended to be used with a type which throws
     template <typename... Targs>
-    explicit success(Targs&&... args) noexcept
+    explicit ok(Targs&&... args) noexcept
         : value(std::forward<Targs>(args)...)
     {
     }
@@ -75,7 +75,7 @@ struct success
 
 /// @brief helper struct to handle 'void' value type specialization
 template <>
-struct success<void>
+struct ok<void>
 {
     // dummy value
     bool value{true};
@@ -83,24 +83,24 @@ struct success<void>
 
 /// @brief helper struct to create an expected which is signalling an error more easily
 template <typename T>
-struct error
+struct err
 {
     // AXIVION Next Construct AutosarC++19_03-A12.1.5 : This is a false positive since there is no fitting constructor
     // available for delegation
-    explicit error(const T& t) noexcept
+    explicit err(const T& t) noexcept
         : value(t)
     {
     }
 
     // AXIVION Next Construct AutosarC++19_03-A18.9.2 : For universal references std::forward must be used
     template <typename U = T, typename = enable_if_not_lvalue_referece_t<U>>
-    explicit error(T&& t) noexcept
+    explicit err(T&& t) noexcept
         : value(std::forward<T>(t))
     {
     }
 
     template <typename... Targs>
-    explicit error(Targs&&... args) noexcept
+    explicit err(Targs&&... args) noexcept
         : value(std::forward<Targs>(args)...)
     {
     }

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/semantic_string.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/semantic_string.inl
@@ -133,7 +133,7 @@ template <typename Child,
           DoesContainInvalidContent<Capacity> DoesContainInvalidContentCall,
           DoesContainInvalidCharacter<Capacity> DoesContainInvalidCharacterCall>
 template <typename T>
-inline expected<SemanticStringError>
+inline expected<void, SemanticStringError>
 SemanticString<Child, Capacity, DoesContainInvalidContentCall, DoesContainInvalidCharacterCall>::append(
     const T& value) noexcept
 {
@@ -145,7 +145,7 @@ template <typename Child,
           DoesContainInvalidContent<Capacity> DoesContainInvalidContentCall,
           DoesContainInvalidCharacter<Capacity> DoesContainInvalidCharacterCall>
 template <typename T>
-inline expected<SemanticStringError>
+inline expected<void, SemanticStringError>
 SemanticString<Child, Capacity, DoesContainInvalidContentCall, DoesContainInvalidCharacterCall>::insert(
     const uint64_t pos, const T& str, const uint64_t count) noexcept
 {

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/semantic_string.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/semantic_string.inl
@@ -47,7 +47,7 @@ SemanticString<Child, Capacity, DoesContainInvalidContentCall, DoesContainInvali
     {
         IOX_LOG(DEBUG) << "Unable to create semantic string since the value \"" << value
                        << "\" exceeds the maximum valid length of " << Capacity << ".";
-        return iox::error<SemanticStringError>(SemanticStringError::ExceedsMaximumLength);
+        return err(SemanticStringError::ExceedsMaximumLength);
     }
 
     string<Capacity> str{TruncateToCapacity, value};
@@ -56,17 +56,17 @@ SemanticString<Child, Capacity, DoesContainInvalidContentCall, DoesContainInvali
     {
         IOX_LOG(DEBUG) << "Unable to create semantic string since the value \"" << value
                        << "\" contains invalid characters";
-        return iox::error<SemanticStringError>(SemanticStringError::ContainsInvalidCharacters);
+        return err(SemanticStringError::ContainsInvalidCharacters);
     }
 
     if (DoesContainInvalidContentCall(str))
     {
         IOX_LOG(DEBUG) << "Unable to create semantic string since the value \"" << value
                        << "\" contains invalid content";
-        return iox::error<SemanticStringError>(SemanticStringError::ContainsInvalidContent);
+        return err(SemanticStringError::ContainsInvalidContent);
     }
 
-    return iox::success<Child>(Child(str));
+    return ok(Child(str));
 }
 
 template <typename Child,
@@ -155,25 +155,25 @@ SemanticString<Child, Capacity, DoesContainInvalidContentCall, DoesContainInvali
         IOX_LOG(DEBUG) << "Unable to insert the value \"" << str
                        << "\" to the semantic string since it would exceed the maximum valid length of " << Capacity
                        << ".";
-        return iox::error<SemanticStringError>(SemanticStringError::ExceedsMaximumLength);
+        return err(SemanticStringError::ExceedsMaximumLength);
     }
 
     if (DoesContainInvalidCharacterCall(temp))
     {
         IOX_LOG(DEBUG) << "Unable to insert the value \"" << str
                        << "\" to the semantic string since it contains invalid characters.";
-        return iox::error<SemanticStringError>(SemanticStringError::ContainsInvalidCharacters);
+        return err(SemanticStringError::ContainsInvalidCharacters);
     }
 
     if (DoesContainInvalidContentCall(str))
     {
         IOX_LOG(DEBUG) << "Unable to insert the value \"" << str
                        << "\" to the semantic string since it would lead to invalid content.";
-        return iox::error<SemanticStringError>(SemanticStringError::ContainsInvalidContent);
+        return err(SemanticStringError::ContainsInvalidContent);
     }
 
     m_data = temp;
-    return iox::success<>();
+    return ok();
 }
 
 template <typename Child,

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -18,9 +18,9 @@
 #define IOX_HOOFS_VOCABULARY_EXPECTED_HPP
 
 #include "iox/attributes.hpp"
+#include "iox/detail/expected_helper.hpp"
 #include "iox/functional_interface.hpp"
 #include "iox/optional.hpp"
-#include "iox/variant.hpp"
 
 #include <utility>
 
@@ -57,9 +57,9 @@ struct success
     T value;
 };
 
-/// @brief helper struct to create an error only expected which is signalling success more easily
+/// @brief helper struct to handle 'void' value type specialization
 /// @code
-///     expected<float> callMe() {
+///     expected<void, float> callMe() {
 ///         //...
 ///         return success<>();
 ///     }
@@ -67,12 +67,14 @@ struct success
 template <>
 struct success<void>
 {
+    // dummy value
+    bool value{true};
 };
 
 /// @brief helper struct to create an expected which is signalling an error more easily
 /// @param T type which the success helper class should contain
 /// @code
-///     expected<float> callMe() {
+///     expected<void, float> callMe() {
 ///         //...
 ///         return error<float>(12.34f);
 ///     }
@@ -100,172 +102,16 @@ struct error
     T value;
 };
 
-template <typename... T>
-class IOX_NO_DISCARD expected;
+/// @brief helper trait for SFINEA to disable specific functions for 'void' value type
+/// @tparam ValueType type of the value which can be stored in the expected
+template <typename ValueType>
+using ExpectedValueTypeNonVoid = typename std::enable_if<!std::is_void<ValueType>::value, ValueType>::type;
 
-/// @brief expected implementation from the C++20 proposal with C++11. The interface
-///         is inspired by the proposal but it has changes since we are not allowed to
-///         throw an exception.
-/// @param ErrorType type of the error which can be stored in the expected
-///
-/// @code
-///     expected<int, float> callMe() {
-///         bool l_errorOccured;
-///         // ... do stuff
-///         if ( l_errorOccured ) {
-///             return error<float>(55.1f);
-///         } else if ( !l_errorOccured ) {
-///             return success<int>(123);
-///         }
-///     }
-///
-///     expected<float> errorOnlyMethod() {
-///         return callMe().or_else([]{
-///             IOX_LOG(ERROR) << "Error Occured\n";
-///             /// perform some action
-///         }).and_then([](expected<int, float> & result){
-///             IOX_LOG(INFO) << "Success, got " << result.value();
-///             /// perform some action
-///         });
-///     }
-///
-///     expected<std::vector<int>, int> allHailHypnotoad(success<std::vector<int>>({6,6,6}));
-///     allHailHypnotoad->push_back(7);
-/// @endcode
-template <typename ErrorType>
-class IOX_NO_DISCARD expected<ErrorType> final : public FunctionalInterface<expected<ErrorType>, void, ErrorType>
-{
-  public:
-    /// @brief default ctor is deleted since you have to clearly state if the
-    ///         expected contains a success value or an error value
-    expected() = delete;
-
-    /// @brief the copy constructor calls the copy constructor of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    expected(const expected&) noexcept = default;
-
-    /// @brief the move constructor calls the move constructor of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    /// @note The move c'tor does not explicitly invalidate the moved-from object but relies on the move c'tor of
-    /// ErrorType to correctly invalidate the stored object
-    expected(expected&& rhs) noexcept;
-
-    // AXIVION DISABLE STYLE AutosarC++19_03-A16.0.1: Required for Windows due to MSVC deficiencies
-#if defined(_WIN32)
-    /// @brief copy conversion constructor to convert an expected which contains value and
-    ///        error type to an expected which contains only an error
-    template <typename ValueType>
-    expected(const expected<ValueType, ErrorType>& rhs) noexcept;
-
-    /// @brief move conversion constructor to convert an expected which contains value and
-    ///        error type to an expected which contains only an error
-    template <typename ValueType>
-    expected(expected<ValueType, ErrorType>&& rhs) noexcept;
-#endif
-    /// @brief calls the destructor of the success value or error value - depending on what
-    ///         is stored in the expected
-    ~expected() noexcept = default;
-
-    /// @brief  calls the copy assignment operator of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    expected& operator=(const expected&) noexcept;
-
-    /// @brief  calls the move assignment operator of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    /// @note The move assignment operator does not explicitly invalidate the moved-from object but relies on the move
-    /// assignment operator of ErrorType to correctly invalidate the stored object
-    expected& operator=(expected&& rhs) noexcept;
-#if defined(_WIN32)
-    /// @brief  calls the copy assignment operator of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    template <typename ValueType>
-    expected& operator=(const expected<ValueType, ErrorType>& rhs) noexcept;
-
-    /// @brief  calls the move assignment operator of the contained success value
-    ///         or the error value - depending on what is stored in the expected
-    template <typename ValueType>
-    expected& operator=(expected<ValueType, ErrorType>&& rhs) noexcept;
-#endif
-    // AXIVION ENABLE STYLE AutosarC++19_03-A16.0.1
-    /// @brief  constructs an expected which is signaling success
-    /// @param[in] successValue value which will be stored in the expected
-    //
-    // we would like to use 'return success<MyType>(myValue)' with an implicit
-    // conversion to return an expected easily
-    // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const success<void>) noexcept;
-
-    /// @brief Creates an expected which is signaling success. This mirrors the c'tor for the 'expected' with a
-    /// 'ValueType'.
-    /// @param[in] in_place_t compile time variable to distinguish between constructors with certain behavior
-    explicit expected(in_place_t) noexcept;
-
-    /// @brief  constructs an expected which is signaling an error and stores the
-    ///         error value provided by errorValue
-    /// @param[in] errorValue error value which will be stored in the expected
-    ///
-    // we would like to use 'return error<MyErrorType>(myErrorValue)' with an implicit
-    // conversion to return an expected easily
-    // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const error<ErrorType>& errorValue) noexcept;
-
-    /// @brief  constructs an expected which is signaling an error and stores the
-    ///         error value provided by value
-    /// @param[in] errorValue error value which will be moved into the expected
-    //
-    // we would like to use 'return error<MyErrorType>(myErrorValue)' with an implicit
-    // conversion to return an expected easily
-    // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(error<ErrorType>&& errorValue) noexcept;
-
-    /// @brief  creates an expected which is signaling success
-    /// @return expected signalling success
-    static expected create_value() noexcept;
-
-    /// @brief  creates an expected which is signaling an error and perfectly forwards
-    ///         the args to the constructor of lErrorType
-    /// @param[in] args... arguments which will be forwarded to the ErrorType constructor
-    /// @return expected signalling error
-    template <typename... Targs>
-    static expected create_error(Targs&&... args) noexcept;
-
-    // AXIVION Next Construct AutosarC++19_03-A13.5.3: Implementation is inspired from std::expected
-    /// @brief  returns true if the expected does not contain an error otherwise false
-    /// @return bool which contains true if the expected contains an error
-    explicit operator bool() const noexcept;
-
-    /// @brief  returns true if the expected contains an error otherwise false
-    /// @return bool which contains true if the expected contains an error
-    bool has_error() const noexcept;
-
-    /// @brief  returns a reference to the contained error value, if the expected
-    ///         does not contain an error the error handler is called
-    /// @return reference to the internally contained error
-    ErrorType& get_error() & noexcept;
-
-    /// @brief  returns a const reference to the contained error value, if the expected
-    ///         does not contain an error the error handler is called
-    /// @return const reference to the internally contained error
-    const ErrorType& get_error() const& noexcept;
-
-    /// @brief  returns a rvalue reference to the contained error value, if the expected
-    ///         does not contain an error the error handler is called
-    /// @return rvalue reference to the internally contained error
-    ErrorType&& get_error() && noexcept;
-
-  private:
-    const ErrorType& get_error_unchecked() const noexcept;
-    explicit expected(variant<ErrorType>&& store) noexcept;
-    variant<ErrorType> m_store{};
-    static constexpr uint64_t ERROR_INDEX{0U};
-};
-
-/// @brief specialization of the expected class which can contain an error as well as a success value
+/// @brief Implementation of the C++23 expected class which can contain an error or a success value
 /// @param ValueType type of the value which can be stored in the expected
 /// @param ErrorType type of the error which can be stored in the expected
 template <typename ValueType, typename ErrorType>
-class IOX_NO_DISCARD expected<ValueType, ErrorType> final
-    : public FunctionalInterface<expected<ValueType, ErrorType>, ValueType, ErrorType>
+class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueType, ErrorType>, ValueType, ErrorType>
 {
   public:
     /// @brief default ctor is deleted since you have to clearly state if the
@@ -290,6 +136,14 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     template <typename... Targs>
     explicit expected(in_place_t, Targs&&... args) noexcept;
 
+    /// @brief Creates an expected which is signaling an error and perfectly forwards
+    ///        the args to the constructor of ErrorType
+    /// @tparam Targs is the template parameter pack for the perfectly forwarded arguments
+    /// @param[in] unexpect_t compile time variable to distinguish between constructors with certain behavior
+    /// @param[in] args... arguments which will be forwarded to the 'ErrorType' constructor
+    template <typename... Targs>
+    explicit expected(unexpect_t, Targs&&... args) noexcept;
+
     /// @brief calls the destructor of the success value or error value - depending on what
     ///         is stored in the expected
     ~expected() noexcept = default;
@@ -308,7 +162,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     ///         provided by successValue to copy construct its success value
     /// @param[in] successValue value which will be stored in the expected
     //
-    // we would like to use 'return success<MyType>(myValue)' with an implicit
+    // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(const success<ValueType>& successValue) noexcept;
@@ -317,7 +171,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     ///         provided by successValue to move construct its success value
     /// @param[in] successValue value which will be moved into the expected
     //
-    // we would like to use 'return success<MyType>(myValue)' with an implicit
+    // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(success<ValueType>&& successValue) noexcept;
@@ -326,7 +180,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     ///         error value provided by errorValue
     /// @param[in] errorValue error value which will be stored in the expected
     ///
-    // we would like to use 'return error<MyErrorType>(myErrorValue)' with an implicit
+    // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(const error<ErrorType>& errorValue) noexcept;
@@ -335,7 +189,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     ///         error value provided by errorValue
     /// @param[in] errorValue error value which will be moved into the expected
     ///
-    // we would like to use 'return error<MyErrorType>(myErrorValue)' with an implicit
+    // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(error<ErrorType>&& errorValue) noexcept;
@@ -353,6 +207,7 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     /// @return expected signalling error
     template <typename... Targs>
     static expected create_error(Targs&&... args) noexcept;
+
     // AXIVION Next Construct AutosarC++19_03-A13.5.3: Implementation is inspired from std::expected
     /// @brief  returns true if the expected does not contain an error otherwise false
     /// @return bool which contains true if the expected contains an error
@@ -367,7 +222,6 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
     /// @return reference to the internally contained error
     ErrorType& get_error() & noexcept;
 
-
     /// @brief  returns a const reference to the contained error value, if the expected
     ///         does not contain an error the error handler is called
     /// @return const reference to the internally contained error
@@ -380,109 +234,107 @@ class IOX_NO_DISCARD expected<ValueType, ErrorType> final
 
     /// @brief  returns a reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return reference to the internally contained value
-    ValueType& value() & noexcept;
+    /// @note this only works for non void ValueTypes
+    template <typename U = ValueType>
+    ExpectedValueTypeNonVoid<U>& value() & noexcept;
 
     /// @brief  returns a const reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return const reference to the internally contained value
-    const ValueType& value() const& noexcept;
+    /// @note this only works for non void ValueTypes
+    template <typename U = ValueType>
+    const ExpectedValueTypeNonVoid<U>& value() const& noexcept;
 
     /// @brief  returns a reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return rvalue reference to the internally contained value
-    ValueType&& value() && noexcept;
+    template <typename U = ValueType>
+    ExpectedValueTypeNonVoid<U>&& value() && noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
     ///         success value. if the expected contains an error the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return reference to the contained value
+    /// @note this only works for non void ValueTypes
     /// @code
-    ///     expected<int, float> frodo(success<int>(45));
+    ///     expected<int, float> frodo(ok(45));
     ///     *frodo += 12;
     ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
-    ValueType& operator*() noexcept;
+    template <typename U = ValueType>
+    ExpectedValueTypeNonVoid<U>& operator*() noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
     ///         success value. if the expected contains an error the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return const reference to the contained value
+    /// @note this only works for non void ValueTypes
     /// @code
-    ///     expected<int, float> frodo(success<int>(45));
+    ///     expected<int, float> frodo(ok(45));
     ///     *frodo += 12;
     ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
-    const ValueType& operator*() const noexcept;
+    template <typename U = ValueType>
+    const ExpectedValueTypeNonVoid<U>& operator*() const noexcept;
 
     /// @brief arrow operator which returns the pointer to the contained success value
     ///         if the expected contains an error the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return pointer of type ValueType to the contained value
+    /// @note this only works for non void ValueTypes
     /// @code
-    ///     expected<std::vector<int>, int> holyPiotr(success<std::vector<int>>({1,2,3}));
+    ///     expected<std::vector<int>, int> holyPiotr(ok<std::vector<int>>({1,2,3}));
     ///     holyPiotr->push_back(4);
     /// @endcode
-    ValueType* operator->() noexcept;
+    template <typename U = ValueType>
+    ExpectedValueTypeNonVoid<U>* operator->() noexcept;
 
     /// @brief arrow operator which returns the pointer to the contained success value
     ///         if the expected contains an error the the error handler is called
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return pointer of type const ValueType to the contained value
+    /// @note this only works for non void ValueTypes
     /// @code
-    ///     expected<std::vector<int>, int> holyPiotr(success<std::vector<int>>({1,2,3}));
+    ///     expected<std::vector<int>, int> holyPiotr(ok<std::vector<int>>({1,2,3}));
     ///     holyPiotr->push_back(4);
     /// @endcode
-    const ValueType* operator->() const noexcept;
+    template <typename U = ValueType>
+    const ExpectedValueTypeNonVoid<U>* operator->() const noexcept;
 
-    /// @brief conversion operator to an error only expected which can be useful
+    /// @brief conversion operator to a 'void' value type expected which can be useful
     ///         if you would like to return only the success of a function
     /// @return converts an expected which can contain a value and an error to an
     ///         expected which contains only an error
     /// @code
     ///     expected<int, int> someErrorProneFunction(){}
     ///
-    ///     expected<int> isItSuccessful() {
+    ///     expected<void, int> isItSuccessful() {
     ///         return someErrorProneFunction();
     ///     }
     /// @endcode
     //
     // AXIVION Next Construct AutosarC++19_03-A13.5.2 , AutosarC++19_03-A13.5.3: see doxygen brief section
-    template <typename T>
+    // template <typename E>
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    operator expected<T>() const noexcept;
+    operator expected<void, ErrorType>() const noexcept;
 
     /// @brief conversion operator to an optional.
+    /// @tparam U helper temlate parameter for SFINEA
     /// @return optional containing the value if the expected contains a value, otherwise a nullopt
-    optional<ValueType> to_optional() const noexcept;
+    /// @note this only works for non void ValueTypes
+    template <typename U = ValueType>
+    optional<ExpectedValueTypeNonVoid<U>> to_optional() const noexcept;
+
+    template <typename T, typename E>
+    friend constexpr bool ::iox::operator==(const expected<T, E>&, const expected<T, E>&) noexcept;
 
   private:
-    explicit expected(variant<ValueType, ErrorType>&& store) noexcept;
-    const ErrorType& get_error_unchecked() const noexcept;
-    const ValueType& value_unchecked() const noexcept;
-    variant<ValueType, ErrorType> m_store;
-    static constexpr uint64_t VALUE_INDEX{0U};
-    static constexpr uint64_t ERROR_INDEX{1U};
+    detail::expected_storage<ValueType, ErrorType> m_store;
 };
-
-template <typename ErrorType>
-class IOX_NO_DISCARD expected<void, ErrorType> : public expected<ErrorType>
-{
-  public:
-    using expected<ErrorType>::expected;
-};
-
-/// @brief equality check for two distinct expected types
-/// @tparam ErrorType type of the error stored in the expected
-/// @param[in] lhs left side of the comparison
-/// @param[in] rhs right side of the comparison
-/// @return true if the expecteds are equal, otherwise false
-template <typename ErrorType>
-constexpr bool operator==(const expected<ErrorType>& lhs, const expected<ErrorType>& rhs) noexcept;
-
-/// @brief inequality check for two distinct expected types
-/// @tparam ErrorType type of the error stored in the expected
-/// @param[in] lhs left side of the comparison
-/// @param[in] rhs right side of the comparison
-/// @return true if the expecteds are not equal, otherwise false
-template <typename ErrorType>
-constexpr bool operator!=(const expected<ErrorType>& lhs, const expected<ErrorType>& rhs) noexcept;
 
 /// @brief equality check for two distinct expected types
 /// @tparam ValueType type of the value stored in the expected

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -253,28 +253,35 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     /// @deprecated use 'error' instead of 'get_error'
     ErrorType&& get_error() && noexcept;
 
-    /// @brief  returns a reference to the contained success value, if the expected
+    /// @brief  returns a lvalue reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
     /// @tparam U helper template parameter for SFINEA
-    /// @return reference to the internally contained value
+    /// @return lvalue reference to the internally contained value
     /// @note this only works for non void ValueTypes
     template <typename U = ValueType>
     enable_if_non_void_t<U>& value() & noexcept;
 
-    /// @brief  returns a const reference to the contained success value, if the expected
+    /// @brief  returns a const lvalue reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
     /// @tparam U helper template parameter for SFINEA
-    /// @return const reference to the internally contained value
+    /// @return const lvalue reference to the internally contained value
     /// @note this only works for non void ValueTypes
     template <typename U = ValueType>
     const enable_if_non_void_t<U>& value() const& noexcept;
 
-    /// @brief  returns a reference to the contained success value, if the expected
+    /// @brief  returns a rvalue reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
     /// @tparam U helper template parameter for SFINEA
     /// @return rvalue reference to the internally contained value
     template <typename U = ValueType>
     enable_if_non_void_t<U>&& value() && noexcept;
+
+    /// @brief  returns a const rvalue reference to the contained success value, if the expected
+    ///         does not contain a success value the error handler is called
+    /// @tparam U helper template parameter for SFINEA
+    /// @return const rvalue reference to the internally contained value
+    template <typename U = ValueType>
+    const enable_if_non_void_t<U>&& value() const&& noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
     ///         success value. if the expected contains an error the error handler is called
@@ -354,6 +361,11 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     friend constexpr bool ::iox::operator==(const expected<T, E>&, const expected<T, E>&) noexcept;
 
   private:
+    template <typename U = ValueType>
+    enable_if_non_void_t<U>& value_checked() & noexcept;
+    template <typename U = ValueType>
+    const enable_if_non_void_t<U>& value_checked() const& noexcept;
+
     ErrorType& error_checked() & noexcept;
     const ErrorType& error_checked() const& noexcept;
 

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -33,7 +33,7 @@ template <typename T>
 using error = detail::err<T>;
 
 /// @brief convenience function to create an 'expected' with a 'void' value type
-/// @param T helper template parameter for SFINEA
+/// @tparam T helper template parameter for SFINEA
 /// @code
 ///     expected<void, uint64_t> callMe() {
 ///         //...
@@ -44,7 +44,8 @@ template <typename T = void, typename = enable_if_void_t<T>>
 detail::ok<void> ok();
 
 /// @brief convenience function to create an 'expected' with a value type by copy
-/// @param T value type for the 'expected'
+/// @tparam T value type for the 'expected'
+/// @param[in] value is the value for the 'expected'
 /// @code
 ///     expected<bool, uint64_t> callMe() {
 ///         //...
@@ -55,7 +56,8 @@ template <typename T, typename = enable_if_non_void_t<T>>
 detail::ok<T> ok(const T& value);
 
 /// @brief convenience function to create an 'expected' with a value type by move
-/// @param T value type for the 'expected'
+/// @tparam T value type for the 'expected'
+/// @param[in] value is the value for the 'expected'
 /// @code
 ///     expected<MyClass, uint64_t> callMe() {
 ///         //...
@@ -68,7 +70,9 @@ template <typename T, typename = enable_if_non_void_t<T>, typename = enable_if_n
 detail::ok<T> ok(T&& value);
 
 /// @brief convenience function to create an 'expected' with a value type by argument forwarding
-/// @param T value type for the 'expected'
+/// @tparam T value type for the 'expected'
+/// @tparam Targs types for the constructor of the value type
+/// @param[in] args... arguments which will be perfectly forwarded to the value type constructor
 /// @code
 ///     expected<SomeClass, uint64_t> callMe() {
 ///         //...
@@ -79,7 +83,8 @@ template <typename T, typename... Targs, typename = enable_if_non_void_t<T>>
 detail::ok<T> ok(Targs&&... args);
 
 /// @brief convenience function to create an 'expected' with an error type by copy
-/// @param T error type for the 'expected'
+/// @tparam T error type for the 'expected'
+/// @param[in] error is the error for the 'expected'
 /// @code
 ///     expected<bool, uint64_t> callMe() {
 ///         //...
@@ -87,10 +92,11 @@ detail::ok<T> ok(Targs&&... args);
 ///     }
 /// @endcode
 template <typename T>
-detail::err<T> err(const T& value);
+detail::err<T> err(const T& error);
 
 /// @brief convenience function to create an 'expected' with an error type by move
-/// @param T error type for the 'expected'
+/// @tparam T error type for the 'expected'
+/// @param[in] error is the error for the 'expected'
 /// @code
 ///     expected<bool, MyError> callMe() {
 ///         //...
@@ -100,10 +106,12 @@ detail::err<T> err(const T& value);
 ///     }
 /// @endcode
 template <typename T, typename = enable_if_not_lvalue_referece_t<T>>
-detail::err<T> err(T&& value);
+detail::err<T> err(T&& error);
 
 /// @brief convenience function to create an 'expected' with an error type by argument forwarding
-/// @param T error type for the 'expected'
+/// @tparam T error type for the 'expected'
+/// @tparam Targs types for the constructor of the error type
+/// @param[in] args... arguments which will be perfectly forwarded to the error type constructor
 /// @code
 ///     expected<bool, SomeError> callMe() {
 ///         //...

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -221,19 +221,36 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     /// @return bool which contains true if the expected contains an error
     bool has_error() const noexcept;
 
-    /// @brief  returns a reference to the contained error value, if the expected
+    /// @brief  returns a lvalue reference to the contained error value, if the expected
     ///         does not contain an error the error handler is called
-    /// @return reference to the internally contained error
-    ErrorType& get_error() & noexcept;
+    /// @return lvalue reference to the internally contained error
+    ErrorType& error() & noexcept;
 
-    /// @brief  returns a const reference to the contained error value, if the expected
+    /// @brief  returns a const lvalue reference to the contained error value, if the expected
     ///         does not contain an error the error handler is called
-    /// @return const reference to the internally contained error
-    const ErrorType& get_error() const& noexcept;
+    /// @return const lvalue reference to the internally contained error
+    const ErrorType& error() const& noexcept;
 
     /// @brief  returns a rvalue reference to the contained error value, if the expected
     ///         does not contain an error the error handler is called
     /// @return rvalue reference to the internally contained error
+    ErrorType&& error() && noexcept;
+
+    /// @brief  returns a const rvalue reference to the contained error value, if the expected
+    ///         does not contain an error the error handler is called
+    /// @return const rvalue reference to the internally contained error
+    const ErrorType&& error() const&& noexcept;
+
+    /// @copydoc expected::error()&
+    /// @deprecated use 'error' instead of 'get_error'
+    ErrorType& get_error() & noexcept;
+
+    /// @copydoc expected::error()const&
+    /// @deprecated use 'error' instead of 'get_error'
+    const ErrorType& get_error() const& noexcept;
+
+    /// @copydoc expected::error()&&
+    /// @deprecated use 'error' instead of 'get_error'
     ErrorType&& get_error() && noexcept;
 
     /// @brief  returns a reference to the contained success value, if the expected
@@ -335,6 +352,10 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
 
     template <typename T, typename E>
     friend constexpr bool ::iox::operator==(const expected<T, E>&, const expected<T, E>&) noexcept;
+
+  private:
+    ErrorType& error_checked() & noexcept;
+    const ErrorType& error_checked() const& noexcept;
 
   private:
     detail::expected_storage<ValueType, ErrorType> m_store;

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -26,86 +26,92 @@
 
 namespace iox
 {
-/// @brief helper struct to create an expected which is signalling success more easily
-/// @param T type which the success helper class should contain
-/// @code
-///     expected<int, float> callMe() {
-///         //...
-///         return success<int>(55);
-///     }
-/// @endcode
 template <typename T = void>
-struct success
-{
-    /// @brief constructor which creates a success helper class by copying
-    ///         the value of t
-    /// @param[in] t value which should be later stored in an expected
-    explicit success(const T& t) noexcept;
+using success = detail::success<T>;
 
-    /// @brief constructor which creates a success helper class by moving
-    ///         the value of t
-    /// @param[in] t value which should be later moved into an expected
-    explicit success(T&& t) noexcept;
-    template <typename... Targs>
+template <typename T>
+using error = detail::error<T>;
 
-    /// @brief constructor which creates a success helper class by forwarding
-    ///         arguments to the constructor of T
-    /// @param[in] args... arguments which will be perfectly forwarded to the
-    ///                     constructor
-    explicit success(Targs&&... args) noexcept;
-
-    T value;
-};
-
-/// @brief helper struct to handle 'void' value type specialization
+/// @brief convenience function to create an 'expected' with a 'void' value type
+/// @param T helper template parameter for SFINEA
 /// @code
-///     expected<void, float> callMe() {
+///     expected<void, uint64_t> callMe() {
 ///         //...
-///         return success<>();
+///         return ok();
 ///     }
 /// @endcode
-template <>
-struct success<void>
-{
-    // dummy value
-    bool value{true};
-};
+template <typename T = void, typename = enable_if_void_t<T>>
+detail::success<void> ok();
 
-/// @brief helper struct to create an expected which is signalling an error more easily
-/// @param T type which the success helper class should contain
+/// @brief convenience function to create an 'expected' with a value type by copy
+/// @param T value type for the 'expected'
 /// @code
-///     expected<void, float> callMe() {
+///     expected<bool, uint64_t> callMe() {
 ///         //...
-///         return error<float>(12.34f);
+///         return ok(true);
+///     }
+/// @endcode
+template <typename T, typename = enable_if_non_void_t<T>>
+detail::success<T> ok(const T& value);
+
+/// @brief convenience function to create an 'expected' with a value type by move
+/// @param T value type for the 'expected'
+/// @code
+///     expected<MyClass, uint64_t> callMe() {
+///         //...
+///         MyClass m;
+///         //...
+///         return ok(std::move(m));
+///     }
+/// @endcode
+template <typename T, typename = enable_if_non_void_t<T>, typename = enable_if_not_lvalue_referece_t<T>>
+detail::success<T> ok(T&& value);
+
+/// @brief convenience function to create an 'expected' with a value type by argument forwarding
+/// @param T value type for the 'expected'
+/// @code
+///     expected<SomeClass, uint64_t> callMe() {
+///         //...
+///         return ok<SomeClass>(42, 73);
+///     }
+/// @endcode
+template <typename T, typename... Targs, typename = enable_if_non_void_t<T>>
+detail::success<T> ok(Targs&&... args);
+
+/// @brief convenience function to create an 'expected' with an error type by copy
+/// @param T error type for the 'expected'
+/// @code
+///     expected<bool, uint64_t> callMe() {
+///         //...
+///         return err(37);
 ///     }
 /// @endcode
 template <typename T>
-struct error
-{
-    /// @brief constructor which creates a error helper class by copying
-    ///         the value of t
-    /// @param[in] t value which should be later stored in an expected
-    explicit error(const T& t) noexcept;
+detail::error<T> err(const T& value);
 
-    /// @brief constructor which creates a error helper class by moving
-    ///         the value of t
-    /// @param[in] t value which should be later moved into an expected
-    explicit error(T&& t) noexcept;
+/// @brief convenience function to create an 'expected' with an error type by move
+/// @param T error type for the 'expected'
+/// @code
+///     expected<bool, MyError> callMe() {
+///         //...
+///         MyError e;
+///         //...
+///         return err(std::move(e));
+///     }
+/// @endcode
+template <typename T, typename = enable_if_not_lvalue_referece_t<T>>
+detail::error<T> err(T&& value);
 
-    /// @brief constructor which creates a error helper class by forwarding
-    ///         arguments to the constructor of T
-    /// @param[in] args... arguments which will be perfectly forwarded to the
-    ///                     constructor
-    template <typename... Targs>
-    explicit error(Targs&&... args) noexcept;
-
-    T value;
-};
-
-/// @brief helper trait for SFINEA to disable specific functions for 'void' value type
-/// @tparam ValueType type of the value which can be stored in the expected
-template <typename ValueType>
-using ExpectedValueTypeNonVoid = typename std::enable_if<!std::is_void<ValueType>::value, ValueType>::type;
+/// @brief convenience function to create an 'expected' with an error type by argument forwarding
+/// @param T error type for the 'expected'
+/// @code
+///     expected<bool, SomeError> callMe() {
+///         //...
+///         return err<SomeError>(13, "Friday");
+///     }
+/// @endcode
+template <typename T, typename... Targs>
+detail::error<T> err(Targs&&... args);
 
 /// @brief Implementation of the C++23 expected class which can contain an error or a success value
 /// @param ValueType type of the value which can be stored in the expected
@@ -165,7 +171,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const success<ValueType>& successValue) noexcept;
+    expected(const detail::success<ValueType>& successValue) noexcept;
 
     /// @brief  constructs an expected which is signaling success and uses the value
     ///         provided by successValue to move construct its success value
@@ -174,7 +180,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(success<ValueType>&& successValue) noexcept;
+    expected(detail::success<ValueType>&& successValue) noexcept;
 
     /// @brief  constructs an expected which is signaling an error and stores the
     ///         error value provided by errorValue
@@ -183,7 +189,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const error<ErrorType>& errorValue) noexcept;
+    expected(const detail::error<ErrorType>& errorValue) noexcept;
 
     /// @brief  constructs an expected which is signaling an error and stores the
     ///         error value provided by errorValue
@@ -192,7 +198,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(error<ErrorType>&& errorValue) noexcept;
+    expected(detail::error<ErrorType>&& errorValue) noexcept;
 
     /// @brief  creates an expected which is signaling success and perfectly forwards
     ///         the args to the constructor of ValueType
@@ -234,30 +240,30 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
 
     /// @brief  returns a reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return reference to the internally contained value
     /// @note this only works for non void ValueTypes
     template <typename U = ValueType>
-    ExpectedValueTypeNonVoid<U>& value() & noexcept;
+    enable_if_non_void_t<U>& value() & noexcept;
 
     /// @brief  returns a const reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return const reference to the internally contained value
     /// @note this only works for non void ValueTypes
     template <typename U = ValueType>
-    const ExpectedValueTypeNonVoid<U>& value() const& noexcept;
+    const enable_if_non_void_t<U>& value() const& noexcept;
 
     /// @brief  returns a reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return rvalue reference to the internally contained value
     template <typename U = ValueType>
-    ExpectedValueTypeNonVoid<U>&& value() && noexcept;
+    enable_if_non_void_t<U>&& value() && noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
     ///         success value. if the expected contains an error the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return reference to the contained value
     /// @note this only works for non void ValueTypes
     /// @code
@@ -266,11 +272,11 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
     template <typename U = ValueType>
-    ExpectedValueTypeNonVoid<U>& operator*() noexcept;
+    enable_if_non_void_t<U>& operator*() noexcept;
 
     /// @brief dereferencing operator which returns a reference to the contained
     ///         success value. if the expected contains an error the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return const reference to the contained value
     /// @note this only works for non void ValueTypes
     /// @code
@@ -279,11 +285,11 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     ///     IOX_LOG(INFO) << *frodo; // prints 57
     /// @endcode
     template <typename U = ValueType>
-    const ExpectedValueTypeNonVoid<U>& operator*() const noexcept;
+    const enable_if_non_void_t<U>& operator*() const noexcept;
 
     /// @brief arrow operator which returns the pointer to the contained success value
     ///         if the expected contains an error the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return pointer of type ValueType to the contained value
     /// @note this only works for non void ValueTypes
     /// @code
@@ -291,11 +297,11 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     ///     holyPiotr->push_back(4);
     /// @endcode
     template <typename U = ValueType>
-    ExpectedValueTypeNonVoid<U>* operator->() noexcept;
+    enable_if_non_void_t<U>* operator->() noexcept;
 
     /// @brief arrow operator which returns the pointer to the contained success value
     ///         if the expected contains an error the the error handler is called
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return pointer of type const ValueType to the contained value
     /// @note this only works for non void ValueTypes
     /// @code
@@ -303,7 +309,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     ///     holyPiotr->push_back(4);
     /// @endcode
     template <typename U = ValueType>
-    const ExpectedValueTypeNonVoid<U>* operator->() const noexcept;
+    const enable_if_non_void_t<U>* operator->() const noexcept;
 
     /// @brief conversion operator to a 'void' value type expected which can be useful
     ///         if you would like to return only the success of a function
@@ -323,11 +329,11 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     operator expected<void, ErrorType>() const noexcept;
 
     /// @brief conversion operator to an optional.
-    /// @tparam U helper temlate parameter for SFINEA
+    /// @tparam U helper template parameter for SFINEA
     /// @return optional containing the value if the expected contains a value, otherwise a nullopt
     /// @note this only works for non void ValueTypes
     template <typename U = ValueType>
-    optional<ExpectedValueTypeNonVoid<U>> to_optional() const noexcept;
+    optional<enable_if_non_void_t<U>> to_optional() const noexcept;
 
     template <typename T, typename E>
     friend constexpr bool ::iox::operator==(const expected<T, E>&, const expected<T, E>&) noexcept;

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -243,15 +243,15 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
 
     /// @copydoc expected::error()&
     /// @deprecated use 'error' instead of 'get_error'
-    ErrorType& get_error() & noexcept;
+    [[deprecated("Use 'error' instead of 'get_error'")]] ErrorType& get_error() & noexcept;
 
     /// @copydoc expected::error()const&
     /// @deprecated use 'error' instead of 'get_error'
-    const ErrorType& get_error() const& noexcept;
+    [[deprecated("Use 'error' instead of 'get_error'")]] const ErrorType& get_error() const& noexcept;
 
     /// @copydoc expected::error()&&
     /// @deprecated use 'error' instead of 'get_error'
-    ErrorType&& get_error() && noexcept;
+    [[deprecated("Use 'error' instead of 'get_error'")]] ErrorType&& get_error() && noexcept;
 
     /// @brief  returns a lvalue reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -209,9 +209,13 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     expected(detail::err<ErrorType>&& errorValue) noexcept;
 
     // AXIVION Next Construct AutosarC++19_03-A13.5.3: Implementation is inspired from std::expected
-    /// @brief  returns true if the expected does not contain an error otherwise false
+    /// @brief  returns true if the expected contains a value type and false if it is an error type
     /// @return bool which contains true if the expected contains an error
     explicit operator bool() const noexcept;
+
+    /// @brief  returns true if the expected contains a value type and false if it is an error type
+    /// @return bool which contains true if the expected contains an error
+    bool has_value() const noexcept;
 
     /// @brief  returns true if the expected contains an error otherwise false
     /// @return bool which contains true if the expected contains an error

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -27,10 +27,10 @@
 namespace iox
 {
 template <typename T = void>
-using success = detail::success<T>;
+using success = detail::ok<T>;
 
 template <typename T>
-using error = detail::error<T>;
+using error = detail::err<T>;
 
 /// @brief convenience function to create an 'expected' with a 'void' value type
 /// @param T helper template parameter for SFINEA
@@ -41,7 +41,7 @@ using error = detail::error<T>;
 ///     }
 /// @endcode
 template <typename T = void, typename = enable_if_void_t<T>>
-detail::success<void> ok();
+detail::ok<void> ok();
 
 /// @brief convenience function to create an 'expected' with a value type by copy
 /// @param T value type for the 'expected'
@@ -52,7 +52,7 @@ detail::success<void> ok();
 ///     }
 /// @endcode
 template <typename T, typename = enable_if_non_void_t<T>>
-detail::success<T> ok(const T& value);
+detail::ok<T> ok(const T& value);
 
 /// @brief convenience function to create an 'expected' with a value type by move
 /// @param T value type for the 'expected'
@@ -65,7 +65,7 @@ detail::success<T> ok(const T& value);
 ///     }
 /// @endcode
 template <typename T, typename = enable_if_non_void_t<T>, typename = enable_if_not_lvalue_referece_t<T>>
-detail::success<T> ok(T&& value);
+detail::ok<T> ok(T&& value);
 
 /// @brief convenience function to create an 'expected' with a value type by argument forwarding
 /// @param T value type for the 'expected'
@@ -76,7 +76,7 @@ detail::success<T> ok(T&& value);
 ///     }
 /// @endcode
 template <typename T, typename... Targs, typename = enable_if_non_void_t<T>>
-detail::success<T> ok(Targs&&... args);
+detail::ok<T> ok(Targs&&... args);
 
 /// @brief convenience function to create an 'expected' with an error type by copy
 /// @param T error type for the 'expected'
@@ -87,7 +87,7 @@ detail::success<T> ok(Targs&&... args);
 ///     }
 /// @endcode
 template <typename T>
-detail::error<T> err(const T& value);
+detail::err<T> err(const T& value);
 
 /// @brief convenience function to create an 'expected' with an error type by move
 /// @param T error type for the 'expected'
@@ -100,7 +100,7 @@ detail::error<T> err(const T& value);
 ///     }
 /// @endcode
 template <typename T, typename = enable_if_not_lvalue_referece_t<T>>
-detail::error<T> err(T&& value);
+detail::err<T> err(T&& value);
 
 /// @brief convenience function to create an 'expected' with an error type by argument forwarding
 /// @param T error type for the 'expected'
@@ -111,7 +111,7 @@ detail::error<T> err(T&& value);
 ///     }
 /// @endcode
 template <typename T, typename... Targs>
-detail::error<T> err(Targs&&... args);
+detail::err<T> err(Targs&&... args);
 
 /// @brief Implementation of the C++23 expected class which can contain an error or a success value
 /// @param ValueType type of the value which can be stored in the expected
@@ -171,7 +171,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const detail::success<ValueType>& successValue) noexcept;
+    expected(const detail::ok<ValueType>& successValue) noexcept;
 
     /// @brief  constructs an expected which is signaling success and uses the value
     ///         provided by successValue to move construct its success value
@@ -180,7 +180,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return ok(myValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(detail::success<ValueType>&& successValue) noexcept;
+    expected(detail::ok<ValueType>&& successValue) noexcept;
 
     /// @brief  constructs an expected which is signaling an error and stores the
     ///         error value provided by errorValue
@@ -189,7 +189,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(const detail::error<ErrorType>& errorValue) noexcept;
+    expected(const detail::err<ErrorType>& errorValue) noexcept;
 
     /// @brief  constructs an expected which is signaling an error and stores the
     ///         error value provided by errorValue
@@ -198,7 +198,7 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // we would like to use 'return err(myErrorValue)' with an implicit
     // conversion to return an expected easily
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
-    expected(detail::error<ErrorType>&& errorValue) noexcept;
+    expected(detail::err<ErrorType>&& errorValue) noexcept;
 
     /// @brief  creates an expected which is signaling success and perfectly forwards
     ///         the args to the constructor of ValueType

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -208,20 +208,6 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
     // NOLINTNEXTLINE(hicpp-explicit-conversions)
     expected(detail::err<ErrorType>&& errorValue) noexcept;
 
-    /// @brief  creates an expected which is signaling success and perfectly forwards
-    ///         the args to the constructor of ValueType
-    /// @param[in] args... arguments which will be forwarded to the ValueType constructor
-    /// @return expected signalling success
-    template <typename... Targs>
-    static expected create_value(Targs&&... args) noexcept;
-
-    /// @brief  creates an expected which is signaling an error and perfectly forwards
-    ///         the args to the constructor of ErrorType
-    /// @param[in] args... arguments which will be forwarded to the ErrorType constructor
-    /// @return expected signalling error
-    template <typename... Targs>
-    static expected create_error(Targs&&... args) noexcept;
-
     // AXIVION Next Construct AutosarC++19_03-A13.5.3: Implementation is inspired from std::expected
     /// @brief  returns true if the expected does not contain an error otherwise false
     /// @return bool which contains true if the expected contains an error

--- a/iceoryx_hoofs/vocabulary/include/iox/semantic_string.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/semantic_string.hpp
@@ -115,7 +115,7 @@ class SemanticString
     /// @param[in] value the value which should be added
     /// @return on failure the error inside the expected describes the failure
     template <typename T>
-    expected<SemanticStringError> append(const T& value) noexcept;
+    expected<void, SemanticStringError> append(const T& value) noexcept;
 
     /// @brief Inserts another string into the SemanticString. If the value contains
     ///        invalid characters or the result would end up in invalid content
@@ -125,7 +125,7 @@ class SemanticString
     /// @param[in] count how many characters of str shall be inserted
     /// @return on failure the error inside the expected describes the failure
     template <typename T>
-    expected<SemanticStringError> insert(const uint64_t pos, const T& str, const uint64_t count) noexcept;
+    expected<void, SemanticStringError> insert(const uint64_t pos, const T& str, const uint64_t count) noexcept;
 
     /// @brief checks if another SemanticString is equal to this string
     /// @param [in] rhs the other SemanticString

--- a/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
@@ -135,7 +135,7 @@ class GatewayGeneric : public gateway_t
     /// @param service The service whose channels hiould be discarded.
     /// @return an empty expected on success, otherwise an error
     ///
-    expected<GatewayError> discardChannel(const capro::ServiceDescription& service) noexcept;
+    expected<void, GatewayError> discardChannel(const capro::ServiceDescription& service) noexcept;
 
   private:
     ConcurrentChannelVector m_channels;

--- a/iceoryx_posh/include/iceoryx_posh/gateway/toml_gateway_config_parser.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/toml_gateway_config_parser.hpp
@@ -70,8 +70,8 @@ class TomlGatewayConfigParser
     static expected<GatewayConfig, TomlGatewayConfigParseError> parse(std::istream& stream) noexcept;
 
   protected:
-    static expected<TomlGatewayConfigParseError> parse(std::istream& stream, GatewayConfig& config) noexcept;
-    static expected<TomlGatewayConfigParseError> validate(const cpptoml::table& parsedToml) noexcept;
+    static expected<void, TomlGatewayConfigParseError> parse(std::istream& stream, GatewayConfig& config) noexcept;
+    static expected<void, TomlGatewayConfigParseError> validate(const cpptoml::table& parsedToml) noexcept;
 
   private:
     static bool hasInvalidCharacter(const std::string& s) noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
@@ -66,13 +66,13 @@ Channel<IceoryxTerminal, ExternalTerminal>::create(const capro::ServiceDescripti
                                                            std::forward<const IceoryxPubSubOptions&>(options));
     if (rawIceoryxTerminalPtr == nullptr)
     {
-        return error<ChannelError>(ChannelError::OBJECT_POOL_FULL);
+        return err(ChannelError::OBJECT_POOL_FULL);
     }
     auto rawExternalTerminalPtr = s_externalTerminals.create(
         service.getServiceIDString(), service.getInstanceIDString(), service.getEventIDString());
     if (rawExternalTerminalPtr == nullptr)
     {
-        return error<ChannelError>(ChannelError::OBJECT_POOL_FULL);
+        return err(ChannelError::OBJECT_POOL_FULL);
     }
 
     // Wrap in smart pointer with custom deleter to ensure automatic cleanup.
@@ -81,7 +81,7 @@ Channel<IceoryxTerminal, ExternalTerminal>::create(const capro::ServiceDescripti
     auto externalTerminalPtr =
         ExternalTerminalPtr(rawExternalTerminalPtr, [](ExternalTerminal* const p) { s_externalTerminals.free(p); });
 
-    return success<Channel>(Channel(service, iceoryxTerminalPtr, externalTerminalPtr));
+    return ok(Channel(service, iceoryxTerminalPtr, externalTerminalPtr));
 }
 
 template <typename IceoryxTerminal, typename ExternalTerminal>

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -145,7 +145,7 @@ inline void GatewayGeneric<channel_t, gateway_t>::forEachChannel(const function_
 }
 
 template <typename channel_t, typename gateway_t>
-inline expected<GatewayError>
+inline expected<void, GatewayError>
 GatewayGeneric<channel_t, gateway_t>::discardChannel(const capro::ServiceDescription& service) noexcept
 {
     auto guardedVector = this->m_channels.getScopeGuard();

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -86,14 +86,14 @@ GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription
         || service.getInstanceIDString() == capro::IdString_t(TruncateToCapacity, "*")
         || service.getEventIDString() == capro::IdString_t(TruncateToCapacity, "*"))
     {
-        return error<GatewayError>(GatewayError::UNSUPPORTED_SERVICE_TYPE);
+        return err(GatewayError::UNSUPPORTED_SERVICE_TYPE);
     }
 
     // Return existing channel if one for the service already exists, otherwise create a new one
     auto existingChannel = findChannel(service);
     if (existingChannel.has_value())
     {
-        return success<channel_t>(existingChannel.value());
+        return ok(existingChannel.value());
     }
     else
     {
@@ -105,13 +105,13 @@ GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription
                                         options);
         if (result.has_error())
         {
-            return error<GatewayError>(GatewayError::UNSUCCESSFUL_CHANNEL_CREATION);
+            return err(GatewayError::UNSUCCESSFUL_CHANNEL_CREATION);
         }
         else
         {
             auto channel = result.value();
             m_channels->push_back(channel);
-            return success<channel_t>(channel);
+            return ok(channel);
         }
     }
 }
@@ -155,11 +155,11 @@ GatewayGeneric<channel_t, gateway_t>::discardChannel(const capro::ServiceDescrip
     if (channel != guardedVector->end())
     {
         guardedVector->erase(channel);
-        return success<void>();
+        return ok();
     }
     else
     {
-        return error<GatewayError>(GatewayError::NONEXISTANT_CHANNEL);
+        return err(GatewayError::NONEXISTANT_CHANNEL);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
@@ -68,7 +68,7 @@ inline expected<SharedPointer<T>, TypedMemPoolError> TypedMemPool<T>::createObje
     auto chunkManagement = acquireChunkManagementPointer();
     if (chunkManagement.has_error())
     {
-        return err(chunkManagement.get_error());
+        return err(chunkManagement.error());
     }
 
     auto newObject = SharedPointer<T>::create(SharedChunk(*chunkManagement), std::forward<Targs>(args)...);
@@ -91,13 +91,13 @@ TypedMemPool<T>::createObjectWithCreationPattern(Targs&&... args) noexcept
     auto chunkManagement = acquireChunkManagementPointer();
     if (chunkManagement.has_error())
     {
-        return err<errorType_t>(in_place_index<0>(), chunkManagement.get_error());
+        return err<errorType_t>(in_place_index<0>(), chunkManagement.error());
     }
 
     auto newObject = T::create(std::forward<Targs>(args)...);
     if (newObject.has_error())
     {
-        return err<errorType_t>(in_place_index<1>(), newObject.get_error());
+        return err<errorType_t>(in_place_index<1>(), newObject.error());
     }
 
     auto sharedPointer = SharedPointer<T>::create(SharedChunk(*chunkManagement), std::move(*newObject));

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
@@ -41,14 +41,14 @@ inline expected<ChunkManagement*, TypedMemPoolError> TypedMemPool<T>::acquireChu
     ChunkHeader* chunkHeader = static_cast<ChunkHeader*>(m_memPool.getChunk());
     if (chunkHeader == nullptr)
     {
-        return error<TypedMemPoolError>(TypedMemPoolError::OutOfChunks);
+        return err(TypedMemPoolError::OutOfChunks);
     }
 
     ChunkManagement* chunkManagement = static_cast<ChunkManagement*>(m_chunkManagementPool.getChunk());
     if (chunkManagement == nullptr)
     {
         errorHandler(PoshError::MEPOO__TYPED_MEMPOOL_HAS_INCONSISTENT_STATE);
-        return error<TypedMemPoolError>(TypedMemPoolError::FatalErrorReachedInconsistentState);
+        return err(TypedMemPoolError::FatalErrorReachedInconsistentState);
     }
 
     auto chunkSettingsResult = mepoo::ChunkSettings::create(sizeof(T), alignof(T));
@@ -58,7 +58,7 @@ inline expected<ChunkManagement*, TypedMemPoolError> TypedMemPool<T>::acquireChu
     new (chunkHeader) ChunkHeader(m_memPool.getChunkSize(), chunkSettings);
     new (chunkManagement) ChunkManagement(chunkHeader, &m_memPool, &m_chunkManagementPool);
 
-    return success<ChunkManagement*>(chunkManagement);
+    return ok(chunkManagement);
 }
 
 template <typename T>
@@ -68,7 +68,7 @@ inline expected<SharedPointer<T>, TypedMemPoolError> TypedMemPool<T>::createObje
     auto chunkManagement = acquireChunkManagementPointer();
     if (chunkManagement.has_error())
     {
-        return error<TypedMemPoolError>(chunkManagement.get_error());
+        return err(chunkManagement.get_error());
     }
 
     auto newObject = SharedPointer<T>::create(SharedChunk(*chunkManagement), std::forward<Targs>(args)...);
@@ -76,10 +76,10 @@ inline expected<SharedPointer<T>, TypedMemPoolError> TypedMemPool<T>::createObje
     if (newObject.has_error())
     {
         errorHandler(PoshError::MEPOO__TYPED_MEMPOOL_MANAGEMENT_SEGMENT_IS_BROKEN);
-        return error<TypedMemPoolError>(TypedMemPoolError::FatalErrorReachedInconsistentState);
+        return err(TypedMemPoolError::FatalErrorReachedInconsistentState);
     }
 
-    return success<SharedPointer<T>>(newObject.value());
+    return ok(newObject.value());
 }
 
 template <typename T>
@@ -91,13 +91,13 @@ TypedMemPool<T>::createObjectWithCreationPattern(Targs&&... args) noexcept
     auto chunkManagement = acquireChunkManagementPointer();
     if (chunkManagement.has_error())
     {
-        return error<errorType_t>(in_place_index<0>(), chunkManagement.get_error());
+        return err<errorType_t>(in_place_index<0>(), chunkManagement.get_error());
     }
 
     auto newObject = T::create(std::forward<Targs>(args)...);
     if (newObject.has_error())
     {
-        return error<errorType_t>(in_place_index<1>(), newObject.get_error());
+        return err<errorType_t>(in_place_index<1>(), newObject.get_error());
     }
 
     auto sharedPointer = SharedPointer<T>::create(SharedChunk(*chunkManagement), std::move(*newObject));
@@ -105,10 +105,10 @@ TypedMemPool<T>::createObjectWithCreationPattern(Targs&&... args) noexcept
     if (sharedPointer.has_error())
     {
         errorHandler(PoshError::MEPOO__TYPED_MEMPOOL_MANAGEMENT_SEGMENT_IS_BROKEN);
-        return error<errorType_t>(in_place_index<0>(), TypedMemPoolError::FatalErrorReachedInconsistentState);
+        return err<errorType_t>(in_place_index<0>(), TypedMemPoolError::FatalErrorReachedInconsistentState);
     }
 
-    return success<SharedPointer<T>>(sharedPointer.value());
+    return ok(sharedPointer.value());
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.hpp
@@ -81,13 +81,13 @@ class ChunkDistributor
     /// @param[in] requestedHistory number of last chunks from history to send if available. If history size is smaller
     /// then the available history size chunks are provided
     /// @return if the queue could be added it returns success, otherwiese a ChunkDistributor error
-    expected<ChunkDistributorError> tryAddQueue(not_null<ChunkQueueData_t* const> queueToAdd,
-                                                const uint64_t requestedHistory = 0U) noexcept;
+    expected<void, ChunkDistributorError> tryAddQueue(not_null<ChunkQueueData_t* const> queueToAdd,
+                                                      const uint64_t requestedHistory = 0U) noexcept;
 
     /// @brief Remove a queue from the internal list of chunk queues
     /// @param[in] queueToRemove is the queue to remove from the list
     /// @return if the queue could be removed it returns success, otherwiese a ChunkDistributor error
-    expected<ChunkDistributorError> tryRemoveQueue(not_null<ChunkQueueData_t* const> queueToRemove) noexcept;
+    expected<void, ChunkDistributorError> tryRemoveQueue(not_null<ChunkQueueData_t* const> queueToRemove) noexcept;
 
     /// @brief Delete all the stored chunk queues
     void removeAllQueues() noexcept;
@@ -108,7 +108,7 @@ class ChunkDistributor
     /// @param[in] lastKnownQueueIndex is used for a fast lookup of the queue with uniqueQueueId
     /// @param[in] chunk is the SharedChunk to be delivered
     /// @return ChunkDistributorError if the queue was not found
-    expected<ChunkDistributorError>
+    expected<void, ChunkDistributorError>
     deliverToQueue(const UniqueId uniqueQueueId, const uint32_t lastKnownQueueIndex, mepoo::SharedChunk chunk) noexcept;
 
     /// @brief Lookup for the index of a queue with a specific iox::UniqueId

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -82,7 +82,7 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(not_null<ChunkQueueData_
                 pushToQueue(queueToAdd, getMembers()->m_history[i].cloneToSharedChunk());
             }
 
-            return success<void>();
+            return ok();
         }
         else
         {
@@ -90,11 +90,11 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(not_null<ChunkQueueData_
             // adding the queue was not possible
             errorHandler(PoshError::POPO__CHUNK_DISTRIBUTOR_OVERFLOW_OF_QUEUE_CONTAINER, ErrorLevel::MODERATE);
 
-            return error<ChunkDistributorError>(ChunkDistributorError::QUEUE_CONTAINER_OVERFLOW);
+            return err(ChunkDistributorError::QUEUE_CONTAINER_OVERFLOW);
         }
     }
 
-    return success<void>();
+    return ok();
 }
 
 template <typename ChunkDistributorDataType>
@@ -111,11 +111,11 @@ ChunkDistributor<ChunkDistributorDataType>::tryRemoveQueue(not_null<ChunkQueueDa
         // AXIVION Next Construct AutosarC++19_03-A0.1.2 : we don't use iter any longer so return value can be ignored
         getMembers()->m_queues.erase(iter);
 
-        return success<void>();
+        return ok();
     }
     else
     {
-        return error<ChunkDistributorError>(ChunkDistributorError::QUEUE_NOT_IN_CONTAINER);
+        return err(ChunkDistributorError::QUEUE_NOT_IN_CONTAINER);
     }
 }
 
@@ -239,7 +239,7 @@ ChunkDistributor<ChunkDistributorDataType>::deliverToQueue(const UniqueId unique
 
         if (!queueIndex.has_value())
         {
-            return error<ChunkDistributorError>(ChunkDistributorError::QUEUE_NOT_IN_CONTAINER);
+            return err(ChunkDistributorError::QUEUE_NOT_IN_CONTAINER);
         }
 
         auto& queue = getMembers()->m_queues[queueIndex.value()];
@@ -262,7 +262,7 @@ ChunkDistributor<ChunkDistributorDataType>::deliverToQueue(const UniqueId unique
         }
     } while (retry);
 
-    return success<>();
+    return ok();
 }
 
 template <typename ChunkDistributorDataType>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -45,7 +45,7 @@ ChunkDistributor<ChunkDistributorDataType>::getMembers() noexcept
 }
 
 template <typename ChunkDistributorDataType>
-inline expected<ChunkDistributorError>
+inline expected<void, ChunkDistributorError>
 ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(not_null<ChunkQueueData_t* const> queueToAdd,
                                                         const uint64_t requestedHistory) noexcept
 {
@@ -98,7 +98,7 @@ ChunkDistributor<ChunkDistributorDataType>::tryAddQueue(not_null<ChunkQueueData_
 }
 
 template <typename ChunkDistributorDataType>
-inline expected<ChunkDistributorError>
+inline expected<void, ChunkDistributorError>
 ChunkDistributor<ChunkDistributorDataType>::tryRemoveQueue(not_null<ChunkQueueData_t* const> queueToRemove) noexcept
 {
     typename MemberType_t::LockGuard_t lock(*getMembers());
@@ -225,7 +225,7 @@ inline bool ChunkDistributor<ChunkDistributorDataType>::pushToQueue(not_null<Chu
 }
 
 template <typename ChunkDistributorDataType>
-inline expected<ChunkDistributorError>
+inline expected<void, ChunkDistributorError>
 ChunkDistributor<ChunkDistributorDataType>::deliverToQueue(const UniqueId uniqueQueueId,
                                                            const uint32_t lastKnownQueueIndex,
                                                            mepoo::SharedChunk chunk IOX_MAYBE_UNUSED) noexcept

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver.inl
@@ -81,17 +81,16 @@ inline expected<const mepoo::ChunkHeader*, ChunkReceiveResult> ChunkReceiver<Chu
         // if the application holds too many chunks, don't provide more
         if (getMembers()->m_chunksInUse.insert(sharedChunk))
         {
-            return success<const mepoo::ChunkHeader*>(
-                const_cast<const mepoo::ChunkHeader*>(sharedChunk.getChunkHeader()));
+            return ok(const_cast<const mepoo::ChunkHeader*>(sharedChunk.getChunkHeader()));
         }
         else
         {
             // release the chunk
             sharedChunk = nullptr;
-            return error<ChunkReceiveResult>(ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL);
+            return err(ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL);
         }
     }
-    return error<ChunkReceiveResult>(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
+    return err(ChunkReceiveResult::NO_CHUNK_AVAILABLE);
 }
 
 template <typename ChunkReceiverDataType>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
@@ -109,7 +109,7 @@ ChunkSender<ChunkSenderDataType>::tryAllocate(const UniquePortId originId,
         mepoo::ChunkSettings::create(userPayloadSize, userPayloadAlignment, userHeaderSize, userHeaderAlignment);
     if (chunkSettingsResult.has_error())
     {
-        return error<AllocationError>(AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER);
+        return err(AllocationError::INVALID_PARAMETER_FOR_USER_PAYLOAD_OR_USER_HEADER);
     }
 
     const auto& chunkSettings = chunkSettingsResult.value();
@@ -128,11 +128,11 @@ ChunkSender<ChunkSenderDataType>::tryAllocate(const UniquePortId originId,
             lastChunkChunkHeader->~ChunkHeader();
             new (lastChunkChunkHeader) mepoo::ChunkHeader(chunkSize, chunkSettings);
             lastChunkChunkHeader->setOriginId(originId);
-            return success<mepoo::ChunkHeader*>(lastChunkChunkHeader);
+            return ok(lastChunkChunkHeader);
         }
         else
         {
-            return error<AllocationError>(AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL);
+            return err(AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL);
         }
     }
     else
@@ -150,19 +150,19 @@ ChunkSender<ChunkSenderDataType>::tryAllocate(const UniquePortId originId,
             {
                 // END of critical section
                 chunk.getChunkHeader()->setOriginId(originId);
-                return success<mepoo::ChunkHeader*>(chunk.getChunkHeader());
+                return ok(chunk.getChunkHeader());
             }
             else
             {
                 // release the allocated chunk
                 chunk = nullptr;
-                return error<AllocationError>(AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL);
+                return err(AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL);
             }
         }
         else
         {
             /// @todo iox-#1012 use error<E2>::from(E1); once available
-            return error<AllocationError>(into<AllocationError>(getChunkResult.get_error()));
+            return err(into<AllocationError>(getChunkResult.get_error()));
         }
     }
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_sender.inl
@@ -162,7 +162,7 @@ ChunkSender<ChunkSenderDataType>::tryAllocate(const UniquePortId originId,
         else
         {
             /// @todo iox-#1012 use error<E2>::from(E1); once available
-            return err(into<AllocationError>(getChunkResult.get_error()));
+            return err(into<AllocationError>(getChunkResult.error()));
         }
     }
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.hpp
@@ -62,7 +62,7 @@ class ClientImpl : public BaseClientT, private RpcInterface<Request<Req>, Client
     /// @brief Sends the given Request and then releases its loan.
     /// @param request to send.
     /// @return Error if sending was not successful
-    expected<ClientSendError> send(Request<Req>&& request) noexcept override;
+    expected<void, ClientSendError> send(Request<Req>&& request) noexcept override;
 
     /// @brief Take the Response from the top of the receive queue.
     /// @return Either a Response or a ChunkReceiveResult.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
@@ -42,7 +42,7 @@ expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::loanU
     auto result = port().allocateRequest(sizeof(Req), alignof(Req));
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
@@ -76,7 +76,7 @@ expected<Response<const Res>, ChunkReceiveResult> ClientImpl<Req, Res, BaseClien
     auto result = port().getResponse();
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
@@ -62,7 +62,7 @@ expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::loan(
 }
 
 template <typename Req, typename Res, typename BaseClientT>
-expected<ClientSendError> ClientImpl<Req, Res, BaseClientT>::send(Request<Req>&& request) noexcept
+expected<void, ClientSendError> ClientImpl<Req, Res, BaseClientT>::send(Request<Req>&& request) noexcept
 {
     // take the ownership of the chunk from the Request to transfer it to 'sendRequest'
     auto payload = request.release();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/client_impl.inl
@@ -42,7 +42,7 @@ expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::loanU
     auto result = port().allocateRequest(sizeof(Req), alignof(Req));
     if (result.has_error())
     {
-        return error<AllocationError>(result.get_error());
+        return err(result.get_error());
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
@@ -50,7 +50,7 @@ expected<Request<Req>, AllocationError> ClientImpl<Req, Res, BaseClientT>::loanU
         auto* requestHeader = iox::popo::RequestHeader::fromPayload(payload);
         this->port().releaseRequest(requestHeader);
     });
-    return success<Request<Req>>(Request<Req>{std::move(request), *this});
+    return ok(Request<Req>{std::move(request), *this});
 }
 
 template <typename Req, typename Res, typename BaseClientT>
@@ -76,7 +76,7 @@ expected<Response<const Res>, ChunkReceiveResult> ClientImpl<Req, Res, BaseClien
     auto result = port().getResponse();
     if (result.has_error())
     {
-        return error<ChunkReceiveResult>(result.get_error());
+        return err(result.get_error());
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();
@@ -84,7 +84,7 @@ expected<Response<const Res>, ChunkReceiveResult> ClientImpl<Req, Res, BaseClien
         auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
         this->port().releaseResponse(responseHeader);
     });
-    return success<Response<const Res>>(Response<const Res>{std::move(response)});
+    return ok(Response<const Res>{std::move(response)});
 }
 
 } // namespace popo

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/listener.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/listener.inl
@@ -24,7 +24,7 @@ namespace popo
 {
 template <uint64_t Capacity>
 template <typename T, typename ContextDataType>
-inline expected<ListenerError>
+inline expected<void, ListenerError>
 ListenerImpl<Capacity>::attachEvent(T& eventOrigin,
                                     const NotificationCallback<T, ContextDataType>& eventCallback) noexcept
 {
@@ -49,7 +49,7 @@ ListenerImpl<Capacity>::attachEvent(T& eventOrigin,
 
 template <uint64_t Capacity>
 template <typename T, typename EventType, typename ContextDataType, typename>
-inline expected<ListenerError> ListenerImpl<Capacity>::attachEvent(
+inline expected<void, ListenerError> ListenerImpl<Capacity>::attachEvent(
     T& eventOrigin, const EventType eventType, const NotificationCallback<T, ContextDataType>& eventCallback) noexcept
 {
     if (eventCallback.m_callback == nullptr)

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/listener.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/listener.inl
@@ -30,7 +30,7 @@ ListenerImpl<Capacity>::attachEvent(T& eventOrigin,
 {
     if (eventCallback.m_callback == nullptr)
     {
-        return error<ListenerError>(ListenerError::EMPTY_EVENT_CALLBACK);
+        return err(ListenerError::EMPTY_EVENT_CALLBACK);
     }
 
     return addEvent(&eventOrigin,
@@ -54,7 +54,7 @@ inline expected<void, ListenerError> ListenerImpl<Capacity>::attachEvent(
 {
     if (eventCallback.m_callback == nullptr)
     {
-        return error<ListenerError>(ListenerError::EMPTY_EVENT_CALLBACK);
+        return err(ListenerError::EMPTY_EVENT_CALLBACK);
     }
 
     return addEvent(&eventOrigin,
@@ -134,19 +134,19 @@ ListenerImpl<Capacity>::addEvent(void* const origin,
     {
         if (m_events[i]->isEqualTo(origin, eventType, eventTypeHash))
         {
-            return error<ListenerError>(ListenerError::EVENT_ALREADY_ATTACHED);
+            return err(ListenerError::EVENT_ALREADY_ATTACHED);
         }
     }
 
     uint32_t index = 0U;
     if (!m_indexManager.pop(index))
     {
-        return error<ListenerError>(ListenerError::LISTENER_FULL);
+        return err(ListenerError::LISTENER_FULL);
     }
 
     m_events[index]->init(
         index, origin, userType, eventType, eventTypeHash, callback, translationCallback, invalidationCallback);
-    return success<uint32_t>(index);
+    return ok(index);
 }
 
 template <uint64_t Capacity>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/client_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/client_port_user.hpp
@@ -91,7 +91,7 @@ class ClientPortUser : public BasePort
     /// @brief Send an allocated request chunk to the server port
     /// @param[in] requestHeader, pointer to the RequestHeader to send
     /// @return ClientSendError if sending was not successful
-    expected<ClientSendError> sendRequest(RequestHeader* const requestHeader) noexcept;
+    expected<void, ClientSendError> sendRequest(RequestHeader* const requestHeader) noexcept;
 
     /// @brief try to connect to the server Caution: There can be delays between calling connect and a change
     /// in the connection state

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/server_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/server_port_user.hpp
@@ -145,7 +145,7 @@ class ServerPortUser : public BasePort
     /// @brief Send an allocated request chunk to the server port
     /// @param[in] chunkHeader, pointer to the ChunkHeader to send
     /// @return ServerSendError if sending was not successful
-    expected<ServerSendError> sendResponse(ResponseHeader* const responseHeader) noexcept;
+    expected<void, ServerSendError> sendResponse(ResponseHeader* const responseHeader) noexcept;
 
     /// @brief offer this server port in the system
     void offer() noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.hpp
@@ -66,7 +66,7 @@ class PublisherImpl : public BasePublisherType, private PublisherInterface<T, H>
     /// @param val Value to copy.
     /// @return Error if unable to allocate memory to loan.
     ///
-    expected<AllocationError> publishCopyOf(const T& val) noexcept;
+    expected<void, AllocationError> publishCopyOf(const T& val) noexcept;
     ///
     /// @brief publishResultOf Loan a sample from memory, execute the provided callable to write to it, then publish it.
     /// @param c Callable with the signature void(T*, ArgTypes...) that write's it's result to T*.
@@ -74,7 +74,7 @@ class PublisherImpl : public BasePublisherType, private PublisherInterface<T, H>
     /// @return Error if unable to allocate memory to loan.
     ///
     template <typename Callable, typename... ArgTypes>
-    expected<AllocationError> publishResultOf(Callable c, ArgTypes... args) noexcept;
+    expected<void, AllocationError> publishResultOf(Callable c, ArgTypes... args) noexcept;
 
   protected:
     using BasePublisherType::port;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
@@ -76,7 +76,7 @@ inline expected<Sample<T, H>, AllocationError> PublisherImpl<T, H, BasePublisher
     auto result = port().tryAllocateChunk(sizeof(T), alignof(T), USER_HEADER_SIZE, alignof(H));
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     else
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
@@ -76,11 +76,11 @@ inline expected<Sample<T, H>, AllocationError> PublisherImpl<T, H, BasePublisher
     auto result = port().tryAllocateChunk(sizeof(T), alignof(T), USER_HEADER_SIZE, alignof(H));
     if (result.has_error())
     {
-        return error<AllocationError>(result.get_error());
+        return err(result.get_error());
     }
     else
     {
-        return success<Sample<T, H>>(convertChunkHeaderToSample(result.value()));
+        return ok(convertChunkHeaderToSample(result.value()));
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/publisher_impl.inl
@@ -43,8 +43,8 @@ inline expected<Sample<T, H>, AllocationError> PublisherImpl<T, H, BasePublisher
 
 template <typename T, typename H, typename BasePublisherType>
 template <typename Callable, typename... ArgTypes>
-inline expected<AllocationError> PublisherImpl<T, H, BasePublisherType>::publishResultOf(Callable c,
-                                                                                         ArgTypes... args) noexcept
+inline expected<void, AllocationError>
+PublisherImpl<T, H, BasePublisherType>::publishResultOf(Callable c, ArgTypes... args) noexcept
 {
     static_assert(is_invocable<Callable, T*, ArgTypes...>::value,
                   "Publisher<T>::publishResultOf expects a valid callable with a specific signature as the "
@@ -59,7 +59,7 @@ inline expected<AllocationError> PublisherImpl<T, H, BasePublisherType>::publish
 }
 
 template <typename T, typename H, typename BasePublisherType>
-inline expected<AllocationError> PublisherImpl<T, H, BasePublisherType>::publishCopyOf(const T& val) noexcept
+inline expected<void, AllocationError> PublisherImpl<T, H, BasePublisherType>::publishCopyOf(const T& val) noexcept
 {
     return loanSample().and_then([&](auto& sample) {
         new (sample.get()) T(val); // Placement new copy-construction of sample, avoid copy-assigment because there

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/request.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/request.inl
@@ -35,7 +35,7 @@ inline expected<void, ClientSendError> Request<T>::send() noexcept
     {
         IOX_LOG(ERROR) << "Tried to send empty Request! Might be an already sent or moved Request!";
         errorHandler(PoshError::POSH__SENDING_EMPTY_REQUEST, ErrorLevel::MODERATE);
-        return error<ClientSendError>(ClientSendError::INVALID_REQUEST);
+        return err(ClientSendError::INVALID_REQUEST);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/request.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/request.inl
@@ -25,7 +25,7 @@ namespace popo
 {
 template <typename T>
 template <typename S, typename>
-inline expected<ClientSendError> Request<T>::send() noexcept
+inline expected<void, ClientSendError> Request<T>::send() noexcept
 {
     if (BaseType::m_members.smartChunkUniquePtr)
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/response.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/response.inl
@@ -25,7 +25,7 @@ namespace popo
 {
 template <typename T>
 template <typename S, typename>
-inline expected<ServerSendError> Response<T>::send() noexcept
+inline expected<void, ServerSendError> Response<T>::send() noexcept
 {
     if (BaseType::m_members.smartChunkUniquePtr)
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/response.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/response.inl
@@ -35,7 +35,7 @@ inline expected<void, ServerSendError> Response<T>::send() noexcept
     {
         IOX_LOG(ERROR) << "Tried to send empty Response! Might be an already sent or moved Response!";
         errorHandler(PoshError::POSH__SENDING_EMPTY_RESPONSE, ErrorLevel::MODERATE);
-        return error<ServerSendError>(ServerSendError::INVALID_RESPONSE);
+        return err(ServerSendError::INVALID_RESPONSE);
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/rpc_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/rpc_interface.hpp
@@ -35,7 +35,7 @@ class RpcInterface
     /// @brief Sends the given Request<T> or Response<T> via the type which implements this interface
     /// @param[in] rpcData is the actual Request<T> or Response<T> instance
     /// @return Error if sending was not successful
-    virtual expected<SendErrorEnum> send(RpcType&& rpcData) noexcept = 0;
+    virtual expected<void, SendErrorEnum> send(RpcType&& rpcData) noexcept = 0;
 
   protected:
     RpcInterface() = default;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.hpp
@@ -69,7 +69,7 @@ class ServerImpl : public BaseServerT, private RpcInterface<Response<Res>, Serve
     /// @brief Sends the given Response and then releases its loan.
     /// @param response to send.
     /// @return Error if sending was not successful
-    expected<ServerSendError> send(Response<Res>&& response) noexcept override;
+    expected<void, ServerSendError> send(Response<Res>&& response) noexcept override;
 
   protected:
     using BaseServerT::port;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
@@ -42,7 +42,7 @@ expected<Request<const Req>, ServerRequestResult> ServerImpl<Req, Res, BaseServe
     auto result = port().getRequest();
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
@@ -61,7 +61,7 @@ ServerImpl<Req, Res, BaseServerT>::loanUninitialized(const Request<const Req>& r
     auto result = port().allocateResponse(requestHeader, sizeof(Res), alignof(Res));
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
@@ -82,7 +82,7 @@ expected<Response<Res>, AllocationError> ServerImpl<Req, Res, BaseServerT>::loan
 }
 
 template <typename Req, typename Res, typename BaseServerT>
-expected<ServerSendError> ServerImpl<Req, Res, BaseServerT>::send(Response<Res>&& response) noexcept
+expected<void, ServerSendError> ServerImpl<Req, Res, BaseServerT>::send(Response<Res>&& response) noexcept
 {
     // take the ownership of the chunk from the Response to transfer it to 'sendResponse'
     auto payload = response.release();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/server_impl.inl
@@ -42,7 +42,7 @@ expected<Request<const Req>, ServerRequestResult> ServerImpl<Req, Res, BaseServe
     auto result = port().getRequest();
     if (result.has_error())
     {
-        return error<ServerRequestResult>(result.get_error());
+        return err(result.get_error());
     }
     auto requestHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(requestHeader)->userPayload();
@@ -50,7 +50,7 @@ expected<Request<const Req>, ServerRequestResult> ServerImpl<Req, Res, BaseServe
         auto* requestHeader = iox::popo::RequestHeader::fromPayload(payload);
         this->port().releaseRequest(requestHeader);
     });
-    return success<Request<const Req>>(Request<const Req>{std::move(request)});
+    return ok(Request<const Req>{std::move(request)});
 }
 
 template <typename Req, typename Res, typename BaseServerT>
@@ -61,7 +61,7 @@ ServerImpl<Req, Res, BaseServerT>::loanUninitialized(const Request<const Req>& r
     auto result = port().allocateResponse(requestHeader, sizeof(Res), alignof(Res));
     if (result.has_error())
     {
-        return error<AllocationError>(result.get_error());
+        return err(result.get_error());
     }
     auto responseHeader = result.value();
     auto payload = mepoo::ChunkHeader::fromUserHeader(responseHeader)->userPayload();
@@ -69,7 +69,7 @@ ServerImpl<Req, Res, BaseServerT>::loanUninitialized(const Request<const Req>& r
         auto* responseHeader = iox::popo::ResponseHeader::fromPayload(payload);
         this->port().releaseResponse(responseHeader);
     });
-    return success<Response<Res>>(Response<Res>{std::move(response), *this});
+    return ok(Response<Res>{std::move(response), *this});
 }
 
 template <typename Req, typename Res, typename BaseServerT>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
@@ -37,14 +37,14 @@ inline expected<Sample<const T, const H>, ChunkReceiveResult> SubscriberImpl<T, 
     auto result = BaseSubscriberType::takeChunk();
     if (result.has_error())
     {
-        return error<ChunkReceiveResult>(result.get_error());
+        return err(result.get_error());
     }
     auto userPayloadPtr = static_cast<const T*>(result.value()->userPayload());
     auto samplePtr = iox::unique_ptr<const T>(userPayloadPtr, [this](const T* userPayload) {
         auto* chunkHeader = iox::mepoo::ChunkHeader::fromUserPayload(userPayload);
         this->port().releaseChunk(chunkHeader);
     });
-    return success<Sample<const T, const H>>(std::move(samplePtr));
+    return ok<Sample<const T, const H>>(std::move(samplePtr));
 }
 
 template <typename T, typename H, typename BaseSubscriberType>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/subscriber_impl.inl
@@ -37,7 +37,7 @@ inline expected<Sample<const T, const H>, ChunkReceiveResult> SubscriberImpl<T, 
     auto result = BaseSubscriberType::takeChunk();
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     auto userPayloadPtr = static_cast<const T*>(result.value()->userPayload());
     auto samplePtr = iox::unique_ptr<const T>(userPayloadPtr, [this](const T* userPayload) {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.hpp
@@ -60,7 +60,7 @@ class UntypedClientImpl : public BaseClientT
     /// @brief Sends the provided memory chunk as request to the server.
     /// @param requestPayload Pointer to the payload of the allocated shared memory chunk.
     /// @return Error if sending was not successful
-    expected<ClientSendError> send(void* const requestPayload) noexcept;
+    expected<void, ClientSendError> send(void* const requestPayload) noexcept;
 
     /// @brief Take the response chunk from the top of the receive queue.
     /// @return The payload pointer of the request chunk taken.

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
@@ -43,7 +43,7 @@ expected<void*, AllocationError> UntypedClientImpl<BaseClientT>::loan(const uint
     auto allocationResult = port().allocateRequest(payloadSize, payloadAlignment);
     if (allocationResult.has_error())
     {
-        return err(allocationResult.get_error());
+        return err(allocationResult.error());
     }
 
     return ok(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());
@@ -77,7 +77,7 @@ expected<const void*, ChunkReceiveResult> UntypedClientImpl<BaseClientT>::take()
     auto responseResult = port().getResponse();
     if (responseResult.has_error())
     {
-        return err(responseResult.get_error());
+        return err(responseResult.error());
     }
 
     return ok(mepoo::ChunkHeader::fromUserHeader(responseResult.value())->userPayload());

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
@@ -60,7 +60,7 @@ void UntypedClientImpl<BaseClientT>::releaseRequest(void* const requestPayload) 
 }
 
 template <typename BaseClientT>
-expected<ClientSendError> UntypedClientImpl<BaseClientT>::send(void* const requestPayload) noexcept
+expected<void, ClientSendError> UntypedClientImpl<BaseClientT>::send(void* const requestPayload) noexcept
 {
     auto* chunkHeader = mepoo::ChunkHeader::fromUserPayload(requestPayload);
     if (chunkHeader == nullptr)

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_client_impl.inl
@@ -43,10 +43,10 @@ expected<void*, AllocationError> UntypedClientImpl<BaseClientT>::loan(const uint
     auto allocationResult = port().allocateRequest(payloadSize, payloadAlignment);
     if (allocationResult.has_error())
     {
-        return error<AllocationError>(allocationResult.get_error());
+        return err(allocationResult.get_error());
     }
 
-    return success<void*>(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());
+    return ok(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());
 }
 
 template <typename BaseClientT>
@@ -65,7 +65,7 @@ expected<void, ClientSendError> UntypedClientImpl<BaseClientT>::send(void* const
     auto* chunkHeader = mepoo::ChunkHeader::fromUserPayload(requestPayload);
     if (chunkHeader == nullptr)
     {
-        return error<ClientSendError>(ClientSendError::INVALID_REQUEST);
+        return err(ClientSendError::INVALID_REQUEST);
     }
 
     return port().sendRequest(static_cast<RequestHeader*>(chunkHeader->userHeader()));
@@ -77,10 +77,10 @@ expected<const void*, ChunkReceiveResult> UntypedClientImpl<BaseClientT>::take()
     auto responseResult = port().getResponse();
     if (responseResult.has_error())
     {
-        return error<ChunkReceiveResult>(responseResult.get_error());
+        return err(responseResult.get_error());
     }
 
-    return success<const void*>(mepoo::ChunkHeader::fromUserHeader(responseResult.value())->userPayload());
+    return ok(mepoo::ChunkHeader::fromUserHeader(responseResult.value())->userPayload());
 }
 
 template <typename BaseClientT>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_publisher_impl.inl
@@ -48,7 +48,7 @@ UntypedPublisherImpl<BasePublisherType>::loan(const uint32_t userPayloadSize,
     auto result = port().tryAllocateChunk(userPayloadSize, userPayloadAlignment, userHeaderSize, userHeaderAlignment);
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     else
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_publisher_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_publisher_impl.inl
@@ -48,11 +48,11 @@ UntypedPublisherImpl<BasePublisherType>::loan(const uint32_t userPayloadSize,
     auto result = port().tryAllocateChunk(userPayloadSize, userPayloadAlignment, userHeaderSize, userHeaderAlignment);
     if (result.has_error())
     {
-        return error<AllocationError>(result.get_error());
+        return err(result.get_error());
     }
     else
     {
-        return success<void*>(result.value()->userPayload());
+        return ok(result.value()->userPayload());
     }
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.hpp
@@ -68,7 +68,7 @@ class UntypedServerImpl : public BaseServerT
     /// @brief Sends the provided memory chunk as response to the client.
     /// @param responsePayload Pointer to the payload of the allocated shared memory chunk.
     /// @return Error if sending was not successful
-    expected<ServerSendError> send(void* const responsePayload) noexcept;
+    expected<void, ServerSendError> send(void* const responsePayload) noexcept;
 
     /// @brief Releases the ownership of the response chunk provided by the payload pointer.
     /// @param responsePayload pointer to the payload of the chunk to be released

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
@@ -42,7 +42,7 @@ expected<const void*, ServerRequestResult> UntypedServerImpl<BaseServerT>::take(
     auto requestResult = port().getRequest();
     if (requestResult.has_error())
     {
-        return err(requestResult.get_error());
+        return err(requestResult.error());
     }
 
     return ok(mepoo::ChunkHeader::fromUserHeader(requestResult.value())->userPayload());
@@ -66,7 +66,7 @@ expected<void*, AllocationError> UntypedServerImpl<BaseServerT>::loan(const Requ
     auto allocationResult = port().allocateResponse(requestHeader, payloadSize, payloadAlignment);
     if (allocationResult.has_error())
     {
-        return err(allocationResult.get_error());
+        return err(allocationResult.error());
     }
 
     return ok(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
@@ -42,10 +42,10 @@ expected<const void*, ServerRequestResult> UntypedServerImpl<BaseServerT>::take(
     auto requestResult = port().getRequest();
     if (requestResult.has_error())
     {
-        return error<ServerRequestResult>(requestResult.get_error());
+        return err(requestResult.get_error());
     }
 
-    return success<const void*>(mepoo::ChunkHeader::fromUserHeader(requestResult.value())->userPayload());
+    return ok(mepoo::ChunkHeader::fromUserHeader(requestResult.value())->userPayload());
 }
 
 template <typename BaseServerT>
@@ -66,10 +66,10 @@ expected<void*, AllocationError> UntypedServerImpl<BaseServerT>::loan(const Requ
     auto allocationResult = port().allocateResponse(requestHeader, payloadSize, payloadAlignment);
     if (allocationResult.has_error())
     {
-        return error<AllocationError>(allocationResult.get_error());
+        return err(allocationResult.get_error());
     }
 
-    return success<void*>(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());
+    return ok(mepoo::ChunkHeader::fromUserHeader(allocationResult.value())->userPayload());
 }
 
 template <typename BaseServerT>
@@ -78,7 +78,7 @@ expected<void, ServerSendError> UntypedServerImpl<BaseServerT>::send(void* const
     auto* chunkHeader = mepoo::ChunkHeader::fromUserPayload(responsePayload);
     if (chunkHeader == nullptr)
     {
-        return error<ServerSendError>(ServerSendError::INVALID_RESPONSE);
+        return err(ServerSendError::INVALID_RESPONSE);
     }
 
     return port().sendResponse(static_cast<ResponseHeader*>(chunkHeader->userHeader()));

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_server_impl.inl
@@ -73,7 +73,7 @@ expected<void*, AllocationError> UntypedServerImpl<BaseServerT>::loan(const Requ
 }
 
 template <typename BaseServerT>
-expected<ServerSendError> UntypedServerImpl<BaseServerT>::send(void* const responsePayload) noexcept
+expected<void, ServerSendError> UntypedServerImpl<BaseServerT>::send(void* const responsePayload) noexcept
 {
     auto* chunkHeader = mepoo::ChunkHeader::fromUserPayload(responsePayload);
     if (chunkHeader == nullptr)

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber_impl.inl
@@ -37,7 +37,7 @@ inline expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<BaseSubsc
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())
     {
-        return err(result.get_error());
+        return err(result.error());
     }
     return ok(result.value()->userPayload());
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber_impl.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber_impl.inl
@@ -37,9 +37,9 @@ inline expected<const void*, ChunkReceiveResult> UntypedSubscriberImpl<BaseSubsc
     auto result = BaseSubscriber::takeChunk();
     if (result.has_error())
     {
-        return error<ChunkReceiveResult>(result.get_error());
+        return err(result.get_error());
     }
-    return success<const void*>(result.value()->userPayload());
+    return ok(result.value()->userPayload());
 }
 
 template <typename BaseSubscriberType>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
@@ -115,7 +115,7 @@ WaitSet<Capacity>::attachImpl(T& eventOrigin,
     {
         if (currentTrigger && currentTrigger->isLogicalEqualTo(&eventOrigin, originType, originTypeHash))
         {
-            return error<WaitSetError>(WaitSetError::ALREADY_ATTACHED);
+            return err(WaitSetError::ALREADY_ATTACHED);
         }
     }
 
@@ -123,7 +123,7 @@ WaitSet<Capacity>::attachImpl(T& eventOrigin,
     auto index = m_indexRepository.pop();
     if (!index)
     {
-        return error<WaitSetError>(WaitSetError::WAIT_SET_FULL);
+        return err(WaitSetError::WAIT_SET_FULL);
     }
 
 
@@ -151,7 +151,7 @@ WaitSet<Capacity>::attachImpl(T& eventOrigin,
                                        originTypeHash);
     }
 
-    return success<uint64_t>(*index);
+    return ok(*index);
 }
 
 template <uint64_t Capacity>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/wait_set.inl
@@ -156,7 +156,7 @@ WaitSet<Capacity>::attachImpl(T& eventOrigin,
 
 template <uint64_t Capacity>
 template <typename T, typename EventType, typename ContextDataType, typename>
-inline expected<WaitSetError>
+inline expected<void, WaitSetError>
 WaitSet<Capacity>::attachEvent(T& eventOrigin,
                                const EventType eventType,
                                const uint64_t eventId,
@@ -180,7 +180,7 @@ WaitSet<Capacity>::attachEvent(T& eventOrigin,
 
 template <uint64_t Capacity>
 template <typename T, typename EventType, typename ContextDataType, typename>
-inline expected<WaitSetError> WaitSet<Capacity>::attachEvent(
+inline expected<void, WaitSetError> WaitSet<Capacity>::attachEvent(
     T& eventOrigin, const EventType eventType, const NotificationCallback<T, ContextDataType>& eventCallback) noexcept
 {
     return attachEvent(eventOrigin, eventType, NotificationInfo::INVALID_ID, eventCallback);
@@ -188,7 +188,7 @@ inline expected<WaitSetError> WaitSet<Capacity>::attachEvent(
 
 template <uint64_t Capacity>
 template <typename T, typename ContextDataType>
-inline expected<WaitSetError> WaitSet<Capacity>::attachEvent(
+inline expected<void, WaitSetError> WaitSet<Capacity>::attachEvent(
     T& eventOrigin, const uint64_t eventId, const NotificationCallback<T, ContextDataType>& eventCallback) noexcept
 {
     return attachImpl(eventOrigin,
@@ -205,7 +205,7 @@ inline expected<WaitSetError> WaitSet<Capacity>::attachEvent(
 
 template <uint64_t Capacity>
 template <typename T, typename ContextDataType>
-inline expected<WaitSetError>
+inline expected<void, WaitSetError>
 WaitSet<Capacity>::attachEvent(T& eventOrigin, const NotificationCallback<T, ContextDataType>& eventCallback) noexcept
 {
     return attachEvent(eventOrigin, NotificationInfo::INVALID_ID, eventCallback);
@@ -213,7 +213,7 @@ WaitSet<Capacity>::attachEvent(T& eventOrigin, const NotificationCallback<T, Con
 
 template <uint64_t Capacity>
 template <typename T, typename StateType, typename ContextDataType, typename>
-inline expected<WaitSetError>
+inline expected<void, WaitSetError>
 WaitSet<Capacity>::attachState(T& stateOrigin,
                                const StateType stateType,
                                const uint64_t id,
@@ -244,7 +244,7 @@ WaitSet<Capacity>::attachState(T& stateOrigin,
 
 template <uint64_t Capacity>
 template <typename T, typename StateType, typename ContextDataType, typename>
-inline expected<WaitSetError> WaitSet<Capacity>::attachState(
+inline expected<void, WaitSetError> WaitSet<Capacity>::attachState(
     T& stateOrigin, const StateType stateType, const NotificationCallback<T, ContextDataType>& stateCallback) noexcept
 {
     return attachState(stateOrigin, stateType, NotificationInfo::INVALID_ID, stateCallback);
@@ -252,7 +252,7 @@ inline expected<WaitSetError> WaitSet<Capacity>::attachState(
 
 template <uint64_t Capacity>
 template <typename T, typename ContextDataType>
-inline expected<WaitSetError> WaitSet<Capacity>::attachState(
+inline expected<void, WaitSetError> WaitSet<Capacity>::attachState(
     T& stateOrigin, const uint64_t id, const NotificationCallback<T, ContextDataType>& stateCallback) noexcept
 {
     auto hasTriggeredCallback = NotificationAttorney::getCallbackForIsStateConditionSatisfied(stateOrigin);
@@ -276,7 +276,7 @@ inline expected<WaitSetError> WaitSet<Capacity>::attachState(
 
 template <uint64_t Capacity>
 template <typename T, typename ContextDataType>
-inline expected<WaitSetError>
+inline expected<void, WaitSetError>
 WaitSet<Capacity>::attachState(T& stateOrigin, const NotificationCallback<T, ContextDataType>& stateCallback) noexcept
 {
     return attachState(stateOrigin, NotificationInfo::INVALID_ID, stateCallback);

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -107,7 +107,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendPortData() noe
                                                               alignof(PortIntrospectionFieldTopic),
                                                               CHUNK_NO_USER_HEADER_SIZE,
                                                               CHUNK_NO_USER_HEADER_ALIGNMENT);
-    if (!maybeChunkHeader.has_error())
+    if (maybeChunkHeader.has_value())
     {
         auto sample = static_cast<PortIntrospectionFieldTopic*>(maybeChunkHeader.value()->userPayload());
         new (sample) PortIntrospectionFieldTopic();
@@ -125,7 +125,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendThroughputData
                                                                         alignof(PortThroughputIntrospectionFieldTopic),
                                                                         CHUNK_NO_USER_HEADER_SIZE,
                                                                         CHUNK_NO_USER_HEADER_ALIGNMENT);
-    if (!maybeChunkHeader.has_error())
+    if (maybeChunkHeader.has_value())
     {
         auto throughputSample =
             static_cast<PortThroughputIntrospectionFieldTopic*>(maybeChunkHeader.value()->userPayload());
@@ -145,7 +145,7 @@ inline void PortIntrospection<PublisherPort, SubscriberPort>::sendSubscriberPort
                                                              alignof(SubscriberPortChangingIntrospectionFieldTopic),
                                                              CHUNK_NO_USER_HEADER_SIZE,
                                                              CHUNK_NO_USER_HEADER_ALIGNMENT);
-    if (!maybeChunkHeader.has_error())
+    if (maybeChunkHeader.has_value())
     {
         auto subscriberPortChangingDataSample =
             static_cast<SubscriberPortChangingIntrospectionFieldTopic*>(maybeChunkHeader.value()->userPayload());

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.inl
@@ -175,7 +175,7 @@ inline void ProcessIntrospection<PublisherPort>::send() noexcept
                                                                   alignof(ProcessIntrospectionFieldTopic),
                                                                   CHUNK_NO_USER_HEADER_SIZE,
                                                                   CHUNK_NO_USER_HEADER_ALIGNMENT);
-        if (!maybeChunkHeader.has_error())
+        if (maybeChunkHeader.has_value())
         {
             auto sample = static_cast<ProcessIntrospectionFieldTopic*>(maybeChunkHeader.value()->userPayload());
             new (sample) ProcessIntrospectionFieldTopic;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/service_registry.hpp
@@ -59,7 +59,7 @@ class ServiceRegistry
     /// @brief Adds a given publisher service description to registry
     /// @param[in] serviceDescription, service to be added
     /// @return ServiceRegistryError, error wrapped in expected
-    expected<Error> addPublisher(const capro::ServiceDescription& serviceDescription) noexcept;
+    expected<void, Error> addPublisher(const capro::ServiceDescription& serviceDescription) noexcept;
 
     /// @brief Removes a given publisher service description from registry if service is found,
     ///        in case of multiple occurrences only one occurrence is removed
@@ -69,7 +69,7 @@ class ServiceRegistry
     /// @brief Adds a given server service description to registry
     /// @param[in] serviceDescription, service to be added
     /// @return ServiceRegistryError, error wrapped in expected
-    expected<Error> addServer(const capro::ServiceDescription& serviceDescription) noexcept;
+    expected<void, Error> addServer(const capro::ServiceDescription& serviceDescription) noexcept;
 
     /// @brief Removes a given server service description from registry if service is found,
     ///        in case of multiple occurrences only one occurrence is removed
@@ -113,8 +113,8 @@ class ServiceRegistry
     uint32_t findIndex(const capro::ServiceDescription& serviceDescription) const noexcept;
 
 
-    expected<Error> add(const capro::ServiceDescription& serviceDescription,
-                        ReferenceCounter_t ServiceDescriptionEntry::*count);
+    expected<void, Error> add(const capro::ServiceDescription& serviceDescription,
+                              ReferenceCounter_t ServiceDescriptionEntry::*count);
 };
 
 } // namespace roudi

--- a/iceoryx_posh/include/iceoryx_posh/popo/listener.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/listener.hpp
@@ -126,9 +126,9 @@ class ListenerImpl
               typename EventType,
               typename ContextDataType,
               typename = std::enable_if_t<std::is_enum<EventType>::value>>
-    expected<ListenerError> attachEvent(T& eventOrigin,
-                                        const EventType eventType,
-                                        const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
+    expected<void, ListenerError> attachEvent(T& eventOrigin,
+                                              const EventType eventType,
+                                              const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
 
     /// @brief Attaches an event. Hereby the event is defined as a class T, the eventOrigin and
     ///        the corresponding callback which will be called when the event occurs.
@@ -141,8 +141,8 @@ class ListenerImpl
     /// with iox::popo::createNotificationCallback
     /// @return If an error occurs the enum packed inside an expected which describes the error.
     template <typename T, typename ContextDataType>
-    expected<ListenerError> attachEvent(T& eventOrigin,
-                                        const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
+    expected<void, ListenerError> attachEvent(T& eventOrigin,
+                                              const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
 
     /// @brief Detaches an event. Hereby, the event is defined as a class T, the eventOrigin and
     ///        the eventType with further specifies the event inside of eventOrigin

--- a/iceoryx_posh/include/iceoryx_posh/popo/request.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/request.hpp
@@ -55,7 +55,7 @@ class Request
     /// release ownership to it.
     /// @details Only available for client (non-const type T)
     template <typename S = T, typename = ForClientOnly<S, T>>
-    expected<ClientSendError> send() noexcept;
+    expected<void, ClientSendError> send() noexcept;
 
     /// @brief Retrieve the request-header of the underlying memory chunk loaned to the sample.
     /// @return The request-header of the underlying memory chunk.

--- a/iceoryx_posh/include/iceoryx_posh/popo/response.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/response.hpp
@@ -56,7 +56,7 @@ class Response
     /// release ownership to it.
     /// @details Only available for server (non-const type T)
     template <typename S = T, typename = ForServerOnly<S, T>>
-    expected<ServerSendError> send() noexcept;
+    expected<void, ServerSendError> send() noexcept;
 
     /// @brief Retrieve the response-header of the underlying memory chunk loaned to the sample.
     /// @return The response-header of the underlying memory chunk.

--- a/iceoryx_posh/include/iceoryx_posh/popo/wait_set.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/wait_set.hpp
@@ -86,10 +86,11 @@ class WaitSet
               typename EventType,
               typename ContextDataType = popo::internal::NoType_t,
               typename = std::enable_if_t<std::is_enum<EventType>::value>>
-    expected<WaitSetError> attachEvent(T& eventOrigin,
-                                       const EventType eventType,
-                                       const uint64_t notificationId = 0U,
-                                       const NotificationCallback<T, ContextDataType>& eventCallback = {}) noexcept;
+    expected<void, WaitSetError>
+    attachEvent(T& eventOrigin,
+                const EventType eventType,
+                const uint64_t notificationId = 0U,
+                const NotificationCallback<T, ContextDataType>& eventCallback = {}) noexcept;
 
     /// @brief attaches an event of a given class to the WaitSet.
     /// @note attachEvent does not take ownership of callback in the underlying eventCallback or the optional
@@ -101,9 +102,9 @@ class WaitSet
               typename EventType,
               typename ContextDataType = popo::internal::NoType_t,
               typename = std::enable_if_t<std::is_enum<EventType>::value, void>>
-    expected<WaitSetError> attachEvent(T& eventOrigin,
-                                       const EventType eventType,
-                                       const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
+    expected<void, WaitSetError> attachEvent(T& eventOrigin,
+                                             const EventType eventType,
+                                             const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
 
     /// @brief attaches an event of a given class to the WaitSet.
     /// @note attachEvent does not take ownership of callback in the underlying eventCallback or the optional
@@ -112,9 +113,10 @@ class WaitSet
     /// @param[in] notificationId an arbitrary user defined id for the event
     /// @param[in] eventCallback a callback which should be assigned to the event
     template <typename T, typename ContextDataType = popo::internal::NoType_t>
-    expected<WaitSetError> attachEvent(T& eventOrigin,
-                                       const uint64_t notificationId = 0U,
-                                       const NotificationCallback<T, ContextDataType>& eventCallback = {}) noexcept;
+    expected<void, WaitSetError>
+    attachEvent(T& eventOrigin,
+                const uint64_t notificationId = 0U,
+                const NotificationCallback<T, ContextDataType>& eventCallback = {}) noexcept;
 
     /// @brief attaches an event of a given class to the WaitSet.
     /// @note attachEvent does not take ownership of callback in the underlying eventCallback or the optional
@@ -122,8 +124,8 @@ class WaitSet
     /// @param[in] eventOrigin the class from which the event originates.
     /// @param[in] eventCallback a callback which should be assigned to the event
     template <typename T, typename ContextDataType = popo::internal::NoType_t>
-    expected<WaitSetError> attachEvent(T& eventOrigin,
-                                       const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
+    expected<void, WaitSetError> attachEvent(T& eventOrigin,
+                                             const NotificationCallback<T, ContextDataType>& eventCallback) noexcept;
 
     /// @brief attaches a state of a given class to the WaitSet.
     /// @note attachState does not take ownership of callback in the underlying stateCallback or the optional
@@ -136,10 +138,11 @@ class WaitSet
               typename StateType,
               typename ContextDataType = popo::internal::NoType_t,
               typename = std::enable_if_t<std::is_enum<StateType>::value>>
-    expected<WaitSetError> attachState(T& stateOrigin,
-                                       const StateType stateType,
-                                       const uint64_t id = 0U,
-                                       const NotificationCallback<T, ContextDataType>& stateCallback = {}) noexcept;
+    expected<void, WaitSetError>
+    attachState(T& stateOrigin,
+                const StateType stateType,
+                const uint64_t id = 0U,
+                const NotificationCallback<T, ContextDataType>& stateCallback = {}) noexcept;
 
     /// @brief attaches a state of a given class to the WaitSet.
     /// @note attachState does not take ownership of callback in the underlying stateCallback or the optional
@@ -151,9 +154,9 @@ class WaitSet
               typename StateType,
               typename ContextDataType = popo::internal::NoType_t,
               typename = std::enable_if_t<std::is_enum<StateType>::value, void>>
-    expected<WaitSetError> attachState(T& stateOrigin,
-                                       const StateType stateType,
-                                       const NotificationCallback<T, ContextDataType>& stateCallback) noexcept;
+    expected<void, WaitSetError> attachState(T& stateOrigin,
+                                             const StateType stateType,
+                                             const NotificationCallback<T, ContextDataType>& stateCallback) noexcept;
 
     /// @brief attaches a state of a given class to the WaitSet.
     /// @note attachState does not take ownership of callback in the underlying stateCallback or the optional
@@ -162,9 +165,10 @@ class WaitSet
     /// @param[in] id an arbitrary user defined id for the state
     /// @param[in] stateCallback a callback which should be assigned to the state
     template <typename T, typename ContextDataType = popo::internal::NoType_t>
-    expected<WaitSetError> attachState(T& stateOrigin,
-                                       const uint64_t id = 0U,
-                                       const NotificationCallback<T, ContextDataType>& stateCallback = {}) noexcept;
+    expected<void, WaitSetError>
+    attachState(T& stateOrigin,
+                const uint64_t id = 0U,
+                const NotificationCallback<T, ContextDataType>& stateCallback = {}) noexcept;
 
     /// @brief attaches a state of a given class to the WaitSet.
     /// @note attachState does not take ownership of callback in the underlying stateCallback or the optional
@@ -172,8 +176,8 @@ class WaitSet
     /// @param[in] stateOrigin the class from which the state originates.
     /// @param[in] stateCallback a callback which should be assigned to the state
     template <typename T, typename ContextDataType = popo::internal::NoType_t>
-    expected<WaitSetError> attachState(T& stateOrigin,
-                                       const NotificationCallback<T, ContextDataType>& stateCallback) noexcept;
+    expected<void, WaitSetError> attachState(T& stateOrigin,
+                                             const NotificationCallback<T, ContextDataType>& stateCallback) noexcept;
 
     /// @brief detaches an event from the WaitSet
     /// @param[in] eventOrigin the origin of the event that should be detached

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/iceoryx_roudi_memory_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/iceoryx_roudi_memory_manager.hpp
@@ -46,11 +46,11 @@ class IceOryxRouDiMemoryManager : public RouDiMemoryInterface
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to create the memory and announce the availability
     /// to its MemoryBlocks
     /// @return an RouDiMemoryManagerError if the MemoryProvider cannot create the memory, otherwise success
-    expected<RouDiMemoryManagerError> createAndAnnounceMemory() noexcept override;
+    expected<void, RouDiMemoryManagerError> createAndAnnounceMemory() noexcept override;
 
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to destroy the memory, which in turn prompts the
     /// MemoryBlocks to destroy their data
-    expected<RouDiMemoryManagerError> destroyMemory() noexcept override;
+    expected<void, RouDiMemoryManagerError> destroyMemory() noexcept override;
 
     const PosixShmMemoryProvider* mgmtMemoryProvider() const noexcept override;
     optional<PortPool*> portPool() noexcept override;

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/memory_provider.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/memory_provider.hpp
@@ -84,12 +84,12 @@ class MemoryProvider
     /// @param [in] memoryBlock is a pointer to a user defined MemoryBlock
     /// @return an MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED error if no further memory blocks can be added,
     /// otherwise success
-    expected<MemoryProviderError> addMemoryBlock(not_null<MemoryBlock*> memoryBlock) noexcept;
+    expected<void, MemoryProviderError> addMemoryBlock(not_null<MemoryBlock*> memoryBlock) noexcept;
 
     /// @brief With this call the memory requested by the MemoryBlocks need to be created. The function should be called
     /// from a MemoryManager which handles one or more MemoryProvider
     /// @return an MemoryProviderError if memory allocation was not successful, otherwise success
-    expected<MemoryProviderError> create() noexcept;
+    expected<void, MemoryProviderError> create() noexcept;
 
     /// @brief This function announces the availability of the memory to the MemoryBlocks. The function should be called
     /// from a MemoryManager which handles one or more MemoryProvider
@@ -99,7 +99,7 @@ class MemoryProvider
     /// requested to handle this appropriately, e.g. call the destructor of the underlying type. The
     /// function should be called from a MemoryManager which handles one or more MemoryProvider
     /// @return an error if memory destruction was not successful, otherwise success
-    expected<MemoryProviderError> destroy() noexcept;
+    expected<void, MemoryProviderError> destroy() noexcept;
 
     /// @brief This function provides the base address of the created memory
     /// @return an optional pointer to the base address of the created memory if the memory is available, otherwise a
@@ -137,7 +137,7 @@ class MemoryProvider
     /// @brief This function needs to be implemented to free the actual memory, e.g. in case of POSIX SHM, shm_unlink
     /// and munmap would need to be called in the implementation of this function
     /// @return a MemoryProviderError if the destruction failed, otherwise success
-    virtual expected<MemoryProviderError> destroyMemory() noexcept = 0;
+    virtual expected<void, MemoryProviderError> destroyMemory() noexcept = 0;
 
     static const char* getErrorString(const MemoryProviderError error) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/posix_shm_memory_provider.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/posix_shm_memory_provider.hpp
@@ -58,7 +58,7 @@ class PosixShmMemoryProvider : public MemoryProvider
 
     /// @copydoc MemoryProvider::destroyMemory
     /// @note This closes and unmaps a POSIX shared memory
-    expected<MemoryProviderError> destroyMemory() noexcept;
+    expected<void, MemoryProviderError> destroyMemory() noexcept;
 
   private:
     ShmName_t m_shmName;

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/roudi_memory_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/roudi_memory_interface.hpp
@@ -48,11 +48,11 @@ class RouDiMemoryInterface
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to create the memory and announce the availability
     /// to its MemoryBlocks
     /// @return an RouDiMemoryManagerError if the MemoryProvider cannot create the memory, otherwise success
-    virtual expected<RouDiMemoryManagerError> createAndAnnounceMemory() noexcept = 0;
+    virtual expected<void, RouDiMemoryManagerError> createAndAnnounceMemory() noexcept = 0;
 
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to destroy the memory, which in turn prompts the
     /// MemoryBlocks to destroy their data
-    virtual expected<RouDiMemoryManagerError> destroyMemory() noexcept = 0;
+    virtual expected<void, RouDiMemoryManagerError> destroyMemory() noexcept = 0;
 
     virtual const PosixShmMemoryProvider* mgmtMemoryProvider() const noexcept = 0;
     virtual optional<PortPool*> portPool() noexcept = 0;

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/roudi_memory_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/roudi_memory_manager.hpp
@@ -66,16 +66,16 @@ class RouDiMemoryManager
     /// @param [in] memoryProvider is a pointer to a user defined MemoryProvider
     /// @return an RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED error if no further memory provider can be added,
     /// otherwise success
-    expected<RouDiMemoryManagerError> addMemoryProvider(MemoryProvider* memoryProvider) noexcept;
+    expected<void, RouDiMemoryManagerError> addMemoryProvider(MemoryProvider* memoryProvider) noexcept;
 
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to create the memory and announce the availability
     /// to its MemoryBlocks
     /// @return an RouDiMemoryManagerError if the MemoryProvider cannot create the memory, otherwise success
-    expected<RouDiMemoryManagerError> createAndAnnounceMemory() noexcept;
+    expected<void, RouDiMemoryManagerError> createAndAnnounceMemory() noexcept;
 
     /// @brief The RouDiMemoryManager calls the the MemoryProvider to destroy the memory, which in turn prompts the
     /// MemoryBlocks to destroy their data
-    expected<RouDiMemoryManagerError> destroyMemory() noexcept;
+    expected<void, RouDiMemoryManagerError> destroyMemory() noexcept;
 
   private:
     mepoo::MePooConfig introspectionMemPoolConfig() const noexcept;

--- a/iceoryx_posh/source/capro/service_description.cpp
+++ b/iceoryx_posh/source/capro/service_description.cpp
@@ -175,13 +175,13 @@ ServiceDescription::deserialize(const cxx::Serialization& serialized) noexcept
     if (!deserializationSuccessful || scope >= static_cast<ScopeUnderlyingType>(Scope::INVALID)
         || interfaceSource >= static_cast<InterfaceUnderlyingType>(Interfaces::INTERFACE_END))
     {
-        return error<cxx::Serialization::Error>(cxx::Serialization::Error::DESERIALIZATION_FAILED);
+        return err(cxx::Serialization::Error::DESERIALIZATION_FAILED);
     }
 
     deserializedObject.m_scope = static_cast<Scope>(scope);
     deserializedObject.m_interfaceSource = static_cast<Interfaces>(interfaceSource);
 
-    return success<ServiceDescription>(deserializedObject);
+    return ok(deserializedObject);
 }
 
 const IdString_t& ServiceDescription::getServiceIDString() const noexcept

--- a/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
@@ -59,7 +59,7 @@ iox::config::TomlGatewayConfigParser::parse(const roudi::ConfigFilePathString_t&
     auto parseResult = TomlGatewayConfigParser::parse(fileStream, config);
     if (parseResult.has_error())
     {
-        return iox::err(parseResult.get_error());
+        return iox::err(parseResult.error());
     }
 
     return iox::ok(config);
@@ -72,7 +72,7 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream) noexcept
     auto parseResult = TomlGatewayConfigParser::parse(stream, config);
     if (parseResult.has_error())
     {
-        return iox::err(parseResult.get_error());
+        return iox::err(parseResult.error());
     }
 
     return iox::ok(config);
@@ -100,7 +100,7 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream, GatewayConfig&
     auto result = validate(*parsedToml);
     if (result.has_error())
     {
-        return iox::err(result.get_error());
+        return iox::err(result.error());
     }
 
     // Prepare config object

--- a/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
@@ -35,7 +35,7 @@ iox::config::TomlGatewayConfigParser::parse(const roudi::ConfigFilePathString_t&
     {
         IOX_LOG(WARN) << "Invalid file path provided. Falling back to built-in config.";
         config.setDefaults();
-        return iox::success<GatewayConfig>(config);
+        return iox::ok(config);
     }
 
     /// @todo iox-#1718 Replace with C++17 std::filesystem::exists()
@@ -44,7 +44,7 @@ iox::config::TomlGatewayConfigParser::parse(const roudi::ConfigFilePathString_t&
     {
         IOX_LOG(WARN) << "Gateway config file not found at: '" << path << "'. Falling back to built-in config.";
         config.setDefaults();
-        return iox::success<GatewayConfig>(config);
+        return iox::ok(config);
     }
 
     IOX_LOG(INFO) << "Using gateway config at: " << path;
@@ -53,17 +53,16 @@ iox::config::TomlGatewayConfigParser::parse(const roudi::ConfigFilePathString_t&
     if (!fileStream.is_open())
     {
         IOX_LOG(ERROR) << "Could not open config file from path '" << path << "'";
-        return iox::error<iox::config::TomlGatewayConfigParseError>(
-            iox::config::TomlGatewayConfigParseError::FILE_OPEN_FAILED);
+        return iox::err(iox::config::TomlGatewayConfigParseError::FILE_OPEN_FAILED);
     }
 
     auto parseResult = TomlGatewayConfigParser::parse(fileStream, config);
     if (parseResult.has_error())
     {
-        return iox::error<iox::config::TomlGatewayConfigParseError>(parseResult.get_error());
+        return iox::err(parseResult.get_error());
     }
 
-    return iox::success<GatewayConfig>(config);
+    return iox::ok(config);
 }
 
 iox::expected<iox::config::GatewayConfig, iox::config::TomlGatewayConfigParseError>
@@ -73,10 +72,10 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream) noexcept
     auto parseResult = TomlGatewayConfigParser::parse(stream, config);
     if (parseResult.has_error())
     {
-        return iox::error<iox::config::TomlGatewayConfigParseError>(parseResult.get_error());
+        return iox::err(parseResult.get_error());
     }
 
-    return iox::success<GatewayConfig>(config);
+    return iox::ok(config);
 }
 
 iox::expected<void, iox::config::TomlGatewayConfigParseError>
@@ -95,13 +94,13 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream, GatewayConfig&
         IOX_LOG(WARN) << iox::config::TOML_GATEWAY_CONFIG_FILE_PARSE_ERROR_STRINGS[errorStringIndex] << ": "
                       << parserException.what();
 
-        return iox::error<iox::config::TomlGatewayConfigParseError>(parserError);
+        return iox::err(parserError);
     }
 
     auto result = validate(*parsedToml);
     if (result.has_error())
     {
-        return iox::error<TomlGatewayConfigParseError>(result.get_error());
+        return iox::err(result.get_error());
     }
 
     // Prepare config object
@@ -118,7 +117,7 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream, GatewayConfig&
         config.m_configuredServices.push_back(entry);
     }
 
-    return iox::success<>();
+    return iox::ok();
 }
 
 iox::expected<void, iox::config::TomlGatewayConfigParseError>
@@ -128,12 +127,12 @@ iox::config::TomlGatewayConfigParser::validate(const cpptoml::table& parsedToml)
     auto serviceArray = parsedToml.get_table_array(GATEWAY_CONFIG_SERVICE_TABLE_NAME);
     if (!serviceArray)
     {
-        return iox::error<TomlGatewayConfigParseError>(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION);
+        return iox::err(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION);
     }
 
     if (serviceArray->get().size() > iox::MAX_GATEWAY_SERVICES)
     {
-        return iox::error<TomlGatewayConfigParseError>(TomlGatewayConfigParseError::MAXIMUM_NUMBER_OF_ENTRIES_EXCEEDED);
+        return iox::err(TomlGatewayConfigParseError::MAXIMUM_NUMBER_OF_ENTRIES_EXCEEDED);
     }
 
     for (const auto& service : *serviceArray)
@@ -145,17 +144,17 @@ iox::config::TomlGatewayConfigParser::validate(const cpptoml::table& parsedToml)
         // check for incomplete service descriptions
         if (!serviceName || !instance || !event)
         {
-            return iox::error<TomlGatewayConfigParseError>(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION);
+            return iox::err(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION);
         }
 
         // check for invalid characters in strings
         if (hasInvalidCharacter(*serviceName) || hasInvalidCharacter(*instance) || hasInvalidCharacter(*event))
         {
-            return iox::error<TomlGatewayConfigParseError>(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION);
+            return iox::err(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION);
         }
     }
 
-    return iox::success<>();
+    return iox::ok();
 }
 
 bool iox::config::TomlGatewayConfigParser::hasInvalidCharacter(const std::string& s) noexcept

--- a/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/source/gateway/toml_gateway_config_parser.cpp
@@ -79,7 +79,7 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream) noexcept
     return iox::success<GatewayConfig>(config);
 }
 
-iox::expected<iox::config::TomlGatewayConfigParseError>
+iox::expected<void, iox::config::TomlGatewayConfigParseError>
 iox::config::TomlGatewayConfigParser::parse(std::istream& stream, GatewayConfig& config) noexcept
 {
     std::shared_ptr<cpptoml::table> parsedToml{nullptr};
@@ -121,7 +121,7 @@ iox::config::TomlGatewayConfigParser::parse(std::istream& stream, GatewayConfig&
     return iox::success<>();
 }
 
-iox::expected<iox::config::TomlGatewayConfigParseError>
+iox::expected<void, iox::config::TomlGatewayConfigParseError>
 iox::config::TomlGatewayConfigParser::validate(const cpptoml::table& parsedToml) noexcept
 {
     // Check for expected fields

--- a/iceoryx_posh/source/mepoo/chunk_settings.cpp
+++ b/iceoryx_posh/source/mepoo/chunk_settings.cpp
@@ -48,19 +48,19 @@ expected<ChunkSettings, ChunkSettings::Error> ChunkSettings::create(const uint32
 
     if (!isPowerOfTwo(adjustedUserPayloadAlignment) || !isPowerOfTwo(adjustedUserHeaderAlignment))
     {
-        return error<ChunkSettings::Error>(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO);
+        return err(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO);
     }
 
     if (adjustedUserHeaderAlignment > alignof(ChunkHeader))
     {
         // for ease of calculation, the alignment of the user-header is restricted to not exceed the alignment of the
         // ChunkHeader
-        return error<ChunkSettings::Error>(ChunkSettings::Error::USER_HEADER_ALIGNMENT_EXCEEDS_CHUNK_HEADER_ALIGNMENT);
+        return err(ChunkSettings::Error::USER_HEADER_ALIGNMENT_EXCEEDS_CHUNK_HEADER_ALIGNMENT);
     }
 
     if (userHeaderSize % adjustedUserHeaderAlignment != 0U)
     {
-        return error<ChunkSettings::Error>(ChunkSettings::Error::USER_HEADER_SIZE_NOT_MULTIPLE_OF_ITS_ALIGNMENT);
+        return err(ChunkSettings::Error::USER_HEADER_SIZE_NOT_MULTIPLE_OF_ITS_ALIGNMENT);
     }
 
     uint64_t requiredChunkSize =
@@ -68,14 +68,14 @@ expected<ChunkSettings, ChunkSettings::Error> ChunkSettings::create(const uint32
 
     if (requiredChunkSize > std::numeric_limits<uint32_t>::max())
     {
-        return error<ChunkSettings::Error>(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE);
+        return err(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE);
     }
 
-    return success<ChunkSettings>(ChunkSettings{userPayloadSize,
-                                                adjustedUserPayloadAlignment,
-                                                userHeaderSize,
-                                                adjustedUserHeaderAlignment,
-                                                static_cast<uint32_t>(requiredChunkSize)});
+    return ok(ChunkSettings{userPayloadSize,
+                            adjustedUserPayloadAlignment,
+                            userHeaderSize,
+                            adjustedUserHeaderAlignment,
+                            static_cast<uint32_t>(requiredChunkSize)});
 }
 uint64_t ChunkSettings::calculateRequiredChunkSize(const uint32_t userPayloadSize,
                                                    const uint32_t userPayloadAlignment,

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -50,12 +50,12 @@ MemPool::MemPool(const greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkS
     {
         auto allocationResult = chunkMemoryAllocator.allocate(static_cast<uint64_t>(m_numberOfChunks) * m_chunkSize,
                                                               CHUNK_MEMORY_ALIGNMENT);
-        cxx::Expects(!allocationResult.has_error());
+        cxx::Expects(allocationResult.has_value());
         m_rawMemory = static_cast<uint8_t*>(allocationResult.value());
 
         allocationResult =
             managementAllocator.allocate(freeList_t::requiredIndexMemorySize(m_numberOfChunks), CHUNK_MEMORY_ALIGNMENT);
-        cxx::Expects(!allocationResult.has_error());
+        cxx::Expects(allocationResult.has_value());
         auto* memoryLoFFLi = allocationResult.value();
         m_freeIndices.init(static_cast<concurrent::LoFFLi::Index_t*>(memoryLoFFLi), m_numberOfChunks);
     }

--- a/iceoryx_posh/source/mepoo/memory_manager.cpp
+++ b/iceoryx_posh/source/mepoo/memory_manager.cpp
@@ -168,7 +168,7 @@ expected<SharedChunk, MemoryManager::Error> MemoryManager::getChunk(const ChunkS
         IOX_LOG(FATAL) << "There are no mempools available!";
 
         errorHandler(iox::PoshError::MEPOO__MEMPOOL_GETCHUNK_CHUNK_WITHOUT_MEMPOOL, ErrorLevel::SEVERE);
-        return error<Error>(Error::NO_MEMPOOLS_AVAILABLE);
+        return err(Error::NO_MEMPOOLS_AVAILABLE);
     }
     else if (memPoolPointer == nullptr)
     {
@@ -179,7 +179,7 @@ expected<SharedChunk, MemoryManager::Error> MemoryManager::getChunk(const ChunkS
           << requiredChunkSize;
 
         errorHandler(iox::PoshError::MEPOO__MEMPOOL_GETCHUNK_CHUNK_IS_TOO_LARGE, ErrorLevel::SEVERE);
-        return error<Error>(Error::NO_MEMPOOL_FOR_REQUESTED_CHUNK_SIZE);
+        return err(Error::NO_MEMPOOL_FOR_REQUESTED_CHUNK_SIZE);
     }
     else if (chunk == nullptr)
     {
@@ -191,14 +191,14 @@ expected<SharedChunk, MemoryManager::Error> MemoryManager::getChunk(const ChunkS
         };
 
         errorHandler(iox::PoshError::MEPOO__MEMPOOL_GETCHUNK_POOL_IS_RUNNING_OUT_OF_CHUNKS, ErrorLevel::MODERATE);
-        return error<Error>(Error::MEMPOOL_OUT_OF_CHUNKS);
+        return err(Error::MEMPOOL_OUT_OF_CHUNKS);
     }
     else
     {
         auto chunkHeader = new (chunk) ChunkHeader(aquiredChunkSize, chunkSettings);
         auto chunkManagement = new (m_chunkManagementPool.front().getChunk())
             ChunkManagement(chunkHeader, memPoolPointer, &m_chunkManagementPool.front());
-        return success<SharedChunk>(SharedChunk(chunkManagement));
+        return ok(SharedChunk(chunkManagement));
     }
 }
 

--- a/iceoryx_posh/source/popo/client_options.cpp
+++ b/iceoryx_posh/source/popo/client_options.cpp
@@ -50,12 +50,12 @@ ClientOptions::deserialize(const cxx::Serialization& serialized) noexcept
         || responseQueueFullPolicy > static_cast<QueueFullPolicyUT>(QueueFullPolicy::DISCARD_OLDEST_DATA)
         || serverTooSlowPolicy > static_cast<ConsumerTooSlowPolicyUT>(ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA))
     {
-        return error<cxx::Serialization::Error>(cxx::Serialization::Error::DESERIALIZATION_FAILED);
+        return err(cxx::Serialization::Error::DESERIALIZATION_FAILED);
     }
 
     clientOptions.responseQueueFullPolicy = static_cast<QueueFullPolicy>(responseQueueFullPolicy);
     clientOptions.serverTooSlowPolicy = static_cast<ConsumerTooSlowPolicy>(serverTooSlowPolicy);
-    return success<ClientOptions>(clientOptions);
+    return ok(clientOptions);
 }
 
 bool ClientOptions::operator==(const ClientOptions& rhs) const noexcept

--- a/iceoryx_posh/source/popo/ports/client_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_user.cpp
@@ -46,7 +46,7 @@ expected<RequestHeader*, AllocationError> ClientPortUser::allocateRequest(const 
 
     if (allocateResult.has_error())
     {
-        return err(allocateResult.get_error());
+        return err(allocateResult.error());
     }
 
     auto* requestHeader = new (allocateResult.value()->userHeader())
@@ -121,7 +121,7 @@ expected<const ResponseHeader*, ChunkReceiveResult> ClientPortUser::getResponse(
 
     if (getChunkResult.has_error())
     {
-        return err(getChunkResult.get_error());
+        return err(getChunkResult.error());
     }
 
     return ok(static_cast<const ResponseHeader*>(getChunkResult.value()->userHeader()));

--- a/iceoryx_posh/source/popo/ports/client_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_user.cpp
@@ -67,7 +67,7 @@ void ClientPortUser::releaseRequest(const RequestHeader* const requestHeader) no
     }
 }
 
-expected<ClientSendError> ClientPortUser::sendRequest(RequestHeader* const requestHeader) noexcept
+expected<void, ClientSendError> ClientPortUser::sendRequest(RequestHeader* const requestHeader) noexcept
 {
     if (requestHeader == nullptr)
     {

--- a/iceoryx_posh/source/popo/ports/server_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_user.cpp
@@ -49,7 +49,7 @@ expected<const RequestHeader*, ServerRequestResult> ServerPortUser::getRequest()
             return err(ServerRequestResult::NO_PENDING_REQUESTS_AND_SERVER_DOES_NOT_OFFER);
         }
         /// @todo iox-#1012 use error<E2>::from(E1); once available
-        return err(into<ServerRequestResult>(getChunkResult.get_error()));
+        return err(into<ServerRequestResult>(getChunkResult.error()));
     }
 
     return ok(static_cast<const RequestHeader*>(getChunkResult.value()->userHeader()));
@@ -98,7 +98,7 @@ ServerPortUser::allocateResponse(const RequestHeader* const requestHeader,
 
     if (allocateResult.has_error())
     {
-        return err(allocateResult.get_error());
+        return err(allocateResult.error());
     }
 
     auto* responseHeader =

--- a/iceoryx_posh/source/popo/ports/server_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_user.cpp
@@ -122,7 +122,7 @@ void ServerPortUser::releaseResponse(const ResponseHeader* const responseHeader)
     }
 }
 
-expected<ServerSendError> ServerPortUser::sendResponse(ResponseHeader* const responseHeader) noexcept
+expected<void, ServerSendError> ServerPortUser::sendResponse(ResponseHeader* const responseHeader) noexcept
 {
     if (responseHeader == nullptr)
     {

--- a/iceoryx_posh/source/popo/publisher_options.cpp
+++ b/iceoryx_posh/source/popo/publisher_options.cpp
@@ -46,11 +46,11 @@ PublisherOptions::deserialize(const cxx::Serialization& serialized) noexcept
     if (!deserializationSuccessful
         || subscriberTooSlowPolicy > static_cast<ConsumerTooSlowPolicyUT>(ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA))
     {
-        return error<cxx::Serialization::Error>(cxx::Serialization::Error::DESERIALIZATION_FAILED);
+        return err(cxx::Serialization::Error::DESERIALIZATION_FAILED);
     }
 
     publisherOptions.subscriberTooSlowPolicy = static_cast<ConsumerTooSlowPolicy>(subscriberTooSlowPolicy);
-    return success<PublisherOptions>(publisherOptions);
+    return ok(publisherOptions);
 }
 } // namespace popo
 } // namespace iox

--- a/iceoryx_posh/source/popo/server_options.cpp
+++ b/iceoryx_posh/source/popo/server_options.cpp
@@ -50,13 +50,13 @@ ServerOptions::deserialize(const cxx::Serialization& serialized) noexcept
         || requestQueueFullPolicy > static_cast<QueueFullPolicyUT>(QueueFullPolicy::DISCARD_OLDEST_DATA)
         || clientTooSlowPolicy > static_cast<ClientTooSlowPolicyUT>(ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA))
     {
-        return error<cxx::Serialization::Error>(cxx::Serialization::Error::DESERIALIZATION_FAILED);
+        return err(cxx::Serialization::Error::DESERIALIZATION_FAILED);
     }
 
     serverOptions.requestQueueFullPolicy = static_cast<QueueFullPolicy>(requestQueueFullPolicy);
     serverOptions.clientTooSlowPolicy = static_cast<ConsumerTooSlowPolicy>(clientTooSlowPolicy);
 
-    return success<ServerOptions>(serverOptions);
+    return ok(serverOptions);
 }
 
 bool ServerOptions::operator==(const ServerOptions& rhs) const noexcept

--- a/iceoryx_posh/source/popo/subscriber_options.cpp
+++ b/iceoryx_posh/source/popo/subscriber_options.cpp
@@ -49,11 +49,11 @@ SubscriberOptions::deserialize(const cxx::Serialization& serialized) noexcept
     if (!deserializationSuccessful
         || queueFullPolicy > static_cast<QueueFullPolicyUT>(QueueFullPolicy::DISCARD_OLDEST_DATA))
     {
-        return error<cxx::Serialization::Error>(cxx::Serialization::Error::DESERIALIZATION_FAILED);
+        return err(cxx::Serialization::Error::DESERIALIZATION_FAILED);
     }
 
     subscriberOptions.queueFullPolicy = static_cast<QueueFullPolicy>(queueFullPolicy);
-    return success<SubscriberOptions>(subscriberOptions);
+    return ok(subscriberOptions);
 }
 } // namespace popo
 } // namespace iox

--- a/iceoryx_posh/source/roudi/application/roudi_main.cpp
+++ b/iceoryx_posh/source/roudi/application/roudi_main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) noexcept
 
     iox::config::CmdLineParserConfigFileOption cmdLineParser;
     auto cmdLineArgs = cmdLineParser.parse(argc, argv);
-    if (cmdLineArgs.has_error() && (cmdLineArgs.get_error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
+    if (cmdLineArgs.has_error() && (cmdLineArgs.error() != iox::config::CmdLineParserResult::INFO_OUTPUT_ONLY))
     {
         IOX_LOG(FATAL) << "Unable to parse command line arguments!";
         return EXIT_FAILURE;
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) noexcept
 
     if (roudiConfig.has_error())
     {
-        auto errorStringIndex = static_cast<uint64_t>(roudiConfig.get_error());
+        auto errorStringIndex = static_cast<uint64_t>(roudiConfig.error());
         IOX_LOG(FATAL) << "Couldn't parse config file. Error: "
                        << iox::roudi::ROUDI_CONFIG_FILE_PARSE_ERROR_STRINGS[errorStringIndex];
         return EXIT_FAILURE;

--- a/iceoryx_posh/source/roudi/memory/iceoryx_roudi_memory_manager.cpp
+++ b/iceoryx_posh/source/roudi/memory/iceoryx_roudi_memory_manager.cpp
@@ -36,7 +36,7 @@ expected<void, RouDiMemoryManagerError> IceOryxRouDiMemoryManager::createAndAnno
 {
     auto result = m_memoryManager.createAndAnnounceMemory();
     auto portPool = m_portPoolBlock.portPool();
-    if (!result.has_error() && portPool.has_value())
+    if (result.has_value() && portPool.has_value())
     {
         m_portPool.emplace(*portPool.value());
     }

--- a/iceoryx_posh/source/roudi/memory/iceoryx_roudi_memory_manager.cpp
+++ b/iceoryx_posh/source/roudi/memory/iceoryx_roudi_memory_manager.cpp
@@ -32,7 +32,7 @@ IceOryxRouDiMemoryManager::IceOryxRouDiMemoryManager(const RouDiConfig_t& roudiC
     });
 }
 
-expected<RouDiMemoryManagerError> IceOryxRouDiMemoryManager::createAndAnnounceMemory() noexcept
+expected<void, RouDiMemoryManagerError> IceOryxRouDiMemoryManager::createAndAnnounceMemory() noexcept
 {
     auto result = m_memoryManager.createAndAnnounceMemory();
     auto portPool = m_portPoolBlock.portPool();
@@ -43,7 +43,7 @@ expected<RouDiMemoryManagerError> IceOryxRouDiMemoryManager::createAndAnnounceMe
     return result;
 }
 
-expected<RouDiMemoryManagerError> IceOryxRouDiMemoryManager::destroyMemory() noexcept
+expected<void, RouDiMemoryManagerError> IceOryxRouDiMemoryManager::destroyMemory() noexcept
 {
     return m_memoryManager.destroyMemory();
 }

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -78,7 +78,7 @@ expected<void, MemoryProviderError> MemoryProvider::create() noexcept
 
     if (memoryResult.has_error())
     {
-        return err(memoryResult.get_error());
+        return err(memoryResult.error());
     }
 
     m_memory = memoryResult.value();

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -36,26 +36,26 @@ expected<void, MemoryProviderError> MemoryProvider::addMemoryBlock(not_null<Memo
 {
     if (isAvailable())
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_ALREADY_CREATED);
+        return err(MemoryProviderError::MEMORY_ALREADY_CREATED);
     }
 
     if (m_memoryBlocks.push_back(memoryBlock))
     {
-        return success<void>();
+        return ok();
     }
-    return error<MemoryProviderError>(MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED);
+    return err(MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED);
 }
 
 expected<void, MemoryProviderError> MemoryProvider::create() noexcept
 {
     if (m_memoryBlocks.empty())
     {
-        return error<MemoryProviderError>(MemoryProviderError::NO_MEMORY_BLOCKS_PRESENT);
+        return err(MemoryProviderError::NO_MEMORY_BLOCKS_PRESENT);
     }
 
     if (isAvailable())
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_ALREADY_CREATED);
+        return err(MemoryProviderError::MEMORY_ALREADY_CREATED);
     }
 
     uint64_t totalSize = 0u;
@@ -78,7 +78,7 @@ expected<void, MemoryProviderError> MemoryProvider::create() noexcept
 
     if (memoryResult.has_error())
     {
-        return error<MemoryProviderError>(memoryResult.get_error());
+        return err(memoryResult.get_error());
     }
 
     m_memory = memoryResult.value();
@@ -101,19 +101,19 @@ expected<void, MemoryProviderError> MemoryProvider::create() noexcept
         auto allocationResult = allocator.allocate(memoryBlock->size(), memoryBlock->alignment());
         if (allocationResult.has_error())
         {
-            return cxx::error<MemoryProviderError>(MemoryProviderError::MEMORY_ALLOCATION_FAILED);
+            return err(MemoryProviderError::MEMORY_ALLOCATION_FAILED);
         }
         memoryBlock->m_memory = allocationResult.value();
     }
 
-    return success<void>();
+    return ok();
 }
 
 expected<void, MemoryProviderError> MemoryProvider::destroy() noexcept
 {
     if (!isAvailable())
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_NOT_AVAILABLE);
+        return err(MemoryProviderError::MEMORY_NOT_AVAILABLE);
     }
 
     for (auto* memoryBlock : m_memoryBlocks)

--- a/iceoryx_posh/source/roudi/memory/memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/memory_provider.cpp
@@ -32,7 +32,7 @@ MemoryProvider::~MemoryProvider() noexcept
     // destroy has to be called manually from outside, since it calls a pure virtual function
 }
 
-expected<MemoryProviderError> MemoryProvider::addMemoryBlock(not_null<MemoryBlock*> memoryBlock) noexcept
+expected<void, MemoryProviderError> MemoryProvider::addMemoryBlock(not_null<MemoryBlock*> memoryBlock) noexcept
 {
     if (isAvailable())
     {
@@ -46,7 +46,7 @@ expected<MemoryProviderError> MemoryProvider::addMemoryBlock(not_null<MemoryBloc
     return error<MemoryProviderError>(MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED);
 }
 
-expected<MemoryProviderError> MemoryProvider::create() noexcept
+expected<void, MemoryProviderError> MemoryProvider::create() noexcept
 {
     if (m_memoryBlocks.empty())
     {
@@ -109,7 +109,7 @@ expected<MemoryProviderError> MemoryProvider::create() noexcept
     return success<void>();
 }
 
-expected<MemoryProviderError> MemoryProvider::destroy() noexcept
+expected<void, MemoryProviderError> MemoryProvider::destroy() noexcept
 {
     if (!isAvailable())
     {

--- a/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_collection_memory_block.cpp
@@ -54,7 +54,7 @@ void MemPoolCollectionMemoryBlock::onMemoryAvailable(not_null<void*> memory) noe
 {
     BumpAllocator allocator(memory, size());
     auto allocationResult = allocator.allocate(sizeof(mepoo::MemoryManager), alignof(mepoo::MemoryManager));
-    cxx::Expects(!allocationResult.has_error());
+    cxx::Expects(allocationResult.has_value());
     auto* memoryManager = allocationResult.value();
     m_memoryManager = new (memoryManager) mepoo::MemoryManager;
 

--- a/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
+++ b/iceoryx_posh/source/roudi/memory/mempool_segment_manager_memory_block.cpp
@@ -51,7 +51,7 @@ void MemPoolSegmentManagerMemoryBlock::onMemoryAvailable(not_null<void*> memory)
 {
     BumpAllocator allocator(memory, size());
     auto allocationResult = allocator.allocate(sizeof(mepoo::SegmentManager<>), alignof(mepoo::SegmentManager<>));
-    cxx::Expects(!allocationResult.has_error());
+    cxx::Expects(allocationResult.has_value());
     auto* segmentManager = allocationResult.value();
     m_segmentManager = new (segmentManager) mepoo::SegmentManager<>(m_segmentConfig, &allocator);
 }

--- a/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
@@ -51,7 +51,7 @@ expected<void*, MemoryProviderError> PosixShmMemoryProvider::createMemory(const 
 {
     if (alignment > internal::pageSize())
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_ALIGNMENT_EXCEEDS_PAGE_SIZE);
+        return err(MemoryProviderError::MEMORY_ALIGNMENT_EXCEEDS_PAGE_SIZE);
     }
 
     if (!posix::SharedMemoryObjectBuilder()
@@ -63,22 +63,22 @@ expected<void*, MemoryProviderError> PosixShmMemoryProvider::createMemory(const 
              .create()
              .and_then([this](auto& sharedMemoryObject) { m_shmObject.emplace(std::move(sharedMemoryObject)); }))
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_CREATION_FAILED);
+        return err(MemoryProviderError::MEMORY_CREATION_FAILED);
     }
 
     auto baseAddress = m_shmObject->getBaseAddress();
     if (baseAddress == nullptr)
     {
-        return error<MemoryProviderError>(MemoryProviderError::MEMORY_CREATION_FAILED);
+        return err(MemoryProviderError::MEMORY_CREATION_FAILED);
     }
 
-    return success<void*>(baseAddress);
+    return ok(baseAddress);
 }
 
 expected<void, MemoryProviderError> PosixShmMemoryProvider::destroyMemory() noexcept
 {
     m_shmObject.reset();
-    return success<void>();
+    return ok();
 }
 
 } // namespace roudi

--- a/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
@@ -75,7 +75,7 @@ expected<void*, MemoryProviderError> PosixShmMemoryProvider::createMemory(const 
     return success<void*>(baseAddress);
 }
 
-expected<MemoryProviderError> PosixShmMemoryProvider::destroyMemory() noexcept
+expected<void, MemoryProviderError> PosixShmMemoryProvider::destroyMemory() noexcept
 {
     m_shmObject.reset();
     return success<void>();

--- a/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
+++ b/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
@@ -74,7 +74,7 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMem
         if (result.has_error())
         {
             IOX_LOG(ERROR) << "Could not create memory: MemoryProviderError = "
-                           << MemoryProvider::getErrorString(result.get_error());
+                           << MemoryProvider::getErrorString(result.error());
             return err(RouDiMemoryManagerError::MEMORY_CREATION_FAILED);
         }
     }
@@ -93,10 +93,10 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::destroyMemory() noex
     for (auto memoryProvider : m_memoryProvider)
     {
         auto destructionResult = memoryProvider->destroy();
-        if (destructionResult.has_error() && destructionResult.get_error() != MemoryProviderError::MEMORY_NOT_AVAILABLE)
+        if (destructionResult.has_error() && destructionResult.error() != MemoryProviderError::MEMORY_NOT_AVAILABLE)
         {
             IOX_LOG(ERROR) << "Could not destroy memory provider! Error: "
-                           << static_cast<uint64_t>(destructionResult.get_error());
+                           << static_cast<uint64_t>(destructionResult.error());
             /// @note do not return on first error but try to cleanup the remaining resources
             if (!result.has_error())
             {

--- a/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
+++ b/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
@@ -56,16 +56,16 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::addMemoryProvider(Me
 {
     if (m_memoryProvider.push_back(memoryProvider))
     {
-        return success<>();
+        return ok();
     }
-    return error<RouDiMemoryManagerError>(RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED);
+    return err(RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED);
 }
 
 expected<void, RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMemory() noexcept
 {
     if (m_memoryProvider.empty())
     {
-        return error<RouDiMemoryManagerError>(RouDiMemoryManagerError::NO_MEMORY_PROVIDER_PRESENT);
+        return err(RouDiMemoryManagerError::NO_MEMORY_PROVIDER_PRESENT);
     }
 
     for (auto memoryProvider : m_memoryProvider)
@@ -75,7 +75,7 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMem
         {
             IOX_LOG(ERROR) << "Could not create memory: MemoryProviderError = "
                            << MemoryProvider::getErrorString(result.get_error());
-            return error<RouDiMemoryManagerError>(RouDiMemoryManagerError::MEMORY_CREATION_FAILED);
+            return err(RouDiMemoryManagerError::MEMORY_CREATION_FAILED);
         }
     }
 
@@ -84,12 +84,12 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMem
         memoryProvider->announceMemoryAvailable();
     }
 
-    return success<>();
+    return ok();
 }
 
 expected<void, RouDiMemoryManagerError> RouDiMemoryManager::destroyMemory() noexcept
 {
-    expected<void, RouDiMemoryManagerError> result = success<void>();
+    expected<void, RouDiMemoryManagerError> result = ok();
     for (auto memoryProvider : m_memoryProvider)
     {
         auto destructionResult = memoryProvider->destroy();
@@ -100,7 +100,7 @@ expected<void, RouDiMemoryManagerError> RouDiMemoryManager::destroyMemory() noex
             /// @note do not return on first error but try to cleanup the remaining resources
             if (!result.has_error())
             {
-                result = error<RouDiMemoryManagerError>(RouDiMemoryManagerError::MEMORY_DESTRUCTION_FAILED);
+                result = err(RouDiMemoryManagerError::MEMORY_DESTRUCTION_FAILED);
             }
         }
     }

--- a/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
+++ b/iceoryx_posh/source/roudi/memory/roudi_memory_manager.cpp
@@ -52,7 +52,7 @@ RouDiMemoryManager::~RouDiMemoryManager() noexcept
     destroyMemory().or_else([](auto) { IOX_LOG(WARN) << "Failed to cleanup RouDiMemoryManager in destructor."; });
 }
 
-expected<RouDiMemoryManagerError> RouDiMemoryManager::addMemoryProvider(MemoryProvider* memoryProvider) noexcept
+expected<void, RouDiMemoryManagerError> RouDiMemoryManager::addMemoryProvider(MemoryProvider* memoryProvider) noexcept
 {
     if (m_memoryProvider.push_back(memoryProvider))
     {
@@ -61,7 +61,7 @@ expected<RouDiMemoryManagerError> RouDiMemoryManager::addMemoryProvider(MemoryPr
     return error<RouDiMemoryManagerError>(RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED);
 }
 
-expected<RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMemory() noexcept
+expected<void, RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMemory() noexcept
 {
     if (m_memoryProvider.empty())
     {
@@ -87,9 +87,9 @@ expected<RouDiMemoryManagerError> RouDiMemoryManager::createAndAnnounceMemory() 
     return success<>();
 }
 
-expected<RouDiMemoryManagerError> RouDiMemoryManager::destroyMemory() noexcept
+expected<void, RouDiMemoryManagerError> RouDiMemoryManager::destroyMemory() noexcept
 {
-    expected<RouDiMemoryManagerError> result = success<void>();
+    expected<void, RouDiMemoryManagerError> result = success<void>();
     for (auto memoryProvider : m_memoryProvider)
     {
         auto destructionResult = memoryProvider->destroy();

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -874,7 +874,7 @@ PortManager::acquirePublisherPortDataWithoutDiscovery(const capro::ServiceDescri
             }))
     {
         errorHandler(PoshError::POSH__PORT_MANAGER_PUBLISHERPORT_NOT_UNIQUE, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::UNIQUE_PUBLISHER_PORT_ALREADY_EXISTS);
+        return err(PortPoolError::UNIQUE_PUBLISHER_PORT_ALREADY_EXISTS);
     }
 
     if (runtimeName == RuntimeName_t{IPC_CHANNEL_ROUDI_NAME})
@@ -884,7 +884,7 @@ PortManager::acquirePublisherPortDataWithoutDiscovery(const capro::ServiceDescri
     else if (isInternal(service))
     {
         errorHandler(PoshError::POSH__PORT_MANAGER_INTERNAL_SERVICE_DESCRIPTION_IS_FORBIDDEN, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::INTERNAL_SERVICE_DESCRIPTION_IS_FORBIDDEN);
+        return err(PortPoolError::INTERNAL_SERVICE_DESCRIPTION_IS_FORBIDDEN);
     }
 
     // we can create a new port
@@ -1002,7 +1002,7 @@ PortManager::acquireServerPortData(const capro::ServiceDescription& service,
                           << serverPortData->m_runtimeName << "' with service '"
                           << service.operator cxx::Serialization().toString() << "'.";
             errorHandler(PoshError::POSH__PORT_MANAGER_SERVERPORT_NOT_UNIQUE, ErrorLevel::MODERATE);
-            return error<PortPoolError>(PortPoolError::UNIQUE_SERVER_PORT_ALREADY_EXISTS);
+            return err(PortPoolError::UNIQUE_SERVER_PORT_ALREADY_EXISTS);
         }
     }
 

--- a/iceoryx_posh/source/roudi/port_manager.cpp
+++ b/iceoryx_posh/source/roudi/port_manager.cpp
@@ -891,7 +891,7 @@ PortManager::acquirePublisherPortDataWithoutDiscovery(const capro::ServiceDescri
     auto maybePublisherPortData = m_portPool->addPublisherPort(
         service, payloadDataSegmentMemoryManager, runtimeName, publisherOptions, portConfigInfo.memoryInfo);
 
-    if (!maybePublisherPortData.has_error())
+    if (maybePublisherPortData.has_value())
     {
         auto publisherPortData = maybePublisherPortData.value();
         if (publisherPortData)
@@ -944,7 +944,7 @@ PortManager::acquireSubscriberPortData(const capro::ServiceDescription& service,
 {
     auto maybeSubscriberPortData =
         m_portPool->addSubscriberPort(service, runtimeName, subscriberOptions, portConfigInfo.memoryInfo);
-    if (!maybeSubscriberPortData.has_error())
+    if (maybeSubscriberPortData.has_value())
     {
         auto subscriberPortData = maybeSubscriberPortData.value();
         if (subscriberPortData)
@@ -1024,7 +1024,7 @@ popo::InterfacePortData* PortManager::acquireInterfacePortData(capro::Interfaces
                                                                const NodeName_t& /*node*/) noexcept
 {
     auto result = m_portPool->addInterfacePort(runtimeName, interface);
-    if (!result.has_error())
+    if (result.has_value())
     {
         return result.value();
     }

--- a/iceoryx_posh/source/roudi/port_pool.cpp
+++ b/iceoryx_posh/source/roudi/port_pool.cpp
@@ -49,13 +49,13 @@ expected<popo::InterfacePortData*, PortPoolError> PortPool::addInterfacePort(con
     if (m_portPoolData->m_interfacePortMembers.hasFreeSpace())
     {
         auto interfacePortData = m_portPoolData->m_interfacePortMembers.insert(runtimeName, interface);
-        return success<popo::InterfacePortData*>(interfacePortData);
+        return ok(interfacePortData);
     }
     else
     {
         IOX_LOG(WARN) << "Out of interface ports! Requested by runtime '" << runtimeName << "'";
         errorHandler(PoshError::PORT_POOL__INTERFACELIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::INTERFACE_PORT_LIST_FULL);
+        return err(PortPoolError::INTERFACE_PORT_LIST_FULL);
     }
 }
 
@@ -66,14 +66,14 @@ expected<runtime::NodeData*, PortPoolError> PortPool::addNodeData(const RuntimeN
     if (m_portPoolData->m_nodeMembers.hasFreeSpace())
     {
         auto nodeData = m_portPoolData->m_nodeMembers.insert(runtimeName, nodeName, nodeDeviceIdentifier);
-        return success<runtime::NodeData*>(nodeData);
+        return ok(nodeData);
     }
     else
     {
         IOX_LOG(WARN) << "Out of node data! Requested by runtime '" << runtimeName << "' and node name '" << nodeName
                       << "'";
         errorHandler(PoshError::PORT_POOL__NODELIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::NODE_DATA_LIST_FULL);
+        return err(PortPoolError::NODE_DATA_LIST_FULL);
     }
 }
 
@@ -83,13 +83,13 @@ PortPool::addConditionVariableData(const RuntimeName_t& runtimeName) noexcept
     if (m_portPoolData->m_conditionVariableMembers.hasFreeSpace())
     {
         auto conditionVariableData = m_portPoolData->m_conditionVariableMembers.insert(runtimeName);
-        return success<popo::ConditionVariableData*>(conditionVariableData);
+        return ok(conditionVariableData);
     }
     else
     {
         IOX_LOG(WARN) << "Out of condition variables! Requested by runtime '" << runtimeName << "'";
         errorHandler(PoshError::PORT_POOL__CONDITION_VARIABLE_LIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::CONDITION_VARIABLE_LIST_FULL);
+        return err(PortPoolError::CONDITION_VARIABLE_LIST_FULL);
     }
 }
 
@@ -129,14 +129,14 @@ PortPool::addPublisherPort(const capro::ServiceDescription& serviceDescription,
     {
         auto publisherPortData = m_portPoolData->m_publisherPortMembers.insert(
             serviceDescription, runtimeName, memoryManager, publisherOptions, memoryInfo);
-        return success<PublisherPortRouDiType::MemberType_t*>(publisherPortData);
+        return ok(publisherPortData);
     }
     else
     {
         IOX_LOG(WARN) << "Out of publisher ports! Requested by runtime '" << runtimeName
                       << "' and with service description '" << serviceDescription << "'";
         errorHandler(PoshError::PORT_POOL__PUBLISHERLIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::PUBLISHER_PORT_LIST_FULL);
+        return err(PortPoolError::PUBLISHER_PORT_LIST_FULL);
     }
 }
 
@@ -151,14 +151,14 @@ PortPool::addSubscriberPort(const capro::ServiceDescription& serviceDescription,
         auto subscriberPortData = constructSubscriber<iox::build::CommunicationPolicy>(
             serviceDescription, runtimeName, subscriberOptions, memoryInfo);
 
-        return success<SubscriberPortType::MemberType_t*>(subscriberPortData);
+        return ok(subscriberPortData);
     }
     else
     {
         IOX_LOG(WARN) << "Out of subscriber ports! Requested by runtime '" << runtimeName
                       << "' and with service description '" << serviceDescription << "'";
         errorHandler(PoshError::PORT_POOL__SUBSCRIBERLIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::SUBSCRIBER_PORT_LIST_FULL);
+        return err(PortPoolError::SUBSCRIBER_PORT_LIST_FULL);
     }
 }
 
@@ -184,12 +184,12 @@ PortPool::addClientPort(const capro::ServiceDescription& serviceDescription,
         IOX_LOG(WARN) << "Out of client ports! Requested by runtime '" << runtimeName
                       << "' and with service description '" << serviceDescription << "'";
         errorHandler(PoshError::PORT_POOL__CLIENTLIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::CLIENT_PORT_LIST_FULL);
+        return err(PortPoolError::CLIENT_PORT_LIST_FULL);
     }
 
     auto clientPortData = m_portPoolData->m_clientPortMembers.insert(
         serviceDescription, runtimeName, clientOptions, memoryManager, memoryInfo);
-    return success<popo::ClientPortData*>(clientPortData);
+    return ok(clientPortData);
 }
 
 expected<popo::ServerPortData*, PortPoolError>
@@ -204,12 +204,12 @@ PortPool::addServerPort(const capro::ServiceDescription& serviceDescription,
         IOX_LOG(WARN) << "Out of server ports! Requested by runtime '" << runtimeName
                       << "' and with service description '" << serviceDescription << "'";
         errorHandler(PoshError::PORT_POOL__SERVERLIST_OVERFLOW, ErrorLevel::MODERATE);
-        return error<PortPoolError>(PortPoolError::SERVER_PORT_LIST_FULL);
+        return err(PortPoolError::SERVER_PORT_LIST_FULL);
     }
 
     auto serverPortData = m_portPoolData->m_serverPortMembers.insert(
         serviceDescription, runtimeName, serverOptions, memoryManager, memoryInfo);
-    return success<popo::ServerPortData*>(serverPortData);
+    return ok(serverPortData);
 }
 
 void PortPool::removePublisherPort(const PublisherPortRouDiType::MemberType_t* const portData) noexcept

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -490,7 +490,7 @@ void ProcessManager::addPublisherForProcess(const RuntimeName_t& name,
                 sendBuffer << runtime::IpcMessageTypeToString(runtime::IpcMessageType::ERROR);
 
                 std::string error;
-                switch (maybePublisher.get_error())
+                switch (maybePublisher.error())
                 {
                 case PortPoolError::UNIQUE_PUBLISHER_PORT_ALREADY_EXISTS:
                 {

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -419,7 +419,7 @@ void ProcessManager::addSubscriberForProcess(const RuntimeName_t& name,
             auto maybeSubscriber =
                 m_portManager.acquireSubscriberPortData(service, subscriberOptions, name, portConfigInfo);
 
-            if (!maybeSubscriber.has_error())
+            if (maybeSubscriber.has_value())
             {
                 // send SubscriberPort to app as a serialized relative pointer
                 auto offset = UntypedRelativePointer::getOffset(segment_id_t{m_mgmtSegmentId}, maybeSubscriber.value());
@@ -471,7 +471,7 @@ void ProcessManager::addPublisherForProcess(const RuntimeName_t& name,
             auto maybePublisher = m_portManager.acquirePublisherPortData(
                 service, publisherOptions, name, &segmentInfo.m_memoryManager.value().get(), portConfigInfo);
 
-            if (!maybePublisher.has_error())
+            if (maybePublisher.has_value())
             {
                 // send PublisherPort to app as a serialized relative pointer
                 auto offset = UntypedRelativePointer::getOffset(segment_id_t{m_mgmtSegmentId}, maybePublisher.value());

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -204,7 +204,7 @@ CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cm
         {
             // CmdLineParser did not understand the parameters, don't run
             m_run = false;
-            return error<CmdLineParserResult>(CmdLineParserResult::UNKNOWN_OPTION_USED);
+            return err(CmdLineParserResult::UNKNOWN_OPTION_USED);
         }
         };
 
@@ -213,13 +213,13 @@ CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cm
             break;
         }
     }
-    return success<CmdLineArgs_t>(CmdLineArgs_t{m_monitoringMode,
-                                                m_logLevel,
-                                                m_compatibilityCheckLevel,
-                                                m_processKillDelay,
-                                                m_uniqueRouDiId,
-                                                m_run,
-                                                iox::roudi::ConfigFilePathString_t("")});
+    return ok(CmdLineArgs_t{m_monitoringMode,
+                            m_logLevel,
+                            m_compatibilityCheckLevel,
+                            m_processKillDelay,
+                            m_uniqueRouDiId,
+                            m_run,
+                            iox::roudi::ConfigFilePathString_t("")});
 } // namespace roudi
 } // namespace config
 } // namespace iox

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
@@ -46,7 +46,7 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
             auto result = CmdLineParser::parse(argc, argv);
             if (result.has_error())
             {
-                return error<CmdLineParserResult>(result.get_error());
+                return err(result.get_error());
             }
             std::cout << std::endl;
             std::cout << "Config File Option:" << std::endl;
@@ -72,7 +72,7 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
             auto result = CmdLineParser::parse(argc, argv, CmdLineArgumentParsingMode::ONE);
             if (result.has_error())
             {
-                return error<CmdLineParserResult>(result.get_error());
+                return err(result.get_error());
             }
         }
         };
@@ -82,13 +82,13 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
             break;
         }
     }
-    return success<CmdLineArgs_t>(CmdLineArgs_t{m_monitoringMode,
-                                                m_logLevel,
-                                                m_compatibilityCheckLevel,
-                                                m_processKillDelay,
-                                                m_uniqueRouDiId,
-                                                m_run,
-                                                m_customConfigFilePath});
+    return ok(CmdLineArgs_t{m_monitoringMode,
+                            m_logLevel,
+                            m_compatibilityCheckLevel,
+                            m_processKillDelay,
+                            m_uniqueRouDiId,
+                            m_run,
+                            m_customConfigFilePath});
 }
 
 } // namespace config

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
@@ -46,7 +46,7 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
             auto result = CmdLineParser::parse(argc, argv);
             if (result.has_error())
             {
-                return err(result.get_error());
+                return err(result.error());
             }
             std::cout << std::endl;
             std::cout << "Config File Option:" << std::endl;
@@ -72,7 +72,7 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
             auto result = CmdLineParser::parse(argc, argv, CmdLineArgumentParsingMode::ONE);
             if (result.has_error())
             {
-                return err(result.get_error());
+                return err(result.error());
             }
         }
         };

--- a/iceoryx_posh/source/roudi/roudi_config_toml_file_provider.cpp
+++ b/iceoryx_posh/source/roudi/roudi_config_toml_file_provider.cpp
@@ -68,15 +68,14 @@ iox::expected<iox::RouDiConfig_t, iox::roudi::RouDiConfigFileParseError> TomlRou
     {
         iox::RouDiConfig_t defaultConfig;
         defaultConfig.setDefaults();
-        return iox::success<iox::RouDiConfig_t>(defaultConfig);
+        return iox::ok(defaultConfig);
     }
 
     std::ifstream fileStream{m_customConfigFilePath.c_str()};
     if (!fileStream.is_open())
     {
         IOX_LOG(ERROR) << "Could not open config file from path '" << m_customConfigFilePath << "'";
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(
-            iox::roudi::RouDiConfigFileParseError::FILE_OPEN_FAILED);
+        return iox::err(iox::roudi::RouDiConfigFileParseError::FILE_OPEN_FAILED);
     }
 
     return TomlRouDiConfigFileProvider::parse(fileStream);
@@ -99,32 +98,29 @@ TomlRouDiConfigFileProvider::parse(std::istream& stream) noexcept
         IOX_LOG(WARN) << iox::roudi::ROUDI_CONFIG_FILE_PARSE_ERROR_STRINGS[errorStringIndex] << ": "
                       << parserException.what();
 
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(parserError);
+        return iox::err(parserError);
     }
 
     auto general = parsedFile->get_table("general");
     if (!general)
     {
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(
-            iox::roudi::RouDiConfigFileParseError::NO_GENERAL_SECTION);
+        return iox::err(iox::roudi::RouDiConfigFileParseError::NO_GENERAL_SECTION);
     }
     auto configFileVersion = general->get_as<uint32_t>("version");
     if (!configFileVersion || *configFileVersion != 1)
     {
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(
-            iox::roudi::RouDiConfigFileParseError::INVALID_CONFIG_FILE_VERSION);
+        return iox::err(iox::roudi::RouDiConfigFileParseError::INVALID_CONFIG_FILE_VERSION);
     }
 
     auto segments = parsedFile->get_table_array("segment");
     if (!segments)
     {
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(iox::roudi::RouDiConfigFileParseError::NO_SEGMENTS);
+        return iox::err(iox::roudi::RouDiConfigFileParseError::NO_SEGMENTS);
     }
 
     if (segments->get().size() > iox::MAX_SHM_SEGMENTS)
     {
-        return iox::error<iox::roudi::RouDiConfigFileParseError>(
-            iox::roudi::RouDiConfigFileParseError::MAX_NUMBER_OF_SEGMENTS_EXCEEDED);
+        return iox::err(iox::roudi::RouDiConfigFileParseError::MAX_NUMBER_OF_SEGMENTS_EXCEEDED);
     }
 
     auto groupOfCurrentProcess = iox::posix::PosixGroup::getGroupOfCurrentProcess().getName();
@@ -137,14 +133,12 @@ TomlRouDiConfigFileProvider::parse(std::istream& stream) noexcept
         auto mempools = segment->get_table_array("mempool");
         if (!mempools)
         {
-            return iox::error<iox::roudi::RouDiConfigFileParseError>(
-                iox::roudi::RouDiConfigFileParseError::SEGMENT_WITHOUT_MEMPOOL);
+            return iox::err(iox::roudi::RouDiConfigFileParseError::SEGMENT_WITHOUT_MEMPOOL);
         }
 
         if (mempools->get().size() > iox::MAX_NUMBER_OF_MEMPOOLS)
         {
-            return iox::error<iox::roudi::RouDiConfigFileParseError>(
-                iox::roudi::RouDiConfigFileParseError::MAX_NUMBER_OF_MEMPOOLS_PER_SEGMENT_EXCEEDED);
+            return iox::err(iox::roudi::RouDiConfigFileParseError::MAX_NUMBER_OF_MEMPOOLS_PER_SEGMENT_EXCEEDED);
         }
 
         for (auto mempool : *mempools)
@@ -153,13 +147,11 @@ TomlRouDiConfigFileProvider::parse(std::istream& stream) noexcept
             auto chunkCount = mempool->get_as<uint32_t>("count");
             if (!chunkSize)
             {
-                return iox::error<iox::roudi::RouDiConfigFileParseError>(
-                    iox::roudi::RouDiConfigFileParseError::MEMPOOL_WITHOUT_CHUNK_SIZE);
+                return iox::err(iox::roudi::RouDiConfigFileParseError::MEMPOOL_WITHOUT_CHUNK_SIZE);
             }
             if (!chunkCount)
             {
-                return iox::error<iox::roudi::RouDiConfigFileParseError>(
-                    iox::roudi::RouDiConfigFileParseError::MEMPOOL_WITHOUT_CHUNK_COUNT);
+                return iox::err(iox::roudi::RouDiConfigFileParseError::MEMPOOL_WITHOUT_CHUNK_COUNT);
             }
             mempoolConfig.addMemPool({*chunkSize, *chunkCount});
         }
@@ -169,7 +161,7 @@ TomlRouDiConfigFileProvider::parse(std::istream& stream) noexcept
              mempoolConfig});
     }
 
-    return iox::success<iox::RouDiConfig_t>(parsedConfig);
+    return iox::ok(parsedConfig);
 }
 } // namespace config
 } // namespace iox

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -37,7 +37,7 @@ expected<void, ServiceRegistry::Error> ServiceRegistry::add(const capro::Service
         // entry exists, increment counter
         auto& entry = m_serviceDescriptions[index];
         ((*entry).*count)++;
-        return success<>();
+        return ok();
     }
 
     // entry does not exist, find a free slot if it exists
@@ -50,7 +50,7 @@ expected<void, ServiceRegistry::Error> ServiceRegistry::add(const capro::Service
         entry.emplace(serviceDescription);
         (*entry).*count = 1U;
         m_freeIndex = NO_INDEX;
-        return success<>();
+        return ok();
     }
 
     // search from start
@@ -60,7 +60,7 @@ expected<void, ServiceRegistry::Error> ServiceRegistry::add(const capro::Service
         {
             entry.emplace(serviceDescription);
             (*entry).*count = 1U;
-            return success<>();
+            return ok();
         }
     }
 
@@ -70,10 +70,10 @@ expected<void, ServiceRegistry::Error> ServiceRegistry::add(const capro::Service
         auto& entry = m_serviceDescriptions.back();
         entry.emplace(serviceDescription);
         (*entry).*count = 1U;
-        return success<>();
+        return ok();
     }
 
-    return error<Error>(Error::SERVICE_REGISTRY_FULL);
+    return err(Error::SERVICE_REGISTRY_FULL);
 }
 
 expected<void, ServiceRegistry::Error>

--- a/iceoryx_posh/source/roudi/service_registry.cpp
+++ b/iceoryx_posh/source/roudi/service_registry.cpp
@@ -26,8 +26,8 @@ ServiceRegistry::ServiceDescriptionEntry::ServiceDescriptionEntry(const capro::S
 {
 }
 
-expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceDescription& serviceDescription,
-                                                      ReferenceCounter_t ServiceDescriptionEntry::*count)
+expected<void, ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceDescription& serviceDescription,
+                                                            ReferenceCounter_t ServiceDescriptionEntry::*count)
 {
     auto index = findIndex(serviceDescription);
     if (index != NO_INDEX)
@@ -76,13 +76,13 @@ expected<ServiceRegistry::Error> ServiceRegistry::add(const capro::ServiceDescri
     return error<Error>(Error::SERVICE_REGISTRY_FULL);
 }
 
-expected<ServiceRegistry::Error>
+expected<void, ServiceRegistry::Error>
 ServiceRegistry::addPublisher(const capro::ServiceDescription& serviceDescription) noexcept
 {
     return add(serviceDescription, &ServiceDescriptionEntry::publisherCount);
 }
 
-expected<ServiceRegistry::Error>
+expected<void, ServiceRegistry::Error>
 ServiceRegistry::addServer(const capro::ServiceDescription& serviceDescription) noexcept
 {
     return add(serviceDescription, &ServiceDescriptionEntry::serverCount);

--- a/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
@@ -155,7 +155,7 @@ PoshRuntimeImpl::requestPublisherFromRoudi(const IpcMessage& sendBuffer) noexcep
     if (sendRequestToRouDi(sendBuffer, receiveBuffer) == false)
     {
         IOX_LOG(ERROR) << "Request publisher got invalid response!";
-        return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_PUBLISHER_INVALID_RESPONSE);
+        return err(IpcMessageErrorType::REQUEST_PUBLISHER_INVALID_RESPONSE);
     }
     else if (receiveBuffer.getNumberOfElements() == 3U)
     {
@@ -169,8 +169,7 @@ PoshRuntimeImpl::requestPublisherFromRoudi(const IpcMessage& sendBuffer) noexcep
             UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
             auto ptr = UntypedRelativePointer::getPtr(segment_id_t{segmentId}, offset);
-            return success<PublisherPortUserType::MemberType_t*>(
-                reinterpret_cast<PublisherPortUserType::MemberType_t*>(ptr));
+            return ok(reinterpret_cast<PublisherPortUserType::MemberType_t*>(ptr));
         }
     }
     else if (receiveBuffer.getNumberOfElements() == 2U)
@@ -180,12 +179,12 @@ PoshRuntimeImpl::requestPublisherFromRoudi(const IpcMessage& sendBuffer) noexcep
         if (stringToIpcMessageType(IpcMessage1.c_str()) == IpcMessageType::ERROR)
         {
             IOX_LOG(ERROR) << "Request publisher received no valid publisher port from RouDi.";
-            return error<IpcMessageErrorType>(stringToIpcMessageErrorType(IpcMessage2.c_str()));
+            return err(stringToIpcMessageErrorType(IpcMessage2.c_str()));
         }
     }
 
     IOX_LOG(ERROR) << "Request publisher got wrong response from IPC channel :'" << receiveBuffer.getMessage() << "'";
-    return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_PUBLISHER_WRONG_IPC_MESSAGE_RESPONSE);
+    return err(IpcMessageErrorType::REQUEST_PUBLISHER_WRONG_IPC_MESSAGE_RESPONSE);
 }
 
 SubscriberPortUserType::MemberType_t*
@@ -266,7 +265,7 @@ PoshRuntimeImpl::requestSubscriberFromRoudi(const IpcMessage& sendBuffer) noexce
     if (sendRequestToRouDi(sendBuffer, receiveBuffer) == false)
     {
         IOX_LOG(ERROR) << "Request subscriber got invalid response!";
-        return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_SUBSCRIBER_INVALID_RESPONSE);
+        return err(IpcMessageErrorType::REQUEST_SUBSCRIBER_INVALID_RESPONSE);
     }
     else if (receiveBuffer.getNumberOfElements() == 3U)
     {
@@ -279,8 +278,7 @@ PoshRuntimeImpl::requestSubscriberFromRoudi(const IpcMessage& sendBuffer) noexce
             UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
             auto ptr = UntypedRelativePointer::getPtr(segment_id_t{segmentId}, offset);
-            return success<SubscriberPortUserType::MemberType_t*>(
-                reinterpret_cast<SubscriberPortUserType::MemberType_t*>(ptr));
+            return ok(reinterpret_cast<SubscriberPortUserType::MemberType_t*>(ptr));
         }
     }
     else if (receiveBuffer.getNumberOfElements() == 2U)
@@ -291,12 +289,12 @@ PoshRuntimeImpl::requestSubscriberFromRoudi(const IpcMessage& sendBuffer) noexce
         if (stringToIpcMessageType(IpcMessage1.c_str()) == IpcMessageType::ERROR)
         {
             IOX_LOG(ERROR) << "Request subscriber received no valid subscriber port from RouDi.";
-            return error<IpcMessageErrorType>(stringToIpcMessageErrorType(IpcMessage2.c_str()));
+            return err(stringToIpcMessageErrorType(IpcMessage2.c_str()));
         }
     }
 
     IOX_LOG(ERROR) << "Request subscriber got wrong response from IPC channel :'" << receiveBuffer.getMessage() << "'";
-    return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_SUBSCRIBER_WRONG_IPC_MESSAGE_RESPONSE);
+    return err(IpcMessageErrorType::REQUEST_SUBSCRIBER_WRONG_IPC_MESSAGE_RESPONSE);
 }
 
 popo::ClientPortUser::MemberType_t* PoshRuntimeImpl::getMiddlewareClient(const capro::ServiceDescription& service,
@@ -370,7 +368,7 @@ PoshRuntimeImpl::requestClientFromRoudi(const IpcMessage& sendBuffer) noexcept
     if (sendRequestToRouDi(sendBuffer, receiveBuffer) == false)
     {
         IOX_LOG(ERROR) << "Request client got invalid response!";
-        return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_CLIENT_INVALID_RESPONSE);
+        return err(IpcMessageErrorType::REQUEST_CLIENT_INVALID_RESPONSE);
     }
     else if (receiveBuffer.getNumberOfElements() == 3U)
     {
@@ -383,8 +381,7 @@ PoshRuntimeImpl::requestClientFromRoudi(const IpcMessage& sendBuffer) noexcept
             UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
             auto ptr = UntypedRelativePointer::getPtr(segment_id_t{segmentId}, offset);
-            return success<popo::ClientPortUser::MemberType_t*>(
-                reinterpret_cast<popo::ClientPortUser::MemberType_t*>(ptr));
+            return ok(reinterpret_cast<popo::ClientPortUser::MemberType_t*>(ptr));
         }
     }
     else if (receiveBuffer.getNumberOfElements() == 2U)
@@ -394,13 +391,13 @@ PoshRuntimeImpl::requestClientFromRoudi(const IpcMessage& sendBuffer) noexcept
         if (stringToIpcMessageType(IpcMessage1.c_str()) == IpcMessageType::ERROR)
         {
             IOX_LOG(ERROR) << "Request client received no valid client port from RouDi.";
-            return error<IpcMessageErrorType>(stringToIpcMessageErrorType(IpcMessage2.c_str()));
+            return err(stringToIpcMessageErrorType(IpcMessage2.c_str()));
         }
     }
 
 
     IOX_LOG(ERROR) << "Request client got wrong response from IPC channel :'" << receiveBuffer.getMessage() << "'";
-    return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_CLIENT_WRONG_IPC_MESSAGE_RESPONSE);
+    return err(IpcMessageErrorType::REQUEST_CLIENT_WRONG_IPC_MESSAGE_RESPONSE);
 }
 
 popo::ServerPortUser::MemberType_t* PoshRuntimeImpl::getMiddlewareServer(const capro::ServiceDescription& service,
@@ -474,7 +471,7 @@ PoshRuntimeImpl::requestServerFromRoudi(const IpcMessage& sendBuffer) noexcept
     if (sendRequestToRouDi(sendBuffer, receiveBuffer) == false)
     {
         IOX_LOG(ERROR) << "Request server got invalid response!";
-        return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_SERVER_INVALID_RESPONSE);
+        return err(IpcMessageErrorType::REQUEST_SERVER_INVALID_RESPONSE);
     }
     else if (receiveBuffer.getNumberOfElements() == 3U)
     {
@@ -487,8 +484,7 @@ PoshRuntimeImpl::requestServerFromRoudi(const IpcMessage& sendBuffer) noexcept
             UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
             auto ptr = UntypedRelativePointer::getPtr(segment_id_t{segmentId}, offset);
-            return success<popo::ServerPortUser::MemberType_t*>(
-                reinterpret_cast<popo::ServerPortUser::MemberType_t*>(ptr));
+            return ok(reinterpret_cast<popo::ServerPortUser::MemberType_t*>(ptr));
         }
     }
     else if (receiveBuffer.getNumberOfElements() == 2U)
@@ -498,12 +494,12 @@ PoshRuntimeImpl::requestServerFromRoudi(const IpcMessage& sendBuffer) noexcept
         if (stringToIpcMessageType(IpcMessage1.c_str()) == IpcMessageType::ERROR)
         {
             IOX_LOG(ERROR) << "Request server received no valid server port from RouDi.";
-            return error<IpcMessageErrorType>(stringToIpcMessageErrorType(IpcMessage2.c_str()));
+            return err(stringToIpcMessageErrorType(IpcMessage2.c_str()));
         }
     }
 
     IOX_LOG(ERROR) << "Request server got wrong response from IPC channel :'" << receiveBuffer.getMessage() << "'";
-    return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_SERVER_WRONG_IPC_MESSAGE_RESPONSE);
+    return err(IpcMessageErrorType::REQUEST_SERVER_WRONG_IPC_MESSAGE_RESPONSE);
 }
 
 popo::InterfacePortData* PoshRuntimeImpl::getMiddlewareInterface(const capro::Interfaces interface,
@@ -582,7 +578,7 @@ PoshRuntimeImpl::requestConditionVariableFromRoudi(const IpcMessage& sendBuffer)
     if (sendRequestToRouDi(sendBuffer, receiveBuffer) == false)
     {
         IOX_LOG(ERROR) << "Request condition variable got invalid response!";
-        return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_CONDITION_VARIABLE_INVALID_RESPONSE);
+        return err(IpcMessageErrorType::REQUEST_CONDITION_VARIABLE_INVALID_RESPONSE);
     }
     else if (receiveBuffer.getNumberOfElements() == 3U)
     {
@@ -595,7 +591,7 @@ PoshRuntimeImpl::requestConditionVariableFromRoudi(const IpcMessage& sendBuffer)
             UntypedRelativePointer::offset_t offset{0U};
             cxx::convert::fromString(receiveBuffer.getElementAtIndex(1U).c_str(), offset);
             auto ptr = UntypedRelativePointer::getPtr(segment_id_t{segmentId}, offset);
-            return success<popo::ConditionVariableData*>(reinterpret_cast<popo::ConditionVariableData*>(ptr));
+            return ok(reinterpret_cast<popo::ConditionVariableData*>(ptr));
         }
     }
     else if (receiveBuffer.getNumberOfElements() == 2U)
@@ -605,13 +601,13 @@ PoshRuntimeImpl::requestConditionVariableFromRoudi(const IpcMessage& sendBuffer)
         if (stringToIpcMessageType(IpcMessage1.c_str()) == IpcMessageType::ERROR)
         {
             IOX_LOG(ERROR) << "Request condition variable received no valid condition variable port from RouDi.";
-            return error<IpcMessageErrorType>(stringToIpcMessageErrorType(IpcMessage2.c_str()));
+            return err(stringToIpcMessageErrorType(IpcMessage2.c_str()));
         }
     }
 
     IOX_LOG(ERROR) << "Request condition variable got wrong response from IPC channel :'" << receiveBuffer.getMessage()
                    << "'";
-    return error<IpcMessageErrorType>(IpcMessageErrorType::REQUEST_CONDITION_VARIABLE_WRONG_IPC_MESSAGE_RESPONSE);
+    return err(IpcMessageErrorType::REQUEST_CONDITION_VARIABLE_WRONG_IPC_MESSAGE_RESPONSE);
 }
 
 popo::ConditionVariableData* PoshRuntimeImpl::getMiddlewareConditionVariable() noexcept

--- a/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
@@ -105,7 +105,7 @@ PoshRuntimeImpl::getMiddlewarePublisher(const capro::ServiceDescription& service
     auto maybePublisher = requestPublisherFromRoudi(sendBuffer);
     if (maybePublisher.has_error())
     {
-        switch (maybePublisher.get_error())
+        switch (maybePublisher.error())
         {
         case IpcMessageErrorType::NO_UNIQUE_CREATED:
             IOX_LOG(WARN) << "Service '" << service << "' already in use by another process.";
@@ -230,7 +230,7 @@ PoshRuntimeImpl::getMiddlewareSubscriber(const capro::ServiceDescription& servic
 
     if (maybeSubscriber.has_error())
     {
-        switch (maybeSubscriber.get_error())
+        switch (maybeSubscriber.error())
         {
         case IpcMessageErrorType::SUBSCRIBER_LIST_FULL:
             IOX_LOG(WARN) << "Service '" << service
@@ -325,7 +325,7 @@ popo::ClientPortUser::MemberType_t* PoshRuntimeImpl::getMiddlewareClient(const c
     auto maybeClient = requestClientFromRoudi(sendBuffer);
     if (maybeClient.has_error())
     {
-        switch (maybeClient.get_error())
+        switch (maybeClient.error())
         {
         case IpcMessageErrorType::CLIENT_LIST_FULL:
             IOX_LOG(WARN) << "Could not create client with service description '" << service
@@ -428,7 +428,7 @@ popo::ServerPortUser::MemberType_t* PoshRuntimeImpl::getMiddlewareServer(const c
     auto maybeServer = requestServerFromRoudi(sendBuffer);
     if (maybeServer.has_error())
     {
-        switch (maybeServer.get_error())
+        switch (maybeServer.error())
         {
         case IpcMessageErrorType::SERVER_LIST_FULL:
             IOX_LOG(WARN) << "Could not create server with service description '" << service
@@ -618,7 +618,7 @@ popo::ConditionVariableData* PoshRuntimeImpl::getMiddlewareConditionVariable() n
     auto maybeConditionVariable = requestConditionVariableFromRoudi(sendBuffer);
     if (maybeConditionVariable.has_error())
     {
-        switch (maybeConditionVariable.get_error())
+        switch (maybeConditionVariable.error())
         {
         case IpcMessageErrorType::CONDITION_VARIABLE_LIST_FULL:
             IOX_LOG(WARN) << "Could not create condition variable as we are out of memory for condition variables.";

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -321,15 +321,15 @@ class Mepoo_IntegrationTest : public Test
             else if (!expectedAllocationError.has_value())
             {
                 hasRunAsExpected = false;
-                std::cout << "Did not expect an error but got: " << static_cast<uint32_t>(allocationResult.get_error())
+                std::cout << "Did not expect an error but got: " << static_cast<uint32_t>(allocationResult.error())
                           << std::endl;
                 EXPECT_TRUE(hasRunAsExpected);
             }
-            else if (allocationResult.get_error() != expectedAllocationError.value())
+            else if (allocationResult.error() != expectedAllocationError.value())
             {
                 hasRunAsExpected = false;
                 std::cout << "Expected error: " << static_cast<uint32_t>(expectedAllocationError.value()) << std::endl;
-                std::cout << "But got: " << static_cast<uint32_t>(allocationResult.get_error()) << std::endl;
+                std::cout << "But got: " << static_cast<uint32_t>(allocationResult.error()) << std::endl;
                 EXPECT_TRUE(hasRunAsExpected);
             }
         }

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -313,7 +313,7 @@ class Mepoo_IntegrationTest : public Test
                                             m_roudiEnv->InterOpWait();
                                         });
 
-            if (!allocationResult.has_error())
+            if (allocationResult.has_value())
             {
                 hasRunAsExpected &= !expectedAllocationError.has_value();
                 EXPECT_FALSE(expectedAllocationError.has_value());

--- a/iceoryx_posh/test/mocks/client_mock.hpp
+++ b/iceoryx_posh/test/mocks/client_mock.hpp
@@ -55,7 +55,10 @@ class MockClientPortUser : public MockBasePort
                 (const uint32_t, const uint32_t),
                 (noexcept));
     MOCK_METHOD(void, releaseRequest, (const iox::popo::RequestHeader* const), (noexcept));
-    MOCK_METHOD(iox::expected<iox::popo::ClientSendError>, sendRequest, (iox::popo::RequestHeader* const), (noexcept));
+    MOCK_METHOD((iox::expected<void, iox::popo::ClientSendError>),
+                sendRequest,
+                (iox::popo::RequestHeader* const),
+                (noexcept));
     MOCK_METHOD(void, connect, (), (noexcept));
     MOCK_METHOD(void, disconnect, (), (noexcept));
     MOCK_METHOD(iox::ConnectionState, getConnectionState, (), (const, noexcept));

--- a/iceoryx_posh/test/mocks/roudi_memory_provider_mock.hpp
+++ b/iceoryx_posh/test/mocks/roudi_memory_provider_mock.hpp
@@ -46,8 +46,8 @@ class MemoryProviderTestImpl : public iox::roudi::MemoryProvider
             createMemoryMock(size, alignment);
         }
 
-        dummyMemory = static_cast<uint8_t*>(iox::alignedAlloc(alignment, size));
-        return iox::success<void*>(dummyMemory);
+        dummyMemory = iox::alignedAlloc(alignment, size);
+        return iox::ok(dummyMemory);
     }
 #ifdef __clang__
 #pragma GCC diagnostic push
@@ -68,7 +68,7 @@ class MemoryProviderTestImpl : public iox::roudi::MemoryProvider
         iox::alignedFree(dummyMemory);
         dummyMemory = nullptr;
 
-        return iox::success<void>();
+        return iox::ok();
     }
 #ifdef __clang__
 #pragma GCC diagnostic push
@@ -79,7 +79,7 @@ class MemoryProviderTestImpl : public iox::roudi::MemoryProvider
 #pragma GCC diagnostic pop
 #endif
 
-    uint8_t* dummyMemory{nullptr};
+    void* dummyMemory{nullptr};
 
   protected:
     bool m_mockCallsEnabled{false};

--- a/iceoryx_posh/test/mocks/roudi_memory_provider_mock.hpp
+++ b/iceoryx_posh/test/mocks/roudi_memory_provider_mock.hpp
@@ -58,7 +58,7 @@ class MemoryProviderTestImpl : public iox::roudi::MemoryProvider
 #pragma GCC diagnostic pop
 #endif
 
-    iox::expected<iox::roudi::MemoryProviderError> destroyMemory() noexcept override
+    iox::expected<void, iox::roudi::MemoryProviderError> destroyMemory() noexcept override
     {
         if (m_mockCallsEnabled)
         {

--- a/iceoryx_posh/test/mocks/server_mock.hpp
+++ b/iceoryx_posh/test/mocks/server_mock.hpp
@@ -63,7 +63,7 @@ class MockServerPortUser : public MockBasePort
                 (const iox::popo::RequestHeader* const, const uint32_t, const uint32_t),
                 (noexcept));
     MOCK_METHOD(void, releaseResponse, (const iox::popo::ResponseHeader* const), (noexcept));
-    MOCK_METHOD(iox::expected<iox::popo::ServerSendError>,
+    MOCK_METHOD((iox::expected<void, iox::popo::ServerSendError>),
                 sendResponse,
                 (iox::popo::ResponseHeader* const),
                 (noexcept));

--- a/iceoryx_posh/test/moduletests/test_capro_service.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_service.cpp
@@ -204,7 +204,7 @@ TEST_F(ServiceDescription_test,
     auto deserializationResult = ServiceDescription::deserialize(serialObj);
 
     ASSERT_TRUE(deserializationResult.has_error());
-    EXPECT_THAT(deserializationResult.get_error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
+    EXPECT_THAT(deserializationResult.error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
 }
 
 /// @attention The purpose of the Serialization is not to be an alternative Constructor. It is intended to send/receive
@@ -233,7 +233,7 @@ TEST_F(ServiceDescription_test,
     auto deserializationResult = ServiceDescription::deserialize(serialObj);
 
     ASSERT_TRUE(deserializationResult.has_error());
-    EXPECT_THAT(deserializationResult.get_error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
+    EXPECT_THAT(deserializationResult.error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
 }
 
 TEST_F(ServiceDescription_test, ServiceDescriptionObjectInitialisationWithEmptyStringLeadsToInvalidDeserialization)
@@ -245,7 +245,7 @@ TEST_F(ServiceDescription_test, ServiceDescriptionObjectInitialisationWithEmptyS
     auto deserializationResult = ServiceDescription::deserialize(invalidSerialObj);
 
     ASSERT_TRUE(deserializationResult.has_error());
-    EXPECT_THAT(deserializationResult.get_error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
+    EXPECT_THAT(deserializationResult.error(), Eq(iox::cxx::Serialization::Error::DESERIALIZATION_FAILED));
 }
 
 TEST_F(ServiceDescription_test, ServiceDescriptionDefaultCtorInitializesStringsToEmptyString)

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
@@ -108,10 +108,10 @@ TEST_F(GatewayGenericTest, IgnoresWildcardServices)
     auto resultThree = sut->addChannel(wildcardInstanceService, StubbedIceoryxTerminal::Options());
     auto resultFour = sut->addChannel(wildcardEventService, StubbedIceoryxTerminal::Options());
 
-    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultOne.get_error());
-    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultTwo.get_error());
-    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultThree.get_error());
-    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultFour.get_error());
+    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultOne.error());
+    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultTwo.error());
+    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultThree.error());
+    EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultFour.error());
 
     EXPECT_EQ(0U, sut->getNumberOfChannels());
 }
@@ -179,7 +179,7 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenExceedingMaximumChannelCapaicity)
 
     auto result = sut->addChannel({"oneTooMany", "oneTooMany", "oneTooMany"}, StubbedIceoryxTerminal::Options());
     EXPECT_EQ(true, result.has_error());
-    EXPECT_EQ(iox::gw::GatewayError::UNSUCCESSFUL_CHANNEL_CREATION, result.get_error());
+    EXPECT_EQ(iox::gw::GatewayError::UNSUCCESSFUL_CHANNEL_CREATION, result.error());
 }
 
 TEST_F(GatewayGenericTest, ThrowsErrorWhenAttemptingToRemoveNonexistantChannel)

--- a/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_chunk_settings.cpp
@@ -129,7 +129,7 @@ TEST(ChunkSettings_test, NoCustomUserPayloadAlignmentAndTooLargeUserPayload_Fail
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
 }
 
 TEST(ChunkSettings_test, CustomUserPayloadAlignmentAndTooLargeUserPayload_Fails)
@@ -144,7 +144,7 @@ TEST(ChunkSettings_test, CustomUserPayloadAlignmentAndTooLargeUserPayload_Fails)
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
 }
 
 TEST(ChunkSettings_test, UserHeaderAndTooLargeUserPayload_Fails)
@@ -159,7 +159,7 @@ TEST(ChunkSettings_test, UserHeaderAndTooLargeUserPayload_Fails)
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::REQUIRED_CHUNK_SIZE_EXCEEDS_MAX_CHUNK_SIZE));
 }
 
 // END EXCEEDING CHUNK SIZE TESTS
@@ -178,7 +178,7 @@ TEST(ChunkSettings_test, UserPayloadAlignmentNotPowerOfTwo_Fails)
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO));
 }
 
 TEST(ChunkSettings_test, UserHeaderAlignmentNotPowerOfTwo_Fails)
@@ -193,7 +193,7 @@ TEST(ChunkSettings_test, UserHeaderAlignmentNotPowerOfTwo_Fails)
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::ALIGNMENT_NOT_POWER_OF_TWO));
 }
 
 TEST(ChunkSettings_test, UserHeaderAlignmentLargerThanChunkHeaderAlignment_Fails)
@@ -208,7 +208,7 @@ TEST(ChunkSettings_test, UserHeaderAlignmentLargerThanChunkHeaderAlignment_Fails
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::USER_HEADER_ALIGNMENT_EXCEEDS_CHUNK_HEADER_ALIGNMENT));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::USER_HEADER_ALIGNMENT_EXCEEDS_CHUNK_HEADER_ALIGNMENT));
 }
 
 TEST(ChunkSettings_test, UserHeaderSizeNotMultipleOfAlignment_Fails)
@@ -223,7 +223,7 @@ TEST(ChunkSettings_test, UserHeaderSizeNotMultipleOfAlignment_Fails)
         ChunkSettings::create(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
 
     ASSERT_TRUE(sutResult.has_error());
-    EXPECT_THAT(sutResult.get_error(), Eq(ChunkSettings::Error::USER_HEADER_SIZE_NOT_MULTIPLE_OF_ITS_ALIGNMENT));
+    EXPECT_THAT(sutResult.error(), Eq(ChunkSettings::Error::USER_HEADER_SIZE_NOT_MULTIPLE_OF_ITS_ALIGNMENT));
 }
 
 // END INVALID USER-HEADER AND USER-PAYLOAD ALIGNMENT TESTS

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -78,7 +78,7 @@ class MePooSegment_test : public Test
 
         iox::expected<uint64_t, iox::FileStatError> get_size() const
         {
-            return iox::success<uint64_t>(m_memorySizeInBytes);
+            return iox::ok(m_memorySizeInBytes);
         }
 
         void* getBaseAddress()
@@ -111,13 +111,12 @@ class MePooSegment_test : public Test
       public:
         iox::expected<SharedMemoryObject_MOCK, SharedMemoryObjectError> create() noexcept
         {
-            return iox::success<SharedMemoryObject_MOCK>(
-                SharedMemoryObject_MOCK(m_name,
-                                        m_memorySizeInBytes,
-                                        m_accessMode,
-                                        m_openMode,
-                                        (m_baseAddressHint) ? *m_baseAddressHint : nullptr,
-                                        m_permissions));
+            return iox::ok(SharedMemoryObject_MOCK(m_name,
+                                                   m_memorySizeInBytes,
+                                                   m_accessMode,
+                                                   m_openMode,
+                                                   (m_baseAddressHint) ? *m_baseAddressHint : nullptr,
+                                                   m_permissions));
         }
     };
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_shm_safe_unmanaged_chunk.cpp
@@ -43,11 +43,11 @@ class ShmSafeUnmanagedChunk_test : public Test
     SharedChunk getChunkFromMemoryManager()
     {
         auto chunkSettingsResult = iox::mepoo::ChunkSettings::create(sizeof(bool), alignof(bool));
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_typed_mempool.cpp
@@ -95,6 +95,6 @@ TEST_F(TypedMemPool_test, OutOfChunksErrorWhenFull)
     EXPECT_FALSE(object3.has_error());
 
     EXPECT_THAT(object4.has_error(), Eq(true));
-    EXPECT_THAT(object4.get_error(), Eq(TypedMemPoolError::OutOfChunks));
+    EXPECT_THAT(object4.error(), Eq(TypedMemPoolError::OutOfChunks));
 }
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -157,7 +157,7 @@ TEST_F(BaseSubscriberTest, ReceiveForwardsErrorsFromUnderlyingPort)
     auto result = sut.takeChunk();
     // ===== Verify ===== //
     ASSERT_EQ(true, result.has_error());
-    EXPECT_EQ(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL, result.get_error());
+    EXPECT_EQ(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL, result.error());
     // ===== Cleanup ===== //
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -138,8 +138,7 @@ TEST_F(BaseSubscriberTest, ReceiveReturnsAllocatedMemoryChunk)
     ::testing::Test::RecordProperty("TEST_ID", "5e3c00e1-bd7c-49bf-adaf-f0d83cd4ab99");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), tryGetChunk)
-        .WillOnce(Return(ByMove(iox::success<const iox::mepoo::ChunkHeader*>(
-            const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
+        .WillOnce(Return(ByMove(iox::ok(const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
     // ===== Test ===== //
     auto result = sut.takeChunk();
     // ===== Verify ===== //
@@ -153,8 +152,7 @@ TEST_F(BaseSubscriberTest, ReceiveForwardsErrorsFromUnderlyingPort)
     ::testing::Test::RecordProperty("TEST_ID", "ff175cb2-ad97-4ba9-ab32-cd73618b0b8b");
     // ===== Setup ===== //
     EXPECT_CALL(sut.port(), tryGetChunk)
-        .WillOnce(Return(ByMove(iox::error<iox::popo::ChunkReceiveResult>(
-            iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL))));
+        .WillOnce(Return(ByMove(iox::err(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL))));
     // ===== Test ===== //
     auto result = sut.takeChunk();
     // ===== Verify ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
@@ -183,7 +183,7 @@ TYPED_TEST(ChunkDistributor_test, QueueOverflow)
     auto queueData = this->getChunkQueueData();
     auto ret = sut.tryAddQueue(queueData.get());
     EXPECT_TRUE(ret.has_error());
-    EXPECT_THAT(ret.get_error(), Eq(iox::popo::ChunkDistributorError::QUEUE_CONTAINER_OVERFLOW));
+    EXPECT_THAT(ret.error(), Eq(iox::popo::ChunkDistributorError::QUEUE_CONTAINER_OVERFLOW));
     EXPECT_TRUE(errorHandlerCalled);
 }
 
@@ -212,7 +212,7 @@ TYPED_TEST(ChunkDistributor_test, RemovingNonExistingQueueChangesNothing)
     auto queueData2 = this->getChunkQueueData();
     auto ret = sut.tryRemoveQueue(queueData2.get());
     EXPECT_TRUE(ret.has_error());
-    EXPECT_THAT(ret.get_error(), Eq(iox::popo::ChunkDistributorError::QUEUE_NOT_IN_CONTAINER));
+    EXPECT_THAT(ret.error(), Eq(iox::popo::ChunkDistributorError::QUEUE_NOT_IN_CONTAINER));
     EXPECT_THAT(sut.hasStoredQueues(), Eq(true));
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -100,7 +100,7 @@ TEST_F(ChunkReceiver_test, getNoChunkFromEmptyQueue)
     ::testing::Test::RecordProperty("TEST_ID", "27846f97-8882-408f-9de3-f74c0aa7e0d8");
     auto maybeChunkHeader = m_chunkReceiver.tryGet();
     ASSERT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_EQ(maybeChunkHeader.get_error(), iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE);
+    EXPECT_EQ(maybeChunkHeader.error(), iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE);
 }
 
 TEST_F(ChunkReceiver_test, getAndReleaseOneChunk)
@@ -181,7 +181,7 @@ TEST_F(ChunkReceiver_test, getTooMuchWithoutRelease)
 
     auto maybeChunkHeader = m_chunkReceiver.tryGet();
     ASSERT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_THAT(maybeChunkHeader.get_error(), Eq(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL));
+    EXPECT_THAT(maybeChunkHeader.error(), Eq(iox::popo::ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL));
 }
 
 TEST_F(ChunkReceiver_test, releaseInvalidChunk)

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -64,11 +64,11 @@ class ChunkReceiver_test : public Test
     iox::mepoo::SharedChunk getChunkFromMemoryManager()
     {
         auto chunkSettingsResult = iox::mepoo::ChunkSettings::create(sizeof(DummySample), alignof(DummySample));
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = m_memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -200,7 +200,7 @@ TEST_F(ChunkSender_test, allocate_Overflow)
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_THAT(maybeChunkHeader.get_error(), Eq(iox::popo::AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL));
+    EXPECT_THAT(maybeChunkHeader.error(), Eq(iox::popo::AllocationError::TOO_MANY_CHUNKS_ALLOCATED_IN_PARALLEL));
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks,
                 Eq(iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY));
 }
@@ -424,7 +424,7 @@ TEST_F(ChunkSender_test, sendTillRunningOutOfChunks)
     auto maybeChunkHeader = m_chunkSender.tryAllocate(
         UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
     EXPECT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_THAT(maybeChunkHeader.get_error(), Eq(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS));
+    EXPECT_THAT(maybeChunkHeader.error(), Eq(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS));
 }
 
 TEST_F(ChunkSender_test, sendInvalidChunk)

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -183,7 +183,7 @@ TEST_F(ChunkSender_test, allocate_Overflow)
     {
         auto maybeChunkHeader = m_chunkSender.tryAllocate(
             UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
-        if (!maybeChunkHeader.has_error())
+        if (maybeChunkHeader.has_value())
         {
             chunks.push_back(*maybeChunkHeader);
         }
@@ -215,7 +215,7 @@ TEST_F(ChunkSender_test, freeChunk)
     {
         auto maybeChunkHeader = m_chunkSender.tryAllocate(
             UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
-        if (!maybeChunkHeader.has_error())
+        if (maybeChunkHeader.has_value())
         {
             chunks.push_back(*maybeChunkHeader);
         }
@@ -260,7 +260,7 @@ TEST_F(ChunkSender_test, sendWithoutReceiver)
     EXPECT_FALSE(maybeChunkHeader.has_error());
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks, Eq(1U));
 
-    if (!maybeChunkHeader.has_error())
+    if (maybeChunkHeader.has_value())
     {
         auto sample = *maybeChunkHeader;
         auto numberOfDeliveries = m_chunkSender.send(sample);
@@ -340,7 +340,7 @@ TEST_F(ChunkSender_test, sendOneWithReceiver)
     EXPECT_FALSE(maybeChunkHeader.has_error());
     EXPECT_THAT(m_memoryManager.getMemPoolInfo(0).m_usedChunks, Eq(1U));
 
-    if (!maybeChunkHeader.has_error())
+    if (maybeChunkHeader.has_value())
     {
         auto sample = (*maybeChunkHeader)->userPayload();
         new (sample) DummySample();
@@ -372,7 +372,7 @@ TEST_F(ChunkSender_test, sendMultipleWithReceiver)
             UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
         EXPECT_FALSE(maybeChunkHeader.has_error());
 
-        if (!maybeChunkHeader.has_error())
+        if (maybeChunkHeader.has_value())
         {
             auto sample = (*maybeChunkHeader)->userPayload();
             new (sample) DummySample();
@@ -407,7 +407,7 @@ TEST_F(ChunkSender_test, sendTillRunningOutOfChunks)
             UniquePortId(), sizeof(DummySample), alignof(DummySample), USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
         EXPECT_FALSE(maybeChunkHeader.has_error());
 
-        if (!maybeChunkHeader.has_error())
+        if (maybeChunkHeader.has_value())
         {
             auto sample = (*maybeChunkHeader)->userPayload();
             new (sample) DummySample();

--- a/iceoryx_posh/test/moduletests/test_popo_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client.cpp
@@ -73,8 +73,7 @@ TEST_F(Client_test, LoanCallsUnderlyingPortWithSuccessResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3bbddee9-49c9-4183-8120-224067260151");
 
-    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult =
-        iox::success<RequestHeader*>{requestMock.userHeader()};
+    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult = iox::ok(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateRequest(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT)).WillOnce(Return(allocateRequestResult));
 
@@ -90,8 +89,7 @@ TEST_F(Client_test, LoanCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "9029b641-09d9-4f47-8627-63fc0c45d7ef");
 
     constexpr AllocationError ALLOCATION_ERROR{AllocationError::RUNNING_OUT_OF_CHUNKS};
-    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult =
-        iox::error<AllocationError>{ALLOCATION_ERROR};
+    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult = iox::err(ALLOCATION_ERROR);
 
     EXPECT_CALL(sut.mockPort, allocateRequest(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT)).WillOnce(Return(allocateRequestResult));
 
@@ -104,8 +102,7 @@ TEST_F(Client_test, SendCallsUnderlyingPort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "92d23ecc-5c37-4254-bb09-ccc0e0e7e0fa");
 
-    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult =
-        iox::success<RequestHeader*>{requestMock.userHeader()};
+    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult = iox::ok(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateRequest(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT)).WillOnce(Return(allocateRequestResult));
 
@@ -114,7 +111,7 @@ TEST_F(Client_test, SendCallsUnderlyingPort)
 
     auto request = std::move(loanResult.value());
 
-    EXPECT_CALL(sut.mockPort, sendRequest(requestMock.userHeader())).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(sut.mockPort, sendRequest(requestMock.userHeader())).WillOnce(Return(iox::ok()));
 
     sut.send(std::move(request))
         .and_then([&]() { GTEST_SUCCEED() << "Request successfully sent"; })
@@ -128,7 +125,7 @@ TEST_F(Client_test, TakeCallsUnderlyingPortWithSuccessResult)
     ::testing::Test::RecordProperty("TEST_ID", "688ed3d9-4292-4cde-81e3-8c2b4d6e3a5f");
 
     const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult =
-        iox::success<const ResponseHeader*>{responseMock.userHeader()};
+        iox::ok<const ResponseHeader*>(responseMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getResponse()).WillOnce(Return(getResponseResult));
 
@@ -144,8 +141,7 @@ TEST_F(Client_test, TakeCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "1aac50ca-5455-4579-9e69-769d569e2b4b");
 
     constexpr ChunkReceiveResult CHUNK_RECEIVE_RESULT{ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL};
-    const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult =
-        iox::error<ChunkReceiveResult>{CHUNK_RECEIVE_RESULT};
+    const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult = iox::err(CHUNK_RECEIVE_RESULT);
 
     EXPECT_CALL(sut.mockPort, getResponse()).WillOnce(Return(getResponseResult));
 

--- a/iceoryx_posh/test/moduletests/test_popo_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client.cpp
@@ -95,7 +95,7 @@ TEST_F(Client_test, LoanCallsUnderlyingPortWithErrorResult)
 
     auto loanResult = sut.loan();
     ASSERT_TRUE(loanResult.has_error());
-    EXPECT_THAT(loanResult.get_error(), Eq(ALLOCATION_ERROR));
+    EXPECT_THAT(loanResult.error(), Eq(ALLOCATION_ERROR));
 }
 
 TEST_F(Client_test, SendCallsUnderlyingPort)
@@ -147,7 +147,7 @@ TEST_F(Client_test, TakeCallsUnderlyingPortWithErrorResult)
 
     auto takeResult = sut.take();
     ASSERT_TRUE(takeResult.has_error());
-    EXPECT_THAT(takeResult.get_error(), Eq(CHUNK_RECEIVE_RESULT));
+    EXPECT_THAT(takeResult.error(), Eq(CHUNK_RECEIVE_RESULT));
 }
 
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
@@ -139,11 +139,11 @@ class ClientPort_test : public Test
                                                                      iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT,
                                                                      userHeaderSize,
                                                                      iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = m_memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_posh/test/moduletests/test_popo_listener.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_listener.cpp
@@ -364,7 +364,7 @@ TEST_F(Listener_test, AttachWithoutEnumOneMoreThanCapacityFails)
                                      createNotificationCallback(Listener_test::triggerCallback<0U>));
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::LISTENER_FULL));
+    EXPECT_THAT(result.error(), Eq(ListenerError::LISTENER_FULL));
 }
 
 TEST_F(Listener_test, AttachingWithEnumIfEnoughSpaceAvailableWorks)
@@ -393,7 +393,7 @@ TEST_F(Listener_test, AttachWithEnumOneMoreThanCapacityFails)
                                      createNotificationCallback(Listener_test::triggerCallback<0U>));
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::LISTENER_FULL));
+    EXPECT_THAT(result.error(), Eq(ListenerError::LISTENER_FULL));
 }
 
 TEST_F(Listener_test, DetachMakesSpaceForAnotherAttachWithEventEnum)
@@ -453,7 +453,7 @@ TEST_F(Listener_test, OverridingAlreadyAttachedEventWithEnumFails)
                                      SimpleEvent::StoepselBachelorParty,
                                      createNotificationCallback(Listener_test::triggerCallback<0U>));
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::EVENT_ALREADY_ATTACHED));
+    EXPECT_THAT(result.error(), Eq(ListenerError::EVENT_ALREADY_ATTACHED));
 }
 
 TEST_F(Listener_test, OverridingAlreadyAttachedEventWithoutEnumFails)
@@ -465,7 +465,7 @@ TEST_F(Listener_test, OverridingAlreadyAttachedEventWithoutEnumFails)
     auto result =
         m_sut->attachEvent(m_simpleEvents[0U], createNotificationCallback(Listener_test::triggerCallback<0U>));
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::EVENT_ALREADY_ATTACHED));
+    EXPECT_THAT(result.error(), Eq(ListenerError::EVENT_ALREADY_ATTACHED));
 }
 
 TEST_F(Listener_test, AttachingSameClassWithTwoDifferentEventsWorks)
@@ -493,7 +493,7 @@ TEST_F(Listener_test, AttachingNullptrCallbackFails)
 
     auto result = m_sut->attachEvent(m_simpleEvents[0U], empty_callback);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::EMPTY_EVENT_CALLBACK));
+    EXPECT_THAT(result.error(), Eq(ListenerError::EMPTY_EVENT_CALLBACK));
 }
 
 TEST_F(Listener_test, AttachingNullptrCallbackWithEventFails)
@@ -505,7 +505,7 @@ TEST_F(Listener_test, AttachingNullptrCallbackWithEventFails)
 
     auto result = m_sut->attachEvent(m_simpleEvents[0U], SimpleEvent::StoepselBachelorParty, empty_callback);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ListenerError::EMPTY_EVENT_CALLBACK));
+    EXPECT_THAT(result.error(), Eq(ListenerError::EMPTY_EVENT_CALLBACK));
 }
 
 TEST_F(Listener_test, DetachingSameClassWithDifferentEventEnumChangesNothing)

--- a/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
@@ -243,7 +243,7 @@ TEST_F(PublisherTest, LoanFailsAndForwardsAllocationErrorsToCaller)
     auto result = sut.loan();
     // ===== Verify ===== //
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS, result.get_error());
+    EXPECT_EQ(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS, result.error());
     // ===== Cleanup ===== //
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher.cpp
@@ -69,7 +69,7 @@ TEST_F(PublisherTest, LoansChunkLargeEnoughForTheType)
 {
     ::testing::Test::RecordProperty("TEST_ID", "38d0779a-1fd5-407d-95aa-2cf24fcf3a09");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result = sut.loan();
     // ===== Verify ===== //
@@ -82,7 +82,7 @@ TEST_F(PublisherTest, LoanedSampleIsDefaultInitialized)
 {
     ::testing::Test::RecordProperty("TEST_ID", "52b5de5e-be1b-4815-8ac6-45b8dd3e9814");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result = sut.loan();
     // ===== Verify ===== //
@@ -97,7 +97,7 @@ TEST_F(PublisherTest, LoanWithArgumentsCallsCustomCtor)
     ::testing::Test::RecordProperty("TEST_ID", "1fd165ed-73a2-4465-a740-6d7b502b0d95");
     constexpr uint64_t CUSTOM_VALUE{73};
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result = sut.loan(CUSTOM_VALUE);
     // ===== Verify ===== //
@@ -111,7 +111,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithAdditionalAr
 {
     ::testing::Test::RecordProperty("TEST_ID", "6e341963-5917-440b-b01a-2fc8fff64def");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf(
@@ -129,7 +129,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfALambdaWithNoAdditional
 {
     ::testing::Test::RecordProperty("TEST_ID", "98bf5461-58c6-401d-a599-8e8f4dc5f806");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf([](DummyData* allocation) {
@@ -153,7 +153,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfACallableStructWithNoAd
         };
     };
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf(CallableStruct{});
@@ -174,7 +174,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfACallableStructWithAddi
         };
     };
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf(CallableStruct{}, 42U, 77.77F);
@@ -198,7 +198,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithNoAd
 {
     ::testing::Test::RecordProperty("TEST_ID", "eae5694a-25c3-48ec-b1ac-518321730773");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf(freeFunctionNoAdditionalArgs);
@@ -211,7 +211,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishTheResultOfFunctionPointerWithAddi
 {
     ::testing::Test::RecordProperty("TEST_ID", "5696d415-1278-4bfe-891f-9c994cd0025e");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     auto result = sut.publishResultOf(freeFunctionWithAdditionalArgs, 42U, 77.77F);
@@ -224,7 +224,7 @@ TEST_F(PublisherTest, CanLoanSamplesAndPublishCopiesOfProvidedValues)
 {
     ::testing::Test::RecordProperty("TEST_ID", "84d2599b-f6b2-497d-b2e9-029b58738552");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     DummyData data(73);
     // ===== Test ===== //
@@ -238,8 +238,7 @@ TEST_F(PublisherTest, LoanFailsAndForwardsAllocationErrorsToCaller)
 {
     ::testing::Test::RecordProperty("TEST_ID", "257750cd-3a1b-4363-a6d2-4318590528bb");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(
-            Return(ByMove(iox::error<iox::popo::AllocationError>(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS))));
+        .WillOnce(Return(ByMove(iox::err(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS))));
     // ===== Test ===== //
     auto result = sut.loan();
     // ===== Verify ===== //
@@ -253,7 +252,7 @@ TEST_F(PublisherTest, LoanedSamplesContainPointerToChunkHeader)
 {
     ::testing::Test::RecordProperty("TEST_ID", "935108d7-bf2f-4557-8722-f7f474f413a3");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result = sut.loan();
     // ===== Verify ===== //
@@ -267,7 +266,7 @@ TEST_F(PublisherTest, PublishingSendsUnderlyingMemoryChunkOnPublisherPort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "743183e2-76cb-4d51-9643-a962d933fdac");
     EXPECT_CALL(portMock, tryAllocateChunk(sizeof(DummyData), _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     EXPECT_CALL(portMock, sendChunk(chunkMock.chunkHeader()));
     // ===== Test ===== //
     sut.loan().and_then([](auto& sample) { sample.publish(); });

--- a/iceoryx_posh/test/moduletests/test_popo_request.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_request.cpp
@@ -64,7 +64,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithErrorResult)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(CLIENT_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(CLIENT_SEND_ERROR));
     EXPECT_FALSE(sutProducer);
 }
 
@@ -86,7 +86,7 @@ TEST_F(Request_test, SendingAlreadySentRequestCallsErrorHandler)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(CLIENT_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(CLIENT_SEND_ERROR));
 
     ASSERT_TRUE(detectedError.has_value());
     EXPECT_THAT(detectedError.value(), Eq(iox::PoshError::POSH__SENDING_EMPTY_REQUEST));
@@ -108,7 +108,7 @@ TEST_F(Request_test, SendingMovedRequestCallsErrorHandler)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(CLIENT_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(CLIENT_SEND_ERROR));
 
     ASSERT_TRUE(detectedError.has_value());
     EXPECT_THAT(detectedError.value(), Eq(iox::PoshError::POSH__SENDING_EMPTY_REQUEST));

--- a/iceoryx_posh/test/moduletests/test_popo_request.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_request.cpp
@@ -34,7 +34,7 @@ class Request_test : public RequestTestCase, public Test
 TEST_F(Request_test, SendCallsInterfaceMockWithSuccessResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cc78dd7b-4dce-43ea-a798-c9aaf0646b49");
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     auto sendResult = sutProducer.send();
 
@@ -45,7 +45,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithSuccessResult)
 TEST_F(Request_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9a6d018e-77b4-4081-984e-39a5229b7fb8");
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     auto movedSut = std::move(sutProducer);
     auto sendResult = movedSut.send();
@@ -58,7 +58,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithErrorResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "127ceb5e-aa9f-4900-9347-33f8925088ba");
     constexpr ClientSendError CLIENT_SEND_ERROR{ClientSendError::SERVER_NOT_AVAILABLE};
-    const iox::expected<void, ClientSendError> mockSendResult = iox::error<ClientSendError>{CLIENT_SEND_ERROR};
+    const iox::expected<void, ClientSendError> mockSendResult = iox::err(CLIENT_SEND_ERROR);
     EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(mockSendResult));
 
     auto sendResult = sutProducer.send();
@@ -72,7 +72,7 @@ TEST_F(Request_test, SendingAlreadySentRequestCallsErrorHandler)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e010085d-3674-4a7e-8704-73405ab49afa");
     constexpr ClientSendError CLIENT_SEND_ERROR{ClientSendError::INVALID_REQUEST};
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     EXPECT_FALSE(sutProducer.send().has_error());
 

--- a/iceoryx_posh/test/moduletests/test_popo_request.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_request.cpp
@@ -58,7 +58,7 @@ TEST_F(Request_test, SendCallsInterfaceMockWithErrorResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "127ceb5e-aa9f-4900-9347-33f8925088ba");
     constexpr ClientSendError CLIENT_SEND_ERROR{ClientSendError::SERVER_NOT_AVAILABLE};
-    const iox::expected<ClientSendError> mockSendResult = iox::error<ClientSendError>{CLIENT_SEND_ERROR};
+    const iox::expected<void, ClientSendError> mockSendResult = iox::error<ClientSendError>{CLIENT_SEND_ERROR};
     EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(mockSendResult));
 
     auto sendResult = sutProducer.send();

--- a/iceoryx_posh/test/moduletests/test_popo_response.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_response.cpp
@@ -64,7 +64,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithErrorResult)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(SERVER_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(SERVER_SEND_ERROR));
     EXPECT_FALSE(sutProducer);
 }
 
@@ -86,7 +86,7 @@ TEST_F(Response_test, SendingAlreadySentResponseCallsErrorHandler)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(SERVER_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(SERVER_SEND_ERROR));
 
     ASSERT_TRUE(detectedError.has_value());
     EXPECT_THAT(detectedError.value(), Eq(iox::PoshError::POSH__SENDING_EMPTY_RESPONSE));
@@ -108,7 +108,7 @@ TEST_F(Response_test, SendingMovedResponseCallsErrorHandler)
     auto sendResult = sutProducer.send();
 
     ASSERT_TRUE(sendResult.has_error());
-    EXPECT_THAT(sendResult.get_error(), Eq(SERVER_SEND_ERROR));
+    EXPECT_THAT(sendResult.error(), Eq(SERVER_SEND_ERROR));
 
     ASSERT_TRUE(detectedError.has_value());
     EXPECT_THAT(detectedError.value(), Eq(iox::PoshError::POSH__SENDING_EMPTY_RESPONSE));

--- a/iceoryx_posh/test/moduletests/test_popo_response.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_response.cpp
@@ -34,7 +34,7 @@ class Response_test : public ResponseTestCase, public Test
 TEST_F(Response_test, SendCallsInterfaceMockWithSuccessResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "70361e1e-78ea-48a2-bd5c-679d604e5da4");
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     auto sendResult = sutProducer.send();
 
@@ -45,7 +45,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithSuccessResult)
 TEST_F(Response_test, SendOnMoveDestinationCallsInterfaceMockWithSuccessResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b86b5884-0319-4819-8bfa-186ac629cd27");
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     auto movedSut = std::move(sutProducer);
     auto sendResult = movedSut.send();
@@ -58,7 +58,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithErrorResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5038ae30-2f09-4f7b-81e4-a7f5bc1b3db4");
     constexpr ServerSendError SERVER_SEND_ERROR{ServerSendError::CLIENT_NOT_AVAILABLE};
-    const iox::expected<void, ServerSendError> mockSendResult = iox::error<ServerSendError>{SERVER_SEND_ERROR};
+    const iox::expected<void, ServerSendError> mockSendResult = iox::err(SERVER_SEND_ERROR);
     EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(mockSendResult));
 
     auto sendResult = sutProducer.send();
@@ -72,7 +72,7 @@ TEST_F(Response_test, SendingAlreadySentResponseCallsErrorHandler)
 {
     ::testing::Test::RecordProperty("TEST_ID", "45e592d2-69d9-47cf-8cdf-b1bdf8592947");
     constexpr ServerSendError SERVER_SEND_ERROR{ServerSendError::INVALID_RESPONSE};
-    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(iox::ok()));
 
     EXPECT_FALSE(sutProducer.send().has_error());
 

--- a/iceoryx_posh/test/moduletests/test_popo_response.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_response.cpp
@@ -58,7 +58,7 @@ TEST_F(Response_test, SendCallsInterfaceMockWithErrorResult)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5038ae30-2f09-4f7b-81e4-a7f5bc1b3db4");
     constexpr ServerSendError SERVER_SEND_ERROR{ServerSendError::CLIENT_NOT_AVAILABLE};
-    const iox::expected<ServerSendError> mockSendResult = iox::error<ServerSendError>{SERVER_SEND_ERROR};
+    const iox::expected<void, ServerSendError> mockSendResult = iox::error<ServerSendError>{SERVER_SEND_ERROR};
     EXPECT_CALL(mockInterface, mockSend(_)).WillOnce(Return(mockSendResult));
 
     auto sendResult = sutProducer.send();

--- a/iceoryx_posh/test/moduletests/test_popo_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server.cpp
@@ -96,7 +96,7 @@ TEST_F(Server_test, TakeCallsUnderlyingPortWithErrorResult)
 
     auto takeResult = sut.take();
     ASSERT_TRUE(takeResult.has_error());
-    EXPECT_THAT(takeResult.get_error(), Eq(SERVER_REQUEST_RESULT));
+    EXPECT_THAT(takeResult.error(), Eq(SERVER_REQUEST_RESULT));
 }
 
 TEST_F(Server_test, LoanCallsUnderlyingPortWithSuccessResult)
@@ -145,7 +145,7 @@ TEST_F(Server_test, LoanCallsUnderlyingPortWithErrorResult)
 
     auto loanResult = sut.loan(request);
     ASSERT_TRUE(loanResult.has_error());
-    EXPECT_THAT(loanResult.get_error(), Eq(ALLOCATION_ERROR));
+    EXPECT_THAT(loanResult.error(), Eq(ALLOCATION_ERROR));
 
     EXPECT_CALL(sut.mockPort, releaseRequest(requestMock.userHeader())).Times(1);
 }

--- a/iceoryx_posh/test/moduletests/test_popo_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server.cpp
@@ -74,7 +74,7 @@ TEST_F(Server_test, TakeCallsUnderlyingPortWithSuccessResult)
     ::testing::Test::RecordProperty("TEST_ID", "a8a76781-7599-4bb9-b3fc-1c9f06ae372b");
 
     const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::success<const RequestHeader*>{requestMock.userHeader()};
+        iox::ok<const RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
 
@@ -90,8 +90,7 @@ TEST_F(Server_test, TakeCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "a9049459-99b6-4567-b022-99299bd423b6");
 
     constexpr ServerRequestResult SERVER_REQUEST_RESULT{ServerRequestResult::TOO_MANY_REQUESTS_HELD_IN_PARALLEL};
-    const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::error<ServerRequestResult>{SERVER_REQUEST_RESULT};
+    const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult = iox::err(SERVER_REQUEST_RESULT);
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
 
@@ -105,7 +104,7 @@ TEST_F(Server_test, LoanCallsUnderlyingPortWithSuccessResult)
     ::testing::Test::RecordProperty("TEST_ID", "926d394d-2a8f-486a-a422-28e424cf266a");
 
     const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::success<const RequestHeader*>{requestMock.userHeader()};
+        iox::ok<const RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
     auto takeResult = sut.take();
@@ -113,7 +112,7 @@ TEST_F(Server_test, LoanCallsUnderlyingPortWithSuccessResult)
     const auto request = std::move(takeResult.value());
 
     const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult =
-        iox::success<ResponseHeader*>{responseMock.userHeader()};
+        iox::ok<ResponseHeader*>(responseMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateResponse(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
         .WillOnce(Return(allocateResponseResult));
@@ -131,7 +130,7 @@ TEST_F(Server_test, LoanCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "2302a61f-bc18-4cad-babb-9a4aeabf1cc7");
 
     const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::success<const RequestHeader*>{requestMock.userHeader()};
+        iox::ok<const RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
     auto takeResult = sut.take();
@@ -139,8 +138,7 @@ TEST_F(Server_test, LoanCallsUnderlyingPortWithErrorResult)
     const auto request = std::move(takeResult.value());
 
     constexpr AllocationError ALLOCATION_ERROR{AllocationError::RUNNING_OUT_OF_CHUNKS};
-    const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult =
-        iox::error<AllocationError>{ALLOCATION_ERROR};
+    const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult = iox::err(ALLOCATION_ERROR);
 
     EXPECT_CALL(sut.mockPort, allocateResponse(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
         .WillOnce(Return(allocateResponseResult));
@@ -157,7 +155,7 @@ TEST_F(Server_test, SendCallsUnderlyingPort)
     ::testing::Test::RecordProperty("TEST_ID", "535414bd-1846-4254-8fa1-78a296c185b5");
 
     const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::success<const RequestHeader*>{requestMock.userHeader()};
+        iox::ok<const RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
     auto takeResult = sut.take();
@@ -165,7 +163,7 @@ TEST_F(Server_test, SendCallsUnderlyingPort)
     const auto request = std::move(takeResult.value());
 
     const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult =
-        iox::success<ResponseHeader*>{responseMock.userHeader()};
+        iox::ok<ResponseHeader*>(responseMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateResponse(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
         .WillOnce(Return(allocateResponseResult));
@@ -173,7 +171,7 @@ TEST_F(Server_test, SendCallsUnderlyingPort)
     auto loanResult = sut.loan(request);
     auto response = std::move(loanResult.value());
 
-    EXPECT_CALL(sut.mockPort, sendResponse(responseMock.userHeader())).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(sut.mockPort, sendResponse(responseMock.userHeader())).WillOnce(Return(iox::ok()));
 
     sut.send(std::move(response))
         .and_then([&]() { GTEST_SUCCEED() << "Response successfully sent"; })

--- a/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
@@ -107,11 +107,11 @@ class ServerPort_test : public Test
                                                          iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT,
                                                          userHeaderSize,
                                                          iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = m_memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_posh/test/moduletests/test_popo_smart_chunk_common.hpp
+++ b/iceoryx_posh/test/moduletests/test_popo_smart_chunk_common.hpp
@@ -93,7 +93,7 @@ using RequestConsumerType = Request<const DummyData>;
 class MockRequestInterface : public RpcInterface<RequestProducerType, ClientSendError>
 {
   public:
-    iox::expected<ClientSendError> send(RequestProducerType&& request) noexcept override
+    iox::expected<void, ClientSendError> send(RequestProducerType&& request) noexcept override
     {
         auto req = std::move(request); // this step is necessary since the mock method doesn't execute the move
         return mockSend(std::move(req));
@@ -103,7 +103,7 @@ class MockRequestInterface : public RpcInterface<RequestProducerType, ClientSend
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #endif
-    MOCK_METHOD(iox::expected<ClientSendError>, mockSend, (RequestProducerType &&), (noexcept));
+    MOCK_METHOD((iox::expected<void, ClientSendError>), mockSend, (RequestProducerType &&), (noexcept));
 #ifdef __clang__
 #pragma GCC diagnostic pop
 #endif
@@ -138,7 +138,7 @@ using ResponseConsumerType = Response<const DummyData>;
 class MockResponseInterface : public RpcInterface<ResponseProducerType, ServerSendError>
 {
   public:
-    iox::expected<ServerSendError> send(ResponseProducerType&& response) noexcept override
+    iox::expected<void, ServerSendError> send(ResponseProducerType&& response) noexcept override
     {
         auto res = std::move(response); // this step is necessary since the mock method doesn't execute the move
         return mockSend(std::move(res));
@@ -148,7 +148,7 @@ class MockResponseInterface : public RpcInterface<ResponseProducerType, ServerSe
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #endif
-    MOCK_METHOD(iox::expected<ServerSendError>, mockSend, (ResponseProducerType &&), (noexcept));
+    MOCK_METHOD((iox::expected<void, ServerSendError>), mockSend, (ResponseProducerType &&), (noexcept));
 #ifdef __clang__
 #pragma GCC diagnostic pop
 #endif

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber.cpp
@@ -151,8 +151,7 @@ TEST_F(SubscriberTest, TakeReturnsAllocatedMemoryChunksWrappedInSample)
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
-        .WillOnce(Return(ByMove(iox::success<const iox::mepoo::ChunkHeader*>(
-            const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
+        .WillOnce(Return(ByMove(iox::ok(const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
     EXPECT_CALL(sut.port(), releaseChunk).Times(AtLeast(1));
     // ===== Test ===== //
     auto maybeSample = sut.take();
@@ -168,8 +167,7 @@ TEST_F(SubscriberTest, ReceivedSamplesAreAutomaticallyDeletedWhenOutOfScope)
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
-        .WillOnce(Return(ByMove(iox::success<const iox::mepoo::ChunkHeader*>(
-            const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
+        .WillOnce(Return(ByMove(iox::ok(const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
     EXPECT_CALL(sut.port(), releaseChunk).Times(AtLeast(1));
     // ===== Test ===== //
     {

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
@@ -91,7 +91,7 @@ TEST_F(SubscriberPortSingleProducer_test, InitialStateNoChunksAvailable)
     auto maybeChunkHeader = m_sutUserSideSingleProducer.tryGetChunk();
 
     ASSERT_TRUE(maybeChunkHeader.has_error());
-    EXPECT_EQ(maybeChunkHeader.get_error(), iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE);
+    EXPECT_EQ(maybeChunkHeader.error(), iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE);
     EXPECT_FALSE(m_sutUserSideSingleProducer.hasNewChunks());
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -141,7 +141,7 @@ TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedForServiceDescriptio
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_EQ(charactersValidity.second, result.has_error());
-    if (!result.has_error())
+    if (result.has_value())
     {
         GatewayConfig& config = result.value();
         EXPECT_FALSE(config.m_configuredServices.empty());

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -119,7 +119,7 @@ TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedInServiceDescription
     ASSERT_EQ(charactersValidity.second, result.has_error());
     if (result.has_error())
     {
-        EXPECT_EQ(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION, result.get_error());
+        EXPECT_EQ(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION, result.error());
     }
 }
 
@@ -148,7 +148,7 @@ TEST_P(TomlGatewayConfigParserSuiteTest, CheckCharactersUsedForServiceDescriptio
     }
     else
     {
-        EXPECT_EQ(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION, result.get_error());
+        EXPECT_EQ(TomlGatewayConfigParseError::INVALID_SERVICE_DESCRIPTION, result.error());
     }
 }
 
@@ -166,7 +166,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoServiceNameInServiceDescriptionReturn
 
     auto result = StubbedTomlGatewayConfigParser::validate(*toml);
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoInstanceNameInServiceDescriptionReturnIncompleteServiceDescriptionError)
@@ -183,7 +183,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoInstanceNameInServiceDescriptionRetur
 
     auto result = StubbedTomlGatewayConfigParser::validate(*toml);
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoEventNameInServiceDescriptionReturnIncompleteServiceDescriptionError)
@@ -200,7 +200,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoEventNameInServiceDescriptionReturnIn
 
     auto result = StubbedTomlGatewayConfigParser::validate(*toml);
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest, NoServicesInConfigReturnIncompleteConfigurationError)
@@ -211,7 +211,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest, NoServicesInConfigReturnIncompleteConfi
     auto result = iox::config::StubbedTomlGatewayConfigParser::validate(*toml);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION, result.error());
 }
 
 /// @note Without argument the iceoryx default config in /etc/iceoryx/gateway_config.toml is used. Then this
@@ -256,7 +256,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest,
@@ -274,7 +274,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest,
@@ -292,7 +292,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_SERVICE_DESCRIPTION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest,
@@ -305,7 +305,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION, result.get_error());
+    EXPECT_EQ(TomlGatewayConfigParseError::INCOMPLETE_CONFIGURATION, result.error());
 }
 
 TEST_F(TomlGatewayConfigParserSuiteTest, DuplicatedServicesDescriptionInTomlFileReturnOnlyOneEntry)
@@ -391,7 +391,7 @@ TEST_F(TomlGatewayConfigParserSuiteTest,
     auto result = TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.get_error(), MAXIMUM_NUMBER_OF_ENTRIES_EXCEEDED);
+    EXPECT_EQ(result.error(), MAXIMUM_NUMBER_OF_ENTRIES_EXCEEDED);
 }
 
 constexpr const char* CONFIG_INVALID_SERVICE_DESCRIPTION = R"(
@@ -423,7 +423,7 @@ TEST_P(TomlGatewayConfigParserTest, ParseMalformedInputFileCausesError)
     auto result = iox::config::TomlGatewayConfigParser::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(expectedErrorCode, result.get_error());
+    EXPECT_EQ(expectedErrorCode, result.error());
 }
 
 #endif // not defined QNX

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_client.cpp
@@ -65,7 +65,7 @@ TEST_F(UntypedClient_test, LoanCallsUnderlyingPortWithSuccessResult)
     constexpr uint64_t PAYLOAD_SIZE{8U};
     constexpr uint64_t PAYLOAD_ALIGNMENT{32U};
     const iox::expected<RequestHeader*, AllocationError> allocateRequestResult =
-        iox::success<RequestHeader*>{requestMock.userHeader()};
+        iox::ok<RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateRequest(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT)).WillOnce(Return(allocateRequestResult));
 
@@ -81,8 +81,7 @@ TEST_F(UntypedClient_test, LoanCallsUnderlyingPortWithErrorResult)
     constexpr uint64_t PAYLOAD_SIZE{8U};
     constexpr uint64_t PAYLOAD_ALIGNMENT{32U};
     constexpr AllocationError ALLOCATION_ERROR{AllocationError::RUNNING_OUT_OF_CHUNKS};
-    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult =
-        iox::error<AllocationError>{ALLOCATION_ERROR};
+    const iox::expected<RequestHeader*, AllocationError> allocateRequestResult = iox::err(ALLOCATION_ERROR);
 
     EXPECT_CALL(sut.mockPort, allocateRequest(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT)).WillOnce(Return(allocateRequestResult));
 
@@ -113,7 +112,7 @@ TEST_F(UntypedClient_test, SendWithValidPayloadPointerCallsUnderlyingPort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "74d86b31-24a8-409e-8b85-7b9ec1c7ad3d");
 
-    EXPECT_CALL(sut.mockPort, sendRequest(requestMock.userHeader())).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(sut.mockPort, sendRequest(requestMock.userHeader())).WillOnce(Return(iox::ok()));
 
     sut.send(requestMock.sample())
         .and_then([&]() { GTEST_SUCCEED() << "Request successfully sent"; })
@@ -136,7 +135,7 @@ TEST_F(UntypedClient_test, TakeCallsUnderlyingPortWithSuccessResult)
     ::testing::Test::RecordProperty("TEST_ID", "9ca260e9-89bb-48aa-8504-0375e35eef9f");
 
     const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult =
-        iox::success<const ResponseHeader*>{responseMock.userHeader()};
+        iox::ok<const ResponseHeader*>(responseMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getResponse()).WillOnce(Return(getResponseResult));
 
@@ -150,8 +149,7 @@ TEST_F(UntypedClient_test, TakeCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "ff524011-3a79-4960-9379-571e2eb87b16");
 
     constexpr ChunkReceiveResult CHUNK_RECEIVE_RESULT{ChunkReceiveResult::TOO_MANY_CHUNKS_HELD_IN_PARALLEL};
-    const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult =
-        iox::error<ChunkReceiveResult>{CHUNK_RECEIVE_RESULT};
+    const iox::expected<const ResponseHeader*, ChunkReceiveResult> getResponseResult = iox::err(CHUNK_RECEIVE_RESULT);
 
     EXPECT_CALL(sut.mockPort, getResponse()).WillOnce(Return(getResponseResult));
 

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_client.cpp
@@ -87,7 +87,7 @@ TEST_F(UntypedClient_test, LoanCallsUnderlyingPortWithErrorResult)
 
     auto loanResult = sut.loan(PAYLOAD_SIZE, PAYLOAD_ALIGNMENT);
     ASSERT_TRUE(loanResult.has_error());
-    EXPECT_THAT(loanResult.get_error(), Eq(ALLOCATION_ERROR));
+    EXPECT_THAT(loanResult.error(), Eq(ALLOCATION_ERROR));
 }
 
 TEST_F(UntypedClient_test, ReleaseRequestWithValidPayloadPointerCallsUnderlyingPort)
@@ -155,7 +155,7 @@ TEST_F(UntypedClient_test, TakeCallsUnderlyingPortWithErrorResult)
 
     auto takeResult = sut.take();
     ASSERT_TRUE(takeResult.has_error());
-    EXPECT_THAT(takeResult.get_error(), Eq(CHUNK_RECEIVE_RESULT));
+    EXPECT_THAT(takeResult.error(), Eq(CHUNK_RECEIVE_RESULT));
 }
 
 TEST_F(UntypedClient_test, ReleaseResponseWithValidPayloadPointerCallsUnderlyingPort)

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
@@ -104,7 +104,7 @@ TEST_F(UntypedPublisherTest, LoanFailsIfPortCannotSatisfyAllocationRequest)
     auto result = sut.loan(ALLOCATION_SIZE);
     // ===== Verify ===== //
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS, result.get_error());
+    EXPECT_EQ(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS, result.error());
     // ===== Cleanup ===== //
 }
 

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_publisher.cpp
@@ -65,7 +65,7 @@ TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeWorks)
                                  USER_PAYLOAD_ALIGNMENT,
                                  iox::CHUNK_NO_USER_HEADER_SIZE,
                                  iox::CHUNK_NO_USER_HEADER_ALIGNMENT))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result = sut.loan(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT);
     // ===== Verify ===== //
@@ -85,7 +85,7 @@ TEST_F(UntypedPublisherTest, LoansChunkWithRequestedSizeAndUserHeaderWorks)
     constexpr uint32_t USER_HEADER_ALIGNMENT = alignof(TestUserHeader);
     EXPECT_CALL(portMockWithUserHeader,
                 tryAllocateChunk(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
     // ===== Test ===== //
     auto result =
         sutWithUserHeader.loan(USER_PAYLOAD_SIZE, USER_PAYLOAD_ALIGNMENT, USER_HEADER_SIZE, USER_HEADER_ALIGNMENT);
@@ -99,8 +99,7 @@ TEST_F(UntypedPublisherTest, LoanFailsIfPortCannotSatisfyAllocationRequest)
     ::testing::Test::RecordProperty("TEST_ID", "b609f96e-ea08-46b2-9b72-d162a8273cb5");
     constexpr uint32_t ALLOCATION_SIZE = 17U;
     EXPECT_CALL(portMock, tryAllocateChunk(ALLOCATION_SIZE, _, _, _))
-        .WillOnce(
-            Return(ByMove(iox::error<iox::popo::AllocationError>(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS))));
+        .WillOnce(Return(ByMove(iox::err(iox::popo::AllocationError::RUNNING_OUT_OF_CHUNKS))));
     // ===== Test ===== //
     auto result = sut.loan(ALLOCATION_SIZE);
     // ===== Verify ===== //
@@ -114,7 +113,7 @@ TEST_F(UntypedPublisherTest, ReleaseDelegatesCallToPort)
     ::testing::Test::RecordProperty("TEST_ID", "e114b083-10c7-403e-a841-a04487a5f1e0");
     constexpr uint32_t ALLOCATION_SIZE = 7U;
     EXPECT_CALL(portMock, tryAllocateChunk(ALLOCATION_SIZE, _, _, _))
-        .WillOnce(Return(ByMove(iox::success<iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader()))));
+        .WillOnce(Return(ByMove(iox::ok(chunkMock.chunkHeader()))));
 
     auto result = sut.loan(ALLOCATION_SIZE);
     ASSERT_FALSE(result.has_error());

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_server.cpp
@@ -63,7 +63,7 @@ TEST_F(UntypedServer_test, TakeCallsUnderlyingPortWithSuccessResult)
     ::testing::Test::RecordProperty("TEST_ID", "0bcaf64f-66d6-4906-ad6e-9bf3ce168c30");
 
     const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::success<const RequestHeader*>{requestMock.userHeader()};
+        iox::ok<const RequestHeader*>(requestMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
 
@@ -77,8 +77,7 @@ TEST_F(UntypedServer_test, TakeCallsUnderlyingPortWithErrorResult)
     ::testing::Test::RecordProperty("TEST_ID", "224e93e3-47f4-4533-8fac-9cb7bbb87f08");
 
     constexpr ServerRequestResult SERVER_REQUEST_RESULT{ServerRequestResult::TOO_MANY_REQUESTS_HELD_IN_PARALLEL};
-    const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult =
-        iox::error<ServerRequestResult>{SERVER_REQUEST_RESULT};
+    const iox::expected<const RequestHeader*, ServerRequestResult> getRequestResult = iox::err(SERVER_REQUEST_RESULT);
 
     EXPECT_CALL(sut.mockPort, getRequest()).WillOnce(Return(getRequestResult));
 
@@ -112,7 +111,7 @@ TEST_F(UntypedServer_test, LoanCallsUnderlyingPortWithSuccessResult)
     constexpr uint64_t PAYLOAD_SIZE{8U};
     constexpr uint64_t PAYLOAD_ALIGNMENT{32U};
     const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult =
-        iox::success<ResponseHeader*>{responseMock.userHeader()};
+        iox::ok<ResponseHeader*>(responseMock.userHeader());
 
     EXPECT_CALL(sut.mockPort, allocateResponse(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
         .WillOnce(Return(allocateResponseResult));
@@ -129,8 +128,7 @@ TEST_F(UntypedServer_test, LoanCallsUnderlyingPortWithErrorResult)
     constexpr uint64_t PAYLOAD_SIZE{8U};
     constexpr uint64_t PAYLOAD_ALIGNMENT{32U};
     constexpr AllocationError ALLOCATION_ERROR{AllocationError::RUNNING_OUT_OF_CHUNKS};
-    const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult =
-        iox::error<AllocationError>{ALLOCATION_ERROR};
+    const iox::expected<ResponseHeader*, AllocationError> allocateResponseResult = iox::err(ALLOCATION_ERROR);
 
     EXPECT_CALL(sut.mockPort, allocateResponse(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
         .WillOnce(Return(allocateResponseResult));
@@ -144,7 +142,7 @@ TEST_F(UntypedServer_test, SendWithValidPayloadPointerCallsUnderlyingPort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "707cfdd8-05ae-490c-8cbb-9a4253135937");
 
-    EXPECT_CALL(sut.mockPort, sendResponse(responseMock.userHeader())).WillOnce(Return(iox::success<void>()));
+    EXPECT_CALL(sut.mockPort, sendResponse(responseMock.userHeader())).WillOnce(Return(iox::ok()));
 
     sut.send(responseMock.sample())
         .and_then([&]() { GTEST_SUCCEED() << "Response successfully sent"; })

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_server.cpp
@@ -83,7 +83,7 @@ TEST_F(UntypedServer_test, TakeCallsUnderlyingPortWithErrorResult)
 
     auto takeResult = sut.take();
     ASSERT_TRUE(takeResult.has_error());
-    EXPECT_THAT(takeResult.get_error(), Eq(SERVER_REQUEST_RESULT));
+    EXPECT_THAT(takeResult.error(), Eq(SERVER_REQUEST_RESULT));
 }
 
 TEST_F(UntypedServer_test, ReleaseRequestWithValidPayloadPointerCallsUnderlyingPort)
@@ -135,7 +135,7 @@ TEST_F(UntypedServer_test, LoanCallsUnderlyingPortWithErrorResult)
 
     auto loanResult = sut.loan(requestMock.userHeader(), PAYLOAD_SIZE, PAYLOAD_ALIGNMENT);
     ASSERT_TRUE(loanResult.has_error());
-    EXPECT_THAT(loanResult.get_error(), Eq(ALLOCATION_ERROR));
+    EXPECT_THAT(loanResult.error(), Eq(ALLOCATION_ERROR));
 }
 
 TEST_F(UntypedServer_test, SendWithValidPayloadPointerCallsUnderlyingPort)

--- a/iceoryx_posh/test/moduletests/test_popo_untyped_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_untyped_subscriber.cpp
@@ -148,8 +148,7 @@ TEST_F(UntypedSubscriberTest, TakeReturnsAllocatedMemoryChunk)
     // ===== Setup ===== //
     EXPECT_CALL(sut, takeChunk)
         .Times(1)
-        .WillOnce(Return(ByMove(iox::success<const iox::mepoo::ChunkHeader*>(
-            const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
+        .WillOnce(Return(ByMove(iox::ok(const_cast<const iox::mepoo::ChunkHeader*>(chunkMock.chunkHeader())))));
     EXPECT_CALL(sut.port(), releaseChunk).Times(AtLeast(1));
     // ===== Test ===== //
     auto maybeChunk = sut.take();

--- a/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_used_chunk_list.cpp
@@ -49,11 +49,11 @@ class UsedChunkList_test : public Test
         constexpr uint32_t USER_PAYLOAD_SIZE{32U};
         auto chunkSettingsResult =
             iox::mepoo::ChunkSettings::create(USER_PAYLOAD_SIZE, iox::CHUNK_DEFAULT_USER_PAYLOAD_ALIGNMENT);
-        iox::cxx::Ensures(!chunkSettingsResult.has_error());
+        iox::cxx::Ensures(chunkSettingsResult.has_value());
         auto& chunkSettings = chunkSettingsResult.value();
 
         auto getChunkResult = memoryManager.getChunk(chunkSettings);
-        iox::cxx::Ensures(!getChunkResult.has_error());
+        iox::cxx::Ensures(getChunkResult.has_value());
         return getChunkResult.value();
     }
 

--- a/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
@@ -706,7 +706,7 @@ TEST_F(WaitSet_test, AttachingSameEventTwiceResultsInError)
     auto result2 = m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_FALSE(m_simpleEvents[0].hasStateSet());
     EXPECT_TRUE(m_simpleEvents[0].hasEventSet());
 }
@@ -719,7 +719,7 @@ TEST_F(WaitSet_test, AttachingSameStateTwiceResultsInError)
     auto result2 = m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_TRUE(m_simpleEvents[0].hasStateSet());
     EXPECT_FALSE(m_simpleEvents[0].hasEventSet());
 }
@@ -732,7 +732,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithNonNullIdTwiceResultsInError)
     auto result2 = m_sut->attachEvent(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_FALSE(m_simpleEvents[0].hasStateSet());
     EXPECT_TRUE(m_simpleEvents[0].hasEventSet());
 }
@@ -745,7 +745,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithNonNullIdTwiceResultsInError)
     auto result2 = m_sut->attachState(m_simpleEvents[0], USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_TRUE(m_simpleEvents[0].hasStateSet());
     EXPECT_FALSE(m_simpleEvents[0].hasEventSet());
 }
@@ -759,7 +759,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithDifferentIdResultsInError)
     auto result2 = m_sut->attachEvent(m_simpleEvents[0], ANOTHER_USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
 }
 
 TEST_F(WaitSet_test, AttachingSameStateWithDifferentIdResultsInError)
@@ -771,7 +771,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithDifferentIdResultsInError)
     auto result2 = m_sut->attachState(m_simpleEvents[0], ANOTHER_USER_DEFINED_EVENT_ID);
 
     ASSERT_TRUE(result2.has_error());
-    EXPECT_THAT(result2.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result2.error(), Eq(WaitSetError::ALREADY_ATTACHED));
 }
 
 TEST_F(WaitSet_test, DetachingAttachedEventIsSuccessful)
@@ -918,7 +918,7 @@ TEST_F(WaitSet_test, AttachingSameEventWithEnumFails)
 
     auto result = m_sut->attachEvent(m_simpleEvents[0], SimpleEvent1::EVENT1);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_THAT(SimpleEventClass::m_simpleEvent1, Eq(SimpleEvent1::EVENT1));
     EXPECT_THAT(m_sut->size(), Eq(1U));
     EXPECT_FALSE(m_simpleEvents[0].hasStateSet());
@@ -970,7 +970,7 @@ TEST_F(WaitSet_test, AttachingSameStateWithEnumFails)
 
     auto result = m_sut->attachState(m_simpleEvents[0], SimpleState1::STATE1);
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(WaitSetError::ALREADY_ATTACHED));
+    EXPECT_THAT(result.error(), Eq(WaitSetError::ALREADY_ATTACHED));
     EXPECT_THAT(SimpleEventClass::m_simpleState1, Eq(SimpleState1::STATE1));
     EXPECT_THAT(m_sut->size(), Eq(1U));
     EXPECT_TRUE(m_simpleEvents[0].hasStateSet());

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -1009,7 +1009,7 @@ TEST_F(PoshRuntime_test, ShutdownUnblocksBlockingClient)
             ASSERT_THAT(sendResult.has_error(), Eq(expectError));
             if (expectError)
             {
-                EXPECT_THAT(sendResult.get_error(), Eq(iox::popo::ClientSendError::SERVER_NOT_AVAILABLE));
+                EXPECT_THAT(sendResult.error(), Eq(iox::popo::ClientSendError::SERVER_NOT_AVAILABLE));
             }
         };
 
@@ -1088,7 +1088,7 @@ TEST_F(PoshRuntime_test, ShutdownUnblocksBlockingServer)
             ASSERT_THAT(sendResult.has_error(), Eq(expectError));
             if (expectError)
             {
-                EXPECT_THAT(sendResult.get_error(), Eq(iox::popo::ServerSendError::CLIENT_NOT_AVAILABLE));
+                EXPECT_THAT(sendResult.error(), Eq(iox::popo::ServerSendError::CLIENT_NOT_AVAILABLE));
             }
         };
 

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser.cpp
@@ -124,7 +124,7 @@ TEST_F(CmdLineParser_test, WrongOptionLeadsUnkownOptionResult)
     auto result = sut.parse(NUMBER_OF_ARGS, args);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.get_error(), CmdLineParserResult::UNKNOWN_OPTION_USED);
+    EXPECT_EQ(result.error(), CmdLineParserResult::UNKNOWN_OPTION_USED);
 }
 
 TEST_F(CmdLineParser_test, HelpLongOptionLeadsToProgrammNotRunning)

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
@@ -125,7 +125,7 @@ TEST_F(CmdLineParserConfigFileOption_test, WrongOptionLeadsUnkownOptionResult)
     auto result = sut.parse(NUMBER_OF_ARGS, args);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(result.get_error(), CmdLineParserResult::UNKNOWN_OPTION_USED);
+    EXPECT_EQ(result.error(), CmdLineParserResult::UNKNOWN_OPTION_USED);
 }
 
 TEST_F(CmdLineParserConfigFileOption_test, UniqueIdOptionLeadsCallingCmdLineParserParseReturningNoError)

--- a/iceoryx_posh/test/moduletests/test_roudi_config_toml_file_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_config_toml_file_provider.cpp
@@ -220,7 +220,7 @@ TEST_P(RoudiConfigTomlFileProvider_test, ParseMalformedInputFileCausesError)
     auto result = iox::config::TomlRouDiConfigFileProvider::parse(stream);
 
     ASSERT_TRUE(result.has_error());
-    EXPECT_EQ(expectedErrorCode, result.get_error());
+    EXPECT_EQ(expectedErrorCode, result.error());
 }
 
 } // namespace

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoyx_roudi_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoyx_roudi_memory_manager.cpp
@@ -162,7 +162,7 @@ TEST_F(IceoryxRoudiMemoryManager_test, CreateAndAnnouceMemoryFailingAfterCalledT
     auto result = m_roudiMemoryManagerTest->createAndAnnounceMemory();
 
     EXPECT_THAT(result.has_error(), Eq(true));
-    EXPECT_THAT(result.get_error(), Eq(iox::roudi::RouDiMemoryManagerError::MEMORY_CREATION_FAILED));
+    EXPECT_THAT(result.error(), Eq(iox::roudi::RouDiMemoryManagerError::MEMORY_CREATION_FAILED));
 }
 
 TEST_F(IceoryxRoudiMemoryManager_test, DestroyMemoryNotFailingAfterCalledTwoTimes)

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_manager.cpp
@@ -67,7 +67,7 @@ TEST_F(RouDiMemoryManager_Test, CallingCreateAndAnnounceMemoryWithoutMemoryProvi
     ::testing::Test::RecordProperty("TEST_ID", "8048cd15-3786-4eaf-9c26-e1cd6dce753c");
     auto expectError = sut.createAndAnnounceMemory();
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(RouDiMemoryManagerError::NO_MEMORY_PROVIDER_PRESENT));
+    EXPECT_THAT(expectError.error(), Eq(RouDiMemoryManagerError::NO_MEMORY_PROVIDER_PRESENT));
 }
 
 TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderSucceeds)
@@ -103,7 +103,7 @@ TEST_F(RouDiMemoryManager_Test, CallingCreateMemoryWithMemoryProviderError)
 
     // If no memory block is added to memory provider, Create and Announce Memory will return a error
     ASSERT_THAT(sut.createAndAnnounceMemory().has_error(), Eq(true));
-    EXPECT_THAT(sut.createAndAnnounceMemory().get_error(), Eq(RouDiMemoryManagerError::MEMORY_CREATION_FAILED));
+    EXPECT_THAT(sut.createAndAnnounceMemory().error(), Eq(RouDiMemoryManagerError::MEMORY_CREATION_FAILED));
 
     ASSERT_FALSE(sut.destroyMemory().has_error());
 }
@@ -141,7 +141,7 @@ TEST_F(RouDiMemoryManager_Test, AddMemoryProviderExceedsCapacity)
 
     auto expectError = sutExhausting.addMemoryProvider(&memoryProvider[iox::MAX_NUMBER_OF_MEMORY_PROVIDER]);
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED));
+    EXPECT_THAT(expectError.error(), Eq(RouDiMemoryManagerError::MEMORY_PROVIDER_EXHAUSTED));
 }
 
 TEST_F(RouDiMemoryManager_Test, OperatorTest)

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -153,7 +153,7 @@ TEST_F(MemoryProvider_Test, AddMemoryBlockExceedsCapacity)
 
     auto expectError = sut.addMemoryBlock(&memoryBlocks[iox::MAX_NUMBER_OF_MEMORY_BLOCKS_PER_MEMORY_PROVIDER]);
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::MEMORY_BLOCKS_EXHAUSTED));
 }
 
 TEST_F(MemoryProvider_Test, CreateWithoutMemoryBlock)
@@ -162,7 +162,7 @@ TEST_F(MemoryProvider_Test, CreateWithoutMemoryBlock)
     EXPECT_CALL(sut, createMemoryMock(_, _)).Times(0);
     auto expectError = sut.create();
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::NO_MEMORY_BLOCKS_PRESENT));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::NO_MEMORY_BLOCKS_PRESENT));
 
     EXPECT_THAT(sut.isAvailable(), Eq(false));
     EXPECT_THAT(sut.isAvailableAnnounced(), Eq(false));
@@ -191,7 +191,7 @@ TEST_F(MemoryProvider_Test, CreationFailed)
 
     auto expectError = sutFailure.create();
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::MEMORY_CREATION_FAILED));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::MEMORY_CREATION_FAILED));
 
     EXPECT_THAT(sut.isAvailable(), Eq(false));
     EXPECT_THAT(sut.isAvailableAnnounced(), Eq(false));
@@ -243,7 +243,7 @@ TEST_F(MemoryProvider_Test, AddMemoryBlockAfterCreation)
 
     auto expectError = sut.addMemoryBlock(&memoryBlock2);
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::MEMORY_ALREADY_CREATED));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::MEMORY_ALREADY_CREATED));
 }
 
 TEST_F(MemoryProvider_Test, MultipleCreates)
@@ -253,7 +253,7 @@ TEST_F(MemoryProvider_Test, MultipleCreates)
 
     auto expectError = sut.create();
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::MEMORY_ALREADY_CREATED));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::MEMORY_ALREADY_CREATED));
 }
 
 TEST_F(MemoryProvider_Test, MultipleAnnouncesAreSuppressed)
@@ -277,7 +277,7 @@ TEST_F(MemoryProvider_Test, MultipleDestroys)
 
     auto expectError = sut.destroy();
     ASSERT_THAT(expectError.has_error(), Eq(true));
-    EXPECT_THAT(expectError.get_error(), Eq(MemoryProviderError::MEMORY_NOT_AVAILABLE));
+    EXPECT_THAT(expectError.error(), Eq(MemoryProviderError::MEMORY_NOT_AVAILABLE));
 }
 
 TEST_F(MemoryProvider_Test, IntialBaseAddressValueIsUnset)

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -41,7 +41,7 @@ class MemoryProviderFailingCreation : public iox::roudi::MemoryProvider
         return iox::error<MemoryProviderError>(MemoryProviderError::MEMORY_CREATION_FAILED);
     }
 
-    iox::expected<MemoryProviderError> destroyMemory() noexcept override
+    iox::expected<void, MemoryProviderError> destroyMemory() noexcept override
     {
         return iox::error<MemoryProviderError>(MemoryProviderError::MEMORY_DESTRUCTION_FAILED);
     }
@@ -66,7 +66,7 @@ class MemoryProvider_Test : public Test
     static constexpr uint64_t COMMON_SETUP_MEMORY_SIZE{16};
     static constexpr uint64_t COMMON_SETUP_MEMORY_ALIGNMENT{8};
 
-    iox::expected<MemoryProviderError> commonSetup()
+    iox::expected<void, MemoryProviderError> commonSetup()
     {
         EXPECT_FALSE(sut.addMemoryBlock(&memoryBlock1).has_error());
         EXPECT_CALL(memoryBlock1, size()).WillRepeatedly(Return(COMMON_SETUP_MEMORY_SIZE));

--- a/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_memory_provider.cpp
@@ -38,12 +38,12 @@ class MemoryProviderFailingCreation : public iox::roudi::MemoryProvider
     iox::expected<void*, MemoryProviderError> createMemory(const uint64_t size IOX_MAYBE_UNUSED,
                                                            const uint64_t alignment IOX_MAYBE_UNUSED) noexcept override
     {
-        return iox::error<MemoryProviderError>(MemoryProviderError::MEMORY_CREATION_FAILED);
+        return iox::err(MemoryProviderError::MEMORY_CREATION_FAILED);
     }
 
     iox::expected<void, MemoryProviderError> destroyMemory() noexcept override
     {
-        return iox::error<MemoryProviderError>(MemoryProviderError::MEMORY_DESTRUCTION_FAILED);
+        return iox::err(MemoryProviderError::MEMORY_DESTRUCTION_FAILED);
     }
 };
 

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -165,8 +165,7 @@ TEST_F(PortIntrospection_test, sendPortData_EmptyList)
     bool chunkWasSent = false;
 
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), tryAllocateChunk(_, _, _, _))
-        .WillOnce(Return(iox::expected<iox::mepoo::ChunkHeader*, iox::popo::AllocationError>::create_value(
-            chunk.get()->chunkHeader())));
+        .WillOnce(Return(ByMove(iox::ok(chunk.get()->chunkHeader()))));
 
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), sendChunk(_))
         .WillOnce(Invoke([&](iox::mepoo::ChunkHeader* const) { chunkWasSent = true; }));
@@ -229,9 +228,10 @@ TEST_F(PortIntrospection_test, addAndRemovePublisher)
     EXPECT_THAT(m_introspectionAccess.addPublisher(portData2), Eq(true));
     EXPECT_THAT(m_introspectionAccess.addPublisher(portData2), Eq(false));
 
+    iox::expected<iox::mepoo::ChunkHeader*, iox::popo::AllocationError> tryAllocateChunkResult =
+        iox::ok(chunk.get()->chunkHeader());
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), tryAllocateChunk(_, _, _, _))
-        .WillRepeatedly(Return(iox::expected<iox::mepoo::ChunkHeader*, iox::popo::AllocationError>::create_value(
-            chunk.get()->chunkHeader())));
+        .WillRepeatedly(Return(tryAllocateChunkResult));
 
     bool chunkWasSent = false;
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), sendChunk(_))
@@ -361,9 +361,10 @@ TEST_F(PortIntrospection_test, addAndRemoveSubscriber)
     EXPECT_THAT(m_introspectionAccess.addSubscriber(recData2), Eq(true));
     EXPECT_THAT(m_introspectionAccess.addSubscriber(recData2), Eq(false));
 
+    iox::expected<iox::mepoo::ChunkHeader*, iox::popo::AllocationError> tryAllocateChunkResult =
+        iox::ok(chunk.get()->chunkHeader());
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), tryAllocateChunk(_, _, _, _))
-        .WillRepeatedly(Return(iox::expected<iox::mepoo::ChunkHeader*, iox::popo::AllocationError>::create_value(
-            chunk.get()->chunkHeader())));
+        .WillRepeatedly(Return(tryAllocateChunkResult));
 
     bool chunkWasSent = false;
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), sendChunk(_))

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager.cpp
@@ -256,7 +256,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfPublishersFails)
             getUniqueSD(), publisherOptions, runtimeName, m_payloadDataSegmentMemoryManager, PortConfigInfo());
         EXPECT_TRUE(errorHandlerCalled);
         ASSERT_TRUE(publisherPortDataResult.has_error());
-        EXPECT_THAT(publisherPortDataResult.get_error(), Eq(PortPoolError::PUBLISHER_PORT_LIST_FULL));
+        EXPECT_THAT(publisherPortDataResult.error(), Eq(PortPoolError::PUBLISHER_PORT_LIST_FULL));
     }
 }
 
@@ -272,7 +272,7 @@ TEST_F(PortManager_test, AcquiringPublisherAsUserWithAnyInternalServiceDescripti
         auto publisherPortDataResult = m_portManager->acquirePublisherPortData(
             service, iox::popo::PublisherOptions(), runtimeName, m_payloadDataSegmentMemoryManager, PortConfigInfo());
         ASSERT_TRUE(publisherPortDataResult.has_error());
-        EXPECT_THAT(publisherPortDataResult.get_error(), Eq(PortPoolError::INTERNAL_SERVICE_DESCRIPTION_IS_FORBIDDEN));
+        EXPECT_THAT(publisherPortDataResult.error(), Eq(PortPoolError::INTERNAL_SERVICE_DESCRIPTION_IS_FORBIDDEN));
     }
 }
 
@@ -321,7 +321,7 @@ TEST_F(PortManager_test, AcquirePublisherPortDataWithSameServiceDescriptionTwice
     if (IS_COMMUNICATION_POLICY_ONE_TO_MANY_ONLY)
     {
         ASSERT_TRUE(acquirePublisherPortResult.has_error());
-        EXPECT_THAT(acquirePublisherPortResult.get_error(), Eq(PortPoolError::UNIQUE_PUBLISHER_PORT_ALREADY_EXISTS));
+        EXPECT_THAT(acquirePublisherPortResult.error(), Eq(PortPoolError::UNIQUE_PUBLISHER_PORT_ALREADY_EXISTS));
         EXPECT_TRUE(detectedError.has_value());
     }
     else
@@ -383,7 +383,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfSubscribersFails)
         auto subscriberPortDataResult =
             m_portManager->acquireSubscriberPortData(getUniqueSD(), subscriberOptions, runtimeName1, PortConfigInfo());
         EXPECT_TRUE(errorHandlerCalled);
-        EXPECT_THAT(subscriberPortDataResult.get_error(), Eq(PortPoolError::SUBSCRIBER_PORT_LIST_FULL));
+        EXPECT_THAT(subscriberPortDataResult.error(), Eq(PortPoolError::SUBSCRIBER_PORT_LIST_FULL));
     }
 }
 
@@ -641,7 +641,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfConditionVariablesFa
         auto conditionVariableResult = m_portManager->acquireConditionVariableData("AnotherToad");
         EXPECT_TRUE(conditionVariableResult.has_error());
         EXPECT_TRUE(errorHandlerCalled);
-        EXPECT_THAT(conditionVariableResult.get_error(), Eq(PortPoolError::CONDITION_VARIABLE_LIST_FULL));
+        EXPECT_THAT(conditionVariableResult.error(), Eq(PortPoolError::CONDITION_VARIABLE_LIST_FULL));
     }
 }
 
@@ -715,7 +715,7 @@ TEST_F(PortManager_test, AcquiringOneMoreThanMaximumNumberOfNodesFails)
     auto nodeResult = m_portManager->acquireNodeData("AnotherProcess", "AnotherNode");
     EXPECT_THAT(nodeResult.has_error(), Eq(true));
     EXPECT_THAT(errorHandlerCalled, Eq(true));
-    EXPECT_THAT(nodeResult.get_error(), Eq(PortPoolError::NODE_DATA_LIST_FULL));
+    EXPECT_THAT(nodeResult.error(), Eq(PortPoolError::NODE_DATA_LIST_FULL));
 }
 
 TEST_F(PortManager_test, DeleteNodePortfromMaximumNumberandAddOneIsSuccessful)

--- a/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
@@ -112,7 +112,7 @@ TEST_F(PosixShmMemoryProvider_Test, CreationFailedWithAlignmentExceedingPageSize
 
     auto expectFailed = sut.create();
     ASSERT_THAT(expectFailed.has_error(), Eq(true));
-    ASSERT_THAT(expectFailed.get_error(), Eq(MemoryProviderError::MEMORY_ALIGNMENT_EXCEEDS_PAGE_SIZE));
+    ASSERT_THAT(expectFailed.error(), Eq(MemoryProviderError::MEMORY_ALIGNMENT_EXCEEDS_PAGE_SIZE));
 
     EXPECT_THAT(shmExists(), Eq(false));
 }

--- a/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_service_registry.cpp
@@ -207,7 +207,7 @@ TYPED_TEST(ServiceRegistry_test, AddMoreThanMaximumNumberOfServiceDescriptionsFa
 
     auto result = this->sut.add(iox::capro::ServiceDescription("Foo", "Bar", "Baz"));
     ASSERT_TRUE(result.has_error());
-    EXPECT_THAT(result.get_error(), Eq(ServiceRegistry::Error::SERVICE_REGISTRY_FULL));
+    EXPECT_THAT(result.error(), Eq(ServiceRegistry::Error::SERVICE_REGISTRY_FULL));
 }
 
 TYPED_TEST(ServiceRegistry_test, AddServiceDescriptionsWhichWasAlreadyAddedAndReturnsOneResult)

--- a/iceoryx_posh/test/stubs/stub_gateway_generic.hpp
+++ b/iceoryx_posh/test/stubs/stub_gateway_generic.hpp
@@ -73,7 +73,7 @@ class StubbedGatewayGeneric : public TestGatewayGeneric<channel_t>
         TestGatewayGeneric<channel_t>::forEachChannel(f);
     }
 
-    iox::expected<iox::gw::GatewayError> discardChannel(const iox::capro::ServiceDescription& service) noexcept
+    iox::expected<void, iox::gw::GatewayError> discardChannel(const iox::capro::ServiceDescription& service) noexcept
     {
         return TestGatewayGeneric<channel_t>::discardChannel(service);
     }

--- a/iceoryx_posh/test/stubs/stub_toml_gateway_config_parser.hpp
+++ b/iceoryx_posh/test/stubs/stub_toml_gateway_config_parser.hpp
@@ -32,7 +32,7 @@ namespace config
 class StubbedTomlGatewayConfigParser : public TomlGatewayConfigParser
 {
   public:
-    static expected<TomlGatewayConfigParseError> validate(const cpptoml::table& parsedToml) noexcept
+    static expected<void, TomlGatewayConfigParseError> validate(const cpptoml::table& parsedToml) noexcept
     {
         return TomlGatewayConfigParser::validate(parsedToml);
     }

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/chunk_mock.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/chunk_mock.hpp
@@ -43,7 +43,7 @@ class ChunkMock
         auto chunkSettingsResult = iox::mepoo::ChunkSettings::create(
             userPayloadSize, userPayloadAlignment, userHeaderSize, userHeaderAlignment);
 
-        iox::cxx::Ensures(!chunkSettingsResult.has_error() && "Invalid parameter for ChunkMock");
+        iox::cxx::EnsuresWithMsg(chunkSettingsResult.has_value(), "Invalid parameter for ChunkMock");
         auto& chunkSettings = chunkSettingsResult.value();
         auto chunkSize = chunkSettings.requiredChunkSize();
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR aligns the `iox::expected` better to the `std::expected`
- remove `expected<E>` in favor of `expected<void, E>`
- replace `get_error` with `error`
- introduce `has_value`
- introduce `ok` and `error` free functions
- introduce `unexpect_t` helper struct for direct initialization

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] ~~Copyright owner are updated in the changed files~~
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #1969 
- Closes #1976 
