### PR TITLE
iox-#1036 builder pattern for unix domain socket

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -25,7 +25,7 @@
 ./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/test/moduletests/test_posix*
 
-./iceoryx_hoofs/include/error_reporting/**/*
+./iceoryx_hoofs/include/iceoryx_hoofs/error_reporting/**/*
 ./iceoryx_hoofs/source/error_reporting/**/*
 ./iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/error_reporting/*
 ./iceoryx_hoofs/testing/error_reporting/*

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -103,6 +103,7 @@
     - `SharedMemory`
     - `MessageQueue`
     - `NamedPipe`
+    - `UnixDomainSocket`
     - `FileLock`
         - Add the ability to adjust path and file permissions of the file lock
     - `Mutex`

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
@@ -68,19 +68,6 @@ class MessageQueue
 
     ~MessageQueue() noexcept;
 
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    static expected<MessageQueue, IpcChannelError>
-    create(const IpcChannelName_t& name,
-           const IpcChannelSide channelSide,
-           const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
-           const uint64_t maxMsgNumber = MAX_NUMBER_OF_MESSAGES) noexcept;
-
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    bool isInitialized() const noexcept
-    {
-        return m_mqDescriptor != INVALID_DESCRIPTOR;
-    }
-
     static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief send a message to queue using std::string.

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/message_queue.hpp
@@ -31,6 +31,8 @@ namespace iox
 {
 namespace posix
 {
+class MessageQueueBuilder;
+
 /// @brief Wrapper class for posix message queue
 ///
 /// @code
@@ -54,7 +56,9 @@ class MessageQueue
     static constexpr uint64_t SHORTEST_VALID_QUEUE_NAME = 2;
     static constexpr uint64_t NULL_TERMINATOR_SIZE = 1;
     static constexpr uint64_t MAX_MESSAGE_SIZE = 4096;
-    static constexpr uint64_t MAX_MESSAGE_NUMBER = 10;
+    static constexpr uint64_t MAX_NUMBER_OF_MESSAGES = 10;
+
+    using Builder_t = MessageQueueBuilder;
 
     MessageQueue() noexcept = delete;
     MessageQueue(const MessageQueue& other) = delete;
@@ -65,10 +69,11 @@ class MessageQueue
     ~MessageQueue() noexcept;
 
     /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    static expected<MessageQueue, IpcChannelError> create(const IpcChannelName_t& name,
-                                                          const IpcChannelSide channelSide,
-                                                          const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
-                                                          const uint64_t maxMsgNumber = MAX_MESSAGE_NUMBER) noexcept;
+    static expected<MessageQueue, IpcChannelError>
+    create(const IpcChannelName_t& name,
+           const IpcChannelSide channelSide,
+           const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
+           const uint64_t maxMsgNumber = MAX_NUMBER_OF_MESSAGES) noexcept;
 
     /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
     bool isInitialized() const noexcept
@@ -101,7 +106,7 @@ class MessageQueue
   private:
     friend class MessageQueueBuilder;
 
-    MessageQueue(const IpcChannelName_t&& name,
+    MessageQueue(const IpcChannelName_t& name,
                  const mq_attr attributes,
                  mqd_t mqDescriptor,
                  const IpcChannelSide channelSide) noexcept;
@@ -146,7 +151,7 @@ class MessageQueueBuilder
     IOX_BUILDER_PARAMETER(uint64_t, maxMsgSize, MessageQueue::MAX_MESSAGE_SIZE)
 
     /// @brief Defines the max number of messages for the message queue.
-    IOX_BUILDER_PARAMETER(uint64_t, maxMsgNumber, MessageQueue::MAX_MESSAGE_NUMBER)
+    IOX_BUILDER_PARAMETER(uint64_t, maxMsgNumber, MessageQueue::MAX_NUMBER_OF_MESSAGES)
 
   public:
     /// @brief create a message queue

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
@@ -23,6 +23,7 @@
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
 #include "iceoryx_platform/semaphore.hpp"
+#include "iox/builder.hpp"
 #include "iox/duration.hpp"
 #include "iox/expected.hpp"
 #include "iox/optional.hpp"
@@ -35,6 +36,8 @@ namespace iox
 {
 namespace posix
 {
+class NamedPipeBuilder;
+
 class NamedPipe
 {
   public:
@@ -51,6 +54,8 @@ class NamedPipe
     /// NOLINTJUSTIFICATION used as safe compile time string literal
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static constexpr const char NAMED_PIPE_PREFIX[] = "iox_np_";
+
+    using Builder_t = NamedPipeBuilder;
 
     using Message_t = string<MAX_MESSAGE_SIZE>;
     using MessageQueue_t = concurrent::LockFreeQueue<Message_t, MAX_NUMBER_OF_MESSAGES>;

--- a/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
+++ b/iceoryx_dust/include/iceoryx_dust/posix_wrapper/named_pipe.hpp
@@ -68,18 +68,6 @@ class NamedPipe
     NamedPipe& operator=(NamedPipe&& rhs) noexcept;
     ~NamedPipe() noexcept;
 
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    static expected<NamedPipe, IpcChannelError> create(const IpcChannelName_t& name,
-                                                       const IpcChannelSide channelSide,
-                                                       const size_t maxMsgSize = MAX_MESSAGE_SIZE,
-                                                       const uint64_t maxMsgNumber = MAX_NUMBER_OF_MESSAGES) noexcept;
-
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    bool isInitialized() const noexcept
-    {
-        return m_data != nullptr;
-    }
-
     /// @brief removes a named pipe artifact from the system
     /// @return true if the artifact was removed, false when no artifact was found and
     ///         IpcChannelError::INTERNAL_LOGIC_ERROR when shm_unlink failed

--- a/iceoryx_dust/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_dust/source/posix_wrapper/message_queue.cpp
@@ -79,11 +79,11 @@ expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noex
     return ok(MessageQueue{std::move(sanitizedName), attributes, mqDescriptor, m_channelSide});
 }
 
-MessageQueue::MessageQueue(const IpcChannelName_t&& name,
+MessageQueue::MessageQueue(const IpcChannelName_t& name,
                            const mq_attr attributes,
                            mqd_t mqDescriptor,
                            const IpcChannelSide channelSide) noexcept
-    : m_name(std::move(name))
+    : m_name(name)
     , m_attributes(attributes)
     , m_mqDescriptor(mqDescriptor)
     , m_channelSide(channelSide)

--- a/iceoryx_dust/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_dust/source/posix_wrapper/message_queue.cpp
@@ -90,20 +90,6 @@ MessageQueue::MessageQueue(const IpcChannelName_t& name,
 {
 }
 
-// NOLINTNEXTLINE(readability-function-size) @todo iox-#832 make a struct out of arguments
-expected<MessageQueue, IpcChannelError> MessageQueue::create(const IpcChannelName_t& name,
-                                                             const IpcChannelSide channelSide,
-                                                             const uint64_t maxMsgSize,
-                                                             const uint64_t maxMsgNumber) noexcept
-{
-    return MessageQueueBuilder()
-        .name(name)
-        .channelSide(channelSide)
-        .maxMsgSize(maxMsgSize)
-        .maxMsgNumber(maxMsgNumber)
-        .create();
-}
-
 MessageQueue::MessageQueue(MessageQueue&& other) noexcept
 {
     *this = std::move(other);

--- a/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
+++ b/iceoryx_dust/source/posix_wrapper/named_pipe.cpp
@@ -120,20 +120,6 @@ expected<NamedPipe, IpcChannelError> NamedPipeBuilder::create() const noexcept
     return ok(NamedPipe{std::move(sharedMemory), data});
 }
 
-// NOLINTNEXTLINE(readability-function-size) @todo iox-#832 make a struct out of arguments
-expected<NamedPipe, IpcChannelError> NamedPipe::create(const IpcChannelName_t& name,
-                                                       const IpcChannelSide channelSide,
-                                                       const size_t maxMsgSize,
-                                                       const uint64_t maxMsgNumber) noexcept
-{
-    return NamedPipeBuilder()
-        .name(name)
-        .channelSide(channelSide)
-        .maxMsgSize(maxMsgSize)
-        .maxMsgNumber(maxMsgNumber)
-        .create();
-}
-
 NamedPipe::NamedPipe(SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept
     : m_sharedMemory(std::move(sharedMemory))
     , m_data(data)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -62,27 +62,6 @@ class UnixDomainSocket
 
     ~UnixDomainSocket() noexcept;
 
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    static expected<UnixDomainSocket, IpcChannelError>
-    create(const IpcChannelName_t& name,
-           const IpcChannelSide channelSide,
-           const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
-           const uint64_t maxMsgNumber = MAX_NUMBER_OF_MESSAGES) noexcept;
-
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    static expected<UnixDomainSocket, IpcChannelError>
-    create(const NoPathPrefix_t,
-           const UdsName_t& name,
-           const IpcChannelSide channelSide,
-           const uint64_t maxMsgSize = MAX_MESSAGE_SIZE,
-           const uint64_t maxMsgNumber = MAX_NUMBER_OF_MESSAGES) noexcept;
-
-    /// @todo iox-#1036 Remove when all channels are ported to the builder pattern
-    bool isInitialized() const noexcept
-    {
-        return m_sockfd != INVALID_FD;
-    }
-
     /// @brief unlink the provided unix domain socket
     /// @param name of the unix domain socket to unlink
     /// @return true if the unix domain socket could be unlinked, false otherwise, IpcChannelError if error occured

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp
@@ -49,6 +49,8 @@ class UnixDomainSocket
     /// @brief The name length is limited by the size of the sockaddr_un::sun_path buffer and the IOX_SOCKET_PATH_PREFIX
     static constexpr size_t LONGEST_VALID_NAME = sizeof(sockaddr_un::sun_path) - 1;
 
+    using Builder_t = UnixDomainSocketBuilder;
+
     using UdsName_t = string<LONGEST_VALID_NAME>;
     using Message_t = string<MAX_MESSAGE_SIZE>;
 

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -156,36 +156,6 @@ UnixDomainSocket::UnixDomainSocket(const UdsName_t& udsName,
 {
 }
 
-expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(const IpcChannelName_t& name,
-                                                                     const IpcChannelSide channelSide,
-                                                                     const uint64_t maxMsgSize,
-                                                                     const uint64_t maxMsgNumber) noexcept
-{
-    return UnixDomainSocketBuilder()
-        .name(name)
-        .channelSide(channelSide)
-        .maxMsgSize(maxMsgSize)
-        .maxMsgNumber(maxMsgNumber)
-        .create();
-}
-
-// NOLINTJUSTIFICATION will be removed
-// NOLINTBEGIN(readability-function-size, bugprone-easily-swappable-parameters)
-expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(const NoPathPrefix_t,
-                                                                     const UdsName_t& name,
-                                                                     const IpcChannelSide channelSide,
-                                                                     const uint64_t maxMsgSize,
-                                                                     const uint64_t maxMsgNumber) noexcept
-{
-    return UnixDomainSocketBuilderNoPathPrefix()
-        .name(name)
-        .channelSide(channelSide)
-        .maxMsgSize(maxMsgSize)
-        .maxMsgNumber(maxMsgNumber)
-        .create();
-}
-// NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
-
 UnixDomainSocket::~UnixDomainSocket() noexcept
 {
     if (destroy().has_error())

--- a/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unix_domain_socket.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2023 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +26,6 @@
 #include <chrono>
 #include <string>
 
-
 namespace iox
 {
 namespace posix
@@ -33,69 +33,158 @@ namespace posix
 constexpr uint64_t UnixDomainSocket::MAX_MESSAGE_SIZE;
 constexpr uint64_t UnixDomainSocket::NULL_TERMINATOR_SIZE;
 
-UnixDomainSocket::UnixDomainSocket(UnixDomainSocket&& other) noexcept
+expected<UnixDomainSocket, IpcChannelError> UnixDomainSocketBuilder::create() const noexcept
 {
-    *this = std::move(other);
-}
-
-// @todo iox-#832
-// NOLINTJUSTIFICATION make a struct out of arguments in #832
-// NOLINTBEGIN(readability-function-size, bugprone-easily-swappable-parameters)
-UnixDomainSocket::UnixDomainSocket(const IpcChannelName_t& name,
-                                   const IpcChannelSide channelSide,
-                                   const uint64_t maxMsgSize,
-                                   const uint64_t maxMsgNumber) noexcept
-    // NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
-    : UnixDomainSocket(
-        NoPathPrefix,
-        [&]() -> UdsName_t {
-            /// invalid names will be forwarded and handled by the other constructor
-            /// separately
-            if (!isValidPathToFile(name))
-            {
-                return name;
-            }
-            return UdsName_t(platform::IOX_UDS_SOCKET_PATH_PREFIX).append(iox::TruncateToCapacity, name);
-        }(),
-        channelSide,
-        maxMsgSize,
-        maxMsgNumber)
-{
-}
-
-// @todo iox-#832
-// NOLINTJUSTIFICATION make a struct out of arguments in #832
-// NOLINTBEGIN(readability-function-size, bugprone-easily-swappable-parameters)
-UnixDomainSocket::UnixDomainSocket(const NoPathPrefix_t,
-                                   const UdsName_t& name,
-                                   const IpcChannelSide channelSide,
-                                   const uint64_t maxMsgSize,
-                                   const uint64_t) noexcept
-    // NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
-    : m_name(name)
-    , m_channelSide(channelSide)
-{
-    if (!isValidPathToFile(name))
+    if (isValidPathToFile(m_name))
     {
-        this->m_isInitialized = false;
-        this->m_errorValue = IpcChannelError::INVALID_CHANNEL_NAME;
-        return;
+        auto udsName =
+            UnixDomainSocket::UdsName_t(platform::IOX_UDS_SOCKET_PATH_PREFIX).append(iox::TruncateToCapacity, m_name);
+        return UnixDomainSocketBuilderNoPathPrefix()
+            .name(udsName)
+            .channelSide(m_channelSide)
+            .maxMsgSize(m_maxMsgSize)
+            .maxMsgNumber(m_maxMsgNumber)
+            .create();
     }
 
-    if (maxMsgSize > MAX_MESSAGE_SIZE)
+    // invalid names will be forwarded and handled by 'UnixDomainSocketBuilderNoPathPrefix'
+    return UnixDomainSocketBuilderNoPathPrefix()
+        .name(m_name)
+        .channelSide(m_channelSide)
+        .maxMsgSize(m_maxMsgSize)
+        .maxMsgNumber(m_maxMsgNumber)
+        .create();
+}
+
+expected<UnixDomainSocket, IpcChannelError> UnixDomainSocketBuilderNoPathPrefix::create() const noexcept
+{
+    if (!isValidPathToFile(m_name))
     {
-        this->m_isInitialized = false;
-        this->m_errorValue = IpcChannelError::MAX_MESSAGE_SIZE_EXCEEDED;
+        return err(IpcChannelError::INVALID_CHANNEL_NAME);
     }
-    else
+
+    if (m_maxMsgSize > UnixDomainSocket::MAX_MESSAGE_SIZE)
     {
-        m_maxMessageSize = maxMsgSize;
-        initalizeSocket().and_then([this]() { this->m_isInitialized = true; }).or_else([this](IpcChannelError& error) {
-            this->m_isInitialized = false;
-            this->m_errorValue = error;
+        return err(IpcChannelError::MAX_MESSAGE_SIZE_EXCEEDED);
+    }
+
+    sockaddr_un sockAddr{};
+    // initialize the sockAddr data structure with the provided name
+    memset(&sockAddr, 0, sizeof(sockAddr));
+    sockAddr.sun_family = AF_LOCAL;
+    if (m_name.size() > UnixDomainSocket::LONGEST_VALID_NAME)
+    {
+        return err(IpcChannelError::INVALID_CHANNEL_NAME);
+    }
+    strncpy(&(sockAddr.sun_path[0]), m_name.c_str(), m_name.size());
+
+    // the mask will be applied to the permissions, we only allow users and group members to have read and write access
+    // the system call always succeeds, no need to check for errors
+    // NOLINTJUSTIFICATION type is defined by POSIX, no logical fault
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
+    mode_t umaskSaved = umask(S_IXUSR | S_IXGRP | S_IRWXO);
+    // Reset to old umask when going out of scope
+    ScopeGuard umaskGuard([&umaskSaved] { umask(umaskSaved); });
+
+    auto socketCall =
+        posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0).failureReturnValue(UnixDomainSocket::ERROR_CODE).evaluate();
+
+    if (socketCall.has_error())
+    {
+        return err(UnixDomainSocket::errnoToEnum(m_name, socketCall.error().errnum));
+    }
+    auto sockfd = socketCall.value().value;
+
+    if (IpcChannelSide::SERVER == m_channelSide)
+    {
+        unlink(&(sockAddr.sun_path[0]));
+
+        auto bindCall =
+            // NOLINTJUSTIFICATION enforced by POSIX API
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+            posixCall(iox_bind)(sockfd, reinterpret_cast<struct sockaddr*>(&sockAddr), sizeof(sockAddr))
+                .failureReturnValue(UnixDomainSocket::ERROR_CODE)
+                .evaluate();
+
+        if (bindCall.has_error())
+        {
+            UnixDomainSocket::closeFileDescriptor(m_name, sockfd, sockAddr, m_channelSide).or_else([](auto) {
+                IOX_LOG(ERROR)
+                    << "Unable to close socket file descriptor in error related cleanup during initialization.";
+            });
+            // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
+            return err(UnixDomainSocket::errnoToEnum(m_name, bindCall.error().errnum));
+        }
+        return ok(UnixDomainSocket{m_name, m_channelSide, sockfd, sockAddr, m_maxMsgSize});
+    }
+    // we use a connected socket, this leads to a behavior closer to the message queue (e.g. error if client
+    // is created and server not present)
+    auto connectCall =
+        // NOLINTJUSTIFICATION enforced by POSIX API
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        posixCall(iox_connect)(sockfd, reinterpret_cast<struct sockaddr*>(&sockAddr), sizeof(sockAddr))
+            .failureReturnValue(UnixDomainSocket::ERROR_CODE)
+            .suppressErrorMessagesForErrnos(ENOENT, ECONNREFUSED)
+            .evaluate();
+
+    if (connectCall.has_error())
+    {
+        UnixDomainSocket::closeFileDescriptor(m_name, sockfd, sockAddr, m_channelSide).or_else([](auto) {
+            IOX_LOG(ERROR) << "Unable to close socket file descriptor in error related cleanup during initialization.";
         });
+        // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
+        return err(UnixDomainSocket::errnoToEnum(m_name, connectCall.error().errnum));
     }
+
+    return ok(UnixDomainSocket{m_name, m_channelSide, sockfd, sockAddr, m_maxMsgSize});
 }
+
+// @todo iox-#832
+// NOLINTJUSTIFICATION make a struct out of arguments in #832
+// NOLINT(readability-function-size, bugprone-easily-swappable-parameters)
+UnixDomainSocket::UnixDomainSocket(const UdsName_t& udsName,
+                                   const IpcChannelSide channelSide,
+                                   const int32_t sockfd,
+                                   const sockaddr_un sockAddr,
+                                   const uint64_t maxMsgSize) noexcept
+    : m_name(udsName)
+    , m_channelSide(channelSide)
+    , m_sockfd(sockfd)
+    , m_sockAddr(sockAddr)
+    , m_maxMessageSize(maxMsgSize)
+
+{
+}
+
+expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(const IpcChannelName_t& name,
+                                                                     const IpcChannelSide channelSide,
+                                                                     const uint64_t maxMsgSize,
+                                                                     const uint64_t maxMsgNumber) noexcept
+{
+    return UnixDomainSocketBuilder()
+        .name(name)
+        .channelSide(channelSide)
+        .maxMsgSize(maxMsgSize)
+        .maxMsgNumber(maxMsgNumber)
+        .create();
+}
+
+// NOLINTJUSTIFICATION will be removed
+// NOLINTBEGIN(readability-function-size, bugprone-easily-swappable-parameters)
+expected<UnixDomainSocket, IpcChannelError> UnixDomainSocket::create(const NoPathPrefix_t,
+                                                                     const UdsName_t& name,
+                                                                     const IpcChannelSide channelSide,
+                                                                     const uint64_t maxMsgSize,
+                                                                     const uint64_t maxMsgNumber) noexcept
+{
+    return UnixDomainSocketBuilderNoPathPrefix()
+        .name(name)
+        .channelSide(channelSide)
+        .maxMsgSize(maxMsgSize)
+        .maxMsgNumber(maxMsgNumber)
+        .create();
+}
+// NOLINTEND(readability-function-size, bugprone-easily-swappable-parameters)
 
 UnixDomainSocket::~UnixDomainSocket() noexcept
 {
@@ -103,6 +192,11 @@ UnixDomainSocket::~UnixDomainSocket() noexcept
     {
         IOX_LOG(ERROR) << "unable to cleanup unix domain socket \"" << m_name << "\" in the destructor";
     }
+}
+
+UnixDomainSocket::UnixDomainSocket(UnixDomainSocket&& other) noexcept
+{
+    *this = std::move(other);
 }
 
 UnixDomainSocket& UnixDomainSocket::operator=(UnixDomainSocket&& other) noexcept
@@ -115,24 +209,16 @@ UnixDomainSocket& UnixDomainSocket::operator=(UnixDomainSocket&& other) noexcept
                            << "\" in the move constructor/move assignment operator";
         }
 
-        m_isInitialized = other.m_isInitialized;
-        m_errorValue = other.m_errorValue;
         m_name = std::move(other.m_name);
         m_channelSide = other.m_channelSide;
         m_sockfd = other.m_sockfd;
         m_sockAddr = other.m_sockAddr;
         m_maxMessageSize = other.m_maxMessageSize;
 
-        other.m_isInitialized = false;
         other.m_sockfd = INVALID_FD;
     }
 
     return *this;
-}
-
-bool UnixDomainSocket::isInitialized() const noexcept
-{
-    return m_isInitialized;
 }
 
 expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const UdsName_t& name) noexcept
@@ -170,15 +256,25 @@ expected<bool, IpcChannelError> UnixDomainSocket::unlinkIfExists(const NoPathPre
 
 expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
 {
-    if (m_sockfd != INVALID_FD)
+    return UnixDomainSocket::closeFileDescriptor(m_name, m_sockfd, m_sockAddr, m_channelSide).and_then([this] {
+        m_sockfd = INVALID_FD;
+    });
+}
+
+expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor(const UdsName_t& name,
+                                                                      const int sockfd,
+                                                                      const sockaddr_un& sockAddr,
+                                                                      IpcChannelSide channelSide) noexcept
+{
+    if (sockfd != INVALID_FD)
     {
-        auto closeCall = posixCall(iox_closesocket)(m_sockfd).failureReturnValue(ERROR_CODE).evaluate();
+        auto closeCall = posixCall(iox_closesocket)(sockfd).failureReturnValue(ERROR_CODE).evaluate();
 
         if (!closeCall.has_error())
         {
-            if (IpcChannelSide::SERVER == m_channelSide)
+            if (IpcChannelSide::SERVER == channelSide)
             {
-                auto unlinkCall = posixCall(unlink)(&(m_sockAddr.sun_path[0]))
+                auto unlinkCall = posixCall(unlink)(&(sockAddr.sun_path[0]))
                                       .failureReturnValue(ERROR_CODE)
                                       .ignoreErrnos(ENOENT)
                                       .evaluate();
@@ -188,19 +284,16 @@ expected<void, IpcChannelError> UnixDomainSocket::closeFileDescriptor() noexcept
                 }
             }
 
-            m_sockfd = INVALID_FD;
-            m_isInitialized = false;
-
             return ok();
         }
-        return err(convertErrnoToIpcChannelError(closeCall.error().errnum));
+        return err(UnixDomainSocket::errnoToEnum(name, closeCall.error().errnum));
     }
     return ok();
 }
 
 expected<void, IpcChannelError> UnixDomainSocket::destroy() noexcept
 {
-    if (m_isInitialized)
+    if (m_sockfd != INVALID_FD)
     {
         return closeFileDescriptor();
     }
@@ -237,7 +330,7 @@ expected<void, IpcChannelError> UnixDomainSocket::timedSend(const std::string& m
 
     if (setsockoptCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(setsockoptCall.error().errnum));
+        return err(errnoToEnum(setsockoptCall.error().errnum));
     }
     auto sendCall = posixCall(iox_sendto)(m_sockfd, msg.c_str(), msg.size() + NULL_TERMINATOR_SIZE, 0, nullptr, 0)
                         .failureReturnValue(ERROR_CODE)
@@ -245,7 +338,7 @@ expected<void, IpcChannelError> UnixDomainSocket::timedSend(const std::string& m
 
     if (sendCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(sendCall.error().errnum));
+        return err(errnoToEnum(sendCall.error().errnum));
     }
     return ok();
 }
@@ -277,7 +370,7 @@ expected<std::string, IpcChannelError> UnixDomainSocket::timedReceive(const unit
 
     if (setsockoptCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(setsockoptCall.error().errnum));
+        return err(errnoToEnum(setsockoptCall.error().errnum));
     }
     // NOLINTJUSTIFICATION needed for recvfrom
     // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
@@ -291,164 +384,98 @@ expected<std::string, IpcChannelError> UnixDomainSocket::timedReceive(const unit
 
     if (recvCall.has_error())
     {
-        return err(convertErrnoToIpcChannelError(recvCall.error().errnum));
+        return err(errnoToEnum(recvCall.error().errnum));
     }
     return ok<std::string>(&message[0]);
 }
 
-expected<void, IpcChannelError> UnixDomainSocket::initalizeSocket() noexcept
+IpcChannelError UnixDomainSocket::errnoToEnum(const int32_t errnum) const noexcept
 {
-    // initialize the sockAddr data structure with the provided name
-    memset(&m_sockAddr, 0, sizeof(m_sockAddr));
-    m_sockAddr.sun_family = AF_LOCAL;
-    if (m_name.size() > LONGEST_VALID_NAME)
-    {
-        return err(IpcChannelError::INVALID_CHANNEL_NAME);
-    }
-    strncpy(&(m_sockAddr.sun_path[0]), m_name.c_str(), m_name.size());
-
-    // the mask will be applied to the permissions, we only allow users and group members to have read and write access
-    // the system call always succeeds, no need to check for errors
-    // NOLINTJUSTIFICATION type is defined by POSIX, no logical fault
-    // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    mode_t umaskSaved = umask(S_IXUSR | S_IXGRP | S_IRWXO);
-    // Reset to old umask when going out of scope
-    ScopeGuard umaskGuard([&] { umask(umaskSaved); });
-
-    auto socketCall = posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0)
-                          .failureReturnValue(ERROR_CODE)
-                          .evaluate()
-                          .and_then([this](auto& r) { m_sockfd = r.value; });
-
-    if (socketCall.has_error())
-    {
-        return err(convertErrnoToIpcChannelError(socketCall.error().errnum));
-    }
-
-    if (IpcChannelSide::SERVER == m_channelSide)
-    {
-        unlink(&(m_sockAddr.sun_path[0]));
-
-        auto bindCall =
-            // NOLINTJUSTIFICATION enforced by POSIX API
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-            posixCall(iox_bind)(m_sockfd, reinterpret_cast<struct sockaddr*>(&m_sockAddr), sizeof(m_sockAddr))
-                .failureReturnValue(ERROR_CODE)
-                .evaluate();
-
-        if (!bindCall.has_error())
-        {
-            return ok();
-        }
-        closeFileDescriptor().or_else([](auto) {
-            IOX_LOG(ERROR) << "Unable to close socket file descriptor in error related cleanup during initialization.";
-        });
-        // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
-        return err(convertErrnoToIpcChannelError(bindCall.error().errnum));
-    }
-    // we use a connected socket, this leads to a behavior closer to the message queue (e.g. error if client
-    // is created and server not present)
-    auto connectCall =
-        // NOLINTJUSTIFICATION enforced by POSIX API
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        posixCall(iox_connect)(m_sockfd, reinterpret_cast<struct sockaddr*>(&m_sockAddr), sizeof(m_sockAddr))
-            .failureReturnValue(ERROR_CODE)
-            .suppressErrorMessagesForErrnos(ENOENT, ECONNREFUSED)
-            .evaluate();
-
-    if (connectCall.has_error())
-    {
-        closeFileDescriptor().or_else([](auto) {
-            IOX_LOG(ERROR) << "Unable to close socket file descriptor in error related cleanup during initialization.";
-        });
-        // possible errors in closeFileDescriptor() are masked and we inform the user about the actual error
-        return err(convertErrnoToIpcChannelError(connectCall.error().errnum));
-    }
-    return ok();
+    return errnoToEnum(m_name, errnum);
 }
 
-IpcChannelError UnixDomainSocket::convertErrnoToIpcChannelError(const int32_t errnum) const noexcept
+IpcChannelError UnixDomainSocket::errnoToEnum(const UdsName_t& name, const int32_t errnum) noexcept
 {
     switch (errnum)
     {
     case EACCES:
     {
-        IOX_LOG(ERROR) << "permission to create unix domain socket denied \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "permission to create unix domain socket denied \"" << name << "\"";
         return IpcChannelError::ACCESS_DENIED;
     }
     case EAFNOSUPPORT:
     {
-        IOX_LOG(ERROR) << "address family not supported for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "address family not supported for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_ARGUMENTS;
     }
     case EINVAL:
     {
-        IOX_LOG(ERROR) << "provided invalid arguments for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "provided invalid arguments for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_ARGUMENTS;
     }
     case EMFILE:
     {
-        IOX_LOG(ERROR) << "process limit reached for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "process limit reached for unix domain socket \"" << name << "\"";
         return IpcChannelError::PROCESS_LIMIT;
     }
     case ENFILE:
     {
-        IOX_LOG(ERROR) << "system limit reached for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "system limit reached for unix domain socket \"" << name << "\"";
         return IpcChannelError::SYSTEM_LIMIT;
     }
     case ENOBUFS:
     {
-        IOX_LOG(ERROR) << "queue is full for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "queue is full for unix domain socket \"" << name << "\"";
         return IpcChannelError::OUT_OF_MEMORY;
     }
     case ENOMEM:
     {
-        IOX_LOG(ERROR) << "out of memory for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "out of memory for unix domain socket \"" << name << "\"";
         return IpcChannelError::OUT_OF_MEMORY;
     }
     case EPROTONOSUPPORT:
     {
-        IOX_LOG(ERROR) << "protocol type not supported for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "protocol type not supported for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_ARGUMENTS;
     }
     case EADDRINUSE:
     {
-        IOX_LOG(ERROR) << "unix domain socket already in use \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "unix domain socket already in use \"" << name << "\"";
         return IpcChannelError::CHANNEL_ALREADY_EXISTS;
     }
     case EBADF:
     {
-        IOX_LOG(ERROR) << "invalid file descriptor for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "invalid file descriptor for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_FILE_DESCRIPTOR;
     }
     case ENOTSOCK:
     {
-        IOX_LOG(ERROR) << "invalid unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "invalid unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_FILE_DESCRIPTOR;
     }
     case EADDRNOTAVAIL:
     {
-        IOX_LOG(ERROR) << "interface or address error for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "interface or address error for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case EFAULT:
     {
-        IOX_LOG(ERROR) << "outside address space error for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "outside address space error for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case ELOOP:
     {
-        IOX_LOG(ERROR) << "too many symbolic links for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "too many symbolic links for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case ENAMETOOLONG:
     {
-        IOX_LOG(ERROR) << "name too long for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "name too long for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case ENOTDIR:
     {
-        IOX_LOG(ERROR) << "not a directory error for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "not a directory error for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case ENOENT:
@@ -458,17 +485,17 @@ IpcChannelError UnixDomainSocket::convertErrnoToIpcChannelError(const int32_t er
     }
     case EROFS:
     {
-        IOX_LOG(ERROR) << "read only error for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "read only error for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_CHANNEL_NAME;
     }
     case EIO:
     {
-        IOX_LOG(ERROR) << "I/O for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "I/O for unix domain socket \"" << name << "\"";
         return IpcChannelError::I_O_ERROR;
     }
     case ENOPROTOOPT:
     {
-        IOX_LOG(ERROR) << "invalid option for unix domain socket \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "invalid option for unix domain socket \"" << name << "\"";
         return IpcChannelError::INVALID_ARGUMENTS;
     }
     case ECONNREFUSED:
@@ -478,7 +505,7 @@ IpcChannelError UnixDomainSocket::convertErrnoToIpcChannelError(const int32_t er
     }
     case ECONNRESET:
     {
-        IOX_LOG(ERROR) << "connection was reset by peer for \"" << m_name << "\"";
+        IOX_LOG(ERROR) << "connection was reset by peer for \"" << name << "\"";
         return IpcChannelError::CONNECTION_RESET_BY_PEER;
     }
     case EWOULDBLOCK:
@@ -488,7 +515,7 @@ IpcChannelError UnixDomainSocket::convertErrnoToIpcChannelError(const int32_t er
     }
     default:
     {
-        IOX_LOG(ERROR) << "internal logic error in unix domain socket \"" << m_name << "\" occurred";
+        IOX_LOG(ERROR) << "internal logic error in unix domain socket \"" << name << "\" occurred";
         return IpcChannelError::INTERNAL_LOGIC_ERROR;
     }
     }

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -109,12 +109,20 @@ class UnixDomainSocket_test : public Test
     const std::chrono::milliseconds WAIT_IN_MS{10};
     std::atomic_bool doWaitForThread{true};
     static constexpr uint64_t MaxMsgNumber = 10U;
-    UnixDomainSocket server{
-        UnixDomainSocket::create(goodName, IpcChannelSide::SERVER, UnixDomainSocket::MAX_MESSAGE_SIZE, MaxMsgNumber)
-            .expect("Valid UnixDomainSocket")};
-    UnixDomainSocket client{
-        UnixDomainSocket::create(goodName, IpcChannelSide::CLIENT, UnixDomainSocket::MAX_MESSAGE_SIZE, MaxMsgNumber)
-            .expect("Valid UnixDomainSocket")};
+    UnixDomainSocket server{UnixDomainSocketBuilder()
+                                .name(goodName)
+                                .channelSide(IpcChannelSide::SERVER)
+                                .maxMsgSize(UnixDomainSocket::MAX_MESSAGE_SIZE)
+                                .maxMsgNumber(MaxMsgNumber)
+                                .create()
+                                .expect("Valid UnixDomainSocket")};
+    UnixDomainSocket client{UnixDomainSocketBuilder()
+                                .name(goodName)
+                                .channelSide(IpcChannelSide::CLIENT)
+                                .maxMsgSize(UnixDomainSocket::MAX_MESSAGE_SIZE)
+                                .maxMsgNumber(MaxMsgNumber)
+                                .create()
+                                .expect("Valid UnixDomainSocket")};
 };
 
 constexpr uint64_t UnixDomainSocket_test::MaxMsgNumber;

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -192,7 +192,14 @@ template <typename IpcChannelType>
 bool IpcInterface<IpcChannelType>::openIpcChannel(const posix::IpcChannelSide channelSide) noexcept
 {
     m_channelSide = channelSide;
-    IpcChannelType::create(m_runtimeName, m_channelSide, m_maxMessageSize, m_maxMessages)
+
+    using IpcChannelBuilder_t = typename IpcChannelType::Builder_t;
+    IpcChannelBuilder_t()
+        .name(m_runtimeName)
+        .channelSide(m_channelSide)
+        .maxMsgSize(m_maxMessageSize)
+        .maxMsgNumber(m_maxMessages)
+        .create()
         .and_then([this](auto& ipcChannel) { this->m_ipcChannel.emplace(std::move(ipcChannel)); })
         .or_else([](auto& err) {
             IOX_LOG(ERROR) << "unable to create ipc channel with error code: " << static_cast<uint8_t>(err);

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -61,7 +61,10 @@ class CMqInterfaceStartupRace_test : public Test
   public:
     virtual void SetUp()
     {
-        platform::IoxIpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER)
+        platform::IoxIpcChannelType::Builder_t()
+            .name(roudi::IPC_CHANNEL_ROUDI_NAME)
+            .channelSide(IpcChannelSide::SERVER)
+            .create()
             .and_then([this](auto& channel) { this->m_roudiQueue.emplace(std::move(channel)); });
         ASSERT_THAT(m_roudiQueue.has_value(), true);
     }
@@ -101,9 +104,11 @@ class CMqInterfaceStartupRace_test : public Test
 
         if (!m_appQueue.has_value())
         {
-            platform::IoxIpcChannelType::create(MqAppName, IpcChannelSide::CLIENT).and_then([this](auto& channel) {
-                this->m_appQueue.emplace(std::move(channel));
-            });
+            platform::IoxIpcChannelType::Builder_t()
+                .name(MqAppName)
+                .channelSide(IpcChannelSide::CLIENT)
+                .create()
+                .and_then([this](auto& channel) { this->m_appQueue.emplace(std::move(channel)); });
         }
         ASSERT_THAT(m_appQueue.has_value(), true);
 
@@ -143,7 +148,10 @@ TEST_F(CMqInterfaceStartupRace_test, ObsoleteRouDiMq)
             exit(EXIT_FAILURE);
         });
 
-        auto m_roudiQueue2 = platform::IoxIpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER);
+        auto m_roudiQueue2 = platform::IoxIpcChannelType::Builder_t()
+                                 .name(roudi::IPC_CHANNEL_ROUDI_NAME)
+                                 .channelSide(IpcChannelSide::SERVER)
+                                 .create();
 
         // check if the app retries to register at RouDi
         request = m_roudiQueue2->timedReceive(15_s);
@@ -191,7 +199,10 @@ TEST_F(CMqInterfaceStartupRace_test, ObsoleteRouDiMqWithFullMq)
             exit(EXIT_FAILURE);
         });
 
-        auto newRoudi = platform::IoxIpcChannelType::create(roudi::IPC_CHANNEL_ROUDI_NAME, IpcChannelSide::SERVER);
+        auto newRoudi = platform::IoxIpcChannelType::Builder_t()
+                            .name(roudi::IPC_CHANNEL_ROUDI_NAME)
+                            .channelSide(IpcChannelSide::SERVER)
+                            .create();
 
         // check if the app retries to register at RouDi
         auto request = newRoudi->timedReceive(15_s);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR builds upon #2015 which needs to be merged first. It adds the builder pattern to `UnixDomainSocket` and ports the `IpcInterface` to the builder API. If someone wants to review before the merge of #2015, the easiest way would be to check the last five commits.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1036
