### PR TITLE
iox-#1755 Distinct overloads for arithmetic types for logstream

### DIFF
--- a/iceoryx_hoofs/reporting/include/iox/detail/log/building_blocks/logformat.inl
+++ b/iceoryx_hoofs/reporting/include/iox/detail/log/building_blocks/logformat.inl
@@ -87,6 +87,11 @@ inline constexpr const char* logFormatDec() noexcept
     return nullptr;
 }
 template <>
+inline constexpr const char* logFormatDec<char>() noexcept
+{
+    return "%c";
+}
+template <>
 inline constexpr const char* logFormatDec<signed char>() noexcept
 {
     return "%hhi";

--- a/iceoryx_hoofs/reporting/include/iox/detail/log/logstream.inl
+++ b/iceoryx_hoofs/reporting/include/iox/detail/log/logstream.inl
@@ -135,6 +135,13 @@ inline LogStream& LogStream::operator<<(const bool val) noexcept
 
 // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : See at declaration in header
 
+inline LogStream& LogStream::operator<<(const char val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
 inline LogStream& LogStream::operator<<(const signed char val) noexcept
 {
     m_logger.logDec(val);

--- a/iceoryx_hoofs/reporting/include/iox/detail/log/logstream.inl
+++ b/iceoryx_hoofs/reporting/include/iox/detail/log/logstream.inl
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 - 2021 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -108,9 +109,10 @@ inline LogStream& LogStream::self() noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
+// AXIVION DISABLE STYLE AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
 // not require to implement '<<='
+
+// AXIVION Next Construct AutosarC++19_03-A3.9.1 : See at declaration in header
 inline LogStream& LogStream::operator<<(const char* cstr) noexcept
 {
     m_logger.logString(cstr);
@@ -118,8 +120,6 @@ inline LogStream& LogStream::operator<<(const char* cstr) noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const std::string& str) noexcept
 {
     m_logger.logString(str.c_str());
@@ -127,26 +127,107 @@ inline LogStream& LogStream::operator<<(const std::string& str) noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const bool val) noexcept
 {
     m_logger.logBool(val);
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
-template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool>>
-inline LogStream& LogStream::operator<<(const T val) noexcept
+// AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : See at declaration in header
+
+inline LogStream& LogStream::operator<<(const signed char val) noexcept
 {
     m_logger.logDec(val);
     m_isFlushed = false;
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
+inline LogStream& LogStream::operator<<(const unsigned char val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const short val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const unsigned short val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const int val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const unsigned int val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const long val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const unsigned long val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const long long val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const unsigned long long val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const float val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const double val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+inline LogStream& LogStream::operator<<(const long double val) noexcept
+{
+    m_logger.logDec(val);
+    m_isFlushed = false;
+    return *this;
+}
+
+// AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
+
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
@@ -156,8 +237,6 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_floating_point<T>::value, bool>>
 inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
 {
@@ -166,8 +245,6 @@ inline LogStream& LogStream::operator<<(const LogHex<T> val) noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogHex<const void* const> val) noexcept
 {
     m_logger.logHex(val.m_value);
@@ -175,8 +252,6 @@ inline LogStream& LogStream::operator<<(const LogHex<const void* const> val) noe
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 template <typename T, typename std::enable_if_t<std::is_integral<T>::value, bool>>
 inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
 {
@@ -186,16 +261,12 @@ inline LogStream& LogStream::operator<<(const LogOct<T> val) noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 template <typename Callable, typename>
 inline LogStream& LogStream::operator<<(const Callable& c) noexcept
 {
     return c(*this);
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 inline LogStream& LogStream::operator<<(const LogLevel value) noexcept
 {
     m_logger.logString(asStringLiteral(value));
@@ -214,14 +285,14 @@ inline LogStreamOff& LogStreamOff::self() noexcept
     return *this;
 }
 
-// AXIVION Next Construct AutosarC++19_03-M5.17.1 : This is not used as shift operator but as stream operator and does
-// not require to implement '<<='
 template <typename T>
 inline LogStreamOff& LogStreamOff::operator<<(T&&) noexcept
 {
     return *this;
 }
 } // namespace internal
+
+// AXIVION ENABLE STYLE AutosarC++19_03-M5.17.1
 
 } // namespace log
 } // namespace iox

--- a/iceoryx_hoofs/reporting/include/iox/log/building_blocks/logformat.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/log/building_blocks/logformat.hpp
@@ -52,6 +52,8 @@ namespace internal
 template <typename T>
 constexpr const char* logFormatDec() noexcept;
 template <>
+constexpr const char* logFormatDec<char>() noexcept;
+template <>
 constexpr const char* logFormatDec<signed char>() noexcept;
 template <>
 constexpr const char* logFormatDec<unsigned char>() noexcept;

--- a/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 - 2021 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -156,17 +157,79 @@ class LogStream
     /// and avoid the std::string dependency; alternatively this could be implemented as free function
     LogStream& operator<<(const std::string& str) noexcept;
 
-    /// @brief Logging support for boolean
-    /// @param[in] val is the boolean to log
+    // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : Basic numeric types are used in order to cover als basic numeric types, independent of the type alias
+
+    /// @brief Logging support for 'boolean'
+    /// @param[in] val is the 'boolean' to log
     /// @return a reference to the LogStream instance
     LogStream& operator<<(const bool val) noexcept;
 
-    /// @brief Logging support for arithmetic numbers in decimal format
-    /// @tparam[in] T is the arithmetic data type of the value to log
-    /// @param[in] val is the number to log
+    /// @brief Logging support for 'signed char'
+    /// @param[in] val is the 'signed char' to log
     /// @return a reference to the LogStream instance
-    template <typename T, typename std::enable_if_t<std::is_arithmetic<T>::value, bool> = 0>
-    LogStream& operator<<(const T val) noexcept;
+    LogStream& operator<<(const signed char val) noexcept;
+
+    /// @brief Logging support for 'unsigned char'
+    /// @param[in] val is the 'unsigned char' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const unsigned char val) noexcept;
+
+    /// @brief Logging support for 'short'
+    /// @param[in] val is the 'short' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const short val) noexcept;
+
+    /// @brief Logging support for 'unsigned shor'
+    /// @param[in] val is the 'unsigned shor' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const unsigned short val) noexcept;
+
+    /// @brief Logging support for 'int'
+    /// @param[in] val is the 'int' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const int val) noexcept;
+
+    /// @brief Logging support for 'unsigned int'
+    /// @param[in] val is the 'unsigned int' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const unsigned int val) noexcept;
+
+    /// @brief Logging support for 'long'
+    /// @param[in] val is the 'long' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const long val) noexcept;
+
+    /// @brief Logging support for 'unsigned long'
+    /// @param[in] val is the 'unsigned long' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const unsigned long val) noexcept;
+
+    /// @brief Logging support for 'long long'
+    /// @param[in] val is the 'long long' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const long long val) noexcept;
+
+    /// @brief Logging support for 'unsigned long long'
+    /// @param[in] val is the 'unsigned long long' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const unsigned long long val) noexcept;
+
+    /// @brief Logging support for 'float'
+    /// @param[in] val is the 'float' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const float val) noexcept;
+
+    /// @brief Logging support for 'double'
+    /// @param[in] val is the 'double' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const double val) noexcept;
+
+    /// @brief Logging support for 'long double'
+    /// @param[in] val is the 'long double' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const long double val) noexcept;
+
+    // AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
 
     /// @brief Logging support for integral numbers in hexadecimal format
     /// @tparam[in] T is the integral data type of the value to log

--- a/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
@@ -157,12 +157,17 @@ class LogStream
     /// and avoid the std::string dependency; alternatively this could be implemented as free function
     LogStream& operator<<(const std::string& str) noexcept;
 
-    // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : Basic numeric types are used in order to cover als basic numeric types, independent of the type alias
-
     /// @brief Logging support for 'boolean'
     /// @param[in] val is the 'boolean' to log
     /// @return a reference to the LogStream instance
     LogStream& operator<<(const bool val) noexcept;
+
+    // AXIVION DISABLE STYLE AutosarC++19_03-A3.9.1 : Basic numeric types are used in order to cover als basic numeric types, independent of the type alias
+
+    /// @brief Logging support for 'char'
+    /// @param[in] val is the 'char' to log
+    /// @return a reference to the LogStream instance
+    LogStream& operator<<(const char val) noexcept;
 
     /// @brief Logging support for 'signed char'
     /// @param[in] val is the 'signed char' to log

--- a/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/log/logstream.hpp
@@ -184,8 +184,8 @@ class LogStream
     /// @return a reference to the LogStream instance
     LogStream& operator<<(const short val) noexcept;
 
-    /// @brief Logging support for 'unsigned shor'
-    /// @param[in] val is the 'unsigned shor' to log
+    /// @brief Logging support for 'unsigned short'
+    /// @param[in] val is the 'unsigned short' to log
     /// @return a reference to the LogStream instance
     LogStream& operator<<(const unsigned short val) noexcept;
 

--- a/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019, 2021 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -350,6 +351,26 @@ TYPED_TEST(IoxLogStreamHexFloatingPoint_test, StreamOperatorLogHex_ValueMax)
     testStreamOperatorLogHexFloatingPoint(this->loggerMock, this->LogValueMax);
 }
 
+template <typename T>
+class Wrapper
+{
+  public:
+    constexpr explicit Wrapper(T value) noexcept
+        : m_value(value)
+    {
+    }
+
+    // NOLINTJUSTIFICATION Implicit conversion is required for the test
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
+    constexpr operator T() const noexcept
+    {
+        return m_value;
+    }
+
+  private:
+    T m_value{};
+};
+
 using ArithmeticTypes =
     Types<bool, int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t, uint32_t, uint64_t, size_t, float, double>;
 
@@ -359,6 +380,8 @@ template <typename Arithmetic>
 class IoxLogStreamArithmetic_test : public IoxLogStream_test
 {
   public:
+    using type_t = Arithmetic;
+
     Arithmetic LogValueLow = std::numeric_limits<Arithmetic>::lowest();
     Arithmetic LogValueMin = std::numeric_limits<Arithmetic>::min();
     Arithmetic LogValueMax = std::numeric_limits<Arithmetic>::max();
@@ -436,6 +459,36 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ValueMax)
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueMax)));
 }
 
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueLow)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "86dccc28-0007-4ab3-88c6-216eeb861fef");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->LogValueLow);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueLow)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueMin)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "72bc51fe-a23f-4c7d-a17f-0e4ad29bee9f");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->LogValueMin);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueMin)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueMax)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "49e79c8b-98c0-4074-aed1-25293bf49bd0");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->LogValueMax);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueMax)));
+}
+
 TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "65cfbc9b-a535-47fa-a543-0c31ba63d4ba");
