### PR TITLE
iox-#1982 FreeRTOS platform implementation

### DIFF
--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -33,7 +33,7 @@ cc_library(
         "source/**/*.cpp",
         "source/**/*.hpp",
     ]),
-    hdrs = glob(["include/**"] + glob(["vocabulary/**"])) + [,
+    hdrs = glob(["include/**"] + glob(["vocabulary/**"])) + [
         ":iceoryx_dust_deployment_hpp",
     ],
     includes = [

--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -15,6 +15,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//bazel:configure_file.bzl", "configure_file")
+
+configure_file(
+    name = "iceoryx_dust_deployment_hpp",
+    src = "cmake/iceoryx_dust_deployment.hpp.in",
+    out = "include/iceoryx_dust/iceoryx_dust_deployment.hpp",
+    config = {
+        "IOX_MAX_NAMED_PIPE_MESSAGE_SIZE": "512",
+        "IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES": "5",
+    },
+)
 
 cc_library(
     name = "iceoryx_dust",
@@ -22,7 +33,9 @@ cc_library(
         "source/**/*.cpp",
         "source/**/*.hpp",
     ]),
-    hdrs = glob(["include/**"] + glob(["vocabulary/**"])),
+    hdrs = glob(["include/**"] + glob(["vocabulary/**"])) + [,
+        ":iceoryx_dust_deployment_hpp",
+    ],
     includes = [
         "include",
         "vocabulary/include/",

--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -22,8 +22,8 @@ configure_file(
     src = "cmake/iceoryx_dust_deployment.hpp.in",
     out = "include/iceoryx_dust/iceoryx_dust_deployment.hpp",
     config = {
-        "IOX_MAX_NAMED_PIPE_MESSAGE_SIZE": "512",
-        "IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES": "5",
+        "IOX_MAX_NAMED_PIPE_MESSAGE_SIZE": "4096",
+        "IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES": "10",
     },
 )
 

--- a/iceoryx_dust/CMakeLists.txt
+++ b/iceoryx_dust/CMakeLists.txt
@@ -27,6 +27,8 @@ include(IceoryxPackageHelper)
 include(IceoryxPlatform)
 include(IceoryxPlatformSettings)
 
+include(cmake/IceoryxDustDeployment.cmake)
+
 if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)
 endif()
@@ -46,6 +48,7 @@ iox_add_library(
     PUBLIC_LIBS                 iceoryx_hoofs::iceoryx_hoofs
     BUILD_INTERFACE             ${PROJECT_SOURCE_DIR}/include
                                 ${PROJECT_SOURCE_DIR}/vocabulary/include
+                                ${CMAKE_BINARY_DIR}/generated/iceoryx/include
     INSTALL_INTERFACE           include/${PREFIX}
     EXPORT_INCLUDE_DIRS         include/
                                 vocabulary/include/
@@ -59,6 +62,22 @@ iox_add_library(
         source/posix_wrapper/named_pipe.cpp
         source/posix_wrapper/signal_watcher.cpp
         source/posix_wrapper/message_queue.cpp
+)
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/iceoryx_dust_deployment.hpp.in"
+  "${CMAKE_BINARY_DIR}/generated/iceoryx/include/iceoryx_dust/iceoryx_dust_deployment.hpp" @ONLY)
+
+install(
+    FILES ${CMAKE_BINARY_DIR}/generated/iceoryx/include/${PROJECT_NAME}/iceoryx_dust_deployment.hpp
+    DESTINATION include/${PREFIX}/${PROJECT_NAME}/
+    COMPONENT dev
+)
+
+# install deployment file to make posh config accessible by other packages
+install(
+    FILES
+        cmake/IceoryxDustDeployment.cmake
+    DESTINATION ${DESTINATION_CONFIGDIR}
 )
 
 #

--- a/iceoryx_dust/cmake/IceoryxDustDeployment.cmake
+++ b/iceoryx_dust/cmake/IceoryxDustDeployment.cmake
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+# Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+# Copyright (c) 2023 by NXP. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# define macro for option configuration
+macro(configure_option)
+    set(ONE_VALUE_ARGS NAME DEFAULT_VALUE)
+    cmake_parse_arguments(CONFIGURE_OPTION "" "${ONE_VALUE_ARGS}" "" ${ARGN})
+
+    if(NOT ${CONFIGURE_OPTION_NAME})
+        set(${CONFIGURE_OPTION_NAME} ${CONFIGURE_OPTION_DEFAULT_VALUE})
+    endif()
+    message(STATUS "[i] ${CONFIGURE_OPTION_NAME}: " ${${CONFIGURE_OPTION_NAME}})
+endmacro()
+
+# configure deployment
+message(STATUS "[i] <<<<<<<<<<<<< Start iceoryx_dust configuration: >>>>>>>>>>>>>")
+
+configure_option(
+    NAME IOX_MAX_NAMED_PIPE_MESSAGE_SIZE
+    DEFAULT_VALUE 4096
+)
+configure_option(
+    NAME IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES
+    DEFAULT_VALUE 10
+)
+
+message(STATUS "[i] <<<<<<<<<<<<<< End iceoryx_dust configuration: >>>>>>>>>>>>>>")
+

--- a/iceoryx_dust/cmake/iceoryx_dust_deployment.hpp.in
+++ b/iceoryx_dust/cmake/iceoryx_dust_deployment.hpp.in
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_POSH_ICEORYX_DUST_DEPLOYMENT_HPP
+#define IOX_POSH_ICEORYX_DUST_DEPLOYMENT_HPP
+
+#include <cstdint>
+
+namespace iox
+{
+namespace build
+{
+constexpr uint64_t IOX_MAX_NAMED_PIPE_MESSAGE_SIZE = static_cast<uint64_t>(@IOX_MAX_NAMED_PIPE_MESSAGE_SIZE@);
+constexpr uint32_t IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES =
+    static_cast<uint32_t>(@IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES@);
+} // namespace build
+} // namespace iox
+
+#endif // IOX_POSH_ICEORYX_DUST_DEPLOYMENT_HPP

--- a/iceoryx_dust/include/iceoryx_dust/internal/cxx/convert.inl
+++ b/iceoryx_dust/include/iceoryx_dust/internal/cxx/convert.inl
@@ -240,6 +240,19 @@ inline bool convert::fromString<unsigned long>(const char* v, unsigned long& des
 }
 #endif
 
+#if defined(__GNUC__) && (INTPTR_MAX == INT32_MAX)
+/// introduced for 32-bit arm-none-eabi-gcc since uintptr_t is not uint32_t despite it has the same size
+/// who knows why ¯\_(ツ)_/¯
+template <>
+inline bool convert::fromString<uintptr_t>(const char* v, uintptr_t& dest) noexcept
+{
+    uint64_t temp{0};
+    bool retVal = fromString(v, temp);
+    dest = temp;
+    return retVal;
+}
+#endif
+
 template <>
 inline bool convert::fromString<uint32_t>(const char* v, uint32_t& dest) noexcept
 {

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
@@ -17,6 +17,7 @@
 #define IOX_DUST_POSIX_WRAPPER_NAMED_PIPE_HPP
 
 #include "iceoryx_dust/design/creation.hpp"
+#include "iceoryx_dust/iceoryx_dust_deployment.hpp"
 #include "iceoryx_hoofs/concurrent/lockfree_queue.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
@@ -39,8 +40,8 @@ class NamedPipe : public DesignPattern::Creation<NamedPipe, IpcChannelError>
   public:
     // no system restrictions at all, except available memory. MAX_MESSAGE_SIZE and MAX_NUMBER_OF_MESSAGES can be
     // increased as long as there is enough memory available
-    static constexpr uint64_t MAX_MESSAGE_SIZE = 4096U;
-    static constexpr uint32_t MAX_NUMBER_OF_MESSAGES = 10U;
+    static constexpr uint64_t MAX_MESSAGE_SIZE = build::IOX_MAX_NAMED_PIPE_MESSAGE_SIZE;
+    static constexpr uint32_t MAX_NUMBER_OF_MESSAGES = build::IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES;
     static_assert(MAX_NUMBER_OF_MESSAGES < IOX_SEM_VALUE_MAX,
                   "The maximum number of supported messages must be less than the maximum allowed semaphore value");
 

--- a/iceoryx_hoofs/container/include/iox/detail/vector.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/vector.inl
@@ -354,7 +354,7 @@ inline bool vector<T, Capacity>::erase(iterator position) noexcept
     {
         // AXIVION Next Line AutosarC++19_03-M5.0.9 : False positive. Pointer arithmetic occurs here.
         uint64_t index{static_cast<uint64_t>(position - begin())};
-        size_t n{index};
+        uint64_t n{index};
         while ((n + 1U) < size())
         {
             // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -16,6 +16,7 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 #define IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 
+#include "iceoryx_platform/errno.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/logging.hpp"
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/posix_call.inl
@@ -16,8 +16,8 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 #define IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_INL
 
-#include "iceoryx_platform/errno.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iceoryx_platform/errno.hpp"
 #include "iox/logging.hpp"
 
 namespace iox

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -73,7 +73,7 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     void* getBaseAddress() noexcept;
 
     /// @brief Returns the underlying file handle of the shared memory
-    int getFileHandle() const noexcept;
+    sharedMemoryHandle_t getFileHandle() const noexcept;
 
     /// @brief True if the shared memory has the ownership. False if an already
     ///        existing shared memory was opened.
@@ -85,7 +85,7 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     SharedMemoryObject(SharedMemory&& sharedMemory, MemoryMap&& memoryMap) noexcept;
 
     friend struct FileManagementInterface<SharedMemoryObject>;
-    int get_file_handle() const noexcept;
+    sharedMemoryHandle_t get_file_handle() const noexcept;
 
   private:
     SharedMemory m_sharedMemory;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -73,7 +73,7 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     void* getBaseAddress() noexcept;
 
     /// @brief Returns the underlying file handle of the shared memory
-    sharedMemoryHandle_t getFileHandle() const noexcept;
+    shm_handle_t getFileHandle() const noexcept;
 
     /// @brief True if the shared memory has the ownership. False if an already
     ///        existing shared memory was opened.
@@ -85,7 +85,7 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     SharedMemoryObject(SharedMemory&& sharedMemory, MemoryMap&& memoryMap) noexcept;
 
     friend struct FileManagementInterface<SharedMemoryObject>;
-    sharedMemoryHandle_t get_file_handle() const noexcept;
+    shm_handle_t get_file_handle() const noexcept;
 
   private:
     SharedMemory m_sharedMemory;

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
@@ -53,7 +53,7 @@ enum class SharedMemoryError
 };
 
 /// @brief Shared memory file descriptor type
-using sharedMemoryHandle_t = int;
+using shm_handle_t = int;
 
 /// @brief Creates a bare metal shared memory object with the posix functions
 ///        shm_open, shm_unlink etc.
@@ -73,7 +73,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     ~SharedMemory() noexcept;
 
     /// @brief returns the file handle of the shared memory
-    sharedMemoryHandle_t getHandle() const noexcept;
+    shm_handle_t getHandle() const noexcept;
 
     /// @brief this class has the ownership of the shared memory when the shared
     ///        memory was created by this class. This is the case when this class
@@ -91,7 +91,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     friend class SharedMemoryBuilder;
 
   private:
-    SharedMemory(const Name_t& name, const sharedMemoryHandle_t handle, const bool hasOwnership) noexcept;
+    SharedMemory(const Name_t& name, const shm_handle_t handle, const bool hasOwnership) noexcept;
 
     bool unlink() noexcept;
     bool close() noexcept;
@@ -101,10 +101,10 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     static SharedMemoryError errnoToEnum(const int32_t errnum) noexcept;
 
     friend struct FileManagementInterface<SharedMemory>;
-    sharedMemoryHandle_t get_file_handle() const noexcept;
+    shm_handle_t get_file_handle() const noexcept;
 
     Name_t m_name;
-    sharedMemoryHandle_t m_handle{INVALID_HANDLE};
+    shm_handle_t m_handle{INVALID_HANDLE};
     bool m_hasOwnership{false};
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
@@ -70,7 +70,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     ~SharedMemory() noexcept;
 
     /// @brief returns the file handle of the shared memory
-    int32_t getHandle() const noexcept;
+    int getHandle() const noexcept;
 
     /// @brief this class has the ownership of the shared memory when the shared
     ///        memory was created by this class. This is the case when this class
@@ -98,7 +98,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     static SharedMemoryError errnoToEnum(const int32_t errnum) noexcept;
 
     friend struct FileManagementInterface<SharedMemory>;
-    int32_t get_file_handle() const noexcept;
+    int get_file_handle() const noexcept;
 
     Name_t m_name;
     int m_handle{INVALID_HANDLE};

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp
@@ -52,6 +52,9 @@ enum class SharedMemoryError
     UNKNOWN_ERROR
 };
 
+/// @brief Shared memory file descriptor type
+using sharedMemoryHandle_t = int;
+
 /// @brief Creates a bare metal shared memory object with the posix functions
 ///        shm_open, shm_unlink etc.
 ///        It must be used in combination with MemoryMap (or manual mmap calls)
@@ -70,7 +73,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     ~SharedMemory() noexcept;
 
     /// @brief returns the file handle of the shared memory
-    int getHandle() const noexcept;
+    sharedMemoryHandle_t getHandle() const noexcept;
 
     /// @brief this class has the ownership of the shared memory when the shared
     ///        memory was created by this class. This is the case when this class
@@ -88,7 +91,7 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     friend class SharedMemoryBuilder;
 
   private:
-    SharedMemory(const Name_t& name, const int handle, const bool hasOwnership) noexcept;
+    SharedMemory(const Name_t& name, const sharedMemoryHandle_t handle, const bool hasOwnership) noexcept;
 
     bool unlink() noexcept;
     bool close() noexcept;
@@ -98,10 +101,10 @@ class SharedMemory : public FileManagementInterface<SharedMemory>
     static SharedMemoryError errnoToEnum(const int32_t errnum) noexcept;
 
     friend struct FileManagementInterface<SharedMemory>;
-    int get_file_handle() const noexcept;
+    sharedMemoryHandle_t get_file_handle() const noexcept;
 
     Name_t m_name;
-    int m_handle{INVALID_HANDLE};
+    sharedMemoryHandle_t m_handle{INVALID_HANDLE};
     bool m_hasOwnership{false};
 };
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -108,13 +108,13 @@ class UnixDomainSocket
   private:
     UnixDomainSocket(const IpcChannelName_t& name,
                      const IpcChannelSide channelSide,
-                     const size_t maxMsgSize = MAX_MESSAGE_SIZE,
+                     const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
                      const uint64_t maxMsgNumber = 10U) noexcept;
 
     UnixDomainSocket(const NoPathPrefix_t,
                      const UdsName_t& name,
                      const IpcChannelSide channelSide,
-                     const size_t maxMsgSize = MAX_MESSAGE_SIZE,
+                     const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
                      const uint64_t maxMsgNumber = 10U) noexcept;
 
     expected<IpcChannelError> destroy() noexcept;
@@ -136,7 +136,7 @@ class UnixDomainSocket
     IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;
     int32_t m_sockfd{INVALID_FD};
     sockaddr_un m_sockAddr{};
-    size_t m_maxMessageSize{MAX_MESSAGE_SIZE};
+    uint64_t m_maxMessageSize{MAX_MESSAGE_SIZE};
 };
 
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
@@ -24,6 +24,7 @@
 #include "iox/string.hpp"
 
 #include <atomic>
+#include <thread>
 
 namespace iox
 {
@@ -34,8 +35,8 @@ constexpr uint64_t MAX_THREAD_NAME_LENGTH = 15U;
 using ThreadName_t = string<MAX_THREAD_NAME_LENGTH>;
 
 /// @todo iox-#1365 remove free functions
-void setThreadName(iox_pthread_t thread, const ThreadName_t& name) noexcept;
-ThreadName_t getThreadName(iox_pthread_t thread) noexcept;
+void setThreadName(std::thread::native_handle_type thread, const ThreadName_t& name) noexcept;
+ThreadName_t getThreadName(std::thread::native_handle_type thread) noexcept;
 
 enum class ThreadError
 {

--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -93,7 +93,7 @@ class Ownership
     Ownership(const uid_t uid, const gid_t gid) noexcept;
 
   private:
-    uid_t m_uid{std::numeric_limits<pid_t>::max()};
+    uid_t m_uid{std::numeric_limits<uid_t>::max()};
     gid_t m_gid{std::numeric_limits<gid_t>::max()};
 };
 

--- a/iceoryx_hoofs/primitives/include/iox/algorithm.hpp
+++ b/iceoryx_hoofs/primitives/include/iox/algorithm.hpp
@@ -150,7 +150,8 @@ struct BestFittingTypeImpl<true, true, false>
 template <uint64_t Value>
 struct BestFittingType
 {
-// gcc warns here that the uint8_t test for BestFittingType<256> is always true... which is correct, but we need it for portability anyway
+// gcc warns here that the uint8_t test for BestFittingType<256> is always true... which is correct, but we need it for
+// portability anyway
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtype-limits"

--- a/iceoryx_hoofs/primitives/include/iox/algorithm.hpp
+++ b/iceoryx_hoofs/primitives/include/iox/algorithm.hpp
@@ -114,9 +114,9 @@ inline constexpr bool doesContainValue(const T) noexcept;
 /// @return true if value is contained in the ValueList, otherwise false
 /// @note be aware that value is tested for exact equality with the entries of ValueList and regular floating-point
 /// comparison rules apply
-template <typename T, typename... ValueList>
+template <typename T1, typename T2, typename... ValueList>
 inline constexpr bool
-doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept;
+doesContainValue(const T1 value, const T2 firstValueListEntry, const ValueList... remainingValueListEntries) noexcept;
 } // namespace algorithm
 
 namespace internal
@@ -150,11 +150,19 @@ struct BestFittingTypeImpl<true, true, false>
 template <uint64_t Value>
 struct BestFittingType
 {
+// gcc warns here that the uint8_t test for BestFittingType<256> is always true... which is correct, but we need it for portability anyway
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#endif
     using Type_t =
         typename internal::BestFittingTypeImpl<(Value > static_cast<uint64_t>(std::numeric_limits<uint8_t>::max())),
                                                (Value > static_cast<uint64_t>(std::numeric_limits<uint16_t>::max())),
                                                (Value
                                                 > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))>::Type_t;
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 };
 
 template <uint64_t Value>

--- a/iceoryx_hoofs/primitives/include/iox/detail/algorithm.inl
+++ b/iceoryx_hoofs/primitives/include/iox/detail/algorithm.inl
@@ -77,9 +77,9 @@ inline constexpr bool doesContainValue(const T) noexcept
     return false;
 }
 
