### PR TITLE
iox-#2052 Implement move/copy constructor and assignment for `FixedPositionContainer` 

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -99,6 +99,7 @@
 - ServiceDiscovery uses instrospection MemPools [#1359](https://github.com/eclipse-iceoryx/iceoryx/issues/1359)
 - LockFreeQueue fails to support move-only types [\#2067](https://github.com/eclipse-iceoryx/iceoryx/issues/2067)
 - Fix musl libc compile (missing sys/stat.h include in mqueue.h for mode_t definition) [\#2072](https://github.com/eclipse-iceoryx/iceoryx/issues/2072)
+- Implement move/copy constructor and assignment for `FixedPositionContainer`. [#2052](https://github.com/eclipse-iceoryx/iceoryx/issues/2052)
 
 **Refactoring:**
 

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -52,6 +52,84 @@ inline FixedPositionContainer<T, CAPACITY>::~FixedPositionContainer() noexcept
 }
 
 template <typename T, uint64_t CAPACITY>
+FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(const FixedPositionContainer& other) noexcept
+{
+    m_size = other.m_size;
+    m_begin_free = other.m_begin_free;
+    m_begin_used = other.m_begin_used;
+
+    for (IndexType i = 0; i < CAPACITY; ++i)
+    {
+        m_data[i] = T{other.m_data[i]};
+        m_status[i] = other.m_status[i];
+        m_next[i] = other.m_next[i];
+    }
+}
+
+template <typename T, uint64_t CAPACITY>
+FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(FixedPositionContainer&& other) noexcept
+{
+    m_size = other.m_size;
+    m_begin_free = other.m_begin_free;
+    m_begin_used = other.m_begin_used;
+
+    for (IndexType i = 0; i < CAPACITY; ++i)
+    {
+        m_data[i] = T{std::move(other.m_data[i])};
+        m_status[i] = other.m_status[i];
+        m_next[i] = other.m_next[i];
+    }
+
+    other.m_size = 0;
+    other.m_begin_free = Index::FIRST;
+    other.m_begin_used = Index::INVALID;
+}
+
+template <typename T, uint64_t CAPACITY>
+FixedPositionContainer<T, CAPACITY>&
+FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& other) noexcept
+{
+    if (this != &other)
+    {
+        m_size = other.m_size;
+        m_begin_free = other.m_begin_free;
+        m_begin_used = other.m_begin_used;
+
+        for (IndexType i = 0; i < CAPACITY; ++i)
+        {
+            m_data[i] = other.m_data[i];
+            m_status[i] = other.m_status[i];
+            m_next[i] = other.m_next[i];
+        }
+    }
+    return *this;
+}
+
+template <typename T, uint64_t CAPACITY>
+FixedPositionContainer<T, CAPACITY>&
+FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& other) noexcept
+{
+    if (this != &other)
+    {
+        m_size = other.m_size;
+        m_begin_free = other.m_begin_free;
+        m_begin_used = other.m_begin_used;
+
+        for (IndexType i = 0; i < CAPACITY; ++i)
+        {
+            m_data[i] = std::move(other.m_data[i]);
+            m_status[i] = other.m_status[i];
+            m_next[i] = other.m_next[i];
+        }
+
+        other.m_size = 0;
+        other.m_begin_free = Index::FIRST;
+        other.m_begin_used = Index::INVALID;
+    }
+    return *this;
+}
+
+template <typename T, uint64_t CAPACITY>
 inline void FixedPositionContainer<T, CAPACITY>::clear() noexcept
 {
     for (IndexType i = 0; i < CAPACITY;)

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -19,6 +19,9 @@
 #define IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_INL
 
 #include "iox/fixed_position_container.hpp"
+#if __cplusplus < 201703L
+#include "iox/detail/fixed_position_container_helper.hpp"
+#endif
 
 namespace iox
 {

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -29,18 +29,7 @@ namespace iox
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer() noexcept
 {
-    for (IndexType i = 0; i < CAPACITY;)
-    {
-        m_status[i] = SlotStatus::FREE;
-
-        IndexType next = static_cast<IndexType>(i + 1U);
-        m_next[i] = next;
-        i = next;
-    }
-    m_next[Index::LAST] = Index::INVALID;
-
-    m_begin_free = Index::FIRST;
-    m_begin_used = Index::INVALID;
+    reset_member();
 }
 
 template <typename T, uint64_t CAPACITY>
@@ -58,12 +47,14 @@ inline FixedPositionContainer<T, CAPACITY>::~FixedPositionContainer() noexcept
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(const FixedPositionContainer& rhs) noexcept
 {
+    reset_member();
     *this = rhs;
 }
 
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(FixedPositionContainer&& rhs) noexcept
 {
+    reset_member();
     *this = std::move(rhs);
 }
 
@@ -173,6 +164,23 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
     m_begin_free = static_cast<IndexType>(rhs.m_size);
     m_begin_used = rhs.empty() ? Index::INVALID : Index::FIRST;
     m_size = rhs.m_size;
+}
+
+template <typename T, uint64_t CAPACITY>
+inline void FixedPositionContainer<T, CAPACITY>::reset_member() noexcept
+{
+    for (IndexType i = 0; i < CAPACITY;)
+    {
+        m_status[i] = SlotStatus::FREE;
+
+        IndexType next = static_cast<IndexType>(i + 1U);
+        m_next[i] = next;
+        i = next;
+    }
+    m_next[Index::LAST] = Index::INVALID;
+
+    m_begin_free = Index::FIRST;
+    m_begin_used = Index::INVALID;
 }
 
 template <typename T, uint64_t CAPACITY>

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -207,8 +207,12 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
     // update member to correct information
     m_begin_free = static_cast<IndexType>(rhs.m_size);
     m_begin_used = rhs.empty() ? Index::INVALID : Index::FIRST;
-    m_next[rhs.m_size - 1] = Index::INVALID;
     m_size = rhs.m_size;
+
+    if (!rhs.empty())
+    {
+        m_next[rhs.m_size - 1] = Index::INVALID;
+    }
 }
 
 template <typename T, uint64_t CAPACITY>

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -70,7 +70,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& rhs
 {
     if (this != &rhs)
     {
-        init(rhs);
+        copy_and_move_impl(rhs);
     }
     return *this;
 }
@@ -81,7 +81,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
 {
     if (this != &rhs)
     {
-        init(std::move(rhs));
+        copy_and_move_impl(std::move(rhs));
 
         // clear rhs
         rhs.clear();
@@ -91,7 +91,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
 
 template <typename T, uint64_t CAPACITY>
 template <typename RhsType>
-inline void FixedPositionContainer<T, CAPACITY>::init(RhsType&& rhs) noexcept
+inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rhs) noexcept
 {
     static_assert(std::is_rvalue_reference<decltype(rhs)>::value
                       || (std::is_lvalue_reference<decltype(rhs)>::value

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -29,7 +29,18 @@ namespace iox
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer() noexcept
 {
-    reset_member();
+    for (IndexType i = 0; i < CAPACITY;)
+    {
+        m_status[i] = SlotStatus::FREE;
+
+        IndexType next = static_cast<IndexType>(i + 1U);
+        m_next[i] = next;
+        i = next;
+    }
+    m_next[Index::LAST] = Index::INVALID;
+
+    m_begin_free = Index::FIRST;
+    m_begin_used = Index::INVALID;
 }
 
 template <typename T, uint64_t CAPACITY>
@@ -47,14 +58,22 @@ inline FixedPositionContainer<T, CAPACITY>::~FixedPositionContainer() noexcept
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(const FixedPositionContainer& rhs) noexcept
 {
-    reset_member();
+    for (IndexType i = 0; i < CAPACITY; ++i)
+    {
+        m_status[i] = SlotStatus::FREE;
+    }
+
     *this = rhs;
 }
 
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(FixedPositionContainer&& rhs) noexcept
 {
-    reset_member();
+    for (IndexType i = 0; i < CAPACITY; ++i)
+    {
+        m_status[i] = SlotStatus::FREE;
+    }
+
     *this = std::move(rhs);
 }
 
@@ -164,23 +183,6 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
     m_begin_free = static_cast<IndexType>(rhs.m_size);
     m_begin_used = rhs.empty() ? Index::INVALID : Index::FIRST;
     m_size = rhs.m_size;
-}
-
-template <typename T, uint64_t CAPACITY>
-inline void FixedPositionContainer<T, CAPACITY>::reset_member() noexcept
-{
-    for (IndexType i = 0; i < CAPACITY;)
-    {
-        m_status[i] = SlotStatus::FREE;
-
-        IndexType next = static_cast<IndexType>(i + 1U);
-        m_next[i] = next;
-        i = next;
-    }
-    m_next[Index::LAST] = Index::INVALID;
-
-    m_begin_free = Index::FIRST;
-    m_begin_used = Index::INVALID;
 }
 
 template <typename T, uint64_t CAPACITY>

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -1,4 +1,5 @@
 // Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,12 +70,12 @@ FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& rhs
 {
     if (this != &rhs)
     {
-        IndexType i = 0U;
-        auto lhsSize = size();
-        auto minSize = algorithm::minVal(lhsSize, rhs.size());
+        IndexType i = Index::FIRST;
+        auto lhs_size = size();
+        auto min_size = algorithm::minVal(lhs_size, rhs.size());
 
         // copy using copy assignment
-        for (; i < minSize; ++i)
+        for (; i < min_size; ++i)
         {
             m_data[i] = rhs.m_data[i];
             m_status[i] = rhs.m_status[i];
@@ -90,7 +91,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& rhs
         }
 
         // with rhs.size smaller than this.size: delete remaining elements of this (erase)
-        for (; i < lhsSize; ++i)
+        for (; i < lhs_size; ++i)
         {
             erase(i);
         }
@@ -118,12 +119,12 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
 {
     if (this != &rhs)
     {
-        IndexType i = 0U;
-        auto lhsSize = size();
-        auto minSize = algorithm::minVal(lhsSize, rhs.size());
+        IndexType i = Index::FIRST;
+        auto lhs_size = size();
+        auto min_size = algorithm::minVal(lhs_size, rhs.size());
 
         // move using move assignment
-        for (; i < minSize; ++i)
+        for (; i < min_size; ++i)
         {
             m_data[i] = std::move(rhs.m_data[i]);
             m_status[i] = rhs.m_status[i];
@@ -139,7 +140,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
         }
 
         // with rhs.size smaller than this.size: delete remaining elements of this (erase)
-        for (; i < lhsSize; ++i)
+        for (; i < lhs_size; ++i)
         {
             erase(i);
         }

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved. reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_HELPER_HPP
+#define IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_HELPER_HPP
+
+#include <utility>
+
+namespace iox
+{
+template <bool IsMove>
+struct AssignmentHelper;
+
+template <>
+struct AssignmentHelper<true>
+{
+    template <typename T>
+    static void assign(T& dest, T&& src)
+    {
+        dest = std::forward<T>(src);
+    }
+};
+
+template <>
+struct AssignmentHelper<false>
+{
+    template <typename T>
+    static void assign(T& dest, const T& src)
+    {
+        dest = src;
+    }
+};
+
+template <bool IsMove>
+struct CtorHelper;
+
+template <>
+struct CtorHelper<true>
+{
+    template <typename T>
+    static void construct(T& dest, T&& src)
+    {
+        new (&dest) T(std::forward<T>(src));
+    }
+};
+
+template <>
+struct CtorHelper<false>
+{
+    template <typename T>
+    static void construct(T& dest, const T& src)
+    {
+        new (&dest) T(src);
+    }
+};
+
+template <bool IsMove>
+struct MoveHelper;
+
+template <>
+struct MoveHelper<true>
+{
+    template <typename Iterator>
+    static auto move_or_copy(Iterator& it) -> decltype(std::move(*it))
+    {
+        return std::move(*it);
+    }
+};
+
+template <>
+struct MoveHelper<false>
+{
+    template <typename Iterator>
+    static auto move_or_copy(Iterator& it) -> decltype(*it)
+    {
+        return *it;
+    }
+};
+
+#endif
+}

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
@@ -21,6 +21,8 @@
 
 namespace iox
 {
+namespace detail
+{
 template <bool IsMove>
 struct AssignmentHelper;
 
@@ -91,4 +93,5 @@ struct MoveHelper<false>
 };
 
 #endif
+}
 }

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -65,11 +65,11 @@ class FixedPositionContainer final
     FixedPositionContainer() noexcept;
     ~FixedPositionContainer() noexcept;
 
-    FixedPositionContainer(const FixedPositionContainer&) noexcept = delete;
-    FixedPositionContainer(FixedPositionContainer&&) noexcept = delete;
+    FixedPositionContainer(const FixedPositionContainer&) noexcept;
+    FixedPositionContainer(FixedPositionContainer&&) noexcept;
 
-    FixedPositionContainer& operator=(const FixedPositionContainer&) noexcept = delete;
-    FixedPositionContainer& operator=(FixedPositionContainer&&) noexcept = delete;
+    FixedPositionContainer& operator=(const FixedPositionContainer&) noexcept;
+    FixedPositionContainer& operator=(FixedPositionContainer&&) noexcept;
 
     /// @brief Clears the container and calls the destructor on all contained elements
     void clear() noexcept;

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -317,6 +317,10 @@ class FixedPositionContainer final
         IndexType m_index;
     };
 
+  private:
+    /// @brief Initialize member variables to prevent undefined or erroneous values.
+    void reset_member() noexcept;
+
     template <typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -317,6 +317,77 @@ class FixedPositionContainer final
         IndexType m_index;
     };
 
+#if __cplusplus < 201703L
+  private:
+    // C++ 14 feature
+    template <bool IsMove>
+    struct AssignmentHelper;
+
+    template <>
+    struct AssignmentHelper<true>
+    {
+        static void assign(T& dest, T&& src)
+        {
+            dest = std::forward<T>(src);
+        }
+    };
+
+    template <>
+    struct AssignmentHelper<false>
+    {
+        static void assign(T& dest, const T& src)
+        {
+            dest = src;
+        }
+    };
+
+    // C++ 14 feature
+    template <bool IsMove>
+    struct CtorHelper;
+
+    template <>
+    struct CtorHelper<true>
+    {
+        static void construct(T& dest, T&& src)
+        {
+            new (&dest) T(std::forward<T>(src));
+        }
+    };
+
+    template <>
+    struct CtorHelper<false>
+    {
+        static void construct(T& dest, const T& src)
+        {
+            new (&dest) T(src);
+        }
+    };
+
+    // C++ 14 feature
+    template <bool IsMove>
+    struct MoveHelper;
+
+    template <>
+    struct MoveHelper<true>
+    {
+        template <typename Iterator>
+        static auto move_or_copy(Iterator& it) -> decltype(std::move(*it))
+        {
+            return std::move(*it);
+        }
+    };
+
+    template <>
+    struct MoveHelper<false>
+    {
+        template <typename Iterator>
+        static auto move_or_copy(Iterator& it) -> decltype(*it)
+        {
+            return *it;
+        }
+    };
+#endif
+
     template <typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -21,6 +21,10 @@
 #include "iox/algorithm.hpp"
 #include "iox/uninitialized_array.hpp"
 
+#if __cplusplus < 201703L
+#include "iox/detail/fixed_position_container_helper.hpp"
+#endif
+
 #include <cstdint>
 #include <functional>
 #include <type_traits>
@@ -316,77 +320,6 @@ class FixedPositionContainer final
         std::reference_wrapper<Container> m_container;
         IndexType m_index;
     };
-
-#if __cplusplus < 201703L
-  private:
-    // C++ 14 feature
-    template <bool IsMove>
-    struct AssignmentHelper;
-
-    template <>
-    struct AssignmentHelper<true>
-    {
-        static void assign(T& dest, T&& src)
-        {
-            dest = std::forward<T>(src);
-        }
-    };
-
-    template <>
-    struct AssignmentHelper<false>
-    {
-        static void assign(T& dest, const T& src)
-        {
-            dest = src;
-        }
-    };
-
-    // C++ 14 feature
-    template <bool IsMove>
-    struct CtorHelper;
-
-    template <>
-    struct CtorHelper<true>
-    {
-        static void construct(T& dest, T&& src)
-        {
-            new (&dest) T(std::forward<T>(src));
-        }
-    };
-
-    template <>
-    struct CtorHelper<false>
-    {
-        static void construct(T& dest, const T& src)
-        {
-            new (&dest) T(src);
-        }
-    };
-
-    // C++ 14 feature
-    template <bool IsMove>
-    struct MoveHelper;
-
-    template <>
-    struct MoveHelper<true>
-    {
-        template <typename Iterator>
-        static auto move_or_copy(Iterator& it) -> decltype(std::move(*it))
-        {
-            return std::move(*it);
-        }
-    };
-
-    template <>
-    struct MoveHelper<false>
-    {
-        template <typename Iterator>
-        static auto move_or_copy(Iterator& it) -> decltype(*it)
-        {
-            return *it;
-        }
-    };
-#endif
 
     template <typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -318,9 +318,6 @@ class FixedPositionContainer final
     };
 
   private:
-    /// @brief Initialize member variables to prevent undefined or erroneous values.
-    void reset_member() noexcept;
-
     template <typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -324,6 +324,9 @@ class FixedPositionContainer final
     IndexType m_size{0};
     IndexType m_begin_free{Index::FIRST};
     IndexType m_begin_used{Index::INVALID};
+
+    template <typename RhsType>
+    void init(RhsType&& rhs) noexcept;
 };
 
 } // namespace iox

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -21,10 +21,6 @@
 #include "iox/algorithm.hpp"
 #include "iox/uninitialized_array.hpp"
 
-#if __cplusplus < 201703L
-#include "iox/detail/fixed_position_container_helper.hpp"
-#endif
-
 #include <cstdint>
 #include <functional>
 #include <type_traits>

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -317,6 +317,9 @@ class FixedPositionContainer final
         IndexType m_index;
     };
 