@@ -463,6 +516,36 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstValueMax)
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueMax)));
 }
 
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueLow)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "77cb68ac-bffb-4cf5-a4c2-119e5aaae307");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstLogValueLow);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueLow)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueMin)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3b042ec2-0a6d-4d24-9a12-dab81736847f");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstLogValueMin);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueMin)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueMax)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "83194cc1-3c2a-4c0e-a413-972a95f36b66");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstLogValueMax);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueMax)));
+}
+
 TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstexprValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e9688979-d209-4718-9810-49684fdd9261");
@@ -485,6 +568,36 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstexprValueMax)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4a6dc777-a53b-4a42-9ab1-e1da893ad884");
     LogStreamSut(this->loggerMock) << this->ConstexprLogValueMax;
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMax)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueLow)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3025b6e3-3abd-49e8-8d3c-f6fa0c164011");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueLow);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueLow)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueMin)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c49ad58d-948a-499a-9e2b-8bbdeb9b5c5e");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueMin);
+
+    ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMin)));
+}
+
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueMax)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8c7637ce-8155-4edc-88e2-a155169934f2");
+    using type_t = typename TestFixture::type_t;
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueMax);
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMax)));

--- a/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
@@ -129,6 +129,45 @@ TEST_F(IoxLogStream_test, StreamOperatorStdString)
     EXPECT_THAT(loggerMock.logs[1].message, StrEq(constLogValue));
 }
 
