### PR TITLE
iox-#1391 Move dust header from legacy path to module path part 3

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -13,6 +13,18 @@
 ---
 
 #
+# Filter to run the CI only on the master and release branches or for pull request to the master, release* and iox-* branches
+#
+
+only_if: $CIRRUS_BRANCH == 'master'
+         || $CIRRUS_BRANCH == 'release*'
+         || ($CIRRUS_PR != '' && ($CIRRUS_BASE_BRANCH == 'master'
+                                  || $CIRRUS_BASE_BRANCH == 'release*'
+                                  || $CIRRUS_BASE_BRANCH == 'iox-*'
+                                  )
+            )
+
+#
 # Templates
 #
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,5 @@
 https://github.com/eclipse-iceoryx/iceoryx/compare/vx.x.x...vx.x.x
 https://github.com/eclipse-iceoryx/iceoryx/tree/vx.x.x
+https://www.misra.org.uk/
 
 iceoryx-dev@eclipse.org

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -1006,7 +1006,7 @@
     #include "iceoryx_hoofs/posix_wrapper/named_pipe.hpp"
 
     // after
-    #include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
+    #include "iox/named_pipe.hpp"
     ```
 
     ```cpp

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -998,7 +998,7 @@
     #include "iceoryx_hoofs/posix_wrapper/internal/message_queue.hpp"
 
     // after
-    #include "iox/message_queue.hpp"
+    #include "iox/posix/message_queue.hpp"
     ```
 
     ```cpp
@@ -1006,7 +1006,7 @@
     #include "iceoryx_hoofs/posix_wrapper/named_pipe.hpp"
 
     // after
-    #include "iox/named_pipe.hpp"
+    #include "iox/posix/named_pipe.hpp"
     ```
 
     ```cpp
@@ -1014,7 +1014,7 @@
     #include "iceoryx_hoofs/posix_wrapper/signal_watcher.hpp"
 
     // after
-    #include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+    #include "iox/posix/signal_watcher.hpp"
     ```
 
     ```cpp

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -998,7 +998,7 @@
     #include "iceoryx_hoofs/posix_wrapper/internal/message_queue.hpp"
 
     // after
-    #include "iceoryx_dust/posix_wrapper/message_queue.hpp"
+    #include "iox/message_queue.hpp"
     ```
 
     ```cpp