+    template <typename RhsType>
+    void copy_and_move_impl(RhsType&& rhs) noexcept;
+
   private:
     UninitializedArray<T, CAPACITY> m_data;
     UninitializedArray<SlotStatus, CAPACITY> m_status;
@@ -324,9 +327,6 @@ class FixedPositionContainer final
     IndexType m_size{0};
     IndexType m_begin_free{Index::FIRST};
     IndexType m_begin_used{Index::INVALID};
-
-    template <typename RhsType>
-    void init(RhsType&& rhs) noexcept;
 };
 
 } // namespace iox

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -74,6 +74,7 @@ struct FixedPositionContainer_test : public Test
 
 TEST_F(FixedPositionContainer_test, ContainerIsNotMovable)
 {
+    GTEST_SKIP() << "@deprecated iox-#2052 Add moveable feature";
     ::testing::Test::RecordProperty("TEST_ID", "5c05f240-9822-427b-9eb5-69fd43f1ac28");
     EXPECT_FALSE(std::is_move_constructible<Sut>::value);
     EXPECT_FALSE(std::is_move_assignable<Sut>::value);
@@ -81,6 +82,7 @@ TEST_F(FixedPositionContainer_test, ContainerIsNotMovable)
 
 TEST_F(FixedPositionContainer_test, ContainerIsNotCopyable)
 {
+    GTEST_SKIP() << "@deprecated iox-#2052 Add copyable feature";
     ::testing::Test::RecordProperty("TEST_ID", "1b421af5-d014-4f9b-98ed-fbfdf5a9beb8");
     EXPECT_FALSE(std::is_copy_constructible<Sut>::value);
     EXPECT_FALSE(std::is_copy_assignable<Sut>::value);
@@ -91,6 +93,224 @@ TEST_F(FixedPositionContainer_test, Capacity)
     ::testing::Test::RecordProperty("TEST_ID", "17669b2f-d53b-4ac9-8190-b1c32f8ec4ba");
     EXPECT_THAT(sut.capacity(), Eq(CAPACITY));
 }
+
+// BEGIN test copy constructor
+
+TEST_F(FixedPositionContainer_test, SimpleContainerCopyConstructor)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "89d40e19-a838-42fb-aebd-95492c690f98");
+
+    fillSut();
+
+    const Sut sut_copy_ctor{sut};
+    auto it = sut.begin();
+    for (const auto& item : sut_copy_ctor)
+    {
+        EXPECT_EQ(item, *it);
+        EXPECT_NE(&item, &(*it));
+        it++;
+    }
+
+    EXPECT_EQ(sut.size(), sut_copy_ctor.size());
+}
+
+TEST_F(FixedPositionContainer_test, ComplexContainerCopyConstructor)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b3c84ca9-0e24-4331-beca-efd53a5c8818");
+
+    fillSutComplex();
+
+    // reset copyCtor counter
+    SetUp();
+
+    const SutComplex sut_complex_copy_ctor{sut_complex};
+    auto it = sut_complex_copy_ctor.begin();
+    for (const auto& item : sut_complex)
+    {
+        EXPECT_EQ(item, *it);
+        EXPECT_NE(&item, &(*it));
+        ++it;
+    }
+
+    EXPECT_EQ(sut_complex.size(), sut_complex_copy_ctor.size());
+    EXPECT_EQ(sut_complex_copy_ctor.begin()->stats.copyCTor, sut_complex.size());
+}
+
+// END test copy constructor
+
+// BEGIN test move constructor
+
+TEST_F(FixedPositionContainer_test, SimpleContainerMoveConstructor)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "869ff262-0157-496b-94ed-da682505cb77");
+
+    fillSut();
+
+    std::vector<DataType> data;
+    for (const auto& item : sut)
+    {
+        data.push_back(item);
+    }
+
+    const Sut sut_move_ctor{std::move(sut)};
+
+    std::size_t index{0};
+    for (const auto& item : sut_move_ctor)
+    {
+        EXPECT_EQ(item, data[index]);
+        index++;
+    }
+
+    // sut should be reset (move ctor)
+    EXPECT_TRUE(sut.empty());
+    EXPECT_EQ(sut_move_ctor.size(), data.size());
+}
+
+TEST_F(FixedPositionContainer_test, ComplexContainerMoveConstructor)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "55084310-88db-4972-a0d1-01dc75e440be");
+
+    fillSutComplex();
+
+    std::vector<ComplexType> data;
+    for (const auto& item : sut_complex)
+    {
+        data.push_back(item);
+    }
+
+    // reset moveCtor counter
+    SetUp();
+
+    const SutComplex sut_complex_move_ctor{std::move(sut_complex)};
+
+    std::size_t index{0};
+    for (const auto& item : sut_complex_move_ctor)
+    {
+        EXPECT_EQ(item.value, data[index].value);
+        index++;
+    }
+
+    // sut_complex should be reset (move ctor)
+    EXPECT_EQ(sut_complex.empty(), true);
+    EXPECT_EQ(sut_complex_move_ctor.size(), data.size());
+    EXPECT_EQ(sut_complex_move_ctor.begin()->stats.moveCTor, data.size());
+}
+
+// END test move constructor
+
+// BEGIN test copy assignment
+
+TEST_F(FixedPositionContainer_test, SimpleContainerCopyAssignment)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "e099d78a-4a6c-4c5f-99d5-84431ee24000");
+
+    fillSut();
+
+    Sut sut_copy_assignment;
+    sut_copy_assignment = sut;
+
+    auto it = sut.begin();
+    for (const auto& item : sut_copy_assignment)
+    {
+        EXPECT_EQ(item, *it);
+        EXPECT_NE(&item, &(*it));
+        ++it;
+    }
+
+    EXPECT_EQ(sut.size(), sut_copy_assignment.size());
+}
+
+TEST_F(FixedPositionContainer_test, ComplexContainerCopyAssignment)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "93dd1e09-69d3-47dc-a021-c2a311b83b86");
+
+    fillSutComplex();
+
+    // reset copyAssignment counter
+    SetUp();
+
+    SutComplex sut_complex_copy_assignment;
+    sut_complex_copy_assignment = sut_complex;
+
+    auto it = sut_complex.begin();
+    for (const auto& item : sut_complex_copy_assignment)
+    {
+        EXPECT_EQ(item, *it);
+        EXPECT_NE(&item, &(*it));
+        ++it;
+    }
+
+    EXPECT_EQ(sut_complex_copy_assignment.begin()->stats.copyAssignment, sut_complex.size());
+    EXPECT_EQ(sut_complex.size(), sut_complex_copy_assignment.size());
+}
+
+// END test copy assignment
+
+// BEGIN test move assignment
+
+TEST_F(FixedPositionContainer_test, SimpleContainerMoveAssignment)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6455982d-20f7-4304-a4b1-5947727e3f83");
+
+    fillSut();
+
+    Sut sut_move_assignment;
+    std::vector<DataType> data;
+    for (const auto& item : sut)
+    {
+        data.push_back(item);
+    }
+
+    sut_move_assignment = std::move(sut);
+
+    std::size_t index{0};
+    for (const auto& item : sut_move_assignment)
+    {
+        EXPECT_EQ(item, data[index]);
+        index++;
+    }
+
+    // sut should be reset (move assignment)
+    EXPECT_TRUE(sut.empty());
+    EXPECT_EQ(sut_move_assignment.size(), data.size());
+}
+
+TEST_F(FixedPositionContainer_test, ComplexContainerMoveAssignment)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5eb677a3-a54d-462d-9597-70dce86c9701");
+
+    fillSutComplex();
+
+    std::vector<ComplexType> data;
+    for (const auto& item : sut_complex)
+    {
+        data.push_back(item);
+    }
+
+    // reset moveAssignment counter
+    SetUp();
+
+    SutComplex sut_complex_move_assignment;
+    sut_complex_move_assignment = std::move(sut_complex);
+
+    std::size_t index{0};
+    for (const auto& item : sut_complex_move_assignment)
+    {
+        EXPECT_EQ(item, data[index]);
+        index++;
+    }
+
+    // sut_complex should be reset (move assignment)
+    EXPECT_TRUE(sut_complex.empty());
+    EXPECT_EQ(sut_complex_move_assignment.begin()->stats.moveAssignment, data.size());
+    EXPECT_EQ(sut_complex_move_assignment.size(), data.size());
+
+    // sut_complex should can be assigned value again
+    sut_complex.emplace(42UL);
+    EXPECT_EQ(sut_complex.begin()->value, 42UL);
+}
+
+// END test move assignment
 
 // BEGIN test empty
 

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -133,7 +133,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorMultipleElementsContainerPreser
     ::testing::Test::RecordProperty("TEST_ID", "6261f53e-8089-4b9b-9b2d-9da0016a2f1e");
 
     constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