-template <typename T, typename... ValueList>
+template <typename T1, typename T2, typename... ValueList>
 inline constexpr bool
-doesContainValue(const T value, const T firstValueListEntry, const ValueList... remainingValueListEntries) noexcept
+doesContainValue(const T1 value, const T2 firstValueListEntry, const ValueList... remainingValueListEntries) noexcept
 {
     // AXIVION Next Line AutosarC++19_03-M6.2.2 : intentional check for exact equality
     return (value == firstValueListEntry) ? true : doesContainValue(value, remainingValueListEntries...);

--- a/iceoryx_hoofs/source/concurrent/loffli.cpp
+++ b/iceoryx_hoofs/source/concurrent/loffli.cpp
@@ -28,7 +28,7 @@ void LoFFLi::init(not_null<Index_t*> freeIndicesMemory, const uint32_t capacity)
     cxx::Expects(capacity > 0 && "A capacity of 0 is not supported!");
     constexpr uint32_t INTERNALLY_RESERVED_INDICES{1U};
     cxx::Expects(capacity < (std::numeric_limits<Index_t>::max() - INTERNALLY_RESERVED_INDICES)
-                 && "Requested capacityexceeds limits!");
+                 && "Requested capacity exceeds limits!");
     cxx::Expects(m_head.is_lock_free() && "std::atomic<LoFFLi::Node> must be lock-free!");
 
     m_nextFreeIndex = freeIndicesMemory;

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -149,8 +149,7 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
 
     gid_t userDefaultGroup = getpwnamCall->value->pw_gid;
     UninitializedArray<gid_t, MaxNumberOfGroups> groups{}; // groups is initialized in iox_getgrouplist
-    // iox_getgrouplist expects int
-    int numGroups = MaxNumberOfGroups;
+    auto numGroups = MaxNumberOfGroups;
 
     auto getgrouplistCall = posixCall(iox_getgrouplist)(userName->c_str(), userDefaultGroup, &groups[0], &numGroups)
                                 .failureReturnValue(-1)

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -47,7 +47,7 @@ PosixGroup::PosixGroup(const PosixGroup::groupName_t& name) noexcept
     else
     {
         IOX_LOG(ERROR) << "Error: Group name not found";
-        m_id = std::numeric_limits<uint32_t>::max();
+        m_id = std::numeric_limits<gid_t>::max();
     }
 }
 