+TEST_F(IoxLogStream_test, StreamOperatorChar)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "2a1fff17-e388-4f84-bb16-30bb3432ae9d");
+    char logValue{'b'};
+    const char constLogValue{'o'};
+    constexpr char constexprLogValue{'b'};
+    LogStreamSut(loggerMock) << logValue;
+    LogStreamSut(loggerMock) << constLogValue;
+    LogStreamSut(loggerMock) << constexprLogValue;
+
+    ASSERT_THAT(loggerMock.logs.size(), Eq(3U));
+    EXPECT_THAT(loggerMock.logs[0].message, StrEq("b"));
+    EXPECT_THAT(loggerMock.logs[1].message, StrEq("o"));
+    EXPECT_THAT(loggerMock.logs[2].message, StrEq("b"));
+}
+
+TEST_F(IoxLogStream_test, StreamOperator8BitTypesWithCharAsCharacterAndEverythingElseAsNumber)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "707d4c04-1999-4713-b930-e113969617e0");
+    char cc{'a'};
+    signed char sc{'a'};
+    unsigned char uc{'a'};
+    int8_t i8{'a'};
+    uint8_t u8{'a'};
+
+    LogStreamSut(loggerMock) << cc;
+    LogStreamSut(loggerMock) << sc;
+    LogStreamSut(loggerMock) << uc;
+    LogStreamSut(loggerMock) << i8;
+    LogStreamSut(loggerMock) << u8;
+
+    ASSERT_THAT(loggerMock.logs.size(), Eq(5U));
+    EXPECT_THAT(loggerMock.logs[0].message, StrEq("a"));
+    EXPECT_THAT(loggerMock.logs[1].message, StrEq("97"));
+    EXPECT_THAT(loggerMock.logs[2].message, StrEq("97"));
+    EXPECT_THAT(loggerMock.logs[3].message, StrEq("97"));
+    EXPECT_THAT(loggerMock.logs[4].message, StrEq("97"));
+}
+
 TEST_F(IoxLogStream_test, StreamOperatorLogLevel)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d85b7ef4-35de-4e11-b0fd-f0de6581a9e6");