-    std::vector<DataType> EXPECTED_VALUE = {0U, 1U, 2U, 3U};
+    std::vector<DataType> EXPECTED_VALUE = {56U, 57U, 58U, 59U};
     for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {
         sut_complex.emplace(EXPECTED_VALUE[i]);
@@ -234,7 +234,7 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromMultipleElementsContainerCl
 {
     ::testing::Test::RecordProperty("TEST_ID", "b9d929ae-23c8-4b5b-ba82-e5af12cdace4");
 
-    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    std::vector<DataType> EXPECTED_VALUE{56U, 57U, 58U, 59U};
     constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
     for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {
@@ -330,7 +330,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsConta
 {
     ::testing::Test::RecordProperty("TEST_ID", "262ad71a-0ee2-4661-b2c8-a3cca9c1cf5e");
 
-    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    std::vector<DataType> EXPECTED_VALUE{56U, 57U, 58U, 59U};
     for (SutComplex::IndexType i = 0; i < EXPECTED_VALUE.size(); ++i)
     {
         sut_complex.emplace(EXPECTED_VALUE[i]);
@@ -426,7 +426,7 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromMultipleElementsConta
 {
     ::testing::Test::RecordProperty("TEST_ID", "c44da583-1ed8-4c83-b5bb-dba5d64b21d9");
 
-    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    std::vector<DataType> EXPECTED_VALUE{56U, 57U, 58U, 59U};
     constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
     for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -288,6 +288,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorWillNotChangeSourceContainer)
 
 // END test copy constructor
 
+
 // BEGIN test move constructor
 
 TEST_F(FixedPositionContainer_test, UsingMoveCtorFromEmptyContainerResultsInEmptyContainer)
@@ -458,6 +459,7 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorAtNonCopyableTypeShouldCompile)
 }
 
 // END test move constructor
+
 
 // BEGIN test copy assignment
 
@@ -1047,6 +1049,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentInsertionShouldFailWhenCa
 
 // END test copy assignment
 
+
 // BEGIN test move assignment
 
 TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromEmptyContainerResultsInEmptyContainer)
@@ -1151,10 +1154,6 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromFullCapacityContainer
 
     EXPECT_THAT(sut_complex.empty(), Eq(true));
 }
-
-/////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////
 
 TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromEmptyToNonEmptyContainer)
 {
@@ -1665,9 +1664,8 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentAtNonCopyableTypeShouldCo
     EXPECT_THAT(move_sut_noncopy.size(), Eq(EXPECTED_SIZE));
 }
 