@@ -149,7 +149,7 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
 
     gid_t userDefaultGroup = getpwnamCall->value->pw_gid;
     UninitializedArray<gid_t, MaxNumberOfGroups> groups{}; // groups is initialized in iox_getgrouplist
-    int32_t numGroups = MaxNumberOfGroups;
+    int numGroups = MaxNumberOfGroups;
 
     auto getgrouplistCall = posixCall(iox_getgrouplist)(userName->c_str(), userDefaultGroup, &groups[0], &numGroups)
                                 .failureReturnValue(-1)
@@ -191,7 +191,7 @@ PosixUser::PosixUser(const PosixUser::userName_t& name) noexcept
     else
     {
         IOX_LOG(ERROR) << "Error: User name not found";
-        m_id = std::numeric_limits<uint32_t>::max();
+        m_id = std::numeric_limits<gid_t>::max();
     }
 }
 

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -149,6 +149,7 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
 
     gid_t userDefaultGroup = getpwnamCall->value->pw_gid;
     UninitializedArray<gid_t, MaxNumberOfGroups> groups{}; // groups is initialized in iox_getgrouplist
+    // iox_getgrouplist expects int
     int numGroups = MaxNumberOfGroups;
 
     auto getgrouplistCall = posixCall(iox_getgrouplist)(userName->c_str(), userDefaultGroup, &groups[0], &numGroups)

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -186,12 +186,12 @@ void* SharedMemoryObject::getBaseAddress() noexcept
     return m_memoryMap.getBaseAddress();
 }
 
-sharedMemoryHandle_t SharedMemoryObject::get_file_handle() const noexcept
+shm_handle_t SharedMemoryObject::get_file_handle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }
 
-sharedMemoryHandle_t SharedMemoryObject::getFileHandle() const noexcept
+shm_handle_t SharedMemoryObject::getFileHandle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -186,12 +186,12 @@ void* SharedMemoryObject::getBaseAddress() noexcept
     return m_memoryMap.getBaseAddress();
 }
 
-int SharedMemoryObject::get_file_handle() const noexcept
+sharedMemoryHandle_t SharedMemoryObject::get_file_handle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }
 
-int SharedMemoryObject::getFileHandle() const noexcept
+sharedMemoryHandle_t SharedMemoryObject::getFileHandle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -186,12 +186,12 @@ void* SharedMemoryObject::getBaseAddress() noexcept
     return m_memoryMap.getBaseAddress();
 }
 
-int32_t SharedMemoryObject::get_file_handle() const noexcept
+int SharedMemoryObject::get_file_handle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }
 
-int32_t SharedMemoryObject::getFileHandle() const noexcept
+int SharedMemoryObject::getFileHandle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -200,12 +200,12 @@ SharedMemory& SharedMemory::operator=(SharedMemory&& rhs) noexcept
     return *this;
 }
 
-int32_t SharedMemory::getHandle() const noexcept
+int SharedMemory::getHandle() const noexcept
 {
     return m_handle;
 }
 
-int32_t SharedMemory::get_file_handle() const noexcept
+int SharedMemory::get_file_handle() const noexcept
 {
     return m_handle;
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -77,7 +77,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     }
 
     // the mask will be applied to the permissions, therefore we need to set it to 0
-    sharedMemoryHandle_t sharedMemoryFileHandle = SharedMemory::INVALID_HANDLE;
+    shm_handle_t sharedMemoryFileHandle = SharedMemory::INVALID_HANDLE;
     mode_t umaskSaved = umask(0U);
     {
         ScopeGuard umaskGuard([&] { umask(umaskSaved); });
@@ -155,7 +155,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     return success<SharedMemory>(SharedMemory(m_name, sharedMemoryFileHandle, hasOwnership));
 }
 
-SharedMemory::SharedMemory(const Name_t& name, const sharedMemoryHandle_t handle, const bool hasOwnership) noexcept
+SharedMemory::SharedMemory(const Name_t& name, const shm_handle_t handle, const bool hasOwnership) noexcept
     : m_name{name}
     , m_handle{handle}
     , m_hasOwnership{hasOwnership}
@@ -200,12 +200,12 @@ SharedMemory& SharedMemory::operator=(SharedMemory&& rhs) noexcept
     return *this;
 }
 
-sharedMemoryHandle_t SharedMemory::getHandle() const noexcept
+shm_handle_t SharedMemory::getHandle() const noexcept
 {
     return m_handle;
 }
 
-sharedMemoryHandle_t SharedMemory::get_file_handle() const noexcept
+shm_handle_t SharedMemory::get_file_handle() const noexcept
 {
     return m_handle;
 }

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/shared_memory.cpp
@@ -77,7 +77,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     }
 
     // the mask will be applied to the permissions, therefore we need to set it to 0
-    int sharedMemoryFileHandle = SharedMemory::INVALID_HANDLE;
+    sharedMemoryHandle_t sharedMemoryFileHandle = SharedMemory::INVALID_HANDLE;
     mode_t umaskSaved = umask(0U);
     {
         ScopeGuard umaskGuard([&] { umask(umaskSaved); });
@@ -155,7 +155,7 @@ expected<SharedMemory, SharedMemoryError> SharedMemoryBuilder::create() noexcept
     return success<SharedMemory>(SharedMemory(m_name, sharedMemoryFileHandle, hasOwnership));
 }
 
-SharedMemory::SharedMemory(const Name_t& name, const int handle, const bool hasOwnership) noexcept
+SharedMemory::SharedMemory(const Name_t& name, const sharedMemoryHandle_t handle, const bool hasOwnership) noexcept
     : m_name{name}
     , m_handle{handle}
     , m_hasOwnership{hasOwnership}
@@ -200,12 +200,12 @@ SharedMemory& SharedMemory::operator=(SharedMemory&& rhs) noexcept
     return *this;
 }
 
-int SharedMemory::getHandle() const noexcept
+sharedMemoryHandle_t SharedMemory::getHandle() const noexcept
 {
     return m_handle;
 }
 
-int SharedMemory::get_file_handle() const noexcept
+sharedMemoryHandle_t SharedMemory::get_file_handle() const noexcept
 {
     return m_handle;
 }

