### PR TITLE
iox-#1036 builder pattern for named pipe

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -102,6 +102,7 @@
     - `MemoryMap`
     - `SharedMemory`
     - `MessageQueue`
+    - `NamedPipe`
     - `FileLock`
         - Add the ability to adjust path and file permissions of the file lock
     - `Mutex`
@@ -1151,3 +1152,23 @@
 
     // after
     auto e = exp.error();
+    ```
+
+52. `UnixDomainSocket`, `MessageQueue` and `NamedPipe` are not default constructible anymore
+
+    ```cpp
+    // before
+    iox::posix::UnixDomainSocket socket;
+
+    // after
+    // option 1
+    iox::optional<iox::posix::UnixDomainSocket> socket;
+    // option 2
+    iox::posix::UnixDomainSocket socket { UnixDomainSocketBuilder()
+        .name("foo")
+        .channelSide(iox::posix::IpcChannelSide::CLIENT)
+        .create()
+        .expect("Valid UnixDomainSocket")
+    };
+
+    ```

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -47,9 +47,6 @@ class UnixDomainSocket
     using UdsName_t = string<LONGEST_VALID_NAME>;
     using Message_t = string<MAX_MESSAGE_SIZE>;
 
-    using result_t = expected<UnixDomainSocket, IpcChannelError>;
-    using errorType_t = IpcChannelError;
-
     UnixDomainSocket() noexcept = delete;
     UnixDomainSocket(const UnixDomainSocket& other) = delete;
     UnixDomainSocket(UnixDomainSocket&& other) noexcept;

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -61,6 +61,8 @@ class CMqInterfaceStartupRace_test : public Test
   public:
     virtual void SetUp()
     {
+        platform::IoxIpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER)
+            .and_then([this](auto& channel) { this->m_roudiQueue.emplace(std::move(channel)); });
         ASSERT_THAT(m_roudiQueue.has_value(), true);
     }
     virtual void TearDown()
@@ -110,8 +112,7 @@ class CMqInterfaceStartupRace_test : public Test
 
     /// @note smart_lock in combination with optional is currently not really usable
     std::mutex m_roudiQueueMutex;
-    platform::IoxIpcChannelType::result_t m_roudiQueue{
-        platform::IoxIpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER)};
+    optional<platform::IoxIpcChannelType> m_roudiQueue;
     std::mutex m_appQueueMutex;
     optional<platform::IoxIpcChannelType> m_appQueue;
 };


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer
This PR builds upon #2014 which needs to be merged first. The PR only touches the named pipe files and the release notes. If someone wants to review before the merge of #2014, the easiest way would be to check the last three commits.

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates #1036