-/////////////////////////////////////////////////////////
-
 // END test move assignment
+
 
 // BEGIN test empty
 

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -370,7 +370,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainer
     EXPECT_THAT(stats.copyAssignment, Eq(EXPECTED_SIZE));
     EXPECT_THAT(stats.moveAssignment, Eq(0));
 
-    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.full(), Eq(true));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
     for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -109,22 +109,6 @@ struct FixedPositionContainer_test : public Test
     ComplexType::Statistics& stats = ComplexType::stats;
 };
 
-TEST_F(FixedPositionContainer_test, ContainerIsNotMovable)
-{
-    GTEST_SKIP() << "@deprecated iox-#2052 Add moveable feature";
-    ::testing::Test::RecordProperty("TEST_ID", "5c05f240-9822-427b-9eb5-69fd43f1ac28");
-    EXPECT_FALSE(std::is_move_constructible<Sut>::value);
-    EXPECT_FALSE(std::is_move_assignable<Sut>::value);
-}
-
-TEST_F(FixedPositionContainer_test, ContainerIsNotCopyable)
-{
-    GTEST_SKIP() << "@deprecated iox-#2052 Add copyable feature";
-    ::testing::Test::RecordProperty("TEST_ID", "1b421af5-d014-4f9b-98ed-fbfdf5a9beb8");
-    EXPECT_FALSE(std::is_copy_constructible<Sut>::value);
-    EXPECT_FALSE(std::is_copy_assignable<Sut>::value);
-}
-
 TEST_F(FixedPositionContainer_test, Capacity)
 {
     ::testing::Test::RecordProperty("TEST_ID", "17669b2f-d53b-4ac9-8190-b1c32f8ec4ba");
@@ -255,7 +239,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorFromNonEmptyWithFirstAndMiddleA
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(CAPACITY - 3U));
 
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -435,7 +419,7 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromNonEmptyWithFirstAndMiddleA
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(CAPACITY - 3U));
 
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -572,6 +556,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromEmptyToNonEmptyContai
     EXPECT_THAT(copy_sut_complex.full(), Eq(0));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(true));
     EXPECT_THAT(copy_sut_complex.size(), Eq(0));
+    EXPECT_THAT(copy_sut_complex.begin(), Eq(copy_sut_complex.end()));
 }
 
 TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromLargerSizeToSmallerSizeContainer)
@@ -597,7 +582,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromLargerSizeToSmallerSi
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -628,7 +613,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentBetweenContainersOfEqalSi
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -659,7 +644,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromSmallerSizeToLargerSi
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -687,7 +672,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstInde
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -721,7 +706,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstInde
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -756,7 +741,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyToNonEmptyCon
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -793,7 +778,7 @@ TEST_F(FixedPositionContainer_test,
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -823,7 +808,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstAndM
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -859,7 +844,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstAndM
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -897,7 +882,7 @@ TEST_F(FixedPositionContainer_test,
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -938,7 +923,7 @@ TEST_F(
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -973,7 +958,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithLastErase
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -1035,7 +1020,7 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentInsertionShouldFailWhenCa
     EXPECT_THAT(copy_sut_complex.full(), Eq(true));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
-    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    auto it = copy_sut_complex.begin();
     for (const auto& value : EXPECTED_VALUE)
     {
         EXPECT_THAT(it->value, Eq(value));
@@ -1662,6 +1647,25 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentAtNonCopyableTypeShouldCo
     move_sut_noncopy = std::move(sut_noncopy);
 
     EXPECT_THAT(move_sut_noncopy.size(), Eq(EXPECTED_SIZE));
+}
+
+TEST_F(FixedPositionContainer_test, IteratorsAfterMoveWorkAsExpected)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "17b91183-9f1e-4ab4-ab27-e34f096674d8");
+
+    std::vector<DataType> EXPECTED_VALUE = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 9U};
+
+    fillSutComplex();
+
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(sut_complex.begin(), Eq(sut_complex.end()));
+    auto it = move_sut_complex.begin();
+    for (SutComplex::IndexType i = 0U; it != move_sut_complex.end(); ++it, ++i)
+    {
+        EXPECT_THAT(it->value, Eq(EXPECTED_VALUE[i]));
+    }
 }
 
 // END test move assignment

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -96,220 +96,320 @@ TEST_F(FixedPositionContainer_test, Capacity)
 
 // BEGIN test copy constructor
 
-TEST_F(FixedPositionContainer_test, SimpleContainerCopyConstructor)
+TEST_F(FixedPositionContainer_test, UsingCopyCtorEmptyContainerResultsInEmptyContainer)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "89d40e19-a838-42fb-aebd-95492c690f98");
+    ::testing::Test::RecordProperty("TEST_ID", "6c528ef3-9c2d-4eb2-93a9-2d998d0db380");
 
-    fillSut();
+    SutComplex copy_sut_complex{sut_complex};
 
-    const Sut sut_copy_ctor{sut};
-    auto it = sut.begin();
-    for (const auto& item : sut_copy_ctor)
-    {
-        EXPECT_EQ(item, *it);
-        EXPECT_NE(&item, &(*it));
-        it++;
-    }
-
-    EXPECT_EQ(sut.size(), sut_copy_ctor.size());
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(true));
 }
 
-TEST_F(FixedPositionContainer_test, ComplexContainerCopyConstructor)
+TEST_F(FixedPositionContainer_test, UsingCopyCtorSingleElementContainerPreservesElement)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "b3c84ca9-0e24-4331-beca-efd53a5c8818");
+    ::testing::Test::RecordProperty("TEST_ID", "f3aaf452-77fa-4535-bf0b-37bedefc2bf6");
 
-    fillSutComplex();
+    constexpr DataType EXPECTED_VALUE{42U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{1U};
 
-    // reset copyCtor counter
-    SetUp();
+    sut_complex.emplace(EXPECTED_VALUE);
+    SutComplex copy_sut_complex{sut_complex};
 
-    const SutComplex sut_complex_copy_ctor{sut_complex};
-    auto it = sut_complex_copy_ctor.begin();
-    for (const auto& item : sut_complex)
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    // actually call copyAssignment
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(copy_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyCtorMultipleElementsContainerPreservesAllElements)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6261f53e-8089-4b9b-9b2d-9da0016a2f1e");
+
+    constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
+    std::vector<DataType> EXPECTED_VALUE = {0U, 1U, 2U, 3U};
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {
-        EXPECT_EQ(item, *it);
-        EXPECT_NE(&item, &(*it));
-        ++it;
+        sut_complex.emplace(EXPECTED_VALUE[i]);
     }
 
-    EXPECT_EQ(sut_complex.size(), sut_complex_copy_ctor.size());
-    // FixedPositionContainer copyCtor will call copyAssignment
-    EXPECT_EQ(sut_complex_copy_ctor.begin()->stats.copyAssignment, sut_complex.size());
+    SutComplex copy_sut_complex{sut_complex};
+
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    // actually call copyAssignment
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(EXPECTED_SIZE));
+    for (Sut::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyCtorFullCapacityContainerPreservesAllElements)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "028704df-b2f3-4133-9c16-b9d2c6a79916");
+
+    fillSutComplex();
+    constexpr SutComplex::IndexType EXPECTED_SIZE{CAPACITY};
+
+    SutComplex copy_sut_complex{sut_complex};
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(true));
+
+    // actually call copyAssignment
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(EXPECTED_SIZE));
+    for (Sut::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(sut_complex.iter_from_index(i)->value));
+        EXPECT_THAT(copy_sut_complex.iter_from_index(i), Ne(sut_complex.iter_from_index(i)));
+    }
 }
 
 // END test copy constructor
 
 // BEGIN test move constructor
 