--- a/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_reporting_logstream.cpp
@@ -134,10 +134,10 @@ TEST_F(IoxLogStream_test, StreamOperatorChar)
     ::testing::Test::RecordProperty("TEST_ID", "2a1fff17-e388-4f84-bb16-30bb3432ae9d");
     char logValue{'b'};
     const char constLogValue{'o'};
-    constexpr char constexprLogValue{'b'};
+    constexpr char CONSTEXPR_LOG_VALUE{'b'};
     LogStreamSut(loggerMock) << logValue;
     LogStreamSut(loggerMock) << constLogValue;
-    LogStreamSut(loggerMock) << constexprLogValue;
+    LogStreamSut(loggerMock) << CONSTEXPR_LOG_VALUE;
 
     ASSERT_THAT(loggerMock.logs.size(), Eq(3U));
     EXPECT_THAT(loggerMock.logs[0].message, StrEq("b"));
@@ -429,19 +429,19 @@ class IoxLogStreamArithmetic_test : public IoxLogStream_test
     const Arithmetic ConstLogValueMin = std::numeric_limits<Arithmetic>::min();
     const Arithmetic ConstLogValueMax = std::numeric_limits<Arithmetic>::max();
 
-    static constexpr Arithmetic ConstexprLogValueLow = std::numeric_limits<Arithmetic>::lowest();
-    static constexpr Arithmetic ConstexprLogValueMin = std::numeric_limits<Arithmetic>::min();
-    static constexpr Arithmetic ConstexprLogValueMax = std::numeric_limits<Arithmetic>::max();
+    static constexpr Arithmetic CONSTEXPR_LOG_VALUE_LOW = std::numeric_limits<Arithmetic>::lowest();
+    static constexpr Arithmetic CONSTEXPR_LOG_VALUE_MIN = std::numeric_limits<Arithmetic>::min();
+    static constexpr Arithmetic CONSTEXPR_LOG_VALUE_MAX = std::numeric_limits<Arithmetic>::max();
 };
 
 template <typename Arithmetic>
-constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::ConstexprLogValueLow;
+constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::CONSTEXPR_LOG_VALUE_LOW;
 
 template <typename Arithmetic>
-constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::ConstexprLogValueMin;
+constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::CONSTEXPR_LOG_VALUE_MIN;
 
 template <typename Arithmetic>
-constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::ConstexprLogValueMax;
+constexpr Arithmetic IoxLogStreamArithmetic_test<Arithmetic>::CONSTEXPR_LOG_VALUE_MAX;
 
 template <typename T>
 std::string convertToString(const T val)
