### PR TITLE
iox-#2087 Fix allocation for mempools larger than 4gb

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -102,6 +102,7 @@
 - cxx::Expects macro conflicts with Microsoft GSL Expects macro [#2080](https://github.com/eclipse-iceoryx/iceoryx/issues/2080)
 - Implement move/copy constructor and assignment for `FixedPositionContainer` [#2052](https://github.com/eclipse-iceoryx/iceoryx/issues/2052)
 - FixedPositionContainer fails to compile on QNX QCC [#2084](https://github.com/eclipse-iceoryx/iceoryx/issues/2084)
+- Chunk fails to be released when more than 4 GiB of chunks have been allocated [#2087](https://github.com/eclipse-iceoryx/iceoryx/issues/2087)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mem_pool.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,11 +70,26 @@ class MemPool
 
     void freeChunk(const void* chunk) noexcept;
 
+    /// @brief Converts an index to a chunk in the MemPool to a pointer
+    /// @param[in] index of the chunk
+    /// @param[in] chunkSize is the size of the chunk
+    /// @param[in] rawMemoryBase it the pointer to the raw memory of the MemPool
+    /// @return the pointer to the chunk
+    static void* indexToPointer(const uint32_t index, const uint32_t chunkSize, void* const rawMemoryBase) noexcept;
+
+    /// @brief Converts a pointer to a chunk in the MemPool to an index
+    /// @param[in] chunk is the pointer to the chunk
+    /// @param[in] chunkSize is the size of the chunk
+    /// @param[in] rawMemoryBase it the pointer to the raw memory of the MemPool
+    /// @return the index to the chunk
+    static uint32_t
+    pointerToIndex(const void* const chunk, const uint32_t chunkSize, const void* const rawMemoryBase) noexcept;
+
   private:
     void adjustMinFree() noexcept;
     bool isMultipleOfAlignment(const uint32_t value) const noexcept;
 
-    RelativePointer<uint8_t> m_rawMemory;
+    RelativePointer<void> m_rawMemory;
 
     uint32_t m_chunkSize{0U};
     /// needs to be 32 bit since loffli supports only 32 bit numbers

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -104,7 +104,7 @@ void* MemPool::getChunk() noexcept
 void* MemPool::indexToPointer(uint32_t index, uint32_t chunkSize, void* const rawMemoryBase) noexcept
 {
     const auto offset = static_cast<uint64_t>(index) * chunkSize;
-    return static_cast<uint8_t*>(rawMemoryBase) + offset;
+    return static_cast<void*>(static_cast<uint8_t*>(rawMemoryBase) + offset);
 }
 
 uint32_t

--- a/iceoryx_posh/source/mepoo/mem_pool.cpp
+++ b/iceoryx_posh/source/mepoo/mem_pool.cpp
@@ -83,8 +83,8 @@ void MemPool::adjustMinFree() noexcept
 
 void* MemPool::getChunk() noexcept
 {
-    uint32_t l_index{0U};
-    if (!m_freeIndices.pop(l_index))
+    uint32_t index{0U};
+    if (!m_freeIndices.pop(index))
     {
         IOX_LOG(WARN,
                 "Mempool [m_chunkSize = " << m_chunkSize << ", numberOfChunks = " << m_numberOfChunks
@@ -97,7 +97,7 @@ void* MemPool::getChunk() noexcept
     m_usedChunks.fetch_add(1U, std::memory_order_relaxed);
     adjustMinFree();
 
-    return m_rawMemory.get() + l_index * m_chunkSize;
+    return m_rawMemory.get() + static_cast<uint64_t>(index) * m_chunkSize;
 }
 
 void MemPool::freeChunk(const void* chunk) noexcept


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

There was a missing cast in the index to pointer conversion in the `MemPool` when the offset to the begin of the memory was larger than 4GB.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2087