-TEST_F(FixedPositionContainer_test, SimpleContainerMoveConstructor)
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromEmptyContainerResultsInEmptyContainer)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "869ff262-0157-496b-94ed-da682505cb77");
+    ::testing::Test::RecordProperty("TEST_ID", "af8958fb-9a09-4987-b290-ce41abdc2354");
 
-    fillSut();
+    SutComplex move_sut_complex{std::move(sut_complex)};
 
-    std::vector<DataType> data;
-    for (const auto& item : sut)
-    {
-        data.push_back(item);
-    }
-
-    const Sut sut_move_ctor{std::move(sut)};
-
-    std::size_t index{0};
-    for (const auto& item : sut_move_ctor)
-    {
-        EXPECT_EQ(item, data[index]);
-        index++;
-    }
-
-    // sut should be reset (move ctor)
-    EXPECT_TRUE(sut.empty());
-    EXPECT_EQ(sut_move_ctor.size(), data.size());
+    EXPECT_THAT(move_sut_complex.empty(), Eq(true));
 }
 
-TEST_F(FixedPositionContainer_test, ComplexContainerMoveConstructor)
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromSingleElementContainerClearsOriginal)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "55084310-88db-4972-a0d1-01dc75e440be");
+    ::testing::Test::RecordProperty("TEST_ID", "df6c1884-43c6-4d1e-b889-6cbf4b9ee726");
+
+    constexpr DataType EXPECTED_VALUE{42U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{1U};
+    sut_complex.emplace(EXPECTED_VALUE);
+
+    SutComplex move_sut_complex{std::move(sut_complex)};
+
+    ASSERT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    // actually call moveAssignment
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
+
+    // make sure clear() been called
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    EXPECT_THAT(move_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromMultipleElementsContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b9d929ae-23c8-4b5b-ba82-e5af12cdace4");
+
+    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        sut_complex.emplace(EXPECTED_VALUE[i]);
+    }
+
+    SutComplex move_sut_complex{std::move(sut_complex)};
+
+    ASSERT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    // actually call moveAssignment
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
+
+    // make sure clear() been called
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromFullCapacityContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8a9ca6d1-5ac3-4e31-9cb9-0476176531e1");
 
     fillSutComplex();
-
-    std::vector<ComplexType> data;
+    constexpr SutComplex::IndexType EXPECTED_SIZE{CAPACITY};
+    std::vector<DataType> EXPECTED_VALUE;
     for (const auto& item : sut_complex)
     {
-        data.push_back(item);
+        EXPECTED_VALUE.emplace_back(item.value);
     }
 
-    // reset moveCtor counter
-    SetUp();
+    SutComplex move_sut_complex{std::move(sut_complex)};
 
-    const SutComplex sut_complex_move_ctor{std::move(sut_complex)};
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    ASSERT_THAT(move_sut_complex.full(), Eq(true));
 
-    std::size_t index{0};
-    for (const auto& item : sut_complex_move_ctor)
+    // actually call moveAssignment
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {
-        EXPECT_EQ(item.value, data[index].value);
-        index++;
+        EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
-
-    // sut_complex should be reset (move ctor)
-    EXPECT_EQ(sut_complex.empty(), true);
-    EXPECT_EQ(sut_complex_move_ctor.size(), data.size());
-    // FixedPositionContainer copyCtor will call copyAssignment
-    EXPECT_EQ(sut_complex_move_ctor.begin()->stats.moveAssignment, data.size());
 }
 
 // END test move constructor
 
 // BEGIN test copy assignment
 
-TEST_F(FixedPositionContainer_test, SimpleContainerCopyAssignment)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromEmptyContainerResultsInEmptyContainer)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "e099d78a-4a6c-4c5f-99d5-84431ee24000");
+    ::testing::Test::RecordProperty("TEST_ID", "013338e3-4330-49b4-8aa4-9b66517bb3bc");
 
-    fillSut();
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
 
-    Sut sut_copy_assignment;
-    sut_copy_assignment = sut;
-
-    auto it = sut.begin();
-    for (const auto& item : sut_copy_assignment)
-    {
-        EXPECT_EQ(item, *it);
-        EXPECT_NE(&item, &(*it));
-        ++it;
-    }
-
-    EXPECT_EQ(sut.size(), sut_copy_assignment.size());
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(true));
 }
 
-TEST_F(FixedPositionContainer_test, ComplexContainerCopyAssignment)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromSingleElementContainerClearsOriginal)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "93dd1e09-69d3-47dc-a021-c2a311b83b86");
+    ::testing::Test::RecordProperty("TEST_ID", "6cf9e9d1-91a9-4403-a25a-52b64dd523be");
 
-    fillSutComplex();
+    constexpr DataType EXPECTED_VALUE{42U};
+    sut_complex.emplace(EXPECTED_VALUE);
 
-    // reset copyAssignment counter
-    SetUp();
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
 
-    SutComplex sut_complex_copy_assignment;
-    sut_complex_copy_assignment = sut_complex;
+    ASSERT_THAT(copy_sut_complex.size(), Eq(sut_complex.size()));
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(sut_complex.size()));
+    EXPECT_THAT(copy_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
+}
 
-    auto it = sut_complex.begin();
-    for (const auto& item : sut_complex_copy_assignment)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "262ad71a-0ee2-4661-b2c8-a3cca9c1cf5e");
+
+    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    for (SutComplex::IndexType i = 0; i < EXPECTED_VALUE.size(); ++i)
     {
-        EXPECT_EQ(item, *it);
-        EXPECT_NE(&item, &(*it));
-        ++it;
+        sut_complex.emplace(EXPECTED_VALUE[i]);
     }
 
-    EXPECT_EQ(sut_complex_copy_assignment.begin()->stats.copyAssignment, sut_complex.size());
-    EXPECT_EQ(sut_complex.size(), sut_complex_copy_assignment.size());
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
+
+    ASSERT_THAT(copy_sut_complex.size(), Eq(sut_complex.size()));
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(sut_complex.size()));
+    for (SutComplex::IndexType i = 0; i < sut_complex.size(); ++i)
+    {
+        EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(sut_complex.iter_from_index(i)->value));
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "b46d0be7-5977-467e-adc4-2e9adc554fdd");
+
+    fillSutComplex();
+    constexpr SutComplex::IndexType EXPECTED_SIZE{CAPACITY};
+    std::vector<DataType> EXPECTED_VALUE;
+    for (const auto& item : sut_complex)
+    {
+        EXPECTED_VALUE.emplace_back(item.value);
+    }
+
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
+
+    ASSERT_THAT(copy_sut_complex.full(), Eq(true));
+    EXPECT_THAT(copy_sut_complex.begin()->stats.copyAssignment, Eq(EXPECTED_SIZE));
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
+    }
 }
 
 // END test copy assignment
 
 // BEGIN test move assignment
 
-TEST_F(FixedPositionContainer_test, SimpleContainerMoveAssignment)
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromEmptyContainerResultsInEmptyContainer)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "6455982d-20f7-4304-a4b1-5947727e3f83");
+    ::testing::Test::RecordProperty("TEST_ID", "711ced12-4b93-47d1-af37-cace03fac2c1");
 
-    fillSut();
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
 
-    Sut sut_move_assignment;
-    std::vector<DataType> data;
-    for (const auto& item : sut)
-    {
-        data.push_back(item);
-    }
-
-    sut_move_assignment = std::move(sut);
-
-    std::size_t index{0};
-    for (const auto& item : sut_move_assignment)
-    {
-        EXPECT_EQ(item, data[index]);
-        index++;
-    }
-
-    // sut should be reset (move assignment)
-    EXPECT_TRUE(sut.empty());
-    EXPECT_EQ(sut_move_assignment.size(), data.size());
+    EXPECT_THAT(move_sut_complex.empty(), Eq(true));
 }
 