@@ -498,7 +498,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ValueMax)
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueMax)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueLow)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "86dccc28-0007-4ab3-88c6-216eeb861fef");
     using type_t = typename TestFixture::type_t;
@@ -508,7 +508,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConv
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueLow)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueMin)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ValueMin)
 {
     ::testing::Test::RecordProperty("TEST_ID", "72bc51fe-a23f-4c7d-a17f-0e4ad29bee9f");
     using type_t = typename TestFixture::type_t;
@@ -518,7 +518,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConv
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->LogValueMin)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ValueMax)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ValueMax)
 {
     ::testing::Test::RecordProperty("TEST_ID", "49e79c8b-98c0-4074-aed1-25293bf49bd0");
     using type_t = typename TestFixture::type_t;
@@ -555,7 +555,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstValueMax)
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueMax)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueLow)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "77cb68ac-bffb-4cf5-a4c2-119e5aaae307");
     using type_t = typename TestFixture::type_t;
@@ -565,7 +565,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConv
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueLow)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueMin)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstValueMin)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3b042ec2-0a6d-4d24-9a12-dab81736847f");
     using type_t = typename TestFixture::type_t;
@@ -575,7 +575,7 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConv
     EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstLogValueMin)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstValueMax)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstValueMax)
 {
     ::testing::Test::RecordProperty("TEST_ID", "83194cc1-3c2a-4c0e-a413-972a95f36b66");
     using type_t = typename TestFixture::type_t;
@@ -588,58 +588,58 @@ TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConv
 TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstexprValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e9688979-d209-4718-9810-49684fdd9261");
-    LogStreamSut(this->loggerMock) << this->ConstexprLogValueLow;
+    LogStreamSut(this->loggerMock) << this->CONSTEXPR_LOG_VALUE_LOW;
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueLow)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_LOW)));
 }
 
 TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstexprValueMin)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f6799599-582a-454c-85b8-b2059a5d50c6");
-    LogStreamSut(this->loggerMock) << this->ConstexprLogValueMin;
+    LogStreamSut(this->loggerMock) << this->CONSTEXPR_LOG_VALUE_MIN;
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMin)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_MIN)));
 }
 
 TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_ConstexprValueMax)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4a6dc777-a53b-4a42-9ab1-e1da893ad884");
-    LogStreamSut(this->loggerMock) << this->ConstexprLogValueMax;
+    LogStreamSut(this->loggerMock) << this->CONSTEXPR_LOG_VALUE_MAX;
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMax)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_MAX)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueLow)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstexprValueLow)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3025b6e3-3abd-49e8-8d3c-f6fa0c164011");
     using type_t = typename TestFixture::type_t;
-    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueLow);
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->CONSTEXPR_LOG_VALUE_LOW);
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueLow)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_LOW)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueMin)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstexprValueMin)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c49ad58d-948a-499a-9e2b-8bbdeb9b5c5e");
     using type_t = typename TestFixture::type_t;
-    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueMin);
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->CONSTEXPR_LOG_VALUE_MIN);
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMin)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_MIN)));
 }
 
-TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitelyConverted_ConstexprValueMax)
+TYPED_TEST(IoxLogStreamArithmetic_test, StreamOperator_WrappedAndImplicitlyConverted_ConstexprValueMax)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8c7637ce-8155-4edc-88e2-a155169934f2");
     using type_t = typename TestFixture::type_t;
-    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->ConstexprLogValueMax);
+    LogStreamSut(this->loggerMock) << Wrapper<type_t>(this->CONSTEXPR_LOG_VALUE_MAX);
 
     ASSERT_THAT(this->loggerMock.logs.size(), Eq(1U));
-    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->ConstexprLogValueMax)));
+    EXPECT_THAT(this->loggerMock.logs[0].message, StrEq(convertToString(this->CONSTEXPR_LOG_VALUE_MAX)));
 }
 
 } // namespace


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds distinct overloads for `LogStream& operator <<`. This enabled implicit type conversion to the underlying type of e.g. `Wrapper<T>` if the implicit `operator T()` is implemented.

Additionally, it is finally possible to log `char` instead of only `signed char` and `unsigned char`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1755