--- a/iceoryx_hoofs/source/posix_wrapper/thread.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/thread.cpp
@@ -22,7 +22,7 @@ namespace iox
 {
 namespace posix
 {
-void setThreadName(iox_pthread_t thread, const ThreadName_t& name) noexcept
+void setThreadName(std::thread::native_handle_type thread, const ThreadName_t& name) noexcept
 {
     posixCall(iox_pthread_setname_np)(thread, name.c_str()).successReturnValue(0).evaluate().or_else([](auto& r) {
         // String length limit is ensured through iox::string
@@ -32,7 +32,7 @@ void setThreadName(iox_pthread_t thread, const ThreadName_t& name) noexcept
     });
 }
 
-ThreadName_t getThreadName(iox_pthread_t thread) noexcept
+ThreadName_t getThreadName(std::thread::native_handle_type thread) noexcept
 {
     // NOLINTJUSTIFICATION required as name buffer for iox_pthread_getname_np
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -43,7 +43,7 @@ UnixDomainSocket::UnixDomainSocket(UnixDomainSocket&& other) noexcept
 // NOLINTBEGIN(readability-function-size, bugprone-easily-swappable-parameters)
 UnixDomainSocket::UnixDomainSocket(const IpcChannelName_t& name,
                                    const IpcChannelSide channelSide,
-                                   const size_t maxMsgSize,
+                                   const uint64_t maxMsgSize,
                                    const uint64_t maxMsgNumber) noexcept
     // NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
     : UnixDomainSocket(
@@ -69,7 +69,7 @@ UnixDomainSocket::UnixDomainSocket(const IpcChannelName_t& name,
 UnixDomainSocket::UnixDomainSocket(const NoPathPrefix_t,
                                    const UdsName_t& name,
                                    const IpcChannelSide channelSide,
-                                   const size_t maxMsgSize,
+                                   const uint64_t maxMsgSize,
                                    const uint64_t) noexcept
     // NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
     : m_name(name)

--- a/iceoryx_platform/CMakeLists.txt
+++ b/iceoryx_platform/CMakeLists.txt
@@ -44,6 +44,8 @@ elseif(WIN32)
     set(ICEORYX_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR}/win/)
 elseif(UNIX)
     set(ICEORYX_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR}/unix/)
+elseif(FREERTOS)
+    set(ICEORYX_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR}/freertos/)
 else()
     set(ICEORYX_PLATFORM ${CMAKE_CURRENT_SOURCE_DIR}/unix/)
     message(WARNING "Could not detect supported platform, but I'm feeling lucky today. Maybe its Unix." )
@@ -69,6 +71,7 @@ iox_add_library(
     PUBLIC_LIBS_LINUX           rt pthread
     PUBLIC_LIBS_UNIX            rt pthread
     PRIVATE_LIBS_QNX            socket
+    PUBLIC_LIBS_FREERTOS        freertos_sdk::FreeRTOS_POSIX
     BUILD_INTERFACE             ${ICEORYX_PLATFORM}/include/
     INSTALL_INTERFACE           include/${PREFIX}
     FILES                       ${ICEORYX_PLATFORM_FILES}

--- a/iceoryx_platform/cmake/IceoryxPackageHelper.cmake
+++ b/iceoryx_platform/cmake/IceoryxPackageHelper.cmake
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
 # Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
 # Copyright (c) 2021 by Timo Röhling. All rights reserved.
+# Copyright (c) 2023 by NXP. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -276,7 +277,8 @@ Macro(iox_add_library)
         PUBLIC_INCLUDES PRIVATE_INCLUDES
         PUBLIC_LIBS_LINUX PRIVATE_LIBS_LINUX PUBLIC_LIBS_QNX PRIVATE_LIBS_QNX
         PUBLIC_LIBS_UNIX PRIVATE_LIBS_UNIX PUBLIC_LIBS_WIN32 PRIVATE_LIBS_WIN32
-        PUBLIC_LIBS_APPLE PRIVATE_LIBS_APPLE EXPORT_INCLUDE_DIRS)
+        PUBLIC_LIBS_APPLE PRIVATE_LIBS_APPLE PUBLIC_LIBS_FREERTOS PRIVATE_LIBS_FREERTOS
+        EXPORT_INCLUDE_DIRS)
     cmake_parse_arguments(IOX "${switches}" "${arguments}" "${multiArguments}" ${ARGN} )
 
     if ( NOT IOX_NO_PACKAGE_SETUP )
@@ -344,6 +346,10 @@ Macro(iox_add_library)
         target_link_libraries(${IOX_TARGET} PUBLIC ${IOX_PUBLIC_LIBS_UNIX} PRIVATE ${IOX_PRIVATE_LIBS_UNIX})
     elseif ( WIN32 )
         target_link_libraries(${IOX_TARGET} PUBLIC ${IOX_PUBLIC_LIBS_WIN32} PRIVATE ${IOX_PRIVATE_LIBS_WIN32})
+    elseif ( FREERTOS )
+        target_link_libraries(${IOX_TARGET} PUBLIC ${IOX_PUBLIC_LIBS_FREERTOS} PRIVATE ${IOX_PRIVATE_LIBS_FREERTOS})
+        # PIC can cause NULL function pointers on bare metal since there is no dynamic linker...
+        set_target_properties( ${IOX_TARGET} PROPERTIES POSITION_INDEPENDENT_CODE OFF )
     endif ( LINUX )
 
     # @todo iox-#1287 lasting fix for rpath without implicit posh dependencies and auto lib detection

--- a/iceoryx_platform/freertos/IceoryxPlatformSettings.cmake
+++ b/iceoryx_platform/freertos/IceoryxPlatformSettings.cmake
@@ -1,0 +1,29 @@
+# Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+# Copyright (c) 2023 by NXP. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set_global(VAR ICEORYX_PLATFORM_STRING      VALUE "FreeRTOS")
+set_global(VAR ICEORYX_CXX_STANDARD         VALUE 17)
+
+set_global(VAR ICEORYX_C_WARNINGS           VALUE -W -Wall -Wextra -Wuninitialized -Wpedantic -Wstrict-aliasing -Wno-psabi) # -Wconversion and -Wcast-align cause a lot of warnings
+set_global(VAR ICEORYX_CXX_WARNINGS         VALUE ${ICEORYX_C_WARNINGS} -Wno-noexcept-type)
+
+if(BUILD_STRICT)
+    set_global(VAR ICEORYX_C_WARNINGS       VALUE ${ICEORYX_C_WARNINGS} -Werror)
+    set_global(VAR ICEORYX_CXX_WARNINGS     VALUE ${ICEORYX_CXX_WARNINGS} -Werror)
+endif()
+
+find_package(freertos_sdk REQUIRED COMPONENTS FreeRTOS_cpp11 FreeRTOS_POSIX)

--- a/iceoryx_platform/freertos/include/iceoryx_platform/acl.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/acl.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_ACL_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_ACL_HPP
+
+#include "iceoryx_platform/types.hpp"
+
+#define ACL_USER_OBJ 0
+#define ACL_USER 1
+#define ACL_GROUP_OBJ 2
+#define ACL_GROUP 3
+#define ACL_OTHER 4
+#define ACL_READ 5
+#define ACL_WRITE 6
+#define ACL_MASK 7
+
+struct __acl_ext
+{
+};
+
+using acl_t = struct __acl_ext*;
+using acl_permset_t = int;
+using acl_perm_t = int;
+using acl_entry_t = int;
+using acl_tag_t = int;
+
+inline int acl_valid(acl_t)
+{
+    return 0;
+}
+
+inline int acl_set_fd(int, acl_t)
+{
+    return 0;
+}
+
+inline acl_t acl_init(int)
+{
+    static struct __acl_ext stub;
+    return &stub;
+}
+
+inline int acl_free(void*)
+{
+    return 0;
+}
+
+inline int acl_create_entry(acl_t*, acl_entry_t*)
+{
+    return 0;
+}
+
+inline int acl_set_tag_type(acl_entry_t, acl_tag_t)
+{
+    return 0;
+}
+
+inline int acl_set_qualifier(acl_entry_t, const void*)
+{
+    return 0;
+}
+
+inline int acl_get_permset(acl_entry_t, acl_permset_t*)
+{
+    return 0;
+}
+
+inline int acl_add_perm(acl_permset_t, acl_perm_t)
+{
+    return 0;
+}
+
+inline char* acl_to_text(acl_t, ssize_t*)
+{
+    return nullptr;
+}
+
+inline acl_t acl_from_text(const char*)
+{
+    return acl_t();
+}
+
+inline acl_t acl_get_fd(int)
+{
+    return acl_t();
+}
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_ACL_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/attributes.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/attributes.hpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_ATTRIBUTES_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_ATTRIBUTES_HPP
+
+/// @brief IOX_NO_DISCARD adds the [[nodiscard]] keyword if it is available for the current compiler.
+
+#if __cplusplus >= 201703L
+#define IOX_NO_DISCARD [[nodiscard]]
+#else
+#define IOX_NO_DISCARD
+#endif
+
+/// @brief IOX_FALLTHROUGH adds the [[fallthrough]] keyword when it is available for the current compiler.
+/// @note
+//    [[fallthrough]] supported since gcc 7 (https://gcc.gnu.org/projects/cxx-status.html)
+///   [[fallthrough]] supported since clang 3.9 (https://clang.llvm.org/cxx_status.html)
+///   activate keywords for gcc>=7 or clang>=4
+
+#if __cplusplus >= 201703L
+// clang prints a warning therefore we exclude it here
+#define IOX_FALLTHROUGH [[fallthrough]]
+#elif (defined(__GNUC__) && (__GNUC__ >= 7)) && !defined(__clang__)
+#define IOX_FALLTHROUGH [[gnu::fallthrough]]
+#else
+#define IOX_FALLTHROUGH
+#endif
+
+/// @brief IOX_MAYBE_UNUSED adds the [[gnu::unused]] attribute when it is available for the current
+/// compiler or uses C++17's 'maybe_unused'.
+#if __cplusplus >= 201703L
+#define IOX_MAYBE_UNUSED [[maybe_unused]]
+#else
+#define IOX_MAYBE_UNUSED [[gnu::unused]]
+#endif
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_ATTRIBUTES_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/dlfcn.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/dlfcn.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_DLFCN_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_DLFCN_HPP
+
+#include <dlfcn.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_DLFCN_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/errno.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/errno.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_ERRNO_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_ERRNO_HPP
+
+#include "FreeRTOS_POSIX/errno.h"
+
+#ifdef configUSE_POSIX_ERRNO
+#ifdef errno
+#undef errno
+#endif
+#define errno FreeRTOS_errno
+#endif
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_ERRNO_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/fcntl.hpp
@@ -22,10 +22,10 @@
 #include <fcntl.h>
 
 /* lock operations for flock(2) */
-#define LOCK_SH         0x01            /* shared file lock */
-#define LOCK_EX         0x02            /* exclusive file lock */
-#define LOCK_NB         0x04            /* don't block when locking */
-#define LOCK_UN         0x08            /* unlock file */
+#define LOCK_SH 0x01 /* shared file lock */
+#define LOCK_EX 0x02 /* exclusive file lock */
+#define LOCK_NB 0x04 /* don't block when locking */
+#define LOCK_UN 0x08 /* unlock file */
 
 int iox_open(const char* pathname, int flags, mode_t mode);
 int iox_ext_open(const char* pathname, int flags, mode_t mode);

--- a/iceoryx_platform/freertos/include/iceoryx_platform/fcntl.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/fcntl.hpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_FCNTL_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_FCNTL_HPP
+
+#include <fcntl.h>
+
+/* lock operations for flock(2) */
+#define LOCK_SH         0x01            /* shared file lock */
+#define LOCK_EX         0x02            /* exclusive file lock */
+#define LOCK_NB         0x04            /* don't block when locking */
+#define LOCK_UN         0x08            /* unlock file */
+
+int iox_open(const char* pathname, int flags, mode_t mode);
+int iox_ext_open(const char* pathname, int flags, mode_t mode);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_FCNTL_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/file.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/file.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_FILE_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_FILE_HPP
+
+#include <sys/file.h>
+
+int iox_flock(int fd, int op);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_FILE_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/getopt.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/getopt.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_GETOPT_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_GETOPT_HPP
+
+#include <getopt.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_GETOPT_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/grp.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/grp.hpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_GRP_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_GRP_HPP
+
+struct group
+{
+    const char* gr_name;
+    const char* gr_passwd;
+    gid_t gr_gid;
+    const char** gr_mem;
+};
+
+inline struct group* getgrnam(const char*)
+{
+    static const char* groupName = "iceoryx_freertos_group";
+    static const char* groupPasswd = "iceoryx_freertos_passwd";
+    static struct group dummy;
+    dummy.gr_name = groupName;
+    dummy.gr_passwd = groupPasswd;
+    dummy.gr_mem = nullptr;
+    dummy.gr_gid = 0;
+    return &dummy;
+}
+
+inline struct group* getgrgid(gid_t)
+{
+    static const char* groupName = "iceoryx_freertos_group";
+    static const char* groupPasswd = "iceoryx_freertos_passwd";
+    static struct group dummy;
+    dummy.gr_name = groupName;
+    dummy.gr_passwd = groupPasswd;
+    dummy.gr_mem = nullptr;
+    dummy.gr_gid = 0;
+    return &dummy;
+}
+
+inline int iox_getgrouplist(const char*, gid_t, gid_t* groups, int* ngroups)
+{
+    groups[0] = 0;
+    *ngroups = 1;
+    return 0;
+}
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_GRP_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/inet.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/inet.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_INET_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_INET_HPP
+
+#include <arpa/inet.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_INET_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/mman.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/mman.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_MMAN_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_MMAN_HPP
+
+#include <sys/types.h>
+
+#define MAP_SHARED 0x01
+#define MAP_PRIVATE 0x02
+#define MAP_FIXED 0x10
+#define MAP_FAILED (void*)-1
+#define PROT_NONE 0
+#define PROT_READ 3
+#define PROT_WRITE 4
+
+int iox_shm_open(const char* name, int oflag, mode_t mode);
+int iox_shm_unlink(const char* name);
+int iox_shm_close(int fd);
+
+void* mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap(void* addr, size_t length);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_MMAN_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/mqueue.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/mqueue.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_MQUEUE_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_MQUEUE_HPP
+
+#include "sys/types.h"
+#include "FreeRTOS_POSIX.h"
+#include "FreeRTOS_POSIX/mqueue.h"
+
+mqd_t iox_mq_open2(const char* name, int oflag);
+mqd_t iox_mq_open4(const char* name, int oflag, mode_t mode, struct mq_attr* attr);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_MQUEUE_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/mqueue.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/mqueue.hpp
@@ -19,9 +19,9 @@
 #ifndef IOX_HOOFS_FREERTOS_PLATFORM_MQUEUE_HPP
 #define IOX_HOOFS_FREERTOS_PLATFORM_MQUEUE_HPP
 
-#include "sys/types.h"
 #include "FreeRTOS_POSIX.h"
 #include "FreeRTOS_POSIX/mqueue.h"
+#include "sys/types.h"
 
 mqd_t iox_mq_open2(const char* name, int oflag);
 mqd_t iox_mq_open4(const char* name, int oflag, mode_t mode, struct mq_attr* attr);

--- a/iceoryx_platform/freertos/include/iceoryx_platform/platform_correction.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/platform_correction.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_PLATFORM_CORRECTION_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_PLATFORM_CORRECTION_HPP
+
+#endif // IOX_HOOFS_UNIX_FREERTOS_PLATFORM_CORRECTION_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/platform_settings.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/platform_settings.hpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_PLATFORM_SETTINGS_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_PLATFORM_SETTINGS_HPP
+
+#include "FreeRTOS_POSIX.h"
+
+#include <cstdint>
+#include <limits.h>
+#include <type_traits>
+
+#ifndef PATH_MAX
+#define PATH_MAX (2 * NAME_MAX)
+#endif
+
+namespace iox
+{
+namespace posix
+{
+class NamedPipe;
+} // namespace posix
+
+namespace platform
+{
+/// defined in the man sem_overview
+constexpr uint64_t IOX_MAX_SEMAPHORE_NAME_LENGTH = NAME_MAX - 4;
+constexpr bool IOX_SUPPORT_NAMED_SEMAPHORE_OVERFLOW_DETECTION = true;
+
+constexpr uint64_t IOX_MAX_FILENAME_LENGTH = 255U;
+constexpr uint64_t IOX_MAX_PATH_LENGTH = 1023U;
+constexpr bool IOX_SHM_WRITE_ZEROS_ON_CREATION = false;
+constexpr uint64_t IOX_MAX_SHM_NAME_LENGTH = PATH_MAX;
+constexpr uint64_t IOX_NUMBER_OF_PATH_SEPARATORS = 1U;
+constexpr const char IOX_PATH_SEPARATORS[IOX_NUMBER_OF_PATH_SEPARATORS] = {'/'};
+constexpr uint64_t IOX_UDS_SOCKET_MAX_MESSAGE_SIZE = 1024;
+constexpr const char IOX_UDS_SOCKET_PATH_PREFIX[] = "/tmp/";
+constexpr const char IOX_LOCK_FILE_PATH_PREFIX[] = "/tmp/";
+
+constexpr uint64_t MAX_USER_NAME_LENGTH = 32;
+constexpr uint64_t MAX_GROUP_NAME_LENGTH = 16;
+
+template <typename C, typename... Cargs>
+using invoke_result = std::result_of<C(Cargs...)>;
+} // namespace platform
+} // namespace iox
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_PLATFORM_SETTINGS_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/pthread.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/pthread.hpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_PTHREAD_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_PTHREAD_HPP
+
+#include "iceoryx_platform/fcntl.hpp"
+#include "iceoryx_platform/types.hpp"
+
+#include <sched.h>
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_POSIX.h"
+#include "FreeRTOS_POSIX/pthread.h"
+
+#include <thread>
+
+#define PTHREAD_MUTEX_STALLED 1
+#define PTHREAD_MUTEX_ROBUST 2
+
+#define PTHREAD_MUTEX_RECURSIVE_NP PTHREAD_MUTEX_RECURSIVE
+#define PTHREAD_MUTEX_FAST_NP PTHREAD_MUTEX_DEFAULT
+
+#define PTHREAD_PROCESS_PRIVATE 0
+#define PTHREAD_PROCESS_SHARED 1
+
+using iox_pthread_t = pthread_t;
+using iox_pthread_attr_t = pthread_attr_t;
+
+inline int iox_pthread_getname_np(std::thread::native_handle_type, char*, size_t)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int iox_pthread_setname_np(std::thread::native_handle_type, const char*)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutexattr_getpshared(const pthread_mutexattr_t*, int*)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutexattr_setpshared(pthread_mutexattr_t*, int)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutexattr_getprotocol(const pthread_mutexattr_t*, int*)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+/* Values for blocking protocol. */
+#define PTHREAD_PRIO_NONE 0
+#define PTHREAD_PRIO_INHERIT 1
+#define PTHREAD_PRIO_PROTECT 2
+
+inline int pthread_mutexattr_setprotocol(pthread_mutexattr_t*, int)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutexattr_setrobust(pthread_mutexattr_t*, int)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutexattr_setprioceiling(pthread_mutexattr_t*, int)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int pthread_mutex_consistent(pthread_mutex_t*)
+{
+    // Not needed on FreeRTOS
+    return 0;
+}
+
+inline int
+iox_pthread_create(iox_pthread_t* thread, const iox_pthread_attr_t* attr, void* (*start_routine)(void*), void* arg)
+{
+    return pthread_create(thread, attr, start_routine, arg);
+}
+
+inline int iox_pthread_join(iox_pthread_t thread, void** retval)
+{
+    return pthread_join(thread, retval);
+}
+
+inline std::thread::native_handle_type iox_pthread_self()
+{
+    return {};
+}
+
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_PTHREAD_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/pwd.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/pwd.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_PWD_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_PWD_HPP
+
+#include "sys/types.h"
+#include <pwd.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_PWD_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/resource.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/resource.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_RESOURCE_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_RESOURCE_HPP
+
+#include <sys/resource.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_RESOURCE_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/sched.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/sched.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_SCHED_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_SCHED_HPP
+
+#include <sched.h>
+
+#define SCHED_FIFO 1
+
+inline int sched_get_priority_max(int) { return 0;}
+inline int sched_get_priority_min(int) { return 0;}
+
+#endif
+

--- a/iceoryx_platform/freertos/include/iceoryx_platform/sched.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/sched.hpp
@@ -22,8 +22,13 @@
 
 #define SCHED_FIFO 1
 
-inline int sched_get_priority_max(int) { return 0;}
-inline int sched_get_priority_min(int) { return 0;}
+inline int sched_get_priority_max(int)
+{
+    return 0;
+}
+inline int sched_get_priority_min(int)
+{
+    return 0;
+}
 
 #endif
-

--- a/iceoryx_platform/freertos/include/iceoryx_platform/semaphore.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/semaphore.hpp
@@ -19,9 +19,9 @@
 #ifndef IOX_HOOFS_FREERTOS_PLATFORM_SEMAPHORE_HPP
 #define IOX_HOOFS_FREERTOS_PLATFORM_SEMAPHORE_HPP
 
-#include <time.h>
 #include "FreeRTOS_POSIX.h"
 #include "FreeRTOS_POSIX/semaphore.h"
+#include <time.h>
 
 #define SEM_FAILED nullptr
 #define IOX_SEM_FAILED SEM_FAILED

--- a/iceoryx_platform/freertos/include/iceoryx_platform/semaphore.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/semaphore.hpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_SEMAPHORE_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_SEMAPHORE_HPP
+
+#include <time.h>
+#include "FreeRTOS_POSIX.h"
+#include "FreeRTOS_POSIX/semaphore.h"
+
+#define SEM_FAILED nullptr
+#define IOX_SEM_FAILED SEM_FAILED
+constexpr uint32_t IOX_SEM_VALUE_MAX = SEM_VALUE_MAX;
+
+using iox_sem_t = sem_t;
+
+inline int iox_sem_getvalue(iox_sem_t* sem, int* sval)
+{
+    return sem_getvalue(sem, sval);
+}
+
+inline int iox_sem_post(iox_sem_t* sem)
+{
+    return sem_post(sem);
+}
+
+inline int iox_sem_wait(iox_sem_t* sem)
+{
+    return sem_wait(sem);
+}
+
+inline int iox_sem_trywait(iox_sem_t* sem)
+{
+    return sem_trywait(sem);
+}
+
+inline int iox_sem_timedwait(iox_sem_t* sem, const struct timespec* abs_timeout)
+{
+    return sem_timedwait(sem, abs_timeout);
+}
+
+inline int iox_sem_destroy(iox_sem_t* sem)
+{
+    return sem_destroy(sem);
+}
+
+inline int iox_sem_init(iox_sem_t* sem, int pshared, unsigned int value)
+{
+    return sem_init(sem, pshared, value);
+}
+
+inline iox_sem_t* iox_sem_open(const char*, int)
+{
+    // Named semaphores are not supported in FreeRTOS+POSIX
+    configASSERT(false);
+    return nullptr;
+}
+
+inline int iox_sem_close(iox_sem_t*)
+{
+    // Named semaphores are not supported in FreeRTOS+POSIX
+    configASSERT(false);
+    return 0;
+}
+
+
+inline iox_sem_t* iox_sem_open_ext(const char*, int, mode_t, unsigned int)
+{
+    // Named semaphores are not supported in FreeRTOS+POSIX
+    configASSERT(false);
+    return nullptr;
+}
+
+inline int iox_sem_unlink(const char*)
+{
+    // Named semaphores are not supported in FreeRTOS+POSIX
+    configASSERT(false);
+    return 0;
+}
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_SEMAPHORE_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/shm_file.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/shm_file.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_SHM_FILE_HPP
+#define IOX_HOOFS_FREERTOS_SHM_FILE_HPP
+
+#include <array>
+#include <cstdint>
+#include <mutex>
+
+class ShmFile
+{
+  public:
+    static constexpr uint32_t MAX_SHM_SEGMENTS = 5U;
+    static constexpr uint32_t MAX_NAME_LENGTH = 128U;
+
+    ShmFile() noexcept;
+    ShmFile(const char* name) noexcept;
+    ~ShmFile();
+
+    bool ftruncate(uint32_t size) noexcept;
+    void* ptr() noexcept;
+
+    const char* name() const noexcept;
+    int fd() const noexcept;
+    uint32_t size() const noexcept;
+    bool empty() const noexcept;
+
+    static std::mutex openFilesMutex;
+    static std::array<ShmFile, MAX_SHM_SEGMENTS> openFiles;
+
+  private:
+    char m_name[MAX_NAME_LENGTH];
+    int m_fd{0};
+    uint32_t m_size{0U};
+    void* m_ptr{nullptr};
+    bool m_full{false};
+
+    static int s_fdCounter;
+};
+
+#endif

--- a/iceoryx_platform/freertos/include/iceoryx_platform/signal.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/signal.hpp
@@ -26,14 +26,14 @@
 
 #include <sys/types.h>
 
-#define SIGHUP   1
-#define SIGINT   2
-#define SIGABRT  6
-#define SIGBUS   7
+#define SIGHUP 1
+#define SIGINT 2
+#define SIGABRT 6
+#define SIGBUS 7
 #define SIGTERM 15
 
-#define SIGKILL  9
-#define SIGTERM  15
+#define SIGKILL 9
+#define SIGTERM 15
 
 using siginfo_t = int;
 

--- a/iceoryx_platform/freertos/include/iceoryx_platform/signal.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/signal.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_SIGNAL_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_SIGNAL_HPP
+
+#include "iceoryx_platform/pthread.hpp"
+
+#include "FreeRTOS.h"
+#include "FreeRTOS_POSIX/signal.h"
+
+#include <sys/types.h>
+
+#define SIGHUP   1
+#define SIGINT   2
+#define SIGABRT  6
+#define SIGBUS   7
+#define SIGTERM 15
+
+#define SIGKILL  9
+#define SIGTERM  15
+
+using siginfo_t = int;
+
+struct sigaction
+{
+    void (*sa_handler)(int);
+    void (*sa_sigaction)(int, siginfo_t*, void*);
+    sigset_t sa_mask;
+    int sa_flags;
+    void (*sa_restorer)(void);
+};
+
+inline int sigaction(int, const struct sigaction*, struct sigaction*)
+{
+    configASSERT(false);
+    return -1;
+}
+
+inline int sigemptyset(sigset_t*)
+{
+    configASSERT(false);
+    return -1;
+}
+
+inline int kill(pid_t, int)
+{
+    configASSERT(false);
+    return -1;
+}
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_SIGNAL_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/socket.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/socket.hpp
@@ -24,74 +24,75 @@
 #include <FreeRTOS_POSIX.h>
 
 /* For setsockopt(2) */
-#define SOL_SOCKET      1
+#define SOL_SOCKET 1
 
-#define SO_DEBUG        1
-#define SO_REUSEADDR    2
-#define SO_TYPE         3
-#define SO_ERROR        4
-#define SO_DONTROUTE    5
-#define SO_BROADCAST    6
-#define SO_SNDBUF       7
-#define SO_RCVBUF       8
-#define SO_SNDBUFFORCE  32
-#define SO_RCVBUFFORCE  33
-#define SO_KEEPALIVE    9
-#define SO_OOBINLINE    10
-#define SO_NO_CHECK     11
-#define SO_PRIORITY     12
-#define SO_LINGER       13
-#define SO_BSDCOMPAT    14
-#define SO_REUSEPORT    15
-#define SO_PASSCRED     16
-#define SO_PEERCRED     17
-#define SO_RCVLOWAT     18
-#define SO_SNDLOWAT     19
-#define SO_RCVTIMEO     20
-#define SO_SNDTIMEO     21
+#define SO_DEBUG 1
+#define SO_REUSEADDR 2
+#define SO_TYPE 3
+#define SO_ERROR 4
+#define SO_DONTROUTE 5
+#define SO_BROADCAST 6
+#define SO_SNDBUF 7
+#define SO_RCVBUF 8
+#define SO_SNDBUFFORCE 32
+#define SO_RCVBUFFORCE 33
+#define SO_KEEPALIVE 9
+#define SO_OOBINLINE 10
+#define SO_NO_CHECK 11
+#define SO_PRIORITY 12
+#define SO_LINGER 13
+#define SO_BSDCOMPAT 14
+#define SO_REUSEPORT 15
+#define SO_PASSCRED 16
+#define SO_PEERCRED 17
+#define SO_RCVLOWAT 18
+#define SO_SNDLOWAT 19
+#define SO_RCVTIMEO 20
+#define SO_SNDTIMEO 21
 
-#define AF_LOCAL        1
+#define AF_LOCAL 1
 
 /* Types of sockets.  */
 enum __socket_type
 {
-  SOCK_STREAM = 1,              /* Sequenced, reliable, connection-based
-                                   byte streams.  */
+    SOCK_STREAM = 1, /* Sequenced, reliable, connection-based
+                        byte streams.  */
 #define SOCK_STREAM SOCK_STREAM
-  SOCK_DGRAM = 2,               /* Connectionless, unreliable datagrams
-                                   of fixed maximum length.  */
+    SOCK_DGRAM = 2, /* Connectionless, unreliable datagrams
+                       of fixed maximum length.  */
 #define SOCK_DGRAM SOCK_DGRAM
-  SOCK_RAW = 3,                 /* Raw protocol interface.  */
+    SOCK_RAW = 3, /* Raw protocol interface.  */
 #define SOCK_RAW SOCK_RAW
-  SOCK_RDM = 4,                 /* Reliably-delivered messages.  */
+    SOCK_RDM = 4, /* Reliably-delivered messages.  */
 #define SOCK_RDM SOCK_RDM
-  SOCK_SEQPACKET = 5,           /* Sequenced, reliable, connection-based,
-                                   datagrams of fixed maximum length.  */
+    SOCK_SEQPACKET = 5, /* Sequenced, reliable, connection-based,
+                           datagrams of fixed maximum length.  */
 #define SOCK_SEQPACKET SOCK_SEQPACKET
-  SOCK_DCCP = 6,                /* Datagram Congestion Control Protocol.  */
+    SOCK_DCCP = 6, /* Datagram Congestion Control Protocol.  */
 #define SOCK_DCCP SOCK_DCCP
-  SOCK_PACKET = 10,             /* Linux specific way of getting packets
-                                   at the dev level.  For writing rarp and
-                                   other similar things on the user level. */
+    SOCK_PACKET = 10, /* Linux specific way of getting packets
+                         at the dev level.  For writing rarp and
+                         other similar things on the user level. */
 #define SOCK_PACKET SOCK_PACKET
 
-  /* Flags to be ORed into the type parameter of socket and socketpair and
-     used for the flags parameter of paccept.  */
+    /* Flags to be ORed into the type parameter of socket and socketpair and
+       used for the flags parameter of paccept.  */
 
-  SOCK_CLOEXEC = 02000000,      /* Atomically set close-on-exec flag for the
-                                   new descriptor(s).  */
+    SOCK_CLOEXEC = 02000000, /* Atomically set close-on-exec flag for the
+                                new descriptor(s).  */
 #define SOCK_CLOEXEC SOCK_CLOEXEC
-  SOCK_NONBLOCK = 00004000      /* Atomically mark descriptor(s) as
-                                   non-blocking.  */
+    SOCK_NONBLOCK = 00004000 /* Atomically mark descriptor(s) as
+                                non-blocking.  */
 #define SOCK_NONBLOCK SOCK_NONBLOCK
 };
 
-using sa_family_t = int; 
-typedef  uint32_t __socklen_t;
+using sa_family_t = int;
+typedef uint32_t __socklen_t;
 typedef __socklen_t socklen_t;
-struct sockaddr_un {
-  sa_family_t sun_family;               /* AF_UNIX */
-  char        sun_path[108];            /* Pathname */
+struct sockaddr_un
+{
+    sa_family_t sun_family; /* AF_UNIX */
+    char sun_path[108];     /* Pathname */
 };
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
 int iox_socket(int domain, int type, int protocol);

--- a/iceoryx_platform/freertos/include/iceoryx_platform/socket.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/socket.hpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_SOCKET_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_SOCKET_HPP
+
+#include <cstdint>
+
+#include <FreeRTOS_POSIX.h>
+
+/* For setsockopt(2) */
+#define SOL_SOCKET      1
+
+#define SO_DEBUG        1
+#define SO_REUSEADDR    2
+#define SO_TYPE         3
+#define SO_ERROR        4
+#define SO_DONTROUTE    5
+#define SO_BROADCAST    6
+#define SO_SNDBUF       7
+#define SO_RCVBUF       8
+#define SO_SNDBUFFORCE  32
+#define SO_RCVBUFFORCE  33
+#define SO_KEEPALIVE    9
+#define SO_OOBINLINE    10
+#define SO_NO_CHECK     11
+#define SO_PRIORITY     12
+#define SO_LINGER       13
+#define SO_BSDCOMPAT    14
+#define SO_REUSEPORT    15
+#define SO_PASSCRED     16
+#define SO_PEERCRED     17
+#define SO_RCVLOWAT     18
+#define SO_SNDLOWAT     19
+#define SO_RCVTIMEO     20
+#define SO_SNDTIMEO     21
+
+#define AF_LOCAL        1
+
+/* Types of sockets.  */
+enum __socket_type
+{
+  SOCK_STREAM = 1,              /* Sequenced, reliable, connection-based
+                                   byte streams.  */
+#define SOCK_STREAM SOCK_STREAM
+  SOCK_DGRAM = 2,               /* Connectionless, unreliable datagrams
+                                   of fixed maximum length.  */
+#define SOCK_DGRAM SOCK_DGRAM
+  SOCK_RAW = 3,                 /* Raw protocol interface.  */
+#define SOCK_RAW SOCK_RAW
+  SOCK_RDM = 4,                 /* Reliably-delivered messages.  */
+#define SOCK_RDM SOCK_RDM
+  SOCK_SEQPACKET = 5,           /* Sequenced, reliable, connection-based,
+                                   datagrams of fixed maximum length.  */
+#define SOCK_SEQPACKET SOCK_SEQPACKET
+  SOCK_DCCP = 6,                /* Datagram Congestion Control Protocol.  */
+#define SOCK_DCCP SOCK_DCCP
+  SOCK_PACKET = 10,             /* Linux specific way of getting packets
+                                   at the dev level.  For writing rarp and
+                                   other similar things on the user level. */
+#define SOCK_PACKET SOCK_PACKET
+
+  /* Flags to be ORed into the type parameter of socket and socketpair and
+     used for the flags parameter of paccept.  */
+
+  SOCK_CLOEXEC = 02000000,      /* Atomically set close-on-exec flag for the
+                                   new descriptor(s).  */
+#define SOCK_CLOEXEC SOCK_CLOEXEC
+  SOCK_NONBLOCK = 00004000      /* Atomically mark descriptor(s) as
+                                   non-blocking.  */
+#define SOCK_NONBLOCK SOCK_NONBLOCK
+};
+
+using sa_family_t = int; 
+typedef  uint32_t __socklen_t;
+typedef __socklen_t socklen_t;
+struct sockaddr_un {
+  sa_family_t sun_family;               /* AF_UNIX */
+  char        sun_path[108];            /* Pathname */
+};
+int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_socket(int domain, int type, int protocol);
+int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
+ssize_t
+iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
+int iox_closesocket(int sockfd);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_SOCKET_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/stat.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/stat.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_STAT_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_STAT_HPP
+
+#include "iceoryx_platform/fcntl.hpp"
+
+struct iox_stat
+{
+    int st_uid;
+    int st_gid;
+    int st_mode;
+    uint32_t st_size;
+};
+using iox_mode_t = int;
+
+int iox_fstat(int fildes, iox_stat* buf);
+int iox_fchmod(int, iox_mode_t);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_STAT_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/stdio.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/stdio.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_STDIO_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_STDIO_HPP
+
+int iox_remove(const char*)
+{
+    return 0;
+}
+
+#endif

--- a/iceoryx_platform/freertos/include/iceoryx_platform/time.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/time.hpp
@@ -19,8 +19,8 @@
 #ifndef IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP
 #define IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP
 
-#include <time.h>
 #include "FreeRTOS_POSIX.h"
 #include "FreeRTOS_POSIX/time.h"
+#include <time.h>
 
 #endif // IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/time.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/time.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP
+
+#include <time.h>
+#include "FreeRTOS_POSIX.h"
+#include "FreeRTOS_POSIX/time.h"
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_TIME_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/types.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/types.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_TYPES_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_TYPES_HPP
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_TYPES_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/un.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/un.hpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_UN_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_UN_HPP
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_UN_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/unistd.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/unistd.hpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_UNISTD_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_UNISTD_HPP
+
+#include <unistd.h>
+
+#define IOX_SEEK_SET SEEK_SET
+
+using iox_off_t = off_t;
+using iox_ssize_t = ssize_t;
+
+int iox_close(int fd);
+int iox_ext_close(int fd);
+int iox_fchown(int fd, uid_t owner, gid_t group);
+int iox_access(const char* pathname, int mode);
+int iox_unlink(const char* pathname);
+iox_off_t iox_lseek(int fd, iox_off_t offset, int whence);
+iox_ssize_t iox_read(int fd, void* buf, size_t count);
+iox_ssize_t iox_write(int fd, const void* buf, size_t count);
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_UNISTD_HPP

--- a/iceoryx_platform/freertos/include/iceoryx_platform/wait.hpp
+++ b/iceoryx_platform/freertos/include/iceoryx_platform/wait.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_FREERTOS_PLATFORM_WAIT_HPP
+#define IOX_HOOFS_FREERTOS_PLATFORM_WAIT_HPP
+
+#include <sys/wait.h>
+
+#endif // IOX_HOOFS_FREERTOS_PLATFORM_WAIT_HPP

--- a/iceoryx_platform/freertos/source/file.cpp
+++ b/iceoryx_platform/freertos/source/file.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/file.hpp"
+
+int iox_flock(int, int)
+{
+    // This file locking is used in iceoryx for two reasons:
+    // 1) To prevent another instance of RouDi to cleanup the memory resources of a running RouDi.
+    // 2) To prevent another Posh application with the same runtime name to cleanup the memory resources of a running
+    // application.
+    //
+    // Both of these things will never happen on FreeRTOS, so we can just leave the implementation empty.
+    return 0;
+}

--- a/iceoryx_platform/freertos/source/fnctl.cpp
+++ b/iceoryx_platform/freertos/source/fnctl.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/fcntl.hpp"
+
+int iox_open(const char*, int, mode_t)
+{
+    // Please see file.cpp to understand why file locks are not needed on FreeRTOS
+    return 0;
+}
+
+int iox_ext_open(const char*, int, mode_t)
+{
+    return 0;
+}

--- a/iceoryx_platform/freertos/source/mman.cpp
+++ b/iceoryx_platform/freertos/source/mman.cpp
@@ -15,8 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_platform/errno.hpp"
 #include "iceoryx_platform/mman.hpp"
+#include "iceoryx_platform/errno.hpp"
 #include "iceoryx_platform/shm_file.hpp"
 
 #include "FreeRTOS.h"

--- a/iceoryx_platform/freertos/source/mman.cpp
+++ b/iceoryx_platform/freertos/source/mman.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/errno.hpp"
+#include "iceoryx_platform/mman.hpp"
+#include "iceoryx_platform/shm_file.hpp"
+
+#include "FreeRTOS.h"
+
+#include <algorithm>
+#include <cstring>
+
+int iox_shm_open(const char* name, int, mode_t)
+{
+    std::lock_guard<std::mutex> lock{ShmFile::openFilesMutex};
+    const auto iter =
+        std::find_if(std::begin(ShmFile::openFiles), std::end(ShmFile::openFiles), [name](const ShmFile& f) {
+            return std::strncmp(name, f.name(), ShmFile::MAX_NAME_LENGTH) == 0;
+        });
+    if (iter == std::end(ShmFile::openFiles))
+    {
+        const auto iter_empty = std::find_if(
+            std::begin(ShmFile::openFiles), std::end(ShmFile::openFiles), [](const ShmFile& f) { return f.empty(); });
+        configASSERT(iter_empty != std::end(ShmFile::openFiles));
+        *iter_empty = ShmFile{name};
+        return iter_empty->fd();
+    }
+    else
+    {
+        return iter->fd();
+    }
+}
+
+int iox_shm_unlink(const char* name)
+{
+    std::lock_guard<std::mutex> lock{ShmFile::openFilesMutex};
+    const auto iter =
+        std::find_if(std::begin(ShmFile::openFiles), std::end(ShmFile::openFiles), [name](const ShmFile& f) {
+            return std::strncmp(name, f.name(), ShmFile::MAX_NAME_LENGTH) == 0;
+        });
+    if (iter != std::end(ShmFile::openFiles))
+    {
+        *iter = ShmFile{};
+        return 0;
+    }
+    else
+    {
+        FreeRTOS_errno = ENOENT;
+        return -1;
+    }
+}
+
+int iox_shm_close(int)
+{
+    // We do all the closing in unlink
+    return 0;
+}
+
+void* mmap(void*, size_t length, int, int, int fd, off_t)
+{
+    std::lock_guard<std::mutex> lock{ShmFile::openFilesMutex};
+    const auto iter = std::find_if(
+        std::begin(ShmFile::openFiles), std::end(ShmFile::openFiles), [fd](const ShmFile& f) { return f.fd() == fd; });
+
+    configASSERT(iter != std::end(ShmFile::openFiles));
+    configASSERT(iter->size() == length);
+    configASSERT(iter->ptr() != nullptr);
+    return iter->ptr();
+}
+
+int munmap(void*, size_t)
+{
+    return 0;
+}

--- a/iceoryx_platform/freertos/source/mqueue.cpp
+++ b/iceoryx_platform/freertos/source/mqueue.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "FreeRTOS.h"
+
+#include "iceoryx_platform/mqueue.hpp"
+
+mqd_t iox_mq_open2(const char*, int)
+{
+    configASSERT(false);
+    return mqd_t{};
+}
+
+mqd_t iox_mq_open4(const char* name, int oflag, mode_t mode, struct mq_attr* attr)
+{
+    return mq_open(name, oflag, mode, attr);
+}

--- a/iceoryx_platform/freertos/source/pwd.cpp
+++ b/iceoryx_platform/freertos/source/pwd.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/pwd.hpp"
+
+struct passwd* getpwnam(const char*)
+{
+    static char value[] = "iceoryx_freertos_dummy";
+    static struct passwd dummy;
+    dummy.pw_name = value;
+    dummy.pw_passwd = value;
+    dummy.pw_uid = 0;
+    dummy.pw_gid = 0;
+    dummy.pw_gecos = 0;
+    dummy.pw_dir = value;
+    dummy.pw_shell = value;
+    return &dummy;
+}
+
+struct passwd* getpwuid(uid_t)
+{
+    static char value[] = "iceoryx_freertos_dummy";
+    static struct passwd dummy;
+    dummy.pw_name = value;
+    dummy.pw_passwd = value;
+    dummy.pw_uid = 0;
+    dummy.pw_gid = 0;
+    dummy.pw_gecos = 0;
+    dummy.pw_dir = value;
+    dummy.pw_shell = value;
+    return &dummy;
+}

--- a/iceoryx_platform/freertos/source/shm_file.cpp
+++ b/iceoryx_platform/freertos/source/shm_file.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <cstring>
+
+#include "iceoryx_platform/shm_file.hpp"
+
+#include "FreeRTOS.h"
+
+std::mutex ShmFile::openFilesMutex;
+std::array<ShmFile, ShmFile::MAX_SHM_SEGMENTS> ShmFile::openFiles{};
+int ShmFile::s_fdCounter{0};
+
+ShmFile::ShmFile() noexcept
+{
+    std::memset(m_name, 0x0, ShmFile::MAX_NAME_LENGTH);
+}
+
+ShmFile::ShmFile(const char* name) noexcept
+    : m_fd(ShmFile::s_fdCounter++)
+    , m_full(true)
+{
+    std::strncpy(m_name, name, ShmFile::MAX_NAME_LENGTH);
+}
+
+ShmFile::~ShmFile()
+{
+    if (m_ptr != nullptr)
+    {
+        vPortFree(m_ptr);
+    }
+}
+
+bool ShmFile::ftruncate(uint32_t size) noexcept
+{
+    m_ptr = pvPortMalloc(size);
+    configASSERT(m_ptr != nullptr);
+    m_size = size;
+    return true;
+}
+
+const char* ShmFile::name() const noexcept
+{
+    return m_name;
+}
+
+void* ShmFile::ptr() noexcept
+{
+    return m_ptr;
+}
+
+uint32_t ShmFile::size() const noexcept
+{
+    return m_size;
+}
+
+int ShmFile::fd() const noexcept
+{
+    return m_fd;
+}
+
+bool ShmFile::empty() const noexcept
+{
+    return !m_full;
+}

--- a/iceoryx_platform/freertos/source/socket.cpp
+++ b/iceoryx_platform/freertos/source/socket.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/socket.hpp"
+#include "FreeRTOS.h"
+
+int iox_bind(int, const struct sockaddr*, socklen_t)
+{
+    configASSERT(false);
+    return -1; // bind(sockfd, addr, addrlen);
+}
+
+int iox_socket(int, int, int)
+{
+    configASSERT(false);
+    return -1; // socket(domain, type, protocol);
+}
+
+int iox_setsockopt(int, int, int, const void*, socklen_t)
+{
+    configASSERT(false);
+    return -1; // setsockopt(sockfd, level, optname, optval, optlen);
+}
+
+ssize_t iox_sendto(int, const void*, size_t, int, const struct sockaddr*, socklen_t)
+{
+    configASSERT(false);
+    return -1; // sendto(sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+ssize_t iox_recvfrom(int, void*, size_t, int, struct sockaddr*, socklen_t*)
+{
+    configASSERT(false);
+    return -1; // recvfrom(sockfd, buf, len, flags, src_addr, addrlen);
+}
+
+int iox_connect(int, const struct sockaddr*, socklen_t)
+{
+    configASSERT(false);
+    return -1; // connect(sockfd, addr, addrlen);
+}
+
+int iox_closesocket(int)
+{
+    configASSERT(false);
+    return -1; // close(sockfd);
+}

--- a/iceoryx_platform/freertos/source/stat.cpp
+++ b/iceoryx_platform/freertos/source/stat.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/stat.hpp"
+#include "iceoryx_platform/shm_file.hpp"
+
+#include <algorithm>
+
+mode_t umask(mode_t)
+{
+    return mode_t{};
+}
+
+int iox_fstat(int fildes, iox_stat* buf)
+{
+    buf->st_uid = 0;
+    buf->st_gid = 0;
+    buf->st_mode = 0777;
+
+    std::lock_guard<std::mutex> lock{ShmFile::openFilesMutex};
+    const auto iter = std::find_if(std::begin(ShmFile::openFiles),
+                                   std::end(ShmFile::openFiles),
+                                   [fildes](const ShmFile& f) { return f.fd() == fildes; });
+    configASSERT(iter != std::end(ShmFile::openFiles));
+    buf->st_size = iter->size();
+    return 0;
+}
+
+int iox_fchmod(int, iox_mode_t)
+{
+    return 0;
+}

--- a/iceoryx_platform/freertos/source/unistd.cpp
+++ b/iceoryx_platform/freertos/source/unistd.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_platform/unistd.hpp"
+#include "iceoryx_platform/shm_file.hpp"
+
+#include "FreeRTOS.h"
+
+#include <algorithm>
+
+int iox_close(int)
+{
+    // The files in ShmFile::openFiles only should be destroyed in iox_shm_unlink.
+    // So, we dont need to do anything here.
+    return 0;
+}
+
+int iox_ext_close(int)
+{
+    return 0;
+}
+
+int ftruncate(int fd, off_t length)
+{
+    std::lock_guard<std::mutex> lock{ShmFile::openFilesMutex};
+    const auto iter = std::find_if(
+        std::begin(ShmFile::openFiles), std::end(ShmFile::openFiles), [fd](const ShmFile& f) { return f.fd() == fd; });
+    configASSERT(iter != std::end(ShmFile::openFiles));
+    return iter->ftruncate(length) ? 0 : -1;
+}
+
+gid_t getgid(void)
+{
+    // Lets just say that on FreeRTOS, all group IDs are 1
+    return 1;
+}
+
+gid_t getegid(void)
+{
+    // Lets just say that on FreeRTOS, all effective group IDs are 1
+    return 1;
+}
+
+uid_t geteuid(void)
+{
+    // Lets just say that on FreeRTOS, all user IDs are 1
+    return 1;
+}
+
+long sysconf(int)
+{
+    // This is only ever used to find the page size. Lets just return 4 kB as usual, even though there is no paging on
+    // FreeRTOS
+    return 4096;
+}
+
+int iox_fchown(int, uid_t, gid_t)
+{
+    return 0;
+}
+
+int iox_access(const char*, int)
+{
+    return 0;
+}
+
+int iox_unlink(const char*)
+{
+    return 0;
+}
+
+iox_off_t iox_lseek(int, iox_off_t offset, int)
+{
+    return offset;
+}
+
+iox_ssize_t iox_read(int, void*, size_t)
+{
+    return 0;
+}
+
+iox_ssize_t iox_write(int, const void*, size_t)
+{
+    return 0;
+}

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by NXP. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +49,8 @@ namespace iox
 namespace platform
 {
 #if defined(_WIN32)
+using IoxIpcChannelType = iox::posix::NamedPipe;
+#elif defined(__FREERTOS__)
 using IoxIpcChannelType = iox::posix::NamedPipe;
 #else
 using IoxIpcChannelType = iox::posix::UnixDomainSocket;

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -28,7 +28,6 @@
 #include "iox/vector.hpp"
 
 #include <chrono>
-#include <csignal>
 #include <thread>
 
 using namespace iox::units::duration_literals;

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser.cpp
@@ -41,7 +41,7 @@ CmdLineParser::parse(int argc, char* argv[], const CmdLineArgumentParsingMode cm
 
     // colon after shortOption means it requires an argument, two colons mean optional argument
     constexpr const char* SHORT_OPTIONS = "hvm:l:u:x:k:";
-    int32_t index;
+    int index;
     int32_t opt{-1};
     while ((opt = getopt_long(argc, argv, SHORT_OPTIONS, LONG_OPTIONS, &index), opt != -1))
     {

--- a/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/source/roudi/roudi_cmd_line_parser_config_file_option.cpp
@@ -33,7 +33,7 @@ expected<CmdLineArgs_t, CmdLineParserResult> CmdLineParserConfigFileOption::pars
 
     // colon after shortOption means it requires an argument, two colons mean optional argument
     constexpr const char* SHORT_OPTIONS = ":hc:";
-    int32_t index;
+    int index;
     int32_t opt{-1};
     while (opt = getopt_long(argc, argv, SHORT_OPTIONS, LONG_OPTIONS, &index), opt != -1)
     {

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -71,7 +71,7 @@ class MePooSegment_test : public Test
             remove("/tmp/roudi_segment_test");
         }
 
-        sharedMemoryHandle_t getFileHandle()
+        shm_handle_t getFileHandle()
         {
             return filehandle;
         }
@@ -90,7 +90,7 @@ class MePooSegment_test : public Test
         void* m_baseAddressHint{nullptr};
         static constexpr int MEM_SIZE = 100000;
         char memory[MEM_SIZE];
-        sharedMemoryHandle_t filehandle;
+        shm_handle_t filehandle;
         static createFct createVerificator;
     };
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -71,7 +71,7 @@ class MePooSegment_test : public Test
             remove("/tmp/roudi_segment_test");
         }
 
-        int getFileHandle()
+        sharedMemoryHandle_t getFileHandle()
         {
             return filehandle;
         }
@@ -90,7 +90,7 @@ class MePooSegment_test : public Test
         void* m_baseAddressHint{nullptr};
         static constexpr int MEM_SIZE = 100000;
         char memory[MEM_SIZE];
-        int filehandle;
+        sharedMemoryHandle_t filehandle;
         static createFct createVerificator;
     };
 

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -82,7 +82,7 @@ void IntrospectionApp::parseCmdLineArguments(int argc,
                                              CmdLineArgumentParsingMode /*cmdLineParsingMode*/) noexcept
 {
     int32_t opt;
-    int32_t index;
+    int index;
 
     while ((opt = getopt_long(argc, argv, shortOptions, longOptions, &index)) != -1)
     {

--- a/tools/scripts/list_stl_dependencies.sh
+++ b/tools/scripts/list_stl_dependencies.sh
@@ -80,7 +80,7 @@ if [[ "$SCOPE" == "check" ]]; then
     echo "Comparing the used system headers against the list.."
     diff $CURRENTLY_USED_HEADERS $USELIST
     if [ $? -eq 1 ]; then
-        echo "Mismatch of expected and found headers. Please check the diff above and remove/add the header in 'tools/used-headers.txt'!"
+        echo "Mismatch of expected and found headers. Please check the diff above and remove/add the header in 'tools/scripts/used-headers.txt'!"
         exit 1
     fi
     echo "No header divergence found!"

--- a/tools/scripts/used-headers.txt
+++ b/tools/scripts/used-headers.txt
@@ -1,7 +1,6 @@
 # QNX platform / libc headers
 arpa/inet.h
 climits
-csignal
 cstdint
 cstdio
 dlfcn.h
@@ -35,7 +34,6 @@ cassert
 chrono
 cmath
 cpptoml.h
-csignal
 cstdint
 cstdio
 cstdlib

--- a/tools/scripts/used-headers.txt
+++ b/tools/scripts/used-headers.txt
@@ -1,6 +1,7 @@
 # QNX platform / libc headers
 arpa/inet.h
 climits
+csignal
 cstdint
 cstdio
 dlfcn.h


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer

### Changes

 - Add freertos iceoryx platform implementation.
 - Add iceoryx_dust cmake configuration for constants in `NamedPipe`, for further memory consumption optimization.
 - Fix a few inconsistencies with integer types that appeared as warnings when building for 32-bit systems:
   - `int32_t` -> `int` for file descriptors
   - `size_t` -> `uint64_t` for vector sizes/indices
   - Use `std::thread::native_handle_type` instead of pthread types, for the cases when the native handle has different type.

### Explanation

Adding this new platform implementation is unfortunately a bit more complicated than with the normal operating systems such as Linux. We tried to make this implementation is general and generic as possible, however, it just wasnt possible always.

Apart from the standard FreeRTOS kernel (https://freertos.org/RTOS.html), this implementation depends on the official FreeRTOS+POSIX extension (https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_POSIX/index.html) and additionally on a little third-party C++ threading library for FreeRTOS (https://github.com/grygorek/FreeRTOS_cpp11).

In order to test this implementation easily, we made this "integration" repository: https://github.com/NXPHoverGames/iceoryx_freertos It basically brings all of the dependencies as well as iceoryx together, provides the CMake build system and compiler toolchain (mostly taken from FreeRTOS_cpp11) in order to be able to build for a particular platform and execute it in an emulator environment (QEMU). Moreover, all of these steps can be easily reproduced because they are wrapped in Docker container image.

For further information and background, I recommend to read the README in our integration repo: https://github.com/NXPHoverGames/iceoryx_freertos/blob/main/README.md as well as the README in the C++ threading lib: https://github.com/grygorek/FreeRTOS_cpp11/blob/master/README.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1982 
