### PR TITLE
iox-#2066 Switch to C++17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --cxxopt="-std=c++14"
+build --cxxopt="-std=c++17"
 
 # For using clang
 build:clang --action_env=BAZEL_COMPILER=clang

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -98,7 +98,7 @@ hicpp-*,
 #        void bar(Foo& foo) {...}
 #
 # * rule: readability-use-anyofallof
-#   justification: requires C++20 and std::ranges but we only use C++14
+#   justification: requires C++20 and std::ranges but we only use C++17
 #
 # * rule: cppcoreguidelines-non-private-member-variables-in-classes
 #   justification: Sometimes it makes sense to have protected members to extend the base class.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ codebase follows these rules, things are work in progress.
     without heap)
 2) **No exceptions are allowed**, all function and methods need to have `noexcept` in their signature
 3) **No undefined behavior**, zero-cost abstract is not feasible in high safety environments
-4) **Use C++14**
+4) **Use C++17**
 5) **[Rule of Five](https://en.cppreference.com/w/cpp/language/rule_of_three)**, if there is a non-default
     destructor needed, the rule of five has to be applied
 6) **Keep the [STL](https://en.wikipedia.org/wiki/Standard_Template_Library) dependencies to a minimum**,

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -51,6 +51,7 @@
 - Extend 'iceperf' with 'WaitSet' [#2003](https://github.com/eclipse-iceoryx/iceoryx/issues/2003)
 - Create iceoryx version header for the C-binding [#1014](https://github.com/eclipse-iceoryx/iceoryx/issues/1014)
 - Create macros to deprecate header and code constructs [#2057](https://github.com/eclipse-iceoryx/iceoryx/issues/2057)
+- Switch to C++17 on all platforms [#2066](https://github.com/eclipse-iceoryx/iceoryx/issues/2066)
 
 **Bugfixes:**
 

--- a/iceoryx_dust/test/moduletests/test_cli_command_line_common.hpp
+++ b/iceoryx_dust/test/moduletests/test_cli_command_line_common.hpp
@@ -35,7 +35,7 @@ struct CmdArgs
         contents = std::make_unique<std::vector<std::string>>(arguments);
         for (uint64_t i = 0; i < static_cast<uint64_t>(argc); ++i)
         {
-            argv[i] = const_cast<char*>((*contents)[i].data());
+            argv[i] = (*contents)[i].data();
         }
     }
 

--- a/iceoryx_hoofs/README.md
+++ b/iceoryx_hoofs/README.md
@@ -11,7 +11,7 @@ The following sections have a column labeled `internal` to indicate that the API
 is not stable and can change anytime. You should never rely on it and there is no
 support if it is used and breaks your code after an update.
 
-Some modules contain STL constructs which are not part of the C++14 standard as well as convenience
+Some modules contain STL constructs which are not part of the C++17 standard as well as convenience
 constructs like the `NewType`. Since the classes re-implements some STL constructs,
 the C++ STL coding guidelines are used for all files in this module, to help the user
 to have a painless transition from the official STL types to ours.

--- a/iceoryx_platform/linux/IceoryxPlatformSettings.cmake
+++ b/iceoryx_platform/linux/IceoryxPlatformSettings.cmake
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set_global(VAR ICEORYX_CXX_STANDARD         VALUE 14)
+set_global(VAR ICEORYX_CXX_STANDARD         VALUE 17)
 set_global(VAR ICEORYX_PLATFORM_STRING      VALUE "Linux")
 
 set_global(VAR ICEORYX_C_FLAGS              VALUE )

--- a/iceoryx_platform/qnx/IceoryxPlatformSettings.cmake
+++ b/iceoryx_platform/qnx/IceoryxPlatformSettings.cmake
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set_global(VAR ICEORYX_PLATFORM_STRING      VALUE "QNX")
-set_global(VAR ICEORYX_CXX_STANDARD         VALUE 14)
+set_global(VAR ICEORYX_CXX_STANDARD         VALUE 17)
 
 set_global(VAR ICEORYX_C_FLAGS              VALUE )
 set_global(VAR ICEORYX_CXX_FLAGS            VALUE )

--- a/iceoryx_posh/test/CMakeLists.txt
+++ b/iceoryx_posh/test/CMakeLists.txt
@@ -57,7 +57,7 @@ iox_add_executable( TARGET                  ${PROJECT_PREFIX}_moduletests
                     INCLUDE_DIRECTORIES     .
                                             ${CMAKE_BINARY_DIR}/generated
                     LIBS                    ${TEST_LINK_LIBS}
-                    LIBS_LINUX              dl
+                    LIBS_LINUX              dl stdc++fs
                     STACK_SIZE              ${ICEORYX_POSH_TEST_STACK_SIZE}
                     FILES
                         ${MODULETESTS_SRC}

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -206,7 +206,7 @@ class PortUser_IntegrationTest : public Test
         static_cast<void>(subscriberPortRouDi.dispatchCaProMessageAndGetPossibleResponse(caproMessage));
 
         // Subscription done and ready to receive samples
-        while (!finished)
+        while (!finished || subscriberPortUser.hasNewChunks())
         {
             // Try to receive chunk
             subscriberPortUser.tryGetChunk()

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -64,7 +64,7 @@ TEST_F(TomlGatewayConfigParserTest, ParsingFileIsSuccessful)
     )";
     tempFile.close();
 
-    iox::roudi::ConfigFilePathString_t configFilePath{iox::TruncateToCapacity, tempFilePath.c_str()};
+    iox::roudi::ConfigFilePathString_t configFilePath{iox::TruncateToCapacity, tempFilePath.u8string().c_str()};
 
     TomlGatewayConfigParser::parse(configFilePath)
         .and_then([](const auto&) { GTEST_SUCCEED() << "We got a config!"; })

--- a/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_toml_gateway_config_parser.cpp
@@ -26,9 +26,7 @@
 #include <cpptoml.h>
 #include <limits> // workaround for missing include in cpptoml.h
 
-#if __cplusplus >= 201703L
 #include <filesystem>
-#endif
 
 #include <fstream>
 #include <string>
@@ -54,9 +52,6 @@ TEST_F(TomlGatewayConfigParserTest, ParsingFileIsSuccessful)
 {
     ::testing::Test::RecordProperty("TEST_ID", "78b50f73-f17f-45e2-a091-aaad6c536c3a");
 
-#if __cplusplus < 201703L
-    GTEST_SKIP() << "The test uses std::filesystem which is only available with C++17";
-#else
     auto tempFilePath = std::filesystem::temp_directory_path();
     tempFilePath.append("test_gateway_config.toml");
 
@@ -77,7 +72,6 @@ TEST_F(TomlGatewayConfigParserTest, ParsingFileIsSuccessful)
             GTEST_FAIL() << "Expected a config but got error: "
                          << iox::config::TOML_GATEWAY_CONFIG_FILE_PARSE_ERROR_STRINGS[static_cast<uint64_t>(error)];
         });
-#endif
 }
 
 class TomlGatewayConfigParserSuiteTest : public TestWithParam<CheckCharactersValidity_t>

--- a/tools/ci/build-test-windows.ps1
+++ b/tools/ci/build-test-windows.ps1
@@ -34,7 +34,7 @@ if ($?) { build\hoofs\test\Debug\hoofs_moduletests.exe --gtest_filter="-*TimingT
 if ($?) { build\hoofs\test\Debug\hoofs_mocktests.exe }
 if ($?) { build\hoofs\test\Debug\hoofs_integrationtests.exe }
 if ($?) { build\binding_c\test\Debug\binding_c_moduletests.exe --gtest_filter="-BindingC_Runtime_test.RuntimeNameLengthIsOutOfLimit:BindingC_Runtime_test.RuntimeNameIsNullptr:*TimingTest*" }
-if ($?) { build\posh\test\Debug\posh_moduletests.exe --gtest_filter="-ChunkHeader_test.ChunkHeaderBinaryCompatibilityCheck:TomlGatewayConfigParserSuiteTest*:IceoryxRoudiApp_test.ConstructorCalledWithArgUniqueIdTwoTimesReturnError:IceoryxRoudiApp_test.ConstructorCalledWithArgVersionSetRunVariableToFalse:ValidTest*:ParseAllMalformedInput*:*TimingTest*:MePooSegment_test.SharedMemoryFileHandleRightsAfterConstructor" }
+if ($?) { build\posh\test\Debug\posh_moduletests.exe --gtest_filter="-ChunkHeader_test.ChunkHeaderBinaryCompatibilityCheck:TomlGatewayConfigParser*:IceoryxRoudiApp_test.ConstructorCalledWithArgUniqueIdTwoTimesReturnError:IceoryxRoudiApp_test.ConstructorCalledWithArgVersionSetRunVariableToFalse:ValidTest*:ParseAllMalformedInput*:*TimingTest*:MePooSegment_test.SharedMemoryFileHandleRightsAfterConstructor" }
 if ($?) { build\posh\test\Debug\posh_integrationtests.exe --gtest_filter="-ChunkBuildingBlocks_IntegrationTest.TwoHopsThreeThreadsNoSoFi:*TimingTest*" }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the last two platforms, Linux and QNX, to the C++17 language standard. This means that we can start using C++17 features.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #2066
