### PR TITLE
iox-#1994 Use logger for 'RouDi is ready for clients' message

### DIFF
--- a/.github/workflows/lint_pull_request.yml
+++ b/.github/workflows/lint_pull_request.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Restore lychee cache
         uses: actions/cache@v3
+        if: always()
         with:
           path: .lycheecache
           key: cache-lychee-all-branches
@@ -53,4 +54,4 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.4
         with:
           fail: true
-          args: --cache --insecure --max-cache-age 1d --verbose --no-progress './**/*.md' --github-token ${{secrets.GITHUB_TOKEN}} --max-concurrency 1
+          args: --cache --insecure --max-cache-age 7d --verbose --no-progress './**/*.md' --github-token ${{secrets.GITHUB_TOKEN}} --max-concurrency 1

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -139,6 +139,7 @@
 - Move `std::chrono` dependency to `iceoryx_dust` [\#536](https://github.com/eclipse-iceoryx/iceoryx/issues/536)
 - Move `std::string` dependency from `iox::string` to `std_string_support.hpp` in `iceoryx_dust` [\#1612](https://github.com/eclipse-iceoryx/iceoryx/issues/1612)
 - Better align `iox::expected` with `std::expected` [\#1969](https://github.com/eclipse-iceoryx/iceoryx/issues/1969)
+- Use logger for "RouDi is ready for clients" message [\#1994](https://github.com/eclipse-iceoryx/iceoryx/issues/1994)
 
 **Workflow:**
 

--- a/iceoryx_examples/singleprocess/README.md
+++ b/iceoryx_examples/singleprocess/README.md
@@ -22,12 +22,12 @@ transmit and receive data.
 
 ### Creating a Single Process RouDi, Publisher and Subscriber
 
- 1. We start by setting the log level to error since we do not want to see all the
+ 1. We start by setting the log level to info since we do not want to see all the
     debug messages.
 
 <!--[geoffrey][iceoryx_examples/singleprocess/single_process.cpp][log level]-->
 ```cpp
-iox::log::LogManager::GetLogManager().SetDefaultLogLevel(iox::log::LogLevel::kError);
+iox::log::Logger::init(iox::log::LogLevel::INFO);
 ```
 
  2. To start RouDi we have to create a configuration for him. We are choosing the

--- a/iceoryx_examples/singleprocess/single_process.cpp
+++ b/iceoryx_examples/singleprocess/single_process.cpp
@@ -110,9 +110,9 @@ void subscriber()
 
 int main()
 {
-    // set the log level to error to see the essence of the example
+    // set the log level to info to to have the output for launch_testing
     //! [log level]
-    iox::log::Logger::init(iox::log::LogLevel::ERROR);
+    iox::log::Logger::init(iox::log::LogLevel::INFO);
     //! [log level]
 
     //! [roudi config]

--- a/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/cmd_line_args.hpp
@@ -29,7 +29,7 @@ namespace config
 struct CmdLineArgs_t
 {
     roudi::MonitoringMode monitoringMode{roudi::MonitoringMode::OFF};
-    iox::log::LogLevel logLevel{iox::log::LogLevel::WARN};
+    iox::log::LogLevel logLevel{iox::log::LogLevel::INFO};
     version::CompatibilityCheckLevel compatibilityCheckLevel{version::CompatibilityCheckLevel::PATCH};
     units::Duration processKillDelay{roudi::PROCESS_DEFAULT_KILL_DELAY};
     optional<uint16_t> uniqueRouDiId{nullopt};

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_cmd_line_parser.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_cmd_line_parser.hpp
@@ -64,7 +64,7 @@ class CmdLineParser
 
   protected:
     bool m_run{true};
-    iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};
+    iox::log::LogLevel m_logLevel{iox::log::LogLevel::INFO};
     roudi::MonitoringMode m_monitoringMode{roudi::MonitoringMode::OFF};
     version::CompatibilityCheckLevel m_compatibilityCheckLevel{version::CompatibilityCheckLevel::PATCH};
     optional<uint16_t> m_uniqueRouDiId;

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -164,6 +164,7 @@ void RouDi::processRuntimeMessages() noexcept
     runtime::IpcInterfaceCreator roudiIpcInterface{IPC_CHANNEL_ROUDI_NAME};
 
     IOX_LOG(INFO) << "RouDi is ready for clients";
+    fflush(stdout); // explicitly flush 'stdout' for 'launch_testing'
 
     while (m_runHandleRuntimeMessageThread)
     {

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -163,8 +163,7 @@ void RouDi::processRuntimeMessages() noexcept
 {
     runtime::IpcInterfaceCreator roudiIpcInterface{IPC_CHANNEL_ROUDI_NAME};
 
-    // the logger is intentionally not used, to ensure that this message is always printed
-    std::cout << "RouDi is ready for clients" << std::endl;
+    IOX_LOG(INFO) << "RouDi is ready for clients";
 
     while (m_runHandleRuntimeMessageThread)
     {

--- a/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_iceoryx_roudi_app.cpp
@@ -99,7 +99,7 @@ TEST_F(IceoryxRoudiApp_test, VerifyConstructorIsSuccessful)
     IceoryxRoudiApp_Child roudi(cmdLineArgs.value(), iox::RouDiConfig_t().setDefaults());
 
     EXPECT_TRUE(roudi.getVariableRun());
-    EXPECT_EQ(roudi.getLogLevel(), iox::log::LogLevel::WARN);
+    EXPECT_EQ(roudi.getLogLevel(), iox::log::LogLevel::INFO);
     EXPECT_EQ(roudi.getMonitoringMode(), roudi::MonitoringMode::OFF);
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR uses the logger to print the `RouDi is ready for clients` message instead of `std::cout`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1994 