-TEST_F(FixedPositionContainer_test, ComplexContainerMoveAssignment)
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromSingleElementContainerClearsOriginal)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "5eb677a3-a54d-462d-9597-70dce86c9701");
+    ::testing::Test::RecordProperty("TEST_ID", "a3902afc-5eba-4e10-8412-f09b7b5d17b8");
+
+    constexpr DataType EXPECTED_VALUE{42U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{1U};
+    sut_complex.emplace(EXPECTED_VALUE);
+
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
+
+    ASSERT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
+
+    // make sure clear() been called
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    EXPECT_THAT(move_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromMultipleElementsContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c44da583-1ed8-4c83-b5bb-dba5d64b21d9");
+
+    std::vector<DataType> EXPECTED_VALUE{0U, 1U, 2U, 3U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{4U};
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        sut_complex.emplace(EXPECTED_VALUE[i]);
+    }
+
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
+
+    ASSERT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
+
+    // make sure clear() been called
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
+    {
+        EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromFullCapacityContainerClearsOriginal)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3196b101-f03a-4029-abb8-77106f0b45d8");
 
     fillSutComplex();
-
-    std::vector<ComplexType> data;
+    constexpr SutComplex::IndexType EXPECTED_SIZE{CAPACITY};
+    std::vector<DataType> EXPECTED_VALUE;
     for (const auto& item : sut_complex)
     {
-        data.push_back(item);
+        EXPECTED_VALUE.emplace_back(item.value);
     }
 
-    // reset moveAssignment counter
-    SetUp();
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
 
-    SutComplex sut_complex_move_assignment;
-    sut_complex_move_assignment = std::move(sut_complex);
+    ASSERT_THAT(move_sut_complex.full(), Eq(true));
+    EXPECT_THAT(move_sut_complex.begin()->stats.moveAssignment, Eq(EXPECTED_SIZE));
 
-    std::size_t index{0};
-    for (const auto& item : sut_complex_move_assignment)
+    // make sure clear() been called
+    EXPECT_THAT(move_sut_complex.begin()->stats.dTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+    for (SutComplex::IndexType i = 0; i < EXPECTED_SIZE; ++i)
     {
-        EXPECT_EQ(item, data[index]);
-        index++;
+        EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
-
-    // sut_complex should be reset (move assignment)
-    EXPECT_TRUE(sut_complex.empty());
-    EXPECT_EQ(sut_complex_move_assignment.begin()->stats.moveAssignment, data.size());
-    EXPECT_EQ(sut_complex_move_assignment.size(), data.size());
-
-    // sut_complex should can be assigned value again
-    sut_complex.emplace(42UL);
-    EXPECT_EQ(sut_complex.begin()->value, 42UL);
 }
 
 // END test move assignment

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -159,8 +159,9 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorSingleElementContainerPreserves
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
     EXPECT_THAT(copy_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
 
-    // actually call copyAssignment
-    EXPECT_THAT(stats.copyAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
     EXPECT_THAT(stats.moveAssignment, Eq(0));
 }
 
@@ -186,8 +187,9 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorMultipleElementsContainerPreser
         EXPECT_THAT(copy_sut_complex.iter_from_index(i), Ne(sut_complex.iter_from_index(i)));
     }
 
-    // actually call copyAssignment
-    EXPECT_THAT(stats.copyAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
     EXPECT_THAT(stats.moveAssignment, Eq(0));
 }
 
@@ -209,17 +211,79 @@ TEST_F(FixedPositionContainer_test, UsingCopyCtorFullCapacityContainerPreservesA
         EXPECT_THAT(copy_sut_complex.iter_from_index(i), Ne(sut_complex.iter_from_index(i)));
     }
 
-    // actually call copyAssignment
-    EXPECT_THAT(stats.copyAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
     EXPECT_THAT(stats.moveAssignment, Eq(0));
 }
 
-TEST_F(FixedPositionContainer_test, UsingCopyCtorFromNonEmptyContainerCopyToEmptyContainer)
+TEST_F(FixedPositionContainer_test, UsingCopyCtorFromNonEmptyWithFirstIndexErasedToEmptyContainer)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "f7e142f3-e236-46f7-82df-52624cb95094");
+    ::testing::Test::RecordProperty("TEST_ID", "acd52957-1d8a-4bd8-a960-e9c040d919c2");
 
-    constexpr DataType EXPECTED_VALUE{42U};
-    constexpr SutComplex::IndexType EXPECTED_SIZE{1U};
+    std::vector<DataType> EXPECTED_VALUE = {63U, 64U, 65U, 66U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{3U};
+
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex copy_sut_complex{sut_complex};
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_EQ(copy_sut_complex.size(), EXPECTED_SIZE);
+    EXPECT_EQ(copy_sut_complex.begin()->value, 64U);
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyCtorFromNonEmptyWithFirstAndMiddleAndLastErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "f21ff6d9-f50a-499f-912a-923bd4273b07");
+
+    std::vector<DataType> EXPECTED_VALUE = {1U, 2U, 3U, 5U, 6U, 7U, 8U};
+
+    fillSutComplex();
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+
+    SutComplex copy_sut_complex{sut_complex};
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(CAPACITY - 3U));
+
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyCtorWillNotChangeSourceContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8d60e04b-341f-4da1-8f3e-2736529d7843");
+
+    std::vector<DataType> EXPECTED_VALUE = {63U, 64U, 65U, 66U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+
+    SutComplex copy_sut_complex{sut_complex};
+
+    EXPECT_THAT(sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    auto it = sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
 }
 
 // END test copy constructor
@@ -239,7 +303,7 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromEmptyContainerResultsInEmpt
     EXPECT_THAT(sut_complex.empty(), Eq(true));
 }
 
-TEST_F(FixedPositionContainer_test, UsingMoveCtorFromSingleElementContainerClearsOriginal)
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromSingleElementToEmptyContainerClearsOriginal)
 {
     ::testing::Test::RecordProperty("TEST_ID", "df6c1884-43c6-4d1e-b889-6cbf4b9ee726");
 
@@ -254,8 +318,9 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromSingleElementContainerClear
     EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
     EXPECT_THAT(move_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
 
-    // actually call moveAssignment
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     EXPECT_THAT(stats.copyAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
@@ -287,8 +352,9 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromMultipleElementsContainerCl
         EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
 
-    // actually call moveAssignment
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     EXPECT_THAT(stats.copyAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
@@ -318,11 +384,62 @@ TEST_F(FixedPositionContainer_test, UsingMoveCtorFromFullCapacityContainerClears
         EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
 
-    // actually call moveAssignment
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     EXPECT_THAT(stats.copyAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromNonEmptyWithFirstIndexErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "de0eaa3c-bf30-4899-95ec-6c23bbd53a24");
+
+    std::vector<DataType> EXPECTED_VALUE = {63U, 64U, 65U, 66U};
+    constexpr SutComplex::IndexType EXPECTED_SIZE{3U};
+
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex move_sut_complex{std::move(sut_complex)};
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    EXPECT_THAT(move_sut_complex.begin()->value, Eq(64U));
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveCtorFromNonEmptyWithFirstAndMiddleAndLastErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "073e3bc6-1e33-46b8-860b-c35d1f599d11");
+
+    std::vector<DataType> EXPECTED_VALUE = {1U, 2U, 3U, 5U, 6U, 7U, 8U};
+
+    fillSutComplex();
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+
+    SutComplex copy_sut_complex{std::move(sut_complex)};
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(CAPACITY - 3U));
+
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
 
     EXPECT_THAT(sut_complex.empty(), Eq(true));
 }
@@ -356,30 +473,34 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromEmptyContainerResults
     EXPECT_THAT(copy_sut_complex.size(), Eq(0));
 }
 
-TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromSingleElementContainerClearsOriginal)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromSingleElementContainer)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6cf9e9d1-91a9-4403-a25a-52b64dd523be");
 
     constexpr DataType EXPECTED_VALUE{42U};
+    constexpr uint64_t EXPECTED_SIZE{1U};
     sut_complex.emplace(EXPECTED_VALUE);
 
     SutComplex copy_sut_complex;
     copy_sut_complex = sut_complex;
 
-    EXPECT_THAT(stats.copyAssignment, Eq(sut_complex.size()));
-    EXPECT_THAT(stats.moveAssignment, Eq(0));
-
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(sut_complex.size()));
     EXPECT_THAT(copy_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
+
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
 }
 
-TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsContainerClearsOriginal)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsContainer)
 {
     ::testing::Test::RecordProperty("TEST_ID", "262ad71a-0ee2-4661-b2c8-a3cca9c1cf5e");
 
     std::vector<DataType> EXPECTED_VALUE{56U, 57U, 58U, 59U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
     for (SutComplex::IndexType i = 0; i < EXPECTED_VALUE.size(); ++i)
     {
         sut_complex.emplace(EXPECTED_VALUE[i]);
@@ -387,9 +508,6 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsConta
 
     SutComplex copy_sut_complex;
     copy_sut_complex = sut_complex;
-
-    EXPECT_THAT(stats.copyAssignment, Eq(sut_complex.size()));
-    EXPECT_THAT(stats.moveAssignment, Eq(0));
 
     EXPECT_THAT(copy_sut_complex.full(), Eq(false));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
@@ -399,9 +517,14 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromMultipleElementsConta
         EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
         EXPECT_THAT(copy_sut_complex.iter_from_index(i), Ne(sut_complex.iter_from_index(i)));
     }
+
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
 }
 
-TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainerClearsOriginal)
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainer)
 {
     ::testing::Test::RecordProperty("TEST_ID", "b46d0be7-5977-467e-adc4-2e9adc554fdd");
 
@@ -416,9 +539,6 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainer
     SutComplex copy_sut_complex;
     copy_sut_complex = sut_complex;
 
-    EXPECT_THAT(stats.copyAssignment, Eq(EXPECTED_SIZE));
-    EXPECT_THAT(stats.moveAssignment, Eq(0));
-
     EXPECT_THAT(copy_sut_complex.full(), Eq(true));
     EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
     EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
@@ -427,6 +547,502 @@ TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromFullCapacityContainer
         EXPECT_THAT(copy_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
         EXPECT_THAT(copy_sut_complex.iter_from_index(i), Ne(sut_complex.iter_from_index(i)));
     }
+
+    EXPECT_THAT(stats.copyCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveCTor, Eq(0));
+    EXPECT_THAT(stats.copyAssignment, Eq(0));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromEmptyToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5d906d20-aacc-4536-86e7-bd4aafcdc2f7");
+
+    std::vector<DataType> EXPECTED_VALUE = {12U, 13U, 14U, 15U, 16U};
+    SutComplex copy_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(0));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(true));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(0));
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromLargerSizeToSmallerSizeContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cce5bca5-7bfd-4909-bd60-acfffbb1611e");
+
+    std::vector<DataType> EXPECTED_VALUE = {21U, 22U, 23U, 24U, 25U};
+    std::vector<DataType> DUMMY_VALUE = {94U, 95U, 96U};
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentBetweenContainersOfEqalSize)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "bd1b1c4b-20a4-464a-b036-8ce4764f3ac5");
+
+    std::vector<DataType> EXPECTED_VALUE = {29U, 28U, 27U, 26U};
+    std::vector<DataType> DUMMY_VALUE = {37U, 38U, 39U, 40U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromSmallerSizeToLargerSizeContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "412b4439-66dd-4e5c-93f7-511e1e965b78");
+
+    std::vector<DataType> EXPECTED_VALUE = {1U, 2U, 3U, 4U};
+    std::vector<DataType> DUMMY_VALUE = {31U, 32U, 33U, 34U, 35U, 36U, 37U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstIndexErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "929e7bae-f276-4ae5-b559-7bb518198e63");
+
+    std::vector<DataType> DUMMY_VALUE = {12U, 32U, 23U, 14U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE.begin() + 1, DUMMY_VALUE.end());
+    constexpr uint64_t EXPECTED_SIZE{3U};
+
+    for (const auto& value : DUMMY_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstIndexErasedToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cd882c6e-1e46-495c-b2cf-24056c144d85");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {65U, 66U, 23U, 7U, 12U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {1U, 3U, 5U, 16U, 18U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyToNonEmptyContainerWithBothFirstIndexErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "ad3d96da-e64a-4252-950c-a36f5333e42a");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {98U, 99U, 100U, 101U, 102U, 103U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {12U, 33U, 544U, 162U, 182U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+    copy_sut_complex.erase(SutComplex::Index::FIRST);
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test,
+       UsingCopyAssignmentFromNonEmptyWithFirstErasedToNonEmptyContainerWithFirstAndSecondErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a3ac8e6d-795e-4e41-bad3-aba39483d6d5");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {56U, 54U, 55U, 33U, 12U, 34U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {18U, 22U, 42U, 323U, 216U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+    copy_sut_complex.erase(SutComplex::Index::FIRST);
+    copy_sut_complex.erase(SutComplex::Index::FIRST + 1);
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "0c6138ce-861e-42d8-b7f2-ecd4ac01537e");
+
+    std::vector<DataType> DUMMY_VALUE = {17U, 26U, 32U, 357U, 30U, 21U, 18U, 100U, 67U, 79U};
+    std::vector<DataType> EXPECTED_VALUE = {26U, 32U, 357U, 21U, 18U, 100U, 67U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "4127ad54-f272-4f61-9737-e41b92d7cf60");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {111U, 112U, 113U, 114U, 115U, 116U, 117U, 118U, 119U, 120U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {189U, 112U, 124U, 1735U, 10U, 11U, 14U, 164U, 123U, 12U};
+    std::vector<DataType> EXPECTED_VALUE = {112U, 113U, 114U, 116U, 117U, 118U, 119U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test,
+       UsingCopyAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainerWithFirstIndexErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "4aea0c73-98c7-45b1-81e0-713c18ea16de");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {101U, 102U, 103U, 104U, 105U, 106U, 107U, 108U, 109U, 110U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {89U, 12U, 24U, 735U, 0U, 1U, 4U, 64U, 23U, 2U};
+    std::vector<DataType> EXPECTED_VALUE = {102U, 103U, 104U, 106U, 107U, 108U, 109U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+    copy_sut_complex.erase(SutComplex::Index::FIRST);
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(
+    FixedPositionContainer_test,
+    UsingCopyAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainerWithNeighboringFirstAndOneBeforeMiddleAndOneBeforeLastErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "7e086470-8b0e-4c82-8c5d-7a9c45312729");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {121U, 122U, 123U, 124U, 125U, 126U, 127U, 128U, 129U, 130U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {79U, 2U, 14U, 725U, 40U, 15U, 34U, 54U, 13U, 32U};
+    std::vector<DataType> EXPECTED_VALUE = {122U, 123U, 124U, 126U, 127U, 128U, 129U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+    copy_sut_complex.erase(SutComplex::Index::FIRST + 1);
+    copy_sut_complex.erase(SutComplex::Index::LAST / 2 + 1);
+    copy_sut_complex.erase(SutComplex::Index::LAST - 1);
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentFromNonEmptyWithLastErasedToFullContainerWithFirstErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "82e562f9-89fe-4998-870f-c575da5a3f79");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {131U, 132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 140U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {23U, 24U, 25U, 26U, 27U, 28U, 29U, 30U, 31U, 32U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin(), DUMMY_VALUE_SRC.end() - 1);
+    constexpr uint64_t EXPECTED_SIZE{9U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+    copy_sut_complex.erase(SutComplex::Index::FIRST);
+
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentWillNotChangeSourceContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "22191ca0-2350-4901-b6f3-1786621f6a17");
+
+    std::vector<DataType> EXPECTED_VALUE = {63U, 64U, 65U, 66U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+
+    SutComplex copy_sut_complex;
+    copy_sut_complex = sut_complex;
+
+    EXPECT_THAT(sut_complex.size(), Eq(EXPECTED_SIZE));
+
+    auto it = sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+}
+
+TEST_F(FixedPositionContainer_test, UsingCopyAssignmentInsertionShouldFailWhenCapacityReached)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "fcbe01f1-b3d4-4794-b291-efeeddd4db7f");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {131U, 132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 140U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {23U, 24U, 25U, 26U, 27U, 28U, 29U, 30U, 31U, 32U};
+    std::vector<DataType> EXPECTED_VALUE = {132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 77U, 88U};
+    constexpr uint64_t EXPECTED_SIZE{CAPACITY};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex copy_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        copy_sut_complex.emplace(value);
+    }
+
+    copy_sut_complex = sut_complex;
+
+    copy_sut_complex.emplace(77U);
+    copy_sut_complex.emplace(88U);
+
+    EXPECT_THAT(copy_sut_complex.full(), Eq(true));
+    EXPECT_THAT(copy_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(copy_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = copy_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    // should failed
+    auto failed_it = copy_sut_complex.emplace(1000000U);
+    EXPECT_THAT(failed_it, Eq(copy_sut_complex.end()));
 }
 
 // END test copy assignment
@@ -463,7 +1079,9 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromSingleElementContaine
     EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
     EXPECT_THAT(move_sut_complex.begin()->value, Eq(EXPECTED_VALUE));
 
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     EXPECT_THAT(stats.copyAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
@@ -493,8 +1111,9 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromMultipleElementsConta
         EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
 
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
-    EXPECT_THAT(stats.copyAssignment, Eq(0));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
 
@@ -524,13 +1143,529 @@ TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromFullCapacityContainer
         EXPECT_THAT(move_sut_complex.iter_from_index(i)->value, Eq(EXPECTED_VALUE[i]));
     }
 
-    EXPECT_THAT(stats.moveAssignment, Eq(EXPECTED_SIZE));
-    EXPECT_THAT(stats.copyAssignment, Eq(0));
+    EXPECT_THAT(stats.copyCTor, Eq(0));
+    EXPECT_THAT(stats.moveCTor, Eq(EXPECTED_SIZE));
+    EXPECT_THAT(stats.moveAssignment, Eq(0));
     // make sure clear() been called
     EXPECT_THAT(stats.dTor, Eq(EXPECTED_SIZE));
 
     EXPECT_THAT(sut_complex.empty(), Eq(true));
 }
+
+/////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromEmptyToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "998e06c0-6879-451e-a493-e3e26944feff");
+
+    std::vector<DataType> EXPECTED_VALUE = {12U, 13U, 14U, 15U, 16U};
+    SutComplex move_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(0));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(true));
+    EXPECT_THAT(move_sut_complex.size(), Eq(0));
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromLargerSizeToSmallerSizeContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c4b5b538-740f-4543-b493-5ea87e0ea8cc");
+
+    std::vector<DataType> EXPECTED_VALUE = {21U, 22U, 23U, 24U, 25U};
+    std::vector<DataType> DUMMY_VALUE = {94U, 95U, 96U};
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    SutComplex move_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentBetweenContainersOfEqalSize)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "50030f15-aefc-4086-aca0-02c1d5e032a1");
+
+    std::vector<DataType> EXPECTED_VALUE = {29U, 28U, 27U, 26U};
+    std::vector<DataType> DUMMY_VALUE = {37U, 38U, 39U, 40U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    SutComplex move_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromSmallerSizeToLargerSizeContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6759de7f-5555-4251-89a2-dbcc3c2f2efb");
+
+    std::vector<DataType> EXPECTED_VALUE = {1U, 2U, 3U, 4U};
+    std::vector<DataType> DUMMY_VALUE = {31U, 32U, 33U, 34U, 35U, 36U, 37U};
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    SutComplex move_sut_complex;
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    for (const auto& value : DUMMY_VALUE)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyWithFirstIndexErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "95c1839b-0755-458c-908b-89b59a914fb5");
+
+    std::vector<DataType> DUMMY_VALUE = {12U, 32U, 23U, 14U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE.begin() + 1, DUMMY_VALUE.end());
+    constexpr uint64_t EXPECTED_SIZE{3U};
+
+    for (const auto& value : DUMMY_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyWithFirstIndexErasedToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "db50dd57-6e56-4343-981b-debb4780d403");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {65U, 66U, 23U, 7U, 12U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {1U, 3U, 5U, 16U, 18U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{4U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyToNonEmptyContainerWithBothFirstIndexErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "2655d41e-06d9-4e85-a356-a0ba256b35ee");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {98U, 99U, 100U, 101U, 102U, 103U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {12U, 33U, 544U, 162U, 182U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+    move_sut_complex.erase(SutComplex::Index::FIRST);
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test,
+       UsingMoveAssignmentFromNonEmptyWithFirstErasedToNonEmptyContainerWithFirstAndSecondErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8aa4a221-ed52-49e9-91c3-81d45d70edc5");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {56U, 54U, 55U, 33U, 12U, 34U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {18U, 22U, 42U, 323U, 216U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin() + 1, DUMMY_VALUE_SRC.end());
+    constexpr uint64_t EXPECTED_SIZE{5U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+    move_sut_complex.erase(SutComplex::Index::FIRST);
+    move_sut_complex.erase(SutComplex::Index::FIRST + 1);
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "646d08e5-d26a-4efe-96e1-fa79ef1549b7");
+
+    std::vector<DataType> DUMMY_VALUE = {17U, 26U, 32U, 357U, 30U, 21U, 18U, 100U, 67U, 79U};
+    std::vector<DataType> EXPECTED_VALUE = {26U, 32U, 357U, 21U, 18U, 100U, 67U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainer)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "62367ed3-a97a-4dae-82f3-e7bacd432b9b");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {111U, 112U, 113U, 114U, 115U, 116U, 117U, 118U, 119U, 120U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {189U, 112U, 124U, 1735U, 10U, 11U, 14U, 164U, 123U, 12U};
+    std::vector<DataType> EXPECTED_VALUE = {112U, 113U, 114U, 116U, 117U, 118U, 119U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test,
+       UsingMoveAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainerWithFirstIndexErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3b57f4cc-7a79-4a0a-a1f2-0a2f1e943fdf");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {101U, 102U, 103U, 104U, 105U, 106U, 107U, 108U, 109U, 110U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {89U, 12U, 24U, 735U, 0U, 1U, 4U, 64U, 23U, 2U};
+    std::vector<DataType> EXPECTED_VALUE = {102U, 103U, 104U, 106U, 107U, 108U, 109U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+    move_sut_complex.erase(SutComplex::Index::FIRST);
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(
+    FixedPositionContainer_test,
+    UsingMoveAssignmentFromNonEmptyWithFirstAndMiddleAndLastErasedToNonEmptyContainerWithNeighboringFirstAndOneBeforeMiddleAndOneBeforeLastErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "74cf9827-99ea-45a8-884d-e8efff9b1290");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {121U, 122U, 123U, 124U, 125U, 126U, 127U, 128U, 129U, 130U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {79U, 2U, 14U, 725U, 40U, 15U, 34U, 54U, 13U, 32U};
+    std::vector<DataType> EXPECTED_VALUE = {122U, 123U, 124U, 126U, 127U, 128U, 129U};
+    constexpr uint64_t EXPECTED_SIZE{7U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST / 2);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+    move_sut_complex.erase(SutComplex::Index::FIRST + 1);
+    move_sut_complex.erase(SutComplex::Index::LAST / 2 + 1);
+    move_sut_complex.erase(SutComplex::Index::LAST - 1);
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentFromNonEmptyWithLastErasedToFullContainerWithFirstErased)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "ca8b489c-c24d-478e-8720-f265687209ea");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {131U, 132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 140U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {23U, 24U, 25U, 26U, 27U, 28U, 29U, 30U, 31U, 32U};
+    std::vector<DataType> EXPECTED_VALUE(DUMMY_VALUE_SRC.begin(), DUMMY_VALUE_SRC.end() - 1);
+    constexpr uint64_t EXPECTED_SIZE{9U};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+    move_sut_complex.erase(SutComplex::Index::FIRST);
+
+    move_sut_complex = std::move(sut_complex);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(false));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentInsertionShouldFailWhenCapacityReached)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "ad438f8a-2b9e-45d3-8d89-feefbccf3f03");
+
+    std::vector<DataType> DUMMY_VALUE_SRC = {131U, 132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 140U};
+    std::vector<DataType> DUMMY_VALUE_DEST = {23U, 24U, 25U, 26U, 27U, 28U, 29U, 30U, 31U, 32U};
+    std::vector<DataType> EXPECTED_VALUE = {132U, 133U, 134U, 135U, 136U, 137U, 138U, 139U, 77U, 88U};
+    constexpr uint64_t EXPECTED_SIZE{CAPACITY};
+
+    for (const auto& value : DUMMY_VALUE_SRC)
+    {
+        sut_complex.emplace(value);
+    }
+    sut_complex.erase(SutComplex::Index::FIRST);
+    sut_complex.erase(SutComplex::Index::LAST);
+
+    SutComplex move_sut_complex;
+    for (const auto& value : DUMMY_VALUE_DEST)
+    {
+        move_sut_complex.emplace(value);
+    }
+
+    move_sut_complex = std::move(sut_complex);
+
+    move_sut_complex.emplace(77U);
+    move_sut_complex.emplace(88U);
+
+    EXPECT_THAT(move_sut_complex.full(), Eq(true));
+    EXPECT_THAT(move_sut_complex.empty(), Eq(false));
+    EXPECT_THAT(move_sut_complex.size(), Eq(EXPECTED_SIZE));
+    auto it = move_sut_complex.iter_from_index(SutComplex::Index::FIRST);
+    for (const auto& value : EXPECTED_VALUE)
+    {
+        EXPECT_THAT(it->value, Eq(value));
+        ++it;
+    }
+
+    EXPECT_THAT(sut_complex.empty(), Eq(true));
+
+    // should failed
+    auto failed_it = move_sut_complex.emplace(1000000U);
+    EXPECT_THAT(failed_it, Eq(move_sut_complex.end()));
+}
+
+TEST_F(FixedPositionContainer_test, UsingMoveAssignmentAtNonCopyableTypeShouldCompile)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d4876d02-d855-4bcc-af39-3d2dc388c40d");
+
+    constexpr uint64_t EXPECTED_SIZE{2U};
+    sut_noncopy.emplace(7U);
+    sut_noncopy.emplace(8U);
+
+    SutNonCopy move_sut_noncopy;
+    move_sut_noncopy = std::move(sut_noncopy);
+
+    EXPECT_THAT(move_sut_noncopy.size(), Eq(EXPECTED_SIZE));
+}
+
+/////////////////////////////////////////////////////////
 
 // END test move assignment
 

--- a/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
+++ b/iceoryx_dust/test/moduletests/test_container_fixed_position_container.cpp
@@ -133,7 +133,8 @@ TEST_F(FixedPositionContainer_test, ComplexContainerCopyConstructor)
     }
 
     EXPECT_EQ(sut_complex.size(), sut_complex_copy_ctor.size());
