### PR TITLE
iox-#1613 Remove EXPECT_DEATH

### DIFF
--- a/doc/design/error-handling.md
+++ b/doc/design/error-handling.md
@@ -281,6 +281,14 @@ TEST(MyTest, valueOnNulloptIsFatal) {
 }
 ```
 
+In cases where the `IOX_EXPECT_FATAL_FAILURE` cannot be used, e.g. testing the `PoshRuntime` with its singleton, `EXPECT_DEATH`
+shall be used with `GTEST_FLAG(death_test_style) = "threadsafe";`.
+
+```cpp
+GTEST_FLAG(death_test_style) = "threadsafe";
+EXPECT_DEATH(bad_call(), ".*");
+```
+
 ## Open points
 
 ### Centralized error handling

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -88,6 +88,8 @@
 - ServiceDescription `Interfaces` and `INTERFACE_NAMES` do not match [\#1977](https://github.com/eclipse-iceoryx/iceoryx/issues/1977)
 - Implement and test nullptr check in c binding [\#1106](https://github.com/eclipse-iceoryx/iceoryx/issues/1106)
 - Fix `expected<void, Error>` is unusable due to `final` [\#1976](https://github.com/eclipse-iceoryx/iceoryx/issues/1976)
+- MacOS tests that use `EXPECT_DEATH` stuck [#898](https://github.com/eclipse-iceoryx/iceoryx/issues/898)
+- Remove `EXPECT_DEATH` [#1613](https://github.com/eclipse-iceoryx/iceoryx/issues/1613)
 
 **Refactoring:**
 

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -62,7 +62,8 @@ MemPool::MemPool(const greater_or_equal<uint32_t, CHUNK_MEMORY_ALIGNMENT> chunkS
     else
     {
         IOX_LOG(FATAL) << "Chunk size must be multiple of '" << CHUNK_MEMORY_ALIGNMENT << "'! Requested size is "
-                       << chunkSize << " for " << numberOfChunks << " chunks!";
+                       << static_cast<uint32_t>(chunkSize) << " for " << static_cast<uint32_t>(numberOfChunks)
+                       << " chunks!";
         errorHandler(PoshError::MEPOO__MEMPOOL_CHUNKSIZE_MUST_BE_MULTIPLE_OF_CHUNK_MEMORY_ALIGNMENT);
     }
 }

--- a/iceoryx_posh/test/integrationtests/test_shm_sigbus_handler.cpp
+++ b/iceoryx_posh/test/integrationtests/test_shm_sigbus_handler.cpp
@@ -45,6 +45,7 @@ TEST(ShmCreatorDeathTest, AllocatingTooMuchMemoryLeadsToExitWithSIGBUS)
             TEST_SHM_NAME, iox::posix::AccessMode::READ_WRITE, iox::posix::OpenMode::PURGE_AND_CREATE);
         ASSERT_FALSE(badShmProvider.addMemoryBlock(&badmempools).has_error());
 
+        GTEST_FLAG(death_test_style) = "threadsafe";
         EXPECT_DEATH(IOX_DISCARD_RESULT(badShmProvider.create()), ".*");
     }
 

--- a/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_memory_manager.cpp
@@ -15,6 +15,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "iceoryx_hoofs/error_handling/error_handling.hpp"
+#include "iceoryx_hoofs/testing/fatal_failure.hpp"
 #include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
@@ -24,6 +26,7 @@
 namespace
 {
 using namespace ::testing;
+using namespace iox::testing;
 
 using iox::mepoo::ChunkHeader;
 using iox::mepoo::ChunkSettings;
@@ -472,7 +475,9 @@ TEST_F(MemoryManager_test, addMemPoolWithChunkCountZeroShouldFail)
 {
     ::testing::Test::RecordProperty("TEST_ID", "be653b65-a2d1-42eb-98b5-d161c6ba7c08");
     mempoolconf.addMemPool({32, 0});
-    EXPECT_DEATH({ sut->configureMemoryManager(mempoolconf, *allocator, *allocator); }, ".*");
+
+    IOX_EXPECT_FATAL_FAILURE<iox::HoofsError>([&] { sut->configureMemoryManager(mempoolconf, *allocator, *allocator); },
+                                              iox::HoofsError::EXPECTS_ENSURES_FAILED);
 }
 
 TEST(MemoryManagerEnumString_test, asStringLiteralConvertsEnumValuesToStrings)

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -140,6 +140,7 @@ TEST_F(PoshRuntime_test, NoAppName)
     ::testing::Test::RecordProperty("TEST_ID", "e053d114-c79c-4391-91e1-8fcfe90ee8e4");
     const iox::RuntimeName_t invalidAppName("");
 
+    GTEST_FLAG(death_test_style) = "threadsafe";
     EXPECT_DEATH({ PoshRuntime::initRuntime(invalidAppName); }, "");
 }
 
@@ -161,6 +162,7 @@ TEST(PoshRuntime, RuntimeFailsWhenAppNameIsNotAFileName)
     {
         const iox::RuntimeName_t invalidAppName(iox::TruncateToCapacity, i);
 
+        GTEST_FLAG(death_test_style) = "threadsafe";
         EXPECT_DEATH(PoshRuntime::initRuntime(invalidAppName), ".*");
     }
 }
@@ -171,6 +173,8 @@ TEST(PoshRuntime, RuntimeFailsWhenAppNameIsNotAFileName)
 TEST(PoshRuntime, AppNameEmpty)
 {
     ::testing::Test::RecordProperty("TEST_ID", "63900656-4fbb-466d-b6cc-f2139121092c");
+
+    GTEST_FLAG(death_test_style) = "threadsafe";
     EXPECT_DEATH({ iox::runtime::PoshRuntime::getInstance(); }, ".*");
 }
 
@@ -1138,6 +1142,7 @@ TEST(PoshRuntimeFactory_test, SetEmptyRuntimeFactoryFails)
     auto mockRuntime = PoshRuntimeMock::create("hypnotoad");
 
     // do not use the setRuntimeFactory in a test with a running RouDiEnvironment
+    GTEST_FLAG(death_test_style) = "threadsafe";
     EXPECT_DEATH(
         {
             class FactoryAccess : public PoshRuntime

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
@@ -15,6 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #if !defined(_WIN32)
+#include "iceoryx_hoofs/testing/fatal_failure.hpp"
+#include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_interface_creator.hpp"
 
 #include "test.hpp"
@@ -27,6 +29,7 @@ using namespace ::testing;
 using namespace iox;
 using namespace iox::posix;
 using namespace iox::runtime;
+using namespace iox::testing;
 
 constexpr char goodName[] = "channel_test";
 constexpr char anotherGoodName[] = "horst";
@@ -67,7 +70,9 @@ TEST_F(IpcInterfaceCreator_test, CreateWithSameNameLeadsToError)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2e8c15c8-1b7b-465b-aae5-6db24fc3c34a");
     IpcInterfaceCreator m_sut{goodName};
-    EXPECT_DEATH({ IpcInterfaceCreator m_sut2{goodName}; }, ".*");
+
+    IOX_EXPECT_FATAL_FAILURE<iox::PoshError>([&] { IpcInterfaceCreator m_sut2{goodName}; },
+                                             iox::PoshError::IPC_INTERFACE__APP_WITH_SAME_NAME_STILL_RUNNING);
 }
 
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR replaces the last remaining `EXPECT_DEATH` with `IOX_EXPECT_FATAL_FAILURE` where feasible. There are a few remaining occurrences which cannot be replaced, e.g. tests for `PoshRuntime` which has a singleton. These tests now use `GTEST_FLAG(death_test_style) = "threadsafe";` to prevent stucking threads.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #1613
- Closes #898