--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -27,9 +27,9 @@ extern "C" {
 
 void iox_runtime_init(const char* const name)
 {
-    IOX_EXPECTS(name != nullptr && "Runtime name is a nullptr!");
-    IOX_EXPECTS(strnlen(name, iox::MAX_RUNTIME_NAME_LENGTH + 1) <= MAX_RUNTIME_NAME_LENGTH
-                && "Runtime name has more than 100 characters!");
+    IOX_EXPECTS_WITH_MSG(name != nullptr, "Runtime name is a nullptr!");
+    IOX_EXPECTS_WITH_MSG(strnlen(name, iox::MAX_RUNTIME_NAME_LENGTH + 1) <= MAX_RUNTIME_NAME_LENGTH,
+                         "Runtime name has more than 100 characters!");
 
     PoshRuntime::initRuntime(RuntimeName_t(iox::TruncateToCapacity, name));
 }

--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -32,10 +32,11 @@ cc_library(
     srcs = glob([
         "cli/source/**/*.cpp",
         "filesystem/source/**/*.cpp",
+        "posix/ipc/source/**/*.cpp",
         "source/**/*.cpp",
         "source/**/*.hpp",
     ]),
-    hdrs = glob(["include/**"]) + glob(["cli/**"]) + glob(["container/**"]) + glob(["filesystem/**"]) + glob(["memory/**"]) + glob(["utility/**"]) + glob(["vocabulary/**"]) + [
+    hdrs = glob(["include/**"]) + glob(["cli/**"]) + glob(["container/**"]) + glob(["filesystem/**"]) + glob(["memory/**"]) + glob(["utility/**"]) + glob(["posix/ipc/**"]) + glob(["vocabulary/**"]) + [
         ":iceoryx_dust_deployment_hpp",
     ],
     includes = [
@@ -44,6 +45,7 @@ cc_library(
         "filesystem/include/",
         "include",
         "memory/include/",
+        "posix/ipc/include/",
         "utility/include/",
         "vocabulary/include/",
     ],

--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -33,19 +33,18 @@ cc_library(
         "cli/source/**/*.cpp",
         "filesystem/source/**/*.cpp",
         "posix/ipc/source/**/*.cpp",
-        "source/**/*.cpp",
-        "source/**/*.hpp",
+        "posix/sync/source/**/*.cpp",
     ]),
-    hdrs = glob(["include/**"]) + glob(["cli/**"]) + glob(["container/**"]) + glob(["filesystem/**"]) + glob(["memory/**"]) + glob(["utility/**"]) + glob(["posix/ipc/**"]) + glob(["vocabulary/**"]) + [
+    hdrs = glob(["cli/**"]) + glob(["container/**"]) + glob(["filesystem/**"]) + glob(["memory/**"]) + glob(["utility/**"]) + glob(["posix/ipc/**"]) + glob(["posix/sync/**"]) + glob(["vocabulary/**"]) + [
         ":iceoryx_dust_deployment_hpp",
     ],
     includes = [
         "cli/include/",
         "container/include/",
         "filesystem/include/",
-        "include",
         "memory/include/",
         "posix/ipc/include/",
+        "posix/sync/include/",
         "utility/include/",
         "vocabulary/include/",
     ],

--- a/iceoryx_dust/BUILD.bazel
+++ b/iceoryx_dust/BUILD.bazel
@@ -20,7 +20,7 @@ load("//bazel:configure_file.bzl", "configure_file")
 configure_file(
     name = "iceoryx_dust_deployment_hpp",
     src = "cmake/iceoryx_dust_deployment.hpp.in",
-    out = "include/iox/iceoryx_dust_deployment.hpp",
+    out = "generated/include/iox/iceoryx_dust_deployment.hpp",
     config = {
         "IOX_MAX_NAMED_PIPE_MESSAGE_SIZE": "4096",
         "IOX_MAX_NAMED_PIPE_NUMBER_OF_MESSAGES": "10",
@@ -42,6 +42,7 @@ cc_library(
         "cli/include/",
         "container/include/",
         "filesystem/include/",
+        "generated/include/",
         "memory/include/",
         "posix/ipc/include/",
         "posix/sync/include/",

--- a/iceoryx_dust/CMakeLists.txt
+++ b/iceoryx_dust/CMakeLists.txt
@@ -71,9 +71,9 @@ iox_add_library(
         cli/source/option_definition.cpp
         cli/source/option_manager.cpp
         filesystem/source/file_reader.cpp
-        source/posix_wrapper/named_pipe.cpp
-        source/posix_wrapper/signal_watcher.cpp
         posix/ipc/source/message_queue.cpp
+        posix/ipc/source/named_pipe.cpp
+        source/posix_wrapper/signal_watcher.cpp
 )
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/iceoryx_dust_deployment.hpp.in"

--- a/iceoryx_dust/CMakeLists.txt
+++ b/iceoryx_dust/CMakeLists.txt
@@ -46,22 +46,22 @@ iox_add_library(
     PRIVATE_LIBS                ${ICEORYX_SANITIZER_FLAGS}
     PRIVATE_LIBS_LINUX          ${CODE_COVERAGE_LIBS}
     PUBLIC_LIBS                 iceoryx_hoofs::iceoryx_hoofs
-    BUILD_INTERFACE             ${PROJECT_SOURCE_DIR}/include
-                                ${PROJECT_SOURCE_DIR}/cli/include
+    BUILD_INTERFACE             ${PROJECT_SOURCE_DIR}/cli/include
                                 ${PROJECT_SOURCE_DIR}/container/include
                                 ${PROJECT_SOURCE_DIR}/filesystem/include
                                 ${PROJECT_SOURCE_DIR}/memory/include
                                 ${PROJECT_SOURCE_DIR}/posix/ipc/include
+                                ${PROJECT_SOURCE_DIR}/posix/sync/include
                                 ${PROJECT_SOURCE_DIR}/utility/include
                                 ${PROJECT_SOURCE_DIR}/vocabulary/include
                                 ${CMAKE_BINARY_DIR}/generated/iceoryx_dust/include
     INSTALL_INTERFACE           include/${PREFIX}
-    EXPORT_INCLUDE_DIRS         include/
-                                cli/include/
+    EXPORT_INCLUDE_DIRS         cli/include/
                                 container/include/
                                 filesystem/include/
                                 memory/include/
                                 posix/ipc/include/
+                                posix/sync/include/
                                 utility/include/
                                 vocabulary/include/
     FILES
@@ -73,7 +73,7 @@ iox_add_library(
         filesystem/source/file_reader.cpp
         posix/ipc/source/message_queue.cpp
         posix/ipc/source/named_pipe.cpp
-        source/posix_wrapper/signal_watcher.cpp
+        posix/sync/source/signal_watcher.cpp
 )
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/iceoryx_dust_deployment.hpp.in"

--- a/iceoryx_dust/CMakeLists.txt
+++ b/iceoryx_dust/CMakeLists.txt
@@ -51,6 +51,7 @@ iox_add_library(
                                 ${PROJECT_SOURCE_DIR}/container/include
                                 ${PROJECT_SOURCE_DIR}/filesystem/include
                                 ${PROJECT_SOURCE_DIR}/memory/include
+                                ${PROJECT_SOURCE_DIR}/posix/ipc/include
                                 ${PROJECT_SOURCE_DIR}/utility/include
                                 ${PROJECT_SOURCE_DIR}/vocabulary/include
                                 ${CMAKE_BINARY_DIR}/generated/iceoryx_dust/include
@@ -60,6 +61,7 @@ iox_add_library(
                                 container/include/
                                 filesystem/include/
                                 memory/include/
+                                posix/ipc/include/
                                 utility/include/
                                 vocabulary/include/
     FILES
@@ -71,7 +73,7 @@ iox_add_library(
         filesystem/source/file_reader.cpp
         source/posix_wrapper/named_pipe.cpp
         source/posix_wrapper/signal_watcher.cpp
-        source/posix_wrapper/message_queue.cpp
+        posix/ipc/source/message_queue.cpp
 )
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/iceoryx_dust_deployment.hpp.in"

--- a/iceoryx_dust/container/include/iox/detail/forward_list.inl
+++ b/iceoryx_dust/container/include/iox/detail/forward_list.inl
@@ -329,7 +329,7 @@ template <typename T, uint64_t Capacity>
 inline T& forward_list<T, Capacity>::front() noexcept
 {
     auto iter = begin();
-    IOX_EXPECTS(isValidElementIdx(iter.m_iterListNodeIdx) && "Invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(iter.m_iterListNodeIdx), "Invalid list element");
     return *iter;
 }
 
@@ -337,7 +337,7 @@ template <typename T, uint64_t Capacity>
 inline const T& forward_list<T, Capacity>::front() const noexcept
 {
     auto citer = cbegin();
-    IOX_EXPECTS(isValidElementIdx(citer.m_iterListNodeIdx) && "Invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(citer.m_iterListNodeIdx), "Invalid list element");
     return *citer;
 }
 
@@ -556,7 +556,7 @@ inline void forward_list<T, Capacity>::setNextIdx(const size_type idx, const siz
 template <typename T, uint64_t Capacity>
 inline const T* forward_list<T, Capacity>::getDataPtrFromIdx(const size_type idx) const noexcept
 {
-    IOX_EXPECTS(isValidElementIdx(idx) && "Invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(idx), "Invalid list element");
 
     // safe since m_data entries are aligned to T
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -597,14 +597,14 @@ inline bool forward_list<T, Capacity>::isInvalidIterator(const const_iterator& i
 {
     // iterator's member m_iterListNodeIdx and nextIndex are not checked here to be <= END_INDEX as this
     // should (can) never happen though normal list operations.
-    IOX_EXPECTS(!isInvalidElement(iter.m_iterListNodeIdx) && "invalidated iterator");
+    IOX_EXPECTS_WITH_MSG(!isInvalidElement(iter.m_iterListNodeIdx), "invalidated iterator");
     return false;
 }
 
 template <typename T, uint64_t Capacity>
 inline bool forward_list<T, Capacity>::isInvalidIterOrDifferentLists(const const_iterator& iter) const noexcept
 {
-    IOX_EXPECTS((this == iter.m_list) && "iterator of other list can't be used");
+    IOX_EXPECTS_WITH_MSG((this == iter.m_list), "iterator of other list can't be used");
     return isInvalidIterator(iter);
 }
 

--- a/iceoryx_dust/posix/ipc/include/iox/message_queue.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/message_queue.hpp
@@ -15,8 +15,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_DUST_POSIX_WRAPPER_MESSAGE_QUEUE_HPP
-#define IOX_DUST_POSIX_WRAPPER_MESSAGE_QUEUE_HPP
+
+#ifndef IOX_DUST_POSIX_IPC_MESSAGE_QUEUE_HPP
+#define IOX_DUST_POSIX_IPC_MESSAGE_QUEUE_HPP
 
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
 #include "iceoryx_platform/fcntl.hpp"
@@ -29,14 +30,12 @@
 
 namespace iox
 {
-namespace posix
-{
 class MessageQueueBuilder;
 
 /// @brief Wrapper class for posix message queue
 ///
 /// @code
-///     auto mq = iox::posix::MessageQueueBuilder()
+///     auto mq = iox::MessageQueueBuilder()
 ///                 .name("/MqName123")
 ///                 .channelSide(iox::posix::IpcChannelSide::CLIENT)
 ///                 .create();
@@ -68,27 +67,28 @@ class MessageQueue
 
     ~MessageQueue() noexcept;
 
-    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief send a message to queue using std::string.
     /// @return true if sent without errors, false otherwise
-    expected<void, IpcChannelError> send(const std::string& msg) const noexcept;
+    expected<void, posix::IpcChannelError> send(const std::string& msg) const noexcept;
 
     /// @todo iox-#1693 zero copy receive with receive(iox::string&); iox::string would be the buffer for mq_receive
 
     /// @brief receive message from queue using std::string.
     /// @return number of characters received. In case of an error, returns -1 and msg is empty.
-    expected<std::string, IpcChannelError> receive() const noexcept;
+    expected<std::string, posix::IpcChannelError> receive() const noexcept;
 
     /// @brief try to receive message from queue for a given timeout duration using std::string. Only defined
     /// for NON_BLOCKING == false.
     /// @return optional containing the received string. In case of an error, nullopt type is returned.
-    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
     /// @brief try to send a message to the queue for a given timeout duration using std::string
-    expected<void, IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
+    expected<void, posix::IpcChannelError> timedSend(const std::string& msg,
+                                                     const units::Duration& timeout) const noexcept;
 
-    static expected<bool, IpcChannelError> isOutdated() noexcept;
+    static expected<bool, posix::IpcChannelError> isOutdated() noexcept;
 
   private:
     friend class MessageQueueBuilder;
@@ -96,23 +96,24 @@ class MessageQueue
     MessageQueue(const IpcChannelName_t& name,
                  const mq_attr attributes,
                  mqd_t mqDescriptor,
-                 const IpcChannelSide channelSide) noexcept;
+                 const posix::IpcChannelSide channelSide) noexcept;
 
-    static expected<mqd_t, IpcChannelError>
-    open(const IpcChannelName_t& name, mq_attr& attributes, const IpcChannelSide channelSide) noexcept;
+    static expected<mqd_t, posix::IpcChannelError>
+    open(const IpcChannelName_t& name, mq_attr& attributes, const posix::IpcChannelSide channelSide) noexcept;
 
-    expected<void, IpcChannelError> close() noexcept;
-    expected<void, IpcChannelError> unlink() noexcept;
-    IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
-    static IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
-    static expected<IpcChannelName_t, IpcChannelError> sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
-    expected<void, IpcChannelError> destroy() noexcept;
+    expected<void, posix::IpcChannelError> close() noexcept;
+    expected<void, posix::IpcChannelError> unlink() noexcept;
+    posix::IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
+    static posix::IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
+    static expected<IpcChannelName_t, posix::IpcChannelError>
+    sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
+    expected<void, posix::IpcChannelError> destroy() noexcept;
 
   private:
     IpcChannelName_t m_name;
     mq_attr m_attributes{};
     mqd_t m_mqDescriptor = INVALID_DESCRIPTOR;
-    IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;
+    posix::IpcChannelSide m_channelSide = posix::IpcChannelSide::CLIENT;
 
 #ifdef __QNX__
     static constexpr int TIMEOUT_ERRNO = EINTR;
@@ -132,7 +133,7 @@ class MessageQueueBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the message queue is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the message queue
     IOX_BUILDER_PARAMETER(uint64_t, maxMsgSize, MessageQueue::MAX_MESSAGE_SIZE)
@@ -143,10 +144,9 @@ class MessageQueueBuilder
   public:
     /// @brief create a message queue
     /// @return On success a 'MessageQueue' is returned and on failure an 'IpcChannelError'.
-    expected<MessageQueue, IpcChannelError> create() const noexcept;
+    expected<MessageQueue, posix::IpcChannelError> create() const noexcept;
 };
 
-} // namespace posix
 } // namespace iox
 
-#endif // IOX_DUST_POSIX_WRAPPER_MESSAGE_QUEUE_HPP
+#endif // IOX_DUST_POSIX_IPC_MESSAGE_QUEUE_HPP

--- a/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_DUST_POSIX_WRAPPER_NAMED_PIPE_HPP
-#define IOX_DUST_POSIX_WRAPPER_NAMED_PIPE_HPP
+
+#ifndef IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP
+#define IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP
 
 #include "iceoryx_hoofs/concurrent/lockfree_queue.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/ipc_channel.hpp"
@@ -33,8 +34,6 @@
 #include <cstdint>
 
 namespace iox
-{
-namespace posix
 {
 class NamedPipeBuilder;
 
@@ -71,51 +70,51 @@ class NamedPipe
     /// @brief removes a named pipe artifact from the system
     /// @return true if the artifact was removed, false when no artifact was found and
     ///         IpcChannelError::INTERNAL_LOGIC_ERROR when shm_unlink failed
-    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief tries to send a message via the named pipe. if the pipe is full IpcChannelError::TIMEOUT is returned
     /// @return on failure an error which describes the failure
-    expected<void, IpcChannelError> trySend(const std::string& message) const noexcept;
+    expected<void, posix::IpcChannelError> trySend(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe. if the pipe is full this call is blocking until the message could be
     ///        delivered
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, IpcChannelError> send(const std::string& message) const noexcept;
+    expected<void, posix::IpcChannelError> send(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe.
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @param[in] timeout the timeout on how long this method should retry to send the message
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, IpcChannelError> timedSend(const std::string& message,
-                                              const units::Duration& timeout) const noexcept;
+    expected<void, posix::IpcChannelError> timedSend(const std::string& message,
+                                                     const units::Duration& timeout) const noexcept;
 
     /// @brief tries to receive a message via the named pipe. if the pipe is empty IpcChannelError::TIMEOUT is returned
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> tryReceive() const noexcept;
+    expected<std::string, posix::IpcChannelError> tryReceive() const noexcept;
 
     /// @brief receives a message via the named pipe. if the pipe is empty this call is blocking until a message was
     ///        received
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> receive() const noexcept;
+    expected<std::string, posix::IpcChannelError> receive() const noexcept;
 
     /// @brief receives a message via the named pipe.
     /// @param[in] timeout the timeout on how long this method should retry to receive a message
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
   private:
     friend class NamedPipeBuilder;
 
     class NamedPipeData;
-    NamedPipe(SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
+    NamedPipe(posix::SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
 
     template <typename Prefix>
     static IpcChannelName_t mapToSharedMemoryName(const Prefix& p, const IpcChannelName_t& name) noexcept;
 
     /// @brief destroys an initialized named pipe.
     /// @return is always successful
-    expected<void, IpcChannelError> destroy() noexcept;
+    expected<void, posix::IpcChannelError> destroy() noexcept;
 
     class NamedPipeData
     {
@@ -128,10 +127,10 @@ class NamedPipe
         NamedPipeData& operator=(NamedPipeData&& rhs) = delete;
         ~NamedPipeData() = default;
 
-        UnnamedSemaphore& sendSemaphore() noexcept;
-        UnnamedSemaphore& receiveSemaphore() noexcept;
+        posix::UnnamedSemaphore& sendSemaphore() noexcept;
+        posix::UnnamedSemaphore& receiveSemaphore() noexcept;
 
-        expected<void, IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
+        expected<void, posix::IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
 
         bool waitForInitialization() const noexcept;
         bool hasValidState() const noexcept;
@@ -145,12 +144,12 @@ class NamedPipe
         static constexpr units::Duration WAIT_FOR_INIT_SLEEP_TIME = units::Duration::fromMilliseconds(1);
 
         std::atomic<uint64_t> initializationGuard{INVALID_DATA};
-        optional<UnnamedSemaphore> m_sendSemaphore;
-        optional<UnnamedSemaphore> m_receiveSemaphore;
+        optional<posix::UnnamedSemaphore> m_sendSemaphore;
+        optional<posix::UnnamedSemaphore> m_receiveSemaphore;
     };
 
   private:
-    SharedMemoryObject m_sharedMemory;
+    posix::SharedMemoryObject m_sharedMemory;
     NamedPipeData* m_data = nullptr;
 };
 
@@ -160,7 +159,7 @@ class NamedPipeBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the named pipe is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the named pipe
     IOX_BUILDER_PARAMETER(size_t, maxMsgSize, NamedPipe::MAX_MESSAGE_SIZE)
@@ -171,10 +170,9 @@ class NamedPipeBuilder
   public:
     /// @brief create a named pipe
     /// @return On success a 'NamedPipe' is returned and on failure an 'IpcChannelError'.
-    expected<NamedPipe, IpcChannelError> create() const noexcept;
+    expected<NamedPipe, posix::IpcChannelError> create() const noexcept;
 };
 
-} // namespace posix
 } // namespace iox
 
-#endif
+#endif // IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP

--- a/iceoryx_dust/posix/ipc/include/iox/posix/message_queue.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/posix/message_queue.hpp
@@ -30,12 +30,14 @@
 
 namespace iox
 {
+namespace posix
+{
 class MessageQueueBuilder;
 
 /// @brief Wrapper class for posix message queue
 ///
 /// @code
-///     auto mq = iox::MessageQueueBuilder()
+///     auto mq = iox::posix::MessageQueueBuilder()
 ///                 .name("/MqName123")
 ///                 .channelSide(iox::posix::IpcChannelSide::CLIENT)
 ///                 .create();
@@ -67,28 +69,27 @@ class MessageQueue
 
     ~MessageQueue() noexcept;
 
-    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief send a message to queue using std::string.
     /// @return true if sent without errors, false otherwise
-    expected<void, posix::IpcChannelError> send(const std::string& msg) const noexcept;
+    expected<void, IpcChannelError> send(const std::string& msg) const noexcept;
 
     /// @todo iox-#1693 zero copy receive with receive(iox::string&); iox::string would be the buffer for mq_receive
 
     /// @brief receive message from queue using std::string.
     /// @return number of characters received. In case of an error, returns -1 and msg is empty.
-    expected<std::string, posix::IpcChannelError> receive() const noexcept;
+    expected<std::string, IpcChannelError> receive() const noexcept;
 
     /// @brief try to receive message from queue for a given timeout duration using std::string. Only defined
     /// for NON_BLOCKING == false.
     /// @return optional containing the received string. In case of an error, nullopt type is returned.
-    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
     /// @brief try to send a message to the queue for a given timeout duration using std::string
-    expected<void, posix::IpcChannelError> timedSend(const std::string& msg,
-                                                     const units::Duration& timeout) const noexcept;
+    expected<void, IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
 
-    static expected<bool, posix::IpcChannelError> isOutdated() noexcept;
+    static expected<bool, IpcChannelError> isOutdated() noexcept;
 
   private:
     friend class MessageQueueBuilder;
@@ -96,24 +97,23 @@ class MessageQueue
     MessageQueue(const IpcChannelName_t& name,
                  const mq_attr attributes,
                  mqd_t mqDescriptor,
-                 const posix::IpcChannelSide channelSide) noexcept;
+                 const IpcChannelSide channelSide) noexcept;
 
-    static expected<mqd_t, posix::IpcChannelError>
-    open(const IpcChannelName_t& name, mq_attr& attributes, const posix::IpcChannelSide channelSide) noexcept;
+    static expected<mqd_t, IpcChannelError>
+    open(const IpcChannelName_t& name, mq_attr& attributes, const IpcChannelSide channelSide) noexcept;
 
-    expected<void, posix::IpcChannelError> close() noexcept;
-    expected<void, posix::IpcChannelError> unlink() noexcept;
-    posix::IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
-    static posix::IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
-    static expected<IpcChannelName_t, posix::IpcChannelError>
-    sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
-    expected<void, posix::IpcChannelError> destroy() noexcept;
+    expected<void, IpcChannelError> close() noexcept;
+    expected<void, IpcChannelError> unlink() noexcept;
+    IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
+    static IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
+    static expected<IpcChannelName_t, IpcChannelError> sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
+    expected<void, IpcChannelError> destroy() noexcept;
 
   private:
     IpcChannelName_t m_name;
     mq_attr m_attributes{};
     mqd_t m_mqDescriptor = INVALID_DESCRIPTOR;
-    posix::IpcChannelSide m_channelSide = posix::IpcChannelSide::CLIENT;
+    IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;
 
 #ifdef __QNX__
     static constexpr int TIMEOUT_ERRNO = EINTR;
@@ -133,7 +133,7 @@ class MessageQueueBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the message queue is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the message queue
     IOX_BUILDER_PARAMETER(uint64_t, maxMsgSize, MessageQueue::MAX_MESSAGE_SIZE)
@@ -144,9 +144,10 @@ class MessageQueueBuilder
   public:
     /// @brief create a message queue
     /// @return On success a 'MessageQueue' is returned and on failure an 'IpcChannelError'.
-    expected<MessageQueue, posix::IpcChannelError> create() const noexcept;
+    expected<MessageQueue, IpcChannelError> create() const noexcept;
 };
 
+} // namespace posix
 } // namespace iox
 
 #endif // IOX_DUST_POSIX_IPC_MESSAGE_QUEUE_HPP

--- a/iceoryx_dust/posix/ipc/include/iox/posix/named_pipe.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/posix/named_pipe.hpp
@@ -35,6 +35,8 @@
 
 namespace iox
 {
+namespace posix
+{
 class NamedPipeBuilder;
 
 class NamedPipe
@@ -70,51 +72,51 @@ class NamedPipe
     /// @brief removes a named pipe artifact from the system
     /// @return true if the artifact was removed, false when no artifact was found and
     ///         IpcChannelError::INTERNAL_LOGIC_ERROR when shm_unlink failed
-    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief tries to send a message via the named pipe. if the pipe is full IpcChannelError::TIMEOUT is returned
     /// @return on failure an error which describes the failure
-    expected<void, posix::IpcChannelError> trySend(const std::string& message) const noexcept;
+    expected<void, IpcChannelError> trySend(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe. if the pipe is full this call is blocking until the message could be
     ///        delivered
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, posix::IpcChannelError> send(const std::string& message) const noexcept;
+    expected<void, IpcChannelError> send(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe.
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @param[in] timeout the timeout on how long this method should retry to send the message
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, posix::IpcChannelError> timedSend(const std::string& message,
-                                                     const units::Duration& timeout) const noexcept;
+    expected<void, IpcChannelError> timedSend(const std::string& message,
+                                              const units::Duration& timeout) const noexcept;
 
     /// @brief tries to receive a message via the named pipe. if the pipe is empty IpcChannelError::TIMEOUT is returned
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, posix::IpcChannelError> tryReceive() const noexcept;
+    expected<std::string, IpcChannelError> tryReceive() const noexcept;
 
     /// @brief receives a message via the named pipe. if the pipe is empty this call is blocking until a message was
     ///        received
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, posix::IpcChannelError> receive() const noexcept;
+    expected<std::string, IpcChannelError> receive() const noexcept;
 
     /// @brief receives a message via the named pipe.
     /// @param[in] timeout the timeout on how long this method should retry to receive a message
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
   private:
     friend class NamedPipeBuilder;
 
     class NamedPipeData;
-    NamedPipe(posix::SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
+    NamedPipe(SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
 
     template <typename Prefix>
     static IpcChannelName_t mapToSharedMemoryName(const Prefix& p, const IpcChannelName_t& name) noexcept;
 
     /// @brief destroys an initialized named pipe.
     /// @return is always successful
-    expected<void, posix::IpcChannelError> destroy() noexcept;
+    expected<void, IpcChannelError> destroy() noexcept;
 
     class NamedPipeData
     {
@@ -127,10 +129,10 @@ class NamedPipe
         NamedPipeData& operator=(NamedPipeData&& rhs) = delete;
         ~NamedPipeData() = default;
 
-        posix::UnnamedSemaphore& sendSemaphore() noexcept;
-        posix::UnnamedSemaphore& receiveSemaphore() noexcept;
+        UnnamedSemaphore& sendSemaphore() noexcept;
+        UnnamedSemaphore& receiveSemaphore() noexcept;
 
-        expected<void, posix::IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
+        expected<void, IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
 
         bool waitForInitialization() const noexcept;
         bool hasValidState() const noexcept;
@@ -144,12 +146,12 @@ class NamedPipe
         static constexpr units::Duration WAIT_FOR_INIT_SLEEP_TIME = units::Duration::fromMilliseconds(1);
 
         std::atomic<uint64_t> initializationGuard{INVALID_DATA};
-        optional<posix::UnnamedSemaphore> m_sendSemaphore;
-        optional<posix::UnnamedSemaphore> m_receiveSemaphore;
+        optional<UnnamedSemaphore> m_sendSemaphore;
+        optional<UnnamedSemaphore> m_receiveSemaphore;
     };
 
   private:
-    posix::SharedMemoryObject m_sharedMemory;
+    SharedMemoryObject m_sharedMemory;
     NamedPipeData* m_data = nullptr;
 };
 
@@ -159,7 +161,7 @@ class NamedPipeBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the named pipe is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the named pipe
     IOX_BUILDER_PARAMETER(size_t, maxMsgSize, NamedPipe::MAX_MESSAGE_SIZE)
@@ -170,9 +172,10 @@ class NamedPipeBuilder
   public:
     /// @brief create a named pipe
     /// @return On success a 'NamedPipe' is returned and on failure an 'IpcChannelError'.
-    expected<NamedPipe, posix::IpcChannelError> create() const noexcept;
+    expected<NamedPipe, IpcChannelError> create() const noexcept;
 };
 
+} // namespace posix
 } // namespace iox
 
 #endif // IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP

--- a/iceoryx_dust/posix/ipc/source/message_queue.cpp
+++ b/iceoryx_dust/posix/ipc/source/message_queue.cpp
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/message_queue.hpp"
+#include "iox/message_queue.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
@@ -28,8 +28,8 @@
 
 namespace iox
 {
-namespace posix
-{
+using namespace iox::posix;
+
 expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noexcept
 {
     auto sanitzedNameResult = MessageQueue::sanitizeIpcChannelName(m_name);
@@ -47,7 +47,7 @@ expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noex
 
     if (m_channelSide == IpcChannelSide::SERVER)
     {
-        posixCall(mq_unlink)(sanitizedName.c_str())
+        posix::posixCall(mq_unlink)(sanitizedName.c_str())
             .failureReturnValue(MessageQueue::ERROR_CODE)
             .ignoreErrnos(ENOENT)
             .evaluate()
@@ -134,7 +134,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
     }
 
 
-    auto mqCall = posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
+    auto mqCall = posix::posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
                       .failureReturnValue(ERROR_CODE)
                       .ignoreErrnos(ENOENT)
                       .evaluate();
@@ -176,8 +176,9 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
         return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
-    auto mqCall =
-        posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U)
+                      .failureReturnValue(ERROR_CODE)
+                      .evaluate();
 
     if (mqCall.has_error())
     {
@@ -193,7 +194,7 @@ expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
+    auto mqCall = posix::posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
                       .failureReturnValue(ERROR_CODE)
                       .evaluate();
 
@@ -227,10 +228,11 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
         // the mask will be applied to the permissions, therefore we need to set it to 0
         mode_t umaskSaved = umask(0);
-        auto mqCall = posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
-                          .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
-                          .suppressErrorMessagesForErrnos(ENOENT)
-                          .evaluate();
+        auto mqCall =
+            posix::posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
+                .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
+                .suppressErrorMessagesForErrnos(ENOENT)
+                .evaluate();
 
         umask(umaskSaved);
 
@@ -245,7 +247,7 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
 expected<void, IpcChannelError> MessageQueue::close() noexcept
 {
-    auto mqCall = posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
 
     if (mqCall.has_error())
     {
@@ -262,7 +264,7 @@ expected<void, IpcChannelError> MessageQueue::unlink() noexcept
         return ok();
     }
 
-    auto mqCall = posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
     if (mqCall.has_error())
     {
         return err(errnoToEnum(mqCall.error().errnum));
@@ -278,7 +280,7 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
+    auto mqCall = posix::posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -310,7 +312,7 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
 
     timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
 
-    auto mqCall = posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
+    auto mqCall = posix::posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -406,5 +408,4 @@ expected<IpcChannelName_t, IpcChannelError> MessageQueue::sanitizeIpcChannelName
     return ok(name);
 }
 
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/ipc/source/message_queue.cpp
+++ b/iceoryx_dust/posix/ipc/source/message_queue.cpp
@@ -28,7 +28,8 @@
 
 namespace iox
 {
-using namespace iox::posix;
+using posix::IpcChannelError;
+using posix::IpcChannelSide;
 
 expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noexcept
 {

--- a/iceoryx_dust/posix/ipc/source/message_queue.cpp
+++ b/iceoryx_dust/posix/ipc/source/message_queue.cpp
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/message_queue.hpp"
+#include "iox/posix/message_queue.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
@@ -28,9 +28,8 @@
 
 namespace iox
 {
-using posix::IpcChannelError;
-using posix::IpcChannelSide;
-
+namespace posix
+{
 expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noexcept
 {
     auto sanitzedNameResult = MessageQueue::sanitizeIpcChannelName(m_name);
@@ -48,7 +47,7 @@ expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noex
 
     if (m_channelSide == IpcChannelSide::SERVER)
     {
-        posix::posixCall(mq_unlink)(sanitizedName.c_str())
+        posixCall(mq_unlink)(sanitizedName.c_str())
             .failureReturnValue(MessageQueue::ERROR_CODE)
             .ignoreErrnos(ENOENT)
             .evaluate()
@@ -135,7 +134,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
     }
 
 
-    auto mqCall = posix::posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
+    auto mqCall = posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
                       .failureReturnValue(ERROR_CODE)
                       .ignoreErrnos(ENOENT)
                       .evaluate();
@@ -177,9 +176,8 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
         return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
-    auto mqCall = posix::posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U)
-                      .failureReturnValue(ERROR_CODE)
-                      .evaluate();
+    auto mqCall =
+        posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U).failureReturnValue(ERROR_CODE).evaluate();
 
     if (mqCall.has_error())
     {
@@ -195,7 +193,7 @@ expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posix::posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
+    auto mqCall = posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
                       .failureReturnValue(ERROR_CODE)
                       .evaluate();
 
@@ -229,11 +227,10 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
         // the mask will be applied to the permissions, therefore we need to set it to 0
         mode_t umaskSaved = umask(0);
-        auto mqCall =
-            posix::posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
-                .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
-                .suppressErrorMessagesForErrnos(ENOENT)
-                .evaluate();
+        auto mqCall = posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
+                          .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
+                          .suppressErrorMessagesForErrnos(ENOENT)
+                          .evaluate();
 
         umask(umaskSaved);
 
@@ -248,7 +245,7 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
 expected<void, IpcChannelError> MessageQueue::close() noexcept
 {
-    auto mqCall = posix::posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
 
     if (mqCall.has_error())
     {
@@ -265,7 +262,7 @@ expected<void, IpcChannelError> MessageQueue::unlink() noexcept
         return ok();
     }
 
-    auto mqCall = posix::posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
     if (mqCall.has_error())
     {
         return err(errnoToEnum(mqCall.error().errnum));
@@ -281,7 +278,7 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posix::posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
+    auto mqCall = posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -313,7 +310,7 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
 
     timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
 
-    auto mqCall = posix::posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
+    auto mqCall = posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -409,4 +406,5 @@ expected<IpcChannelName_t, IpcChannelError> MessageQueue::sanitizeIpcChannelName
     return ok(name);
 }
 
+} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -27,7 +27,16 @@
 
 namespace iox
 {
-using namespace iox::posix;
+using posix::AccessMode;
+using posix::IpcChannelError;
+using posix::IpcChannelSide;
+using posix::OpenMode;
+using posix::SemaphoreWaitState;
+using posix::SharedMemory;
+using posix::SharedMemoryObject;
+using posix::SharedMemoryObjectBuilder;
+using posix::UnnamedSemaphore;
+using posix::UnnamedSemaphoreBuilder;
 
 /// NOLINTJUSTIFICATION see declaration in header
 /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
+#include "iox/named_pipe.hpp"
 #include "iox/bump_allocator.hpp"
 #include "iox/deadline_timer.hpp"
 #include "iox/filesystem.hpp"
@@ -27,8 +27,8 @@
 
 namespace iox
 {
-namespace posix
-{
+using namespace iox::posix;
+
 /// NOLINTJUSTIFICATION see declaration in header
 /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
@@ -361,5 +361,4 @@ bool NamedPipe::NamedPipeData::hasValidState() const noexcept
     return initializationGuard.load() == VALID_DATA;
 }
 
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/named_pipe.hpp"
+#include "iox/posix/named_pipe.hpp"
 #include "iox/bump_allocator.hpp"
 #include "iox/deadline_timer.hpp"
 #include "iox/filesystem.hpp"
@@ -27,17 +27,8 @@
 
 namespace iox
 {
-using posix::AccessMode;
-using posix::IpcChannelError;
-using posix::IpcChannelSide;
-using posix::OpenMode;
-using posix::SemaphoreWaitState;
-using posix::SharedMemory;
-using posix::SharedMemoryObject;
-using posix::SharedMemoryObjectBuilder;
-using posix::UnnamedSemaphore;
-using posix::UnnamedSemaphoreBuilder;
-
+namespace posix
+{
 /// NOLINTJUSTIFICATION see declaration in header
 /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
@@ -370,4 +361,5 @@ bool NamedPipe::NamedPipeData::hasValidState() const noexcept
     return initializationGuard.load() == VALID_DATA;
 }
 
+} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/sync/include/iox/posix/signal_watcher.hpp
+++ b/iceoryx_dust/posix/sync/include/iox/posix/signal_watcher.hpp
@@ -13,8 +13,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
-#define IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
+
+#ifndef IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP
+#define IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP
 
 #include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
@@ -24,6 +25,8 @@
 
 namespace iox
 {
+namespace posix
+{
 /// @brief The SignalWatcher waits for SIGINT and SIGTERM. One can wait until the
 ///        signal has occurred or ask the watcher if it has occurred.
 /// @code
@@ -31,7 +34,7 @@ namespace iox
 ///   #include <iceoryx_hoofs/posix/signal_watcher.hpp>
 ///   void loopUntilTerminationRequested()
 ///   {
-///       while(!iox::hasTerminationRequested())
+///       while(!iox::posix::hasTerminationRequested())
 ///       {
 ///           // your algorithm
 ///       }
@@ -40,7 +43,7 @@ namespace iox
 ///   // another possibility is to block until SIGINT or SIGTERM has occurred
 ///   void blockUntilCtrlC() {
 ///       // your objects which spawn threads
-///       iox::waitForTerminationRequest();
+///       iox::posix::waitForTerminationRequest();
 ///   }
 /// @endcode
 class SignalWatcher
@@ -68,11 +71,11 @@ class SignalWatcher
   private:
     friend void internalSignalHandler(int) noexcept;
     mutable std::atomic<uint64_t> m_numberOfWaiters{0U};
-    mutable optional<posix::UnnamedSemaphore> m_semaphore;
+    mutable optional<UnnamedSemaphore> m_semaphore;
 
     std::atomic_bool m_hasSignalOccurred{false};
-    posix::SignalGuard m_sigTermGuard;
-    posix::SignalGuard m_sigIntGuard;
+    SignalGuard m_sigTermGuard;
+    SignalGuard m_sigIntGuard;
 };
 
 /// @brief convenience function, calls SignalWatcher::getInstance().waitForSignal();
@@ -80,6 +83,7 @@ void waitForTerminationRequest() noexcept;
 
 /// @brief convenience function, calls SignalWatcher::getInstance().wasSignalTriggered();
 bool hasTerminationRequested() noexcept;
+} // namespace posix
 } // namespace iox
 
-#endif
+#endif // IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP

--- a/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
+++ b/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
@@ -24,8 +24,6 @@
 
 namespace iox
 {
-namespace posix
-{
 /// @brief The SignalWatcher waits for SIGINT and SIGTERM. One can wait until the
 ///        signal has occurred or ask the watcher if it has occurred.
 /// @code
@@ -33,7 +31,7 @@ namespace posix
 ///   #include <iceoryx_hoofs/posix/signal_watcher.hpp>
 ///   void loopUntilTerminationRequested()
 ///   {
-///       while(!iox::posix::hasTerminationRequested())
+///       while(!iox::hasTerminationRequested())
 ///       {
 ///           // your algorithm
 ///       }
@@ -42,7 +40,7 @@ namespace posix
 ///   // another possibility is to block until SIGINT or SIGTERM has occurred
 ///   void blockUntilCtrlC() {
 ///       // your objects which spawn threads
-///       iox::posix::waitForTerminationRequest();
+///       iox::waitForTerminationRequest();
 ///   }
 /// @endcode
 class SignalWatcher
@@ -70,11 +68,11 @@ class SignalWatcher
   private:
     friend void internalSignalHandler(int) noexcept;
     mutable std::atomic<uint64_t> m_numberOfWaiters{0U};
-    mutable optional<UnnamedSemaphore> m_semaphore;
+    mutable optional<posix::UnnamedSemaphore> m_semaphore;
 
     std::atomic_bool m_hasSignalOccurred{false};
-    SignalGuard m_sigTermGuard;
-    SignalGuard m_sigIntGuard;
+    posix::SignalGuard m_sigTermGuard;
+    posix::SignalGuard m_sigIntGuard;
 };
 
 /// @brief convenience function, calls SignalWatcher::getInstance().waitForSignal();
@@ -82,7 +80,6 @@ void waitForTerminationRequest() noexcept;
 
 /// @brief convenience function, calls SignalWatcher::getInstance().wasSignalTriggered();
 bool hasTerminationRequested() noexcept;
-} // namespace posix
 } // namespace iox
 
 #endif

--- a/iceoryx_dust/posix/sync/source/signal_watcher.cpp
+++ b/iceoryx_dust/posix/sync/source/signal_watcher.cpp
@@ -13,12 +13,11 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+
+#include "iox/signal_watcher.hpp"
 #include "iceoryx_platform/unistd.hpp"
 
 namespace iox
-{
-namespace posix
 {
 void internalSignalHandler(int) noexcept
 {
@@ -44,10 +43,11 @@ void internalSignalHandler(int) noexcept
 
 SignalWatcher::SignalWatcher() noexcept
     : m_sigTermGuard(
-        registerSignalHandler(Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
-    , m_sigIntGuard(registerSignalHandler(Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
+        registerSignalHandler(posix::Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
+    , m_sigIntGuard(
+          registerSignalHandler(posix::Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
 {
-    UnnamedSemaphoreBuilder()
+    posix::UnnamedSemaphoreBuilder()
         .isInterProcessCapable(false)
         .create(m_semaphore)
 
@@ -88,5 +88,4 @@ bool hasTerminationRequested() noexcept
 {
     return SignalWatcher::getInstance().wasSignalTriggered();
 }
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/sync/source/signal_watcher.cpp
+++ b/iceoryx_dust/posix/sync/source/signal_watcher.cpp
@@ -14,10 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "iceoryx_platform/unistd.hpp"
 
 namespace iox
+{
+namespace posix
 {
 void internalSignalHandler(int) noexcept
 {
@@ -43,11 +45,10 @@ void internalSignalHandler(int) noexcept
 
 SignalWatcher::SignalWatcher() noexcept
     : m_sigTermGuard(
-        registerSignalHandler(posix::Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
-    , m_sigIntGuard(
-          registerSignalHandler(posix::Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
+        registerSignalHandler(Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
+    , m_sigIntGuard(registerSignalHandler(Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
 {
-    posix::UnnamedSemaphoreBuilder()
+    UnnamedSemaphoreBuilder()
         .isInterProcessCapable(false)
         .create(m_semaphore)
 
@@ -88,4 +89,5 @@ bool hasTerminationRequested() noexcept
 {
     return SignalWatcher::getInstance().wasSignalTriggered();
 }
+} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
+++ b/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
@@ -14,15 +14,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_hoofs/testing/barrier.hpp"
 #include "iceoryx_hoofs/testing/watch_dog.hpp"
+#include "iox/signal_watcher.hpp"
 #include "test.hpp"
 #include <atomic>
 
 namespace
 {
 using namespace ::testing;
+using namespace iox;
 using namespace iox::posix;
 
 class SignalWatcherTester : public SignalWatcher

--- a/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
+++ b/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
@@ -16,14 +16,13 @@
 
 #include "iceoryx_hoofs/testing/barrier.hpp"
 #include "iceoryx_hoofs/testing/watch_dog.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "test.hpp"
 #include <atomic>
 
 namespace
 {
 using namespace ::testing;
-using namespace iox;
 using namespace iox::posix;
 
 class SignalWatcherTester : public SignalWatcher

--- a/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
@@ -14,12 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -112,7 +112,7 @@ int main()
 
     CounterService counterService;
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [init]
 
     return (EXIT_SUCCESS);

--- a/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -112,7 +112,7 @@ int main()
 
     CounterService counterService;
 
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
     //! [init]
 
     return (EXIT_SUCCESS);

--- a/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -32,7 +32,7 @@ void sending()
     iox::popo::Publisher<CounterTopic> myPublisherLeft({"Radar", "FrontLeft", "Counter"});
     iox::popo::Publisher<CounterTopic> myPublisherRight({"Radar", "FrontRight", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
     {
         if (counter % 3 == 0)
         {

--- a/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -32,7 +32,7 @@ void sending()
     iox::popo::Publisher<CounterTopic> myPublisherLeft({"Radar", "FrontLeft", "Counter"});
     iox::popo::Publisher<CounterTopic> myPublisherRight({"Radar", "FrontRight", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
     {
         if (counter % 3 == 0)
         {

--- a/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
@@ -14,12 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -91,7 +91,7 @@ int main()
     // send a heartbeat every 4 seconds
     //! [create heartbeat]
     std::thread heartbeatThread([&] {
-        while (!iox::posix::hasTerminationRequested())
+        while (!iox::hasTerminationRequested())
         {
             heartbeat.trigger();
             std::this_thread::sleep_for(std::chrono::seconds(4));
@@ -131,7 +131,7 @@ int main()
 
     // wait until someone presses CTRL+C
     //! [wait for sigterm]
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [wait for sigterm]
 
     // optional detachEvent, but not required.

--- a/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -91,7 +91,7 @@ int main()
     // send a heartbeat every 4 seconds
     //! [create heartbeat]
     std::thread heartbeatThread([&] {
-        while (!iox::hasTerminationRequested())
+        while (!iox::posix::hasTerminationRequested())
         {
             heartbeat.trigger();
             std::this_thread::sleep_for(std::chrono::seconds(4));
@@ -131,7 +131,7 @@ int main()
 
     // wait until someone presses CTRL+C
     //! [wait for sigterm]
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
     //! [wait for sigterm]
 
     // optional detachEvent, but not required.

--- a/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
@@ -16,9 +16,9 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-complexdata";
 
@@ -46,7 +46,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
         publisher.loan()

--- a/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-complexdata";
 
@@ -46,7 +46,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         ++ct;
         publisher.loan()

--- a/iceoryx_examples/complexdata/iox_publisher_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_vector.cpp
@@ -16,9 +16,9 @@
 
 #include "iox/vector.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-vector";
 
@@ -34,7 +34,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         publisher.loan()
             .and_then([&](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_publisher_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_vector.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-vector";
 
@@ -34,7 +34,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         publisher.loan()
             .and_then([&](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
@@ -16,9 +16,9 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 #include "iox/string.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-subscriber-complexdata";
@@ -32,7 +32,7 @@ int main()
     iox::popo::Subscriber<ComplexDataType> subscriber({"Group", "Instance", "ComplexDataTopic"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "iox/string.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-subscriber-complexdata";
@@ -32,7 +32,7 @@ int main()
     iox::popo::Subscriber<ComplexDataType> subscriber({"Group", "Instance", "ComplexDataTopic"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 #include "iox/string.hpp"
 #include "iox/vector.hpp"
 
@@ -31,7 +31,7 @@ int main()
     iox::popo::Subscriber<iox::vector<double, 5>> subscriber({"Radar", "FrontRight", "VectorData"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "iox/string.hpp"
 #include "iox/vector.hpp"
 
@@ -31,7 +31,7 @@ int main()
     iox::popo::Subscriber<iox::vector<double, 5>> subscriber({"Radar", "FrontRight", "VectorData"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/ice_access_control/iox_display_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_display_app.cpp
@@ -16,10 +16,10 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -35,7 +35,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "HMI-Display", "Object"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto takeResult = subscriber.take();
 

--- a/iceoryx_examples/ice_access_control/iox_display_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_display_app.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -35,7 +35,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "HMI-Display", "Object"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         auto takeResult = subscriber.take();
 

--- a/iceoryx_examples/ice_access_control/iox_radar_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_radar_app.cpp
@@ -16,9 +16,9 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -32,7 +32,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"});
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/ice_access_control/iox_radar_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_radar_app.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -32,7 +32,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"});
 
     double ct = 0.0;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/icedelivery/iox_publisher.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher.cpp
@@ -20,8 +20,8 @@
 //! [include publisher]
 #include "iceoryx_posh/popo/publisher.hpp"
 //! [include publisher]
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -41,7 +41,7 @@ int main()
     //! [create publisher]
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
         double sampleValue1 = ct + 89;

--- a/iceoryx_examples/icedelivery/iox_publisher.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/publisher.hpp"
 //! [include publisher]
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -41,7 +41,7 @@ int main()
     //! [create publisher]
 
     double ct = 0.0;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         ++ct;
         double sampleValue1 = ct + 89;

--- a/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
@@ -20,9 +20,9 @@
 //! [include topic data]
 
 //! [includes]
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -39,7 +39,7 @@ int main()
     //! [create untyped publisher]
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
@@ -22,7 +22,7 @@
 //! [includes]
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -39,7 +39,7 @@ int main()
     //! [create untyped publisher]
 
     double ct = 0.0;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/icedelivery/iox_subscriber.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber.cpp
@@ -20,8 +20,8 @@
 //! [include subscriber]
 #include "iceoryx_posh/popo/subscriber.hpp"
 //! [include subscriber]
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icedelivery/iox_subscriber.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/subscriber.hpp"
 //! [include subscriber]
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
@@ -18,9 +18,9 @@
 //! [includes]
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -38,7 +38,7 @@ int main()
 
     // run until interrupted by Ctrl-C
     //! [loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
@@ -20,7 +20,7 @@
 
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -38,7 +38,7 @@ int main()
 
     // run until interrupted by Ctrl-C
     //! [loop]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
+++ b/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
@@ -18,8 +18,8 @@
 #include "discovery_monitor.hpp"
 //! [include custom discovery]
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     discovery.registerCallback(callback);
     //! [register callback]
 
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         // here the app would run its functional code while the
         // service availability is monitored in the background

--- a/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
+++ b/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
@@ -19,7 +19,7 @@
 //! [include custom discovery]
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     discovery.registerCallback(callback);
     //! [register callback]
 
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         // here the app would run its functional code while the
         // service availability is monitored in the background

--- a/iceoryx_examples/icediscovery/iox_find_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_find_service.cpp
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include ServiceDiscovery]
 #include "iceoryx_posh/runtime/service_discovery.hpp"
 //! [include ServiceDiscovery]
@@ -39,7 +39,7 @@ int main()
     iox::runtime::ServiceDiscovery serviceDiscovery;
     //! [create ServiceDiscovery object]
 
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         std::cout << "\n=========================================" << std::endl;
 

--- a/iceoryx_examples/icediscovery/iox_find_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_find_service.cpp
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [include ServiceDiscovery]
 #include "iceoryx_posh/runtime/service_discovery.hpp"
 //! [include ServiceDiscovery]
@@ -39,7 +39,7 @@ int main()
     iox::runtime::ServiceDiscovery serviceDiscovery;
     //! [create ServiceDiscovery object]
 
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         std::cout << "\n=========================================" << std::endl;
 

--- a/iceoryx_examples/icediscovery/iox_offer_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_offer_service.cpp
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-offer-service";
 
@@ -37,7 +37,7 @@ int main()
     cameraPublishers.emplace_back(iox::capro::ServiceDescription{"Camera", "BackLeft", "Image"});
 
     bool offer = false;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         if (offer)
         {

--- a/iceoryx_examples/icediscovery/iox_offer_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_offer_service.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-offer-service";
 
@@ -37,7 +37,7 @@ int main()
     cameraPublishers.emplace_back(iox::capro::ServiceDescription{"Camera", "BackLeft", "Image"});
 
     bool offer = false;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         if (offer)
         {

--- a/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
@@ -18,8 +18,8 @@
 #include "discovery_blocking.hpp"
 //! [include custom discovery]
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 

--- a/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
@@ -19,7 +19,7 @@
 //! [include custom discovery]
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 

--- a/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
@@ -19,7 +19,7 @@
 //! [include topic]
 
 //! [include sig watcher]
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include sig watcher]
 
 //! [include]
@@ -43,7 +43,7 @@ int main()
 
     double ct = 0.0;
     //! [wait for term]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     //! [wait for term]
     {
         ++ct;

--- a/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
@@ -19,7 +19,7 @@
 //! [include topic]
 
 //! [include sig watcher]
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [include sig watcher]
 
 //! [include]
@@ -43,7 +43,7 @@ int main()
 
     double ct = 0.0;
     //! [wait for term]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     //! [wait for term]
     {
         ++ct;

--- a/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
@@ -17,9 +17,9 @@
 //! [include]
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [initialize subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [receive]
         auto takeResult = subscriber.take();

--- a/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [include]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [initialize subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [receive]
         auto takeResult = subscriber.take();

--- a/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
@@ -16,9 +16,9 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -63,7 +63,7 @@ int main()
     double ct = 0.0;
 
     std::thread publishData([&]() {
-        while (!iox::posix::hasTerminationRequested())
+        while (!iox::hasTerminationRequested())
         {
             ++ct;
 
@@ -76,7 +76,7 @@ int main()
         }
     });
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
 
     // this is optional, but since the iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER option is used,
     // a slow subscriber might block the shutdown and this call unblocks the publisher

--- a/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -63,7 +63,7 @@ int main()
     double ct = 0.0;
 
     std::thread publishData([&]() {
-        while (!iox::hasTerminationRequested())
+        while (!iox::posix::hasTerminationRequested())
         {
             ++ct;
 
@@ -76,7 +76,7 @@ int main()
         }
     });
 
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
 
     // this is optional, but since the iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER option is used,
     // a slow subscriber might block the shutdown and this call unblocks the publisher

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -16,9 +16,9 @@
 
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     //! [subscribe]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take().and_then(
             [](auto& sample) { std::cout << APP_NAME << " got value: " << sample->x << std::endl; });

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     //! [subscribe]
 
     // run until interrupted by Ctrl-C
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         subscriber.take().and_then(
             [](auto& sample) { std::cout << APP_NAME << " got value: " << sample->x << std::endl; });

--- a/iceoryx_examples/request_response/client_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/client_cxx_basic.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [send request]
         client.loan()

--- a/iceoryx_examples/request_response/client_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/client_cxx_basic.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [send request]
         client.loan()

--- a/iceoryx_examples/request_response/client_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/client_cxx_untyped.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [send request]
         client.loan(sizeof(AddRequest), alignof(AddRequest))

--- a/iceoryx_examples/request_response/client_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/client_cxx_untyped.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [send request]
         client.loan(sizeof(AddRequest), alignof(AddRequest))

--- a/iceoryx_examples/request_response/client_cxx_waitset.cpp
+++ b/iceoryx_examples/request_response/client_cxx_waitset.cpp
@@ -17,11 +17,11 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>

--- a/iceoryx_examples/request_response/client_cxx_waitset.cpp
+++ b/iceoryx_examples/request_response/client_cxx_waitset.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>

--- a/iceoryx_examples/request_response/server_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/server_cxx_basic.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](const auto& request) {

--- a/iceoryx_examples/request_response/server_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/server_cxx_basic.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](const auto& request) {

--- a/iceoryx_examples/request_response/server_cxx_listener.cpp
+++ b/iceoryx_examples/request_response/server_cxx_listener.cpp
@@ -17,10 +17,10 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -76,7 +76,7 @@ int main()
     //! [attach listener]
 
     //! [wait for termination]
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [wait for termination]
 
     //! [cleanup]

--- a/iceoryx_examples/request_response/server_cxx_listener.cpp
+++ b/iceoryx_examples/request_response/server_cxx_listener.cpp
@@ -20,7 +20,7 @@
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -76,7 +76,7 @@ int main()
     //! [attach listener]
 
     //! [wait for termination]
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
     //! [wait for termination]
 
     //! [cleanup]

--- a/iceoryx_examples/request_response/server_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/server_cxx_untyped.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](auto& requestPayload) {

--- a/iceoryx_examples/request_response/server_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/server_cxx_untyped.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](auto& requestPayload) {

--- a/iceoryx_examples/singleprocess/single_process.cpp
+++ b/iceoryx_examples/singleprocess/single_process.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
@@ -25,6 +24,7 @@
 #include "iceoryx_posh/runtime/posh_runtime_single_process.hpp"
 #include "iox/detail/convert.hpp"
 #include "iox/logging.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -59,7 +59,7 @@ void publisher()
     //! [send]
     uint64_t counter{0};
     constexpr const char GREEN_RIGHT_ARROW[] = "\033[32m->\033[m ";
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         publisher.loan().and_then([&](auto& sample) {
             sample->counter = counter++;
@@ -83,7 +83,7 @@ void subscriber()
 
     //! [receive]
     constexpr const char ORANGE_LEFT_ARROW[] = "\033[33m<-\033[m ";
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         if (iox::SubscribeState::SUBSCRIBED == subscriber.getSubscriptionState())
         {
@@ -136,7 +136,7 @@ int main()
     //! [run]
     std::thread publisherThread(publisher), subscriberThread(subscriber);
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
 
     publisherThread.join();
     subscriberThread.join();

--- a/iceoryx_examples/singleprocess/single_process.cpp
+++ b/iceoryx_examples/singleprocess/single_process.cpp
@@ -24,7 +24,7 @@
 #include "iceoryx_posh/runtime/posh_runtime_single_process.hpp"
 #include "iox/detail/convert.hpp"
 #include "iox/logging.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -59,7 +59,7 @@ void publisher()
     //! [send]
     uint64_t counter{0};
     constexpr const char GREEN_RIGHT_ARROW[] = "\033[32m->\033[m ";
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         publisher.loan().and_then([&](auto& sample) {
             sample->counter = counter++;
@@ -83,7 +83,7 @@ void subscriber()
 
     //! [receive]
     constexpr const char ORANGE_LEFT_ARROW[] = "\033[33m<-\033[m ";
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         if (iox::SubscribeState::SUBSCRIBED == subscriber.getSubscriptionState())
         {
@@ -136,7 +136,7 @@ int main()
     //! [run]
     std::thread publisherThread(publisher), subscriberThread(subscriber);
 
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
 
     publisherThread.join();
     subscriberThread.join();

--- a/iceoryx_examples/user_header/publisher_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_cxx_api.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -40,7 +40,7 @@ int main()
     uint64_t timestamp = 42;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/publisher_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -40,7 +40,7 @@ int main()
     uint64_t timestamp = 42;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
@@ -17,7 +17,7 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include differs from typed C++ API]
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 //! [include differs from typed C++ API]
@@ -42,7 +42,7 @@ int main()
     uint64_t timestamp = 73;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
@@ -17,7 +17,7 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [include differs from typed C++ API]
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 //! [include differs from typed C++ API]
@@ -42,7 +42,7 @@ int main()
     uint64_t timestamp = 73;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/subscriber_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_cxx_api.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take sample]
         subscriber.take().and_then([&](auto& sample) {

--- a/iceoryx_examples/user_header/subscriber_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [take sample]
         subscriber.take().and_then([&](auto& sample) {

--- a/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
@@ -17,9 +17,9 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take chunk]
         subscriber.take().and_then([&](auto& userPayload) {

--- a/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::hasTerminationRequested())
+    while (!iox::posix::hasTerminationRequested())
     {
         //! [take chunk]
         subscriber.take().and_then([&](auto& userPayload) {

--- a/iceoryx_examples/waitset/ice_waitset_publisher.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_publisher.cpp
@@ -14,9 +14,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -27,7 +27,7 @@ void sending()
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-publisher-waitset");
     iox::popo::Publisher<CounterTopic> myPublisher({"Radar", "FrontLeft", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
     {
         myPublisher.publishCopyOf(CounterTopic{counter})
             .and_then([&] { std::cout << "Sending: " << counter << std::endl; })

--- a/iceoryx_examples/waitset/ice_waitset_publisher.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_publisher.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -27,7 +27,7 @@ void sending()
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-publisher-waitset");
     iox::popo::Publisher<CounterTopic> myPublisher({"Radar", "FrontLeft", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
     {
         myPublisher.publishCopyOf(CounterTopic{counter})
             .and_then([&] { std::cout << "Sending: " << counter << std::endl; })

--- a/iceoryx_hoofs/BUILD.bazel
+++ b/iceoryx_hoofs/BUILD.bazel
@@ -21,7 +21,7 @@ load("//bazel:configure_version.bzl", "configure_version")
 configure_file(
     name = "iceoryx_hoofs_deployment_hpp",
     src = "cmake/iceoryx_hoofs_deployment.hpp.in",
-    out = "include/iox/iceoryx_hoofs_deployment.hpp",
+    out = "generated/include/iox/iceoryx_hoofs_deployment.hpp",
     config = {
         # FIXME: for values see "iceoryx_hoofs/cmake/IceoryxHoofsDeployment.cmake" ... for now some nice defaults
         "IOX_MINIMAL_LOG_LEVEL": "TRACE",
@@ -31,7 +31,7 @@ configure_file(
 configure_version(
     name = "iceoryx_versions_h",
     src = "cmake/iceoryx_versions.h.in",
-    out = "include/iceoryx_versions.h",
+    out = "generated/include/iceoryx_versions.h",
     version_from = "//:VERSION",
 )
 
@@ -62,6 +62,7 @@ cc_library(
         "design/include",
         "filesystem/include",
         "functional/include",
+        "generated/include",
         "include/",
         "legacy/include/",
         "memory/include/",

--- a/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
+++ b/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
@@ -80,7 +80,7 @@ function(iox_create_lsan_runtime_blacklist BLACKLIST_FILE_PATH)
     # count      bytes template
     #     8        642 libacl.so.1
     #     1         24 iox::posix::UnixDomainSocket::timedReceive
-    #     1         24 iox::posix::MessageQueue::receive
+    #     1         24 iox::MessageQueue::receive
     if(NOT EXISTS ${BLACKLIST_FILE_PATH})
         file(WRITE  ${BLACKLIST_FILE_PATH} "# This file is auto-generated from iceoryx_hoofs/cmake/IceoryxPlatform.cmake\n")
         file(APPEND ${BLACKLIST_FILE_PATH} "#leak:libacl.so.1\n")
@@ -131,7 +131,7 @@ if(ADDRESS_SANITIZER OR THREAD_SANITIZER)
         elseif(THREAD_SANITIZER)
             set(ICEORYX_SANITIZER_FLAGS ${ICEORYX_SANITIZER_COMMON_FLAGS} ${ICEORYX_THREAD_SANITIZER_FLAGS} CACHE INTERNAL "")
         endif()
-        
+
         # unset local variables , to avoid polluting global space
         unset(ICEORYX_SANITIZER_BLACKLIST)
         unset(ICEORYX_SANITIZER_COMMON_FLAGS)

--- a/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
+++ b/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
@@ -80,7 +80,7 @@ function(iox_create_lsan_runtime_blacklist BLACKLIST_FILE_PATH)
     # count      bytes template
     #     8        642 libacl.so.1
     #     1         24 iox::posix::UnixDomainSocket::timedReceive
-    #     1         24 iox::MessageQueue::receive
+    #     1         24 iox::posix::MessageQueue::receive
     if(NOT EXISTS ${BLACKLIST_FILE_PATH})
         file(WRITE  ${BLACKLIST_FILE_PATH} "# This file is auto-generated from iceoryx_hoofs/cmake/IceoryxPlatform.cmake\n")
         file(APPEND ${BLACKLIST_FILE_PATH} "#leak:libacl.so.1\n")

--- a/iceoryx_hoofs/container/include/iox/detail/list.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/list.inl
@@ -330,7 +330,7 @@ template <typename T, uint64_t Capacity>
 inline T& list<T, Capacity>::front() noexcept
 {
     auto iter = begin();
-    IOX_EXPECTS(isValidElementIdx(iter.m_iterListNodeIdx) && "invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(iter.m_iterListNodeIdx), "invalid list element");
     return *iter;
 }
 
@@ -338,7 +338,7 @@ template <typename T, uint64_t Capacity>
 inline const T& list<T, Capacity>::front() const noexcept
 {
     auto citer = cbegin();
-    IOX_EXPECTS(isValidElementIdx(citer.m_iterListNodeIdx) && "invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(citer.m_iterListNodeIdx), "invalid list element");
     return *citer;
 }
 
@@ -346,7 +346,7 @@ template <typename T, uint64_t Capacity>
 inline T& list<T, Capacity>::back() noexcept
 {
     auto iter = end();
-    IOX_EXPECTS(isValidElementIdx((--iter).m_iterListNodeIdx) && "invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx((--iter).m_iterListNodeIdx), "invalid list element");
     return *iter;
 }
 
@@ -354,7 +354,7 @@ template <typename T, uint64_t Capacity>
 inline const T& list<T, Capacity>::back() const noexcept
 {
     auto citer = cend();
-    IOX_EXPECTS(isValidElementIdx((--citer).m_iterListNodeIdx) && "invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx((--citer).m_iterListNodeIdx), "invalid list element");
     return *citer;
 }
 
@@ -653,7 +653,7 @@ inline void list<T, Capacity>::setNextIdx(const size_type idx, const size_type n
 template <typename T, uint64_t Capacity>
 inline const T* list<T, Capacity>::getDataPtrFromIdx(const size_type idx) const noexcept
 {
-    IOX_EXPECTS(isValidElementIdx(idx) && "invalid list element");
+    IOX_EXPECTS_WITH_MSG(isValidElementIdx(idx), "invalid list element");
 
     /// @NOLINTJUSTIFICATION provide type safe access to the encapsulated untyped m_data array
     /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
@@ -684,14 +684,14 @@ inline bool list<T, Capacity>::isInvalidIterator(const const_iterator& iter) con
     // freeList / invalid elements will have the prevIdx set to INVALID_INDEX
     // additional check on e.g. nextIdx or m_iterListNodeIdx (<INVALID_INDEX) are omitted as this
     // should (can) never happen though normal list operations.
-    IOX_EXPECTS((getPrevIdx(iter) < INVALID_INDEX) && "invalidated iterator");
+    IOX_EXPECTS_WITH_MSG((getPrevIdx(iter) < INVALID_INDEX), "invalidated iterator");
     return false;
 }
 
 template <typename T, uint64_t Capacity>
 inline bool list<T, Capacity>::isInvalidIterOrDifferentLists(const const_iterator& iter) const noexcept
 {
-    IOX_EXPECTS((this == iter.m_list) && "iterator of other list can't be used");
+    IOX_EXPECTS_WITH_MSG((this == iter.m_list), "iterator of other list can't be used");
     return isInvalidIterator(iter);
 }
 

--- a/iceoryx_hoofs/source/concurrent/loffli.cpp
+++ b/iceoryx_hoofs/source/concurrent/loffli.cpp
@@ -25,11 +25,11 @@ namespace concurrent
 {
 void LoFFLi::init(not_null<Index_t*> freeIndicesMemory, const uint32_t capacity) noexcept
 {
-    IOX_EXPECTS(capacity > 0 && "A capacity of 0 is not supported!");
+    IOX_EXPECTS_WITH_MSG(capacity > 0, "A capacity of 0 is not supported!");
     constexpr uint32_t INTERNALLY_RESERVED_INDICES{1U};
-    IOX_EXPECTS(capacity < (std::numeric_limits<Index_t>::max() - INTERNALLY_RESERVED_INDICES)
-                && "Requested capacity exceeds limits!");
-    IOX_EXPECTS(m_head.is_lock_free() && "std::atomic<LoFFLi::Node> must be lock-free!");
+    IOX_EXPECTS_WITH_MSG(capacity < (std::numeric_limits<Index_t>::max() - INTERNALLY_RESERVED_INDICES),
+                         "Requested capacity exceeds limits!");
+    IOX_EXPECTS_WITH_MSG(m_head.is_lock_free(), "std::atomic<LoFFLi::Node> must be lock-free!");
 
     m_nextFreeIndex = freeIndicesMemory;
     m_size = capacity;

--- a/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/expected.hpp
@@ -18,6 +18,7 @@
 #define IOX_HOOFS_VOCABULARY_EXPECTED_HPP
 
 #include "iox/attributes.hpp"
+#include "iox/detail/deprecation_marker.hpp"
 #include "iox/detail/expected_helper.hpp"
 #include "iox/functional_interface.hpp"
 #include "iox/optional.hpp"
@@ -243,15 +244,15 @@ class IOX_NO_DISCARD expected final : public FunctionalInterface<expected<ValueT
 
     /// @copydoc expected::error()&
     /// @deprecated use 'error' instead of 'get_error'
-    [[deprecated("Use 'error' instead of 'get_error'")]] ErrorType& get_error() & noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please use 'error' instead of 'get_error'") ErrorType& get_error() & noexcept;
 
     /// @copydoc expected::error()const&
     /// @deprecated use 'error' instead of 'get_error'
-    [[deprecated("Use 'error' instead of 'get_error'")]] const ErrorType& get_error() const& noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please use 'error' instead of 'get_error'") const ErrorType& get_error() const& noexcept;
 
     /// @copydoc expected::error()&&
     /// @deprecated use 'error' instead of 'get_error'
-    [[deprecated("Use 'error' instead of 'get_error'")]] ErrorType&& get_error() && noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please use 'error' instead of 'get_error'") ErrorType&& get_error() && noexcept;
 
     /// @brief  returns a lvalue reference to the contained success value, if the expected
     ///         does not contain a success value the error handler is called

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -32,9 +32,9 @@
 #include "iox/optional.hpp"
 #include "iox/relative_pointer.hpp"
 
-#include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 #include "iox/message_queue.hpp"
+#include "iox/named_pipe.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -50,9 +50,9 @@ namespace iox
 namespace platform
 {
 #if defined(_WIN32)
-using IoxIpcChannelType = iox::posix::NamedPipe;
+using IoxIpcChannelType = iox::NamedPipe;
 #elif defined(__FREERTOS__)
-using IoxIpcChannelType = iox::posix::NamedPipe;
+using IoxIpcChannelType = iox::NamedPipe;
 #else
 using IoxIpcChannelType = iox::posix::UnixDomainSocket;
 #endif

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -32,9 +32,9 @@
 #include "iox/optional.hpp"
 #include "iox/relative_pointer.hpp"
 
-#include "iceoryx_dust/posix_wrapper/message_queue.hpp"
 #include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
+#include "iox/message_queue.hpp"
 
 #include <cstdint>
 #include <cstdlib>

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -33,8 +33,8 @@
 #include "iox/relative_pointer.hpp"
 
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
-#include "iox/message_queue.hpp"
-#include "iox/named_pipe.hpp"
+#include "iox/posix/message_queue.hpp"
+#include "iox/posix/named_pipe.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -50,9 +50,9 @@ namespace iox
 namespace platform
 {
 #if defined(_WIN32)
-using IoxIpcChannelType = iox::NamedPipe;
+using IoxIpcChannelType = iox::posix::NamedPipe;
 #elif defined(__FREERTOS__)
-using IoxIpcChannelType = iox::NamedPipe;
+using IoxIpcChannelType = iox::posix::NamedPipe;
 #else
 using IoxIpcChannelType = iox::posix::UnixDomainSocket;
 #endif

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
@@ -48,7 +48,7 @@ class RouDiApp
   protected:
     /// @brief waits for the next signal to RouDi daemon
     [[deprecated("in 3.0, removed in 4.0, use iox::posix::waitForTerminationRequest() from "
-                 "'iceoryx_dust/posix_wrapper/signal_watcher.hpp'")]] bool
+                 "'iox/signal_watcher.hpp'")]] bool
     waitForSignal() noexcept;
 
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
@@ -48,7 +48,7 @@ class RouDiApp
   protected:
     /// @brief waits for the next signal to RouDi daemon
     [[deprecated("in 3.0, removed in 4.0, use iox::posix::waitForTerminationRequest() from "
-                 "'iox/signal_watcher.hpp'")]] bool
+                 "'iox/posix/signal_watcher.hpp'")]] bool
     waitForSignal() noexcept;
 
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
@@ -21,6 +21,7 @@
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_posh/roudi/cmd_line_args.hpp"
+#include "iox/detail/deprecation_marker.hpp"
 #include "iox/logging.hpp"
 
 #include <cstdint>
@@ -47,9 +48,8 @@ class RouDiApp
 
   protected:
     /// @brief waits for the next signal to RouDi daemon
-    [[deprecated("in 3.0, removed in 4.0, use iox::posix::waitForTerminationRequest() from "
-                 "'iox/posix/signal_watcher.hpp'")]] bool
-    waitForSignal() noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please use iox::posix::waitForTerminationRequest() from 'iox/posix/signal_watcher.hpp'")
+    bool waitForSignal() noexcept;
 
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};
     roudi::MonitoringMode m_monitoringMode{roudi::MonitoringMode::ON};

--- a/iceoryx_posh/roudi_env/source/runtime_test_interface.cpp
+++ b/iceoryx_posh/roudi_env/source/runtime_test_interface.cpp
@@ -36,9 +36,9 @@ RuntimeTestInterface::RuntimeTestInterface()
 {
     std::lock_guard<std::mutex> lock(RuntimeTestInterface::s_runtimeAccessMutex);
 
-    IOX_EXPECTS(PoshRuntime::getRuntimeFactory() == PoshRuntime::defaultRuntimeFactory
-                && "The RuntimeTestInterface can only be used in combination with the "
-                   "PoshRuntime::defaultRuntimeFactory! Someone else already switched the factory!");
+    IOX_EXPECTS_WITH_MSG(PoshRuntime::getRuntimeFactory() == PoshRuntime::defaultRuntimeFactory,
+                         "The RuntimeTestInterface can only be used in combination with the "
+                         "PoshRuntime::defaultRuntimeFactory! Someone else already switched the factory!");
 
     PoshRuntime::setRuntimeFactory(RuntimeTestInterface::runtimeFactoryGetInstance);
 }

--- a/iceoryx_posh/source/popo/ports/client_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_roudi.cpp
@@ -150,7 +150,7 @@ ClientPortRouDi::handleCaProMessageForStateConnectRequested(const capro::CaproMe
     switch (caProMessage.m_type)
     {
     case capro::CaproMessageType::ACK:
-        IOX_EXPECTS(caProMessage.m_chunkQueueData != nullptr && "Invalid request queue passed to client");
+        IOX_EXPECTS_WITH_MSG(caProMessage.m_chunkQueueData != nullptr, "Invalid request queue passed to client");
         IOX_EXPECTS(!m_chunkSender
                          .tryAddQueue(static_cast<ServerChunkQueueData_t*>(caProMessage.m_chunkQueueData),
                                       caProMessage.m_historyCapacity)

--- a/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
@@ -17,11 +17,11 @@
 
 #include "iceoryx_posh/roudi/iceoryx_roudi_app.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
 #include "iceoryx_posh/roudi/iceoryx_roudi_components.hpp"
 #include "iox/optional.hpp"
 #include "iox/scoped_static.hpp"
+#include "iox/signal_watcher.hpp"
 
 namespace iox
 {
@@ -50,7 +50,7 @@ uint8_t IceOryxRouDiApp::run() noexcept
                                                            m_compatibilityCheckLevel,
                                                            m_processKillDelay,
                                                            m_processTeminationDelay});
-        iox::posix::waitForTerminationRequest();
+        iox::waitForTerminationRequest();
     }
     return EXIT_SUCCESS;
 }

--- a/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
@@ -20,8 +20,8 @@
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
 #include "iceoryx_posh/roudi/iceoryx_roudi_components.hpp"
 #include "iox/optional.hpp"
+#include "iox/posix/signal_watcher.hpp"
 #include "iox/scoped_static.hpp"
-#include "iox/signal_watcher.hpp"
 
 namespace iox
 {
@@ -50,7 +50,7 @@ uint8_t IceOryxRouDiApp::run() noexcept
                                                            m_compatibilityCheckLevel,
                                                            m_processKillDelay,
                                                            m_processTeminationDelay});
-        iox::waitForTerminationRequest();
+        iox::posix::waitForTerminationRequest();
     }
     return EXIT_SUCCESS;
 }

--- a/iceoryx_posh/source/roudi/application/roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/roudi_app.cpp
@@ -17,7 +17,6 @@
 
 #include "iceoryx_posh/roudi/roudi_app.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_platform/getopt.hpp"
 #include "iceoryx_platform/resource.hpp"
 #include "iceoryx_platform/semaphore.hpp"
@@ -26,6 +25,7 @@
 #include "iceoryx_posh/roudi/cmd_line_args.hpp"
 #include "iox/logging.hpp"
 #include "iox/optional.hpp"
+#include "iox/signal_watcher.hpp"
 
 namespace iox
 {
@@ -79,7 +79,7 @@ bool RouDiApp::checkAndOptimizeConfig(const RouDiConfig_t& config) noexcept
 
 bool RouDiApp::waitForSignal() noexcept
 {
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     return true;
 }
 

--- a/iceoryx_posh/source/roudi/application/roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/roudi_app.cpp
@@ -25,7 +25,7 @@
 #include "iceoryx_posh/roudi/cmd_line_args.hpp"
 #include "iox/logging.hpp"
 #include "iox/optional.hpp"
-#include "iox/signal_watcher.hpp"
+#include "iox/posix/signal_watcher.hpp"
 
 namespace iox
 {
@@ -79,7 +79,7 @@ bool RouDiApp::checkAndOptimizeConfig(const RouDiConfig_t& config) noexcept
 
 bool RouDiApp::waitForSignal() noexcept
 {
-    iox::waitForTerminationRequest();
+    iox::posix::waitForTerminationRequest();
     return true;
 }
 

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -242,7 +242,7 @@ bool IpcInterface<posix::UnixDomainSocket>::ipcChannelMapsToFile() noexcept
 }
 
 template <>
-bool IpcInterface<posix::NamedPipe>::ipcChannelMapsToFile() noexcept
+bool IpcInterface<NamedPipe>::ipcChannelMapsToFile() noexcept
 {
     return true;
 }
@@ -263,7 +263,7 @@ void IpcInterface<IpcChannelType>::cleanupOutdatedIpcChannel(const RuntimeName_t
 }
 
 template class IpcInterface<posix::UnixDomainSocket>;
-template class IpcInterface<posix::NamedPipe>;
+template class IpcInterface<NamedPipe>;
 template class IpcInterface<MessageQueue>;
 
 } // namespace runtime

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -264,7 +264,7 @@ void IpcInterface<IpcChannelType>::cleanupOutdatedIpcChannel(const RuntimeName_t
 
 template class IpcInterface<posix::UnixDomainSocket>;
 template class IpcInterface<posix::NamedPipe>;
-template class IpcInterface<posix::MessageQueue>;
+template class IpcInterface<MessageQueue>;
 
 } // namespace runtime
 } // namespace iox

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -242,7 +242,7 @@ bool IpcInterface<posix::UnixDomainSocket>::ipcChannelMapsToFile() noexcept
 }
 
 template <>
-bool IpcInterface<NamedPipe>::ipcChannelMapsToFile() noexcept
+bool IpcInterface<posix::NamedPipe>::ipcChannelMapsToFile() noexcept
 {
     return true;
 }
@@ -263,8 +263,8 @@ void IpcInterface<IpcChannelType>::cleanupOutdatedIpcChannel(const RuntimeName_t
 }
 
 template class IpcInterface<posix::UnixDomainSocket>;
-template class IpcInterface<NamedPipe>;
-template class IpcInterface<MessageQueue>;
+template class IpcInterface<posix::NamedPipe>;
+template class IpcInterface<posix::MessageQueue>;
 
 } // namespace runtime
 } // namespace iox

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -18,11 +18,11 @@
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "test.hpp"
 
-#include "iceoryx_dust/posix_wrapper/message_queue.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_message.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp"
 #include "iox/duration.hpp"
+#include "iox/message_queue.hpp"
 #include "iox/std_string_support.hpp"
 
 

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -22,7 +22,7 @@
 #include "iceoryx_posh/internal/runtime/ipc_message.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp"
 #include "iox/duration.hpp"
-#include "iox/message_queue.hpp"
+#include "iox/posix/message_queue.hpp"
 #include "iox/std_string_support.hpp"
 
 

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -111,9 +111,9 @@ class PortUser_IntegrationTest : public Test
 
     Watchdog m_deadlockWatchdog{DEADLOCK_TIMEOUT};
 
-    uint64_t m_receiveCounter{0U};
+    std::atomic<uint64_t> m_receiveCounter{0U};
     std::atomic<uint64_t> m_sendCounter{0U};
-    std::atomic<uint64_t> m_publisherRunFinished{0U};
+    std::atomic<bool> m_publisherRunFinished{false};
 
     // Memory objects
     iox::BumpAllocator m_memoryAllocator{g_memory, MEMORY_SIZE};
@@ -178,9 +178,7 @@ class PortUser_IntegrationTest : public Test
     }
 
     template <typename SubscriberPortType>
-    void subscriberThread(uint32_t numberOfPublishers,
-                          SubscriberPortType& subscriberPortRouDi,
-                          SubscriberPortUser& subscriberPortUser)
+    void subscriberThread(SubscriberPortType& subscriberPortRouDi, SubscriberPortUser& subscriberPortUser)
     {
         bool finished{false};
 
@@ -213,17 +211,14 @@ class PortUser_IntegrationTest : public Test
             // Try to receive chunk
             subscriberPortUser.tryGetChunk()
                 .and_then([&](auto& chunkHeader) {
-                    m_receiveCounter++;
+                    m_receiveCounter.fetch_add(1, std::memory_order_relaxed);
                     subscriberPortUser.releaseChunk(chunkHeader);
                 })
                 .or_else([&](auto& result) {
                     if (result == ChunkReceiveResult::NO_CHUNK_AVAILABLE)
                     {
                         // Nothing received -> check if publisher(s) still running
-                        if (m_publisherRunFinished.load(std::memory_order_relaxed) == numberOfPublishers)
-                        {
-                            finished = true;
-                        }
+                        finished = m_publisherRunFinished.load(std::memory_order_relaxed);
                     }
                     else
                     {
@@ -298,8 +293,17 @@ class PortUser_IntegrationTest : public Test
         }
 
         // Subscriber is ready to receive -> start sending samples
-        for (size_t i = 0U; i < ITERATIONS; i++)
+        size_t i = 0U;
+        while (i < ITERATIONS)
         {
+            // slow down to ensure there is no overflow
+            auto receiveCounter = m_receiveCounter.load(std::memory_order_relaxed);
+            auto sendCounter = m_sendCounter.load(std::memory_order_seq_cst);
+            if (sendCounter - receiveCounter > 100)
+            {
+                std::this_thread::yield();
+                continue;
+            }
             publisherPortUser
                 .tryAllocateChunk(sizeof(DummySample),
                                   alignof(DummySample),
@@ -310,66 +314,59 @@ class PortUser_IntegrationTest : public Test
                     new (sample) DummySample();
                     static_cast<DummySample*>(sample)->m_dummy = i;
                     publisherPortUser.sendChunk(chunkHeader);
-                    m_sendCounter++;
+                    m_sendCounter.fetch_add(1, std::memory_order_relaxed);
                 })
                 .or_else([](auto error) {
                     // Errors shall never occur
                     GTEST_FAIL() << "Error in tryAllocateChunk(): " << static_cast<uint32_t>(error);
                 });
 
-            /// Add some jitter to make thread breathe
-            std::this_thread::sleep_for(std::chrono::milliseconds(rand() % 4));
-        }
+            ++i;
 
-        // Signal the subscriber thread we're done
-        m_publisherRunFinished++;
+            /// Add some jitter to make thread breathe
+            std::this_thread::sleep_for(std::chrono::microseconds(100 + rand() % 50));
+        }
     }
 };
 
-TIMING_TEST_F(PortUser_IntegrationTest, SingleProducer, Repeat(5), [&] {
+TEST_F(PortUser_IntegrationTest, SingleProducer)
+{
     ::testing::Test::RecordProperty("TEST_ID", "bb62ac02-2b7d-4d1c-8699-9f5ba4d9bd5a");
 
-    std::thread subscribingThread([this] {
-        constexpr uint32_t NUMBER_OF_PUBLISHERS_SINGLE_PRODUCER = 1U;
-        subscriberThread(NUMBER_OF_PUBLISHERS_SINGLE_PRODUCER,
-                         m_subscriberPortRouDiSingleProducer,
-                         m_subscriberPortUserSingleProducer);
-    });
+    std::thread subscribingThread(
+        [this] { subscriberThread(m_subscriberPortRouDiSingleProducer, m_subscriberPortUserSingleProducer); });
     std::thread publishingThread([this] {
         constexpr uint32_t INDEX_OF_PUBLISHER_SINGLE_PRODUCER = 0U;
         publisherThread(
             INDEX_OF_PUBLISHER_SINGLE_PRODUCER, m_publisherPortRouDiVector.front(), m_publisherPortUserVector.front());
     });
 
+    if (publishingThread.joinable())
+    {
+        publishingThread.join();
+    }
+    m_publisherRunFinished.store(true, std::memory_order_relaxed);
+
     if (subscribingThread.joinable())
     {
         subscribingThread.join();
     }
 
-    if (publishingThread.joinable())
-    {
-        publishingThread.join();
-    }
+    EXPECT_THAT(m_receiveCounter.load(std::memory_order_relaxed), Eq(m_sendCounter.load(std::memory_order_relaxed)));
+    EXPECT_FALSE(PortUser_IntegrationTest::m_subscriberPortUserMultiProducer.hasLostChunksSinceLastCall());
+}
 
-    TIMING_TEST_EXPECT_TRUE(m_sendCounter.load(std::memory_order_relaxed) == m_receiveCounter);
-    TIMING_TEST_EXPECT_FALSE(PortUser_IntegrationTest::m_subscriberPortUserMultiProducer.hasLostChunksSinceLastCall());
-})
-
-TIMING_TEST_F(PortUser_IntegrationTest, MultiProducer, Repeat(5), [&] {
+TEST_F(PortUser_IntegrationTest, MultiProducer)
+{
     ::testing::Test::RecordProperty("TEST_ID", "d27279d3-26c0-4489-9208-bd361120525a");
-    std::thread subscribingThread([this] {
-        subscriberThread(NUMBER_OF_PUBLISHERS, m_subscriberPortRouDiMultiProducer, m_subscriberPortUserMultiProducer);
-    });
+
+    std::thread subscribingThread(
+        [this] { subscriberThread(m_subscriberPortRouDiMultiProducer, m_subscriberPortUserMultiProducer); });
 
     for (uint32_t i = 0U; i < NUMBER_OF_PUBLISHERS; i++)
     {
         m_publisherThreadVector.emplace_back(
             [i, this] { publisherThread(i, m_publisherPortRouDiVector[i], m_publisherPortUserVector[i]); });
-    }
-
-    if (subscribingThread.joinable())
-    {
-        subscribingThread.join();
     }
 
     for (uint32_t i = 0U; i < NUMBER_OF_PUBLISHERS; i++)
@@ -379,9 +376,15 @@ TIMING_TEST_F(PortUser_IntegrationTest, MultiProducer, Repeat(5), [&] {
             m_publisherThreadVector[i].join();
         }
     }
+    m_publisherRunFinished.store(true, std::memory_order_relaxed);
 
-    TIMING_TEST_EXPECT_TRUE(m_sendCounter.load(std::memory_order_relaxed) == m_receiveCounter);
-    TIMING_TEST_EXPECT_FALSE(PortUser_IntegrationTest::m_subscriberPortUserMultiProducer.hasLostChunksSinceLastCall());
-})
+    if (subscribingThread.joinable())
+    {
+        subscribingThread.join();
+    }
+
+    EXPECT_THAT(m_receiveCounter.load(std::memory_order_relaxed), Eq(m_sendCounter.load(std::memory_order_relaxed)));
+    EXPECT_FALSE(PortUser_IntegrationTest::m_subscriberPortUserMultiProducer.hasLostChunksSinceLastCall());
+}
 
 } // namespace

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -324,7 +324,12 @@ class PortUser_IntegrationTest : public Test
             ++i;
 
             /// Add some jitter to make thread breathe
-            std::this_thread::sleep_for(std::chrono::microseconds(100 + rand() % 50));
+            /// On Windows even when asked for short sleeps the OS suspends the execution for multiple milliseconds;
+            /// therefore lets sleep only every second iteration
+            if (i % 2 == 0)
+            {
+                std::this_thread::sleep_for(std::chrono::microseconds(100 + rand() % 50));
+            }
         }
     }
 };

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
@@ -15,11 +15,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/message_queue.hpp"
 #include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 #include "iceoryx_platform/platform_settings.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_interface_base.hpp"
+#include "iox/message_queue.hpp"
 #include "iox/std_chrono_support.hpp"
 
 #include "test.hpp"

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
@@ -15,11 +15,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_dust/posix_wrapper/named_pipe.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 #include "iceoryx_platform/platform_settings.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_interface_base.hpp"
 #include "iox/message_queue.hpp"
+#include "iox/named_pipe.hpp"
 #include "iox/std_chrono_support.hpp"
 
 #include "test.hpp"

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
@@ -18,8 +18,8 @@
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 #include "iceoryx_platform/platform_settings.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_interface_base.hpp"
-#include "iox/message_queue.hpp"
-#include "iox/named_pipe.hpp"
+#include "iox/posix/message_queue.hpp"
+#include "iox/posix/named_pipe.hpp"
 #include "iox/std_chrono_support.hpp"
 
 #include "test.hpp"

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/mocks/posh_runtime_mock.hpp
@@ -28,10 +28,10 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
     static std::unique_ptr<PoshRuntimeMock> create(const iox::RuntimeName_t& name)
     {
         auto& runtime = mockRuntime();
-        IOX_EXPECTS(!runtime.has_value() && "Using multiple PoshRuntimeMock in parallel is not supported!");
-        IOX_EXPECTS(PoshRuntime::getRuntimeFactory() == PoshRuntime::defaultRuntimeFactory
-                    && "The PoshRuntimeMock can only be used in combination with the "
-                       "PoshRuntime::defaultRuntimeFactory! Someone else already switched the factory!");
+        IOX_EXPECTS_WITH_MSG(!runtime.has_value(), "Using multiple PoshRuntimeMock in parallel is not supported!");
+        IOX_EXPECTS_WITH_MSG(PoshRuntime::getRuntimeFactory() == PoshRuntime::defaultRuntimeFactory,
+                             "The PoshRuntimeMock can only be used in combination with the "
+                             "PoshRuntime::defaultRuntimeFactory! Someone else already switched the factory!");
 
         runtime = new PoshRuntimeMock(name);
         PoshRuntime::setRuntimeFactory(mockRuntimeFactory);
@@ -95,8 +95,9 @@ class PoshRuntimeMock : public iox::runtime::PoshRuntime
     static PoshRuntime& mockRuntimeFactory(iox::optional<const iox::RuntimeName_t*> name) noexcept
     {
         auto& runtime = mockRuntime();
-        IOX_EXPECTS(!name.has_value() && "PoshRuntime::initRuntime must not be used with a PoshRuntimeMock!");
-        IOX_EXPECTS(runtime.has_value() && "This should never happen! If you see this, something went horribly wrong!");
+        IOX_EXPECTS_WITH_MSG(!name.has_value(), "PoshRuntime::initRuntime must not be used with a PoshRuntimeMock!");
+        IOX_EXPECTS_WITH_MSG(runtime.has_value(),
+                             "This should never happen! If you see this, something went horribly wrong!");
         return *runtime.value();
     }
 

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/roudi_environment/roudi_environment.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/roudi_environment/roudi_environment.hpp
@@ -19,6 +19,7 @@
 #define IOX_POSH_ROUDI_ENVIRONMENT_ROUDI_ENVIRONMENT_HPP
 
 #include "iceoryx_posh/roudi_env/roudi_env.hpp"
+#include "iox/detail/deprecation_marker.hpp"
 
 #include <chrono>
 
@@ -27,8 +28,7 @@ namespace iox
 namespace roudi
 {
 /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'iox::roudi_env::RouDiEnv'
-class [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'iox::roudi_env::RouDiEnv'")]] RouDiEnvironment
-    : public roudi_env::RouDiEnv
+class IOX_DEPRECATED_SINCE(3, "Please port to 'iox::roudi_env::RouDiEnv'") RouDiEnvironment : public roudi_env::RouDiEnv
 {
   public:
     using ParentType = roudi_env::RouDiEnv;
@@ -36,22 +36,21 @@ class [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'iox::roud
     using ParentType::operator=;
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'setDiscoveryLoopWaitToFinishTimeout'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'setDiscoveryLoopWaitToFinishTimeout'")]] void
-    SetInterOpWaitingTime(const std::chrono::milliseconds& v) noexcept
+    IOX_DEPRECATED_SINCE(3, "Please port to 'setDiscoveryLoopWaitToFinishTimeout'")
+    void SetInterOpWaitingTime(const std::chrono::milliseconds& v) noexcept
     {
         setDiscoveryLoopWaitToFinishTimeout(units::Duration::fromMilliseconds(v.count()));
     }
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'triggerDiscoveryLoopAndWaitToFinish'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'triggerDiscoveryLoopAndWaitToFinish'")]] void
-    InterOpWait() noexcept
+    IOX_DEPRECATED_SINCE(3, "Please port to 'triggerDiscoveryLoopAndWaitToFinish'") void InterOpWait() noexcept
     {
         triggerDiscoveryLoopAndWaitToFinish();
     }
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'cleanupAppResources'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'cleanupAppResources'")]] void CleanupAppResources(
-        const RuntimeName_t& name) noexcept
+    IOX_DEPRECATED_SINCE(3, "Please port to 'cleanupAppResources'")
+    void CleanupAppResources(const RuntimeName_t& name) noexcept
     {
         cleanupAppResources(name);
     }

--- a/iceoryx_posh/testing/include/iceoryx_posh/testing/roudi_gtest.hpp
+++ b/iceoryx_posh/testing/include/iceoryx_posh/testing/roudi_gtest.hpp
@@ -18,6 +18,7 @@
 #define IOX_POSH_TESTUTILS_ROUDI_GTEST_HPP
 
 #include "iceoryx_posh/roudi_env/roudi_env.hpp"
+#include "iox/detail/deprecation_marker.hpp"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -33,16 +34,15 @@ class RouDi_GTest : public iox::roudi_env::RouDiEnv, public ::testing::Test
     RouDi_GTest(const iox::RouDiConfig_t& roudiConfig) noexcept;
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'setDiscoveryLoopWaitToFinishTimeout'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'setDiscoveryLoopWaitToFinishTimeout'")]] void
-    SetInterOpWaitingTime(const std::chrono::milliseconds& v) noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please port to 'setDiscoveryLoopWaitToFinishTimeout'")
+    void SetInterOpWaitingTime(const std::chrono::milliseconds& v) noexcept;
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'triggerDiscoveryLoopAndWaitToFinish'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'triggerDiscoveryLoopAndWaitToFinish'")]] void
-    InterOpWait() noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please port to 'triggerDiscoveryLoopAndWaitToFinish'") void InterOpWait() noexcept;
 
     /// @deprecated Deprecated in 3.0, removed in 4.0, please port to 'cleanupAppResources'
-    [[deprecated("Deprecated in 3.0, removed in 4.0, please port to 'cleanupAppResources'")]] void
-    CleanupAppResources(const RuntimeName_t& name) noexcept;
+    IOX_DEPRECATED_SINCE(3, "Please port to 'cleanupAppResources'")
+    void CleanupAppResources(const RuntimeName_t& name) noexcept;
 };
 
 } // namespace testing


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the posix wrapper in iceoryx dust to the new module location.

Additionally `IOX_EXPECTS_WITH_MSG` and `IOX_DEPRECATED_SINCE` is used where appropriate.

Finally it also fixes a race condition in the `PortUser_IntegrationTest` which was uncovered on the aarch64 build.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1391