-    EXPECT_EQ(sut_complex_copy_ctor.begin()->stats.copyCTor, sut_complex.size());
+    // FixedPositionContainer copyCtor will call copyAssignment
+    EXPECT_EQ(sut_complex_copy_ctor.begin()->stats.copyAssignment, sut_complex.size());
 }
 
 // END test copy constructor
@@ -193,7 +194,8 @@ TEST_F(FixedPositionContainer_test, ComplexContainerMoveConstructor)
     // sut_complex should be reset (move ctor)
     EXPECT_EQ(sut_complex.empty(), true);
     EXPECT_EQ(sut_complex_move_ctor.size(), data.size());
-    EXPECT_EQ(sut_complex_move_ctor.begin()->stats.moveCTor, data.size());
+    // FixedPositionContainer copyCtor will call copyAssignment
+    EXPECT_EQ(sut_complex_move_ctor.begin()->stats.moveAssignment, data.size());
 }
 
 // END test move constructor


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
- Move/copy constructors and assignment for `FixedPositionContainer` are implemented.
- At present, when invoking the move/copy constructor or assignment for `FixedPositionContainer`, only the move/copy assignment of elements within `FixedPositionContainer::m_data` gets triggered (without calling the constructor). This is 
because the `FixedPositionContainer` constructor is realized using assignment, mirroring the behavior of `vector`.
- Unit tests are added. To test the newly added code under the following scenarios, you can execute it via `build/dust/test/dust_moduletests`:
  - From an empty container
  - From a single-element container
  - From a multi-element container
  - From a full-capacity container
- For move cases, the criteria for determining whether `FixedPositionContainer::clear()` has been executed is based on detecting if the element (`ComplexType`) has invoked the `DTor`.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes **#2052**
