### PR TITLE
iox-#1391 Remove posix from include path and namespace in dust

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -1000,7 +1000,7 @@
     #include "iceoryx_hoofs/posix_wrapper/internal/message_queue.hpp"
 
     // after
-    #include "iox/posix/message_queue.hpp"
+    #include "iox/message_queue.hpp"
     ```
 
     ```cpp
@@ -1008,7 +1008,7 @@
     #include "iceoryx_hoofs/posix_wrapper/named_pipe.hpp"
 
     // after
-    #include "iox/posix/named_pipe.hpp"
+    #include "iox/named_pipe.hpp"
     ```
 
     ```cpp
@@ -1016,7 +1016,7 @@
     #include "iceoryx_hoofs/posix_wrapper/signal_watcher.hpp"
 
     // after
-    #include "iox/posix/signal_watcher.hpp"
+    #include "iox/signal_watcher.hpp"
     ```
 
     ```cpp

--- a/iceoryx_dust/posix/ipc/include/iox/message_queue.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/message_queue.hpp
@@ -30,14 +30,12 @@
 
 namespace iox
 {
-namespace posix
-{
 class MessageQueueBuilder;
 
 /// @brief Wrapper class for posix message queue
 ///
 /// @code
-///     auto mq = iox::posix::MessageQueueBuilder()
+///     auto mq = iox::MessageQueueBuilder()
 ///                 .name("/MqName123")
 ///                 .channelSide(iox::posix::IpcChannelSide::CLIENT)
 ///                 .create();
@@ -69,27 +67,28 @@ class MessageQueue
 
     ~MessageQueue() noexcept;
 
-    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief send a message to queue using std::string.
     /// @return true if sent without errors, false otherwise
-    expected<void, IpcChannelError> send(const std::string& msg) const noexcept;
+    expected<void, posix::IpcChannelError> send(const std::string& msg) const noexcept;
 
     /// @todo iox-#1693 zero copy receive with receive(iox::string&); iox::string would be the buffer for mq_receive
 
     /// @brief receive message from queue using std::string.
     /// @return number of characters received. In case of an error, returns -1 and msg is empty.
-    expected<std::string, IpcChannelError> receive() const noexcept;
+    expected<std::string, posix::IpcChannelError> receive() const noexcept;
 
     /// @brief try to receive message from queue for a given timeout duration using std::string. Only defined
     /// for NON_BLOCKING == false.
     /// @return optional containing the received string. In case of an error, nullopt type is returned.
-    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
     /// @brief try to send a message to the queue for a given timeout duration using std::string
-    expected<void, IpcChannelError> timedSend(const std::string& msg, const units::Duration& timeout) const noexcept;
+    expected<void, posix::IpcChannelError> timedSend(const std::string& msg,
+                                                     const units::Duration& timeout) const noexcept;
 
-    static expected<bool, IpcChannelError> isOutdated() noexcept;
+    static expected<bool, posix::IpcChannelError> isOutdated() noexcept;
 
   private:
     friend class MessageQueueBuilder;
@@ -97,23 +96,24 @@ class MessageQueue
     MessageQueue(const IpcChannelName_t& name,
                  const mq_attr attributes,
                  mqd_t mqDescriptor,
-                 const IpcChannelSide channelSide) noexcept;
+                 const posix::IpcChannelSide channelSide) noexcept;
 
-    static expected<mqd_t, IpcChannelError>
-    open(const IpcChannelName_t& name, mq_attr& attributes, const IpcChannelSide channelSide) noexcept;
+    static expected<mqd_t, posix::IpcChannelError>
+    open(const IpcChannelName_t& name, mq_attr& attributes, const posix::IpcChannelSide channelSide) noexcept;
 
-    expected<void, IpcChannelError> close() noexcept;
-    expected<void, IpcChannelError> unlink() noexcept;
-    IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
-    static IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
-    static expected<IpcChannelName_t, IpcChannelError> sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
-    expected<void, IpcChannelError> destroy() noexcept;
+    expected<void, posix::IpcChannelError> close() noexcept;
+    expected<void, posix::IpcChannelError> unlink() noexcept;
+    posix::IpcChannelError errnoToEnum(const int32_t errnum) const noexcept;
+    static posix::IpcChannelError errnoToEnum(const IpcChannelName_t& name, const int32_t errnum) noexcept;
+    static expected<IpcChannelName_t, posix::IpcChannelError>
+    sanitizeIpcChannelName(const IpcChannelName_t& name) noexcept;
+    expected<void, posix::IpcChannelError> destroy() noexcept;
 
   private:
     IpcChannelName_t m_name;
     mq_attr m_attributes{};
     mqd_t m_mqDescriptor = INVALID_DESCRIPTOR;
-    IpcChannelSide m_channelSide = IpcChannelSide::CLIENT;
+    posix::IpcChannelSide m_channelSide = posix::IpcChannelSide::CLIENT;
 
 #ifdef __QNX__
     static constexpr int TIMEOUT_ERRNO = EINTR;
@@ -133,7 +133,7 @@ class MessageQueueBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the message queue is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the message queue
     IOX_BUILDER_PARAMETER(uint64_t, maxMsgSize, MessageQueue::MAX_MESSAGE_SIZE)
@@ -144,10 +144,9 @@ class MessageQueueBuilder
   public:
     /// @brief create a message queue
     /// @return On success a 'MessageQueue' is returned and on failure an 'IpcChannelError'.
-    expected<MessageQueue, IpcChannelError> create() const noexcept;
+    expected<MessageQueue, posix::IpcChannelError> create() const noexcept;
 };
 
-} // namespace posix
 } // namespace iox
 
 #endif // IOX_DUST_POSIX_IPC_MESSAGE_QUEUE_HPP

--- a/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
@@ -35,8 +35,6 @@
 
 namespace iox
 {
-namespace posix
-{
 class NamedPipeBuilder;
 
 class NamedPipe
@@ -72,51 +70,51 @@ class NamedPipe
     /// @brief removes a named pipe artifact from the system
     /// @return true if the artifact was removed, false when no artifact was found and
     ///         IpcChannelError::INTERNAL_LOGIC_ERROR when shm_unlink failed
-    static expected<bool, IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
+    static expected<bool, posix::IpcChannelError> unlinkIfExists(const IpcChannelName_t& name) noexcept;
 
     /// @brief tries to send a message via the named pipe. if the pipe is full IpcChannelError::TIMEOUT is returned
     /// @return on failure an error which describes the failure
-    expected<void, IpcChannelError> trySend(const std::string& message) const noexcept;
+    expected<void, posix::IpcChannelError> trySend(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe. if the pipe is full this call is blocking until the message could be
     ///        delivered
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, IpcChannelError> send(const std::string& message) const noexcept;
+    expected<void, posix::IpcChannelError> send(const std::string& message) const noexcept;
 
     /// @brief sends a message via the named pipe.
     /// @param[in] message the message which should be sent, is not allowed to be longer then MAX_MESSAGE_SIZE
     /// @param[in] timeout the timeout on how long this method should retry to send the message
     /// @return success when message was sent otherwise an error which describes the failure
-    expected<void, IpcChannelError> timedSend(const std::string& message,
-                                              const units::Duration& timeout) const noexcept;
+    expected<void, posix::IpcChannelError> timedSend(const std::string& message,
+                                                     const units::Duration& timeout) const noexcept;
 
     /// @brief tries to receive a message via the named pipe. if the pipe is empty IpcChannelError::TIMEOUT is returned
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> tryReceive() const noexcept;
+    expected<std::string, posix::IpcChannelError> tryReceive() const noexcept;
 
     /// @brief receives a message via the named pipe. if the pipe is empty this call is blocking until a message was
     ///        received
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> receive() const noexcept;
+    expected<std::string, posix::IpcChannelError> receive() const noexcept;
 
     /// @brief receives a message via the named pipe.
     /// @param[in] timeout the timeout on how long this method should retry to receive a message
     /// @return on success a string containing the message, otherwise an error which describes the failure
-    expected<std::string, IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
+    expected<std::string, posix::IpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
   private:
     friend class NamedPipeBuilder;
 
     class NamedPipeData;
-    NamedPipe(SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
+    NamedPipe(posix::SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
 
     template <typename Prefix>
     static IpcChannelName_t mapToSharedMemoryName(const Prefix& p, const IpcChannelName_t& name) noexcept;
 
     /// @brief destroys an initialized named pipe.
     /// @return is always successful
-    expected<void, IpcChannelError> destroy() noexcept;
+    expected<void, posix::IpcChannelError> destroy() noexcept;
 
     class NamedPipeData
     {
@@ -129,10 +127,10 @@ class NamedPipe
         NamedPipeData& operator=(NamedPipeData&& rhs) = delete;
         ~NamedPipeData() = default;
 
-        UnnamedSemaphore& sendSemaphore() noexcept;
-        UnnamedSemaphore& receiveSemaphore() noexcept;
+        posix::UnnamedSemaphore& sendSemaphore() noexcept;
+        posix::UnnamedSemaphore& receiveSemaphore() noexcept;
 
-        expected<void, IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
+        expected<void, posix::IpcChannelError> initialize(const uint32_t maxMsgNumber) noexcept;
 
         bool waitForInitialization() const noexcept;
         bool hasValidState() const noexcept;
@@ -146,12 +144,12 @@ class NamedPipe
         static constexpr units::Duration WAIT_FOR_INIT_SLEEP_TIME = units::Duration::fromMilliseconds(1);
 
         std::atomic<uint64_t> initializationGuard{INVALID_DATA};
-        optional<UnnamedSemaphore> m_sendSemaphore;
-        optional<UnnamedSemaphore> m_receiveSemaphore;
+        optional<posix::UnnamedSemaphore> m_sendSemaphore;
+        optional<posix::UnnamedSemaphore> m_receiveSemaphore;
     };
 
   private:
-    SharedMemoryObject m_sharedMemory;
+    posix::SharedMemoryObject m_sharedMemory;
     NamedPipeData* m_data = nullptr;
 };
 
@@ -161,7 +159,7 @@ class NamedPipeBuilder
     IOX_BUILDER_PARAMETER(IpcChannelName_t, name, "")
 
     /// @brief Defines how the named pipe is opened, i.e. as client or server
-    IOX_BUILDER_PARAMETER(IpcChannelSide, channelSide, IpcChannelSide::CLIENT)
+    IOX_BUILDER_PARAMETER(posix::IpcChannelSide, channelSide, posix::IpcChannelSide::CLIENT)
 
     /// @brief Defines the max message size of the named pipe
     IOX_BUILDER_PARAMETER(size_t, maxMsgSize, NamedPipe::MAX_MESSAGE_SIZE)
@@ -172,10 +170,9 @@ class NamedPipeBuilder
   public:
     /// @brief create a named pipe
     /// @return On success a 'NamedPipe' is returned and on failure an 'IpcChannelError'.
-    expected<NamedPipe, IpcChannelError> create() const noexcept;
+    expected<NamedPipe, posix::IpcChannelError> create() const noexcept;
 };
 
-} // namespace posix
 } // namespace iox
 
 #endif // IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP

--- a/iceoryx_dust/posix/ipc/source/message_queue.cpp
+++ b/iceoryx_dust/posix/ipc/source/message_queue.cpp
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/posix/message_queue.hpp"
+#include "iox/message_queue.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
@@ -28,8 +28,9 @@
 
 namespace iox
 {
-namespace posix
-{
+using posix::IpcChannelError;
+using posix::IpcChannelSide;
+
 expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noexcept
 {
     auto sanitzedNameResult = MessageQueue::sanitizeIpcChannelName(m_name);
@@ -47,7 +48,7 @@ expected<MessageQueue, IpcChannelError> MessageQueueBuilder::create() const noex
 
     if (m_channelSide == IpcChannelSide::SERVER)
     {
-        posixCall(mq_unlink)(sanitizedName.c_str())
+        posix::posixCall(mq_unlink)(sanitizedName.c_str())
             .failureReturnValue(MessageQueue::ERROR_CODE)
             .ignoreErrnos(ENOENT)
             .evaluate()
@@ -134,7 +135,7 @@ expected<bool, IpcChannelError> MessageQueue::unlinkIfExists(const IpcChannelNam
     }
 
 
-    auto mqCall = posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
+    auto mqCall = posix::posixCall(mq_unlink)(sanitizedIpcChannelName->c_str())
                       .failureReturnValue(ERROR_CODE)
                       .ignoreErrnos(ENOENT)
                       .evaluate();
@@ -176,8 +177,9 @@ expected<void, IpcChannelError> MessageQueue::send(const std::string& msg) const
         return err(IpcChannelError::MESSAGE_TOO_LONG);
     }
 
-    auto mqCall =
-        posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_send)(m_mqDescriptor, msg.c_str(), messageSize, 1U)
+                      .failureReturnValue(ERROR_CODE)
+                      .evaluate();
 
     if (mqCall.has_error())
     {
@@ -193,7 +195,7 @@ expected<std::string, IpcChannelError> MessageQueue::receive() const noexcept
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
+    auto mqCall = posix::posixCall(mq_receive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr)
                       .failureReturnValue(ERROR_CODE)
                       .evaluate();
 
@@ -227,10 +229,11 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
         // the mask will be applied to the permissions, therefore we need to set it to 0
         mode_t umaskSaved = umask(0);
-        auto mqCall = posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
-                          .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
-                          .suppressErrorMessagesForErrnos(ENOENT)
-                          .evaluate();
+        auto mqCall =
+            posix::posixCall(iox_mq_open4)(sanitizedName.c_str(), openFlags, MessageQueue::FILE_MODE, &attributes)
+                .failureReturnValue(MessageQueue::INVALID_DESCRIPTOR)
+                .suppressErrorMessagesForErrnos(ENOENT)
+                .evaluate();
 
         umask(umaskSaved);
 
@@ -245,7 +248,7 @@ MessageQueue::open(const IpcChannelName_t& name, mq_attr& attributes, const IpcC
 
 expected<void, IpcChannelError> MessageQueue::close() noexcept
 {
-    auto mqCall = posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_close)(m_mqDescriptor).failureReturnValue(ERROR_CODE).evaluate();
 
     if (mqCall.has_error())
     {
@@ -262,7 +265,7 @@ expected<void, IpcChannelError> MessageQueue::unlink() noexcept
         return ok();
     }
 
-    auto mqCall = posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
+    auto mqCall = posix::posixCall(mq_unlink)(m_name.c_str()).failureReturnValue(ERROR_CODE).evaluate();
     if (mqCall.has_error())
     {
         return err(errnoToEnum(mqCall.error().errnum));
@@ -278,7 +281,7 @@ expected<std::string, IpcChannelError> MessageQueue::timedReceive(const units::D
     /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char message[MAX_MESSAGE_SIZE];
 
-    auto mqCall = posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
+    auto mqCall = posix::posixCall(mq_timedreceive)(m_mqDescriptor, &message[0], MAX_MESSAGE_SIZE, nullptr, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -310,7 +313,7 @@ expected<void, IpcChannelError> MessageQueue::timedSend(const std::string& msg,
 
     timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
 
-    auto mqCall = posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
+    auto mqCall = posix::posixCall(mq_timedsend)(m_mqDescriptor, msg.c_str(), messageSize, 1U, &timeOut)
                       .failureReturnValue(ERROR_CODE)
                       // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
                       .ignoreErrnos(TIMEOUT_ERRNO)
@@ -406,5 +409,4 @@ expected<IpcChannelName_t, IpcChannelError> MessageQueue::sanitizeIpcChannelName
     return ok(name);
 }
 
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/posix/named_pipe.hpp"
+#include "iox/named_pipe.hpp"
 #include "iox/bump_allocator.hpp"
 #include "iox/deadline_timer.hpp"
 #include "iox/filesystem.hpp"
@@ -27,8 +27,17 @@
 
 namespace iox
 {
-namespace posix
-{
+using posix::AccessMode;
+using posix::IpcChannelError;
+using posix::IpcChannelSide;
+using posix::OpenMode;
+using posix::SemaphoreWaitState;
+using posix::SharedMemory;
+using posix::SharedMemoryObject;
+using posix::SharedMemoryObjectBuilder;
+using posix::UnnamedSemaphore;
+using posix::UnnamedSemaphoreBuilder;
+
 /// NOLINTJUSTIFICATION see declaration in header
 /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
@@ -361,5 +370,4 @@ bool NamedPipe::NamedPipeData::hasValidState() const noexcept
     return initializationGuard.load() == VALID_DATA;
 }
 
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
+++ b/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
@@ -13,9 +13,8 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-#ifndef IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP
-#define IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP
+#ifndef IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
+#define IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
 
 #include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
@@ -25,8 +24,6 @@
 
 namespace iox
 {
-namespace posix
-{
 /// @brief The SignalWatcher waits for SIGINT and SIGTERM. One can wait until the
 ///        signal has occurred or ask the watcher if it has occurred.
 /// @code
@@ -34,7 +31,7 @@ namespace posix
 ///   #include <iceoryx_hoofs/posix/signal_watcher.hpp>
 ///   void loopUntilTerminationRequested()
 ///   {
-///       while(!iox::posix::hasTerminationRequested())
+///       while(!iox::hasTerminationRequested())
 ///       {
 ///           // your algorithm
 ///       }
@@ -43,7 +40,7 @@ namespace posix
 ///   // another possibility is to block until SIGINT or SIGTERM has occurred
 ///   void blockUntilCtrlC() {
 ///       // your objects which spawn threads
-///       iox::posix::waitForTerminationRequest();
+///       iox::waitForTerminationRequest();
 ///   }
 /// @endcode
 class SignalWatcher
@@ -71,11 +68,11 @@ class SignalWatcher
   private:
     friend void internalSignalHandler(int) noexcept;
     mutable std::atomic<uint64_t> m_numberOfWaiters{0U};
-    mutable optional<UnnamedSemaphore> m_semaphore;
+    mutable optional<posix::UnnamedSemaphore> m_semaphore;
 
     std::atomic_bool m_hasSignalOccurred{false};
-    SignalGuard m_sigTermGuard;
-    SignalGuard m_sigIntGuard;
+    posix::SignalGuard m_sigTermGuard;
+    posix::SignalGuard m_sigIntGuard;
 };
 
 /// @brief convenience function, calls SignalWatcher::getInstance().waitForSignal();
@@ -83,7 +80,6 @@ void waitForTerminationRequest() noexcept;
 
 /// @brief convenience function, calls SignalWatcher::getInstance().wasSignalTriggered();
 bool hasTerminationRequested() noexcept;
-} // namespace posix
 } // namespace iox
 
-#endif // IOX_DUST_POSIX_SYNC_SIGNAL_WATCHER_HPP
+#endif

--- a/iceoryx_dust/posix/sync/source/signal_watcher.cpp
+++ b/iceoryx_dust/posix/sync/source/signal_watcher.cpp
@@ -14,12 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "iceoryx_platform/unistd.hpp"
 
 namespace iox
-{
-namespace posix
 {
 void internalSignalHandler(int) noexcept
 {
@@ -45,10 +43,11 @@ void internalSignalHandler(int) noexcept
 
 SignalWatcher::SignalWatcher() noexcept
     : m_sigTermGuard(
-        registerSignalHandler(Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
-    , m_sigIntGuard(registerSignalHandler(Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
+        registerSignalHandler(posix::Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
+    , m_sigIntGuard(
+          registerSignalHandler(posix::Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
 {
-    UnnamedSemaphoreBuilder()
+    posix::UnnamedSemaphoreBuilder()
         .isInterProcessCapable(false)
         .create(m_semaphore)
 
@@ -89,5 +88,4 @@ bool hasTerminationRequested() noexcept
 {
     return SignalWatcher::getInstance().wasSignalTriggered();
 }
-} // namespace posix
 } // namespace iox

--- a/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
+++ b/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
@@ -16,13 +16,14 @@
 
 #include "iceoryx_hoofs/testing/barrier.hpp"
 #include "iceoryx_hoofs/testing/watch_dog.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "test.hpp"
 #include <atomic>
 
 namespace
 {
 using namespace ::testing;
+using namespace iox;
 using namespace iox::posix;
 
 class SignalWatcherTester : public SignalWatcher

--- a/iceoryx_examples/callbacks/README.md
+++ b/iceoryx_examples/callbacks/README.md
@@ -74,7 +74,7 @@ Next thing is a `heartbeatThread` which will trigger our heartbeat trigger every
 <!--[geoffrey][iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp][create heartbeat]-->
 ```cpp
 std::thread heartbeatThread([&] {
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         heartbeat.trigger();
         std::this_thread::sleep_for(std::chrono::seconds(4));
@@ -133,7 +133,7 @@ was signaled.
 
 <!--[geoffrey][iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp][wait for sigterm]-->
 ```cpp
-iox::posix::waitForTerminationRequest();
+iox::waitForTerminationRequest();
 ```
 
 When `waitForTerminationRequest` unblocks we clean up all resources and terminate the process
@@ -238,7 +238,7 @@ iox::runtime::PoshRuntime::initRuntime(APP_NAME);
 
 CounterService counterService;
 
-iox::posix::waitForTerminationRequest();
+iox::waitForTerminationRequest();
 ```
 
 Our `CounterService` has the following members:

--- a/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_listener_as_class_member.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -112,7 +112,7 @@ int main()
 
     CounterService counterService;
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [init]
 
     return (EXIT_SUCCESS);

--- a/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_publisher.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -32,7 +32,7 @@ void sending()
     iox::popo::Publisher<CounterTopic> myPublisherLeft({"Radar", "FrontLeft", "Counter"});
     iox::popo::Publisher<CounterTopic> myPublisherRight({"Radar", "FrontRight", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
     {
         if (counter % 3 == 0)
         {

--- a/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
+++ b/iceoryx_examples/callbacks/ice_callbacks_subscriber.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -91,7 +91,7 @@ int main()
     // send a heartbeat every 4 seconds
     //! [create heartbeat]
     std::thread heartbeatThread([&] {
-        while (!iox::posix::hasTerminationRequested())
+        while (!iox::hasTerminationRequested())
         {
             heartbeat.trigger();
             std::this_thread::sleep_for(std::chrono::seconds(4));
@@ -131,7 +131,7 @@ int main()
 
     // wait until someone presses CTRL+C
     //! [wait for sigterm]
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [wait for sigterm]
 
     // optional detachEvent, but not required.

--- a/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_complexdata.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-complexdata";
 
@@ -46,7 +46,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
         publisher.loan()

--- a/iceoryx_examples/complexdata/iox_publisher_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_publisher_vector.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-publisher-vector";
 
@@ -34,7 +34,7 @@ int main()
 
     uint64_t ct = 0;
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         publisher.loan()
             .and_then([&](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_complexdata.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "iox/string.hpp"
 
 constexpr char APP_NAME[] = "iox-cpp-subscriber-complexdata";
@@ -32,7 +32,7 @@ int main()
     iox::popo::Subscriber<ComplexDataType> subscriber({"Group", "Instance", "ComplexDataTopic"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
+++ b/iceoryx_examples/complexdata/iox_subscriber_vector.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "iox/string.hpp"
 #include "iox/vector.hpp"
 
@@ -31,7 +31,7 @@ int main()
     iox::popo::Subscriber<iox::vector<double, 5>> subscriber({"Radar", "FrontRight", "VectorData"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take()
             .and_then([](auto& sample) {

--- a/iceoryx_examples/ice_access_control/iox_display_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_display_app.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -35,7 +35,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "HMI-Display", "Object"});
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto takeResult = subscriber.take();
 

--- a/iceoryx_examples/ice_access_control/iox_radar_app.cpp
+++ b/iceoryx_examples/ice_access_control/iox_radar_app.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -32,7 +32,7 @@ int main()
     iox::popo::Publisher<RadarObject> publisher({"Radar", "FrontLeft", "Object"});
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/icedelivery/README.md
+++ b/iceoryx_examples/icedelivery/README.md
@@ -23,9 +23,9 @@ First off, let's include the publisher, the runtime and the signal handler:
 
 <!--[geoffrey][iceoryx_examples/icedelivery/iox_publisher_untyped.cpp][includes]-->
 ```cpp
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 You might be wondering what the publisher application is sending? It's this struct.
@@ -130,9 +130,9 @@ Similar to the publisher, we include the topic data, the subscriber, the runtime
 ```cpp
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 To make RouDi aware of the subscriber a runtime object is created, once again with a unique identifier string:
@@ -155,7 +155,7 @@ Again in a while-loop we do the following:
 
 <!--[geoffrey][iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp][[loop] [chunk happy path]]-->
 ```cpp
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 {
     subscriber
         .take()

--- a/iceoryx_examples/icedelivery/iox_publisher.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/publisher.hpp"
 //! [include publisher]
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -41,7 +41,7 @@ int main()
     //! [create publisher]
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
         double sampleValue1 = ct + 89;

--- a/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped.cpp
@@ -22,7 +22,7 @@
 //! [includes]
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -39,7 +39,7 @@ int main()
     //! [create untyped publisher]
 
     double ct = 0.0;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         ++ct;
 

--- a/iceoryx_examples/icedelivery/iox_subscriber.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/subscriber.hpp"
 //! [include subscriber]
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped.cpp
@@ -20,7 +20,7 @@
 
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [includes]
 
 #include <iostream>
@@ -38,7 +38,7 @@ int main()
 
     // run until interrupted by Ctrl-C
     //! [loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber
             .take()

--- a/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
+++ b/iceoryx_examples/icediscovery/iox_discovery_monitor.cpp
@@ -19,7 +19,7 @@
 //! [include custom discovery]
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     discovery.registerCallback(callback);
     //! [register callback]
 
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         // here the app would run its functional code while the
         // service availability is monitored in the background

--- a/iceoryx_examples/icediscovery/iox_find_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_find_service.cpp
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include ServiceDiscovery]
 #include "iceoryx_posh/runtime/service_discovery.hpp"
 //! [include ServiceDiscovery]
@@ -39,7 +39,7 @@ int main()
     iox::runtime::ServiceDiscovery serviceDiscovery;
     //! [create ServiceDiscovery object]
 
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         std::cout << "\n=========================================" << std::endl;
 

--- a/iceoryx_examples/icediscovery/iox_offer_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_offer_service.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 constexpr char APP_NAME[] = "iox-offer-service";
 
@@ -37,7 +37,7 @@ int main()
     cameraPublishers.emplace_back(iox::capro::ServiceDescription{"Camera", "BackLeft", "Image"});
 
     bool offer = false;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         if (offer)
         {

--- a/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
@@ -19,7 +19,7 @@
 //! [include custom discovery]
 
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 

--- a/iceoryx_examples/icehello/README.md
+++ b/iceoryx_examples/icehello/README.md
@@ -65,14 +65,14 @@ In iceoryx, a publisher and a subscriber are connected only if all three IDs mat
 For exiting on Ctrl+C, we use the `SignalWatcher`
 <!--[geoffrey][iceoryx_examples/icehello/iox_publisher_helloworld.cpp][include sig watcher]-->
 ```cpp
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 and loop in our `while` loop until it states that `SIGINT` or `SIGTERM` was sent via
 the function `hasTerminationRequested`.
 <!--[geoffrey][iceoryx_examples/icehello/iox_publisher_helloworld.cpp][wait for term]-->
 ```cpp
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 ```
 
 In order to send our sample, we loan some shared memory inside the `while` loop:
@@ -125,9 +125,9 @@ The subscriber needs to have similar includes, but unlike the publisher `subscri
 ```cpp
 #include "topic_data.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 As well as the publisher, the subscriber needs to register with the daemon RouDi:

--- a/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_publisher_helloworld.cpp
@@ -19,7 +19,7 @@
 //! [include topic]
 
 //! [include sig watcher]
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include sig watcher]
 
 //! [include]
@@ -43,7 +43,7 @@ int main()
 
     double ct = 0.0;
     //! [wait for term]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     //! [wait for term]
     {
         ++ct;

--- a/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
+++ b/iceoryx_examples/icehello/iox_subscriber_helloworld.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [initialize subscriber]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [receive]
         auto takeResult = subscriber.take();

--- a/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_publisher_with_options.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -63,7 +63,7 @@ int main()
     double ct = 0.0;
 
     std::thread publishData([&]() {
-        while (!iox::posix::hasTerminationRequested())
+        while (!iox::hasTerminationRequested())
         {
             ++ct;
 
@@ -76,7 +76,7 @@ int main()
         }
     });
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
 
     // this is optional, but since the iox::popo::ConsumerTooSlowPolicy::WAIT_FOR_CONSUMER option is used,
     // a slow subscriber might block the shutdown and this call unblocks the publisher

--- a/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
+++ b/iceoryx_examples/iceoptions/iox_subscriber_with_options.cpp
@@ -18,7 +18,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <iostream>
 
@@ -76,7 +76,7 @@ int main()
     //! [subscribe]
 
     // run until interrupted by Ctrl-C
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         subscriber.take().and_then(
             [](auto& sample) { std::cout << APP_NAME << " got value: " << sample->x << std::endl; });

--- a/iceoryx_examples/request_response/README.md
+++ b/iceoryx_examples/request_response/README.md
@@ -35,11 +35,11 @@ At first, the includes for the client port, request-response types, WaitSet, and
 ```cpp
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 Afterwards we prepare some `ContextData` where we can store the Fibonacci numbers
@@ -177,10 +177,10 @@ At first, the includes for the server port, Listener, request-response types and
 ```cpp
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 Then a callback is created that shall be called when the server receives a request.
@@ -246,7 +246,7 @@ With that the preparation is done and the main thread can just sleep or do other
 
 <!-- [geoffrey] [iceoryx_examples/request_response/server_cxx_listener.cpp][wait for termination] -->
 ```cpp
-iox::posix::waitForTerminationRequest();
+iox::waitForTerminationRequest();
 ```
 
 Once the user wants to shutdown the server, the server event is detached from the listener:

--- a/iceoryx_examples/request_response/client_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/client_cxx_basic.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [send request]
         client.loan()

--- a/iceoryx_examples/request_response/client_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/client_cxx_untyped.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_client.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -40,7 +40,7 @@ int main()
     uint64_t fibonacciCurrent = 1;
     int64_t requestSequenceId = 0;
     int64_t expectedResponseSequenceId = requestSequenceId;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [send request]
         client.loan(sizeof(AddRequest), alignof(AddRequest))

--- a/iceoryx_examples/request_response/client_cxx_waitset.cpp
+++ b/iceoryx_examples/request_response/client_cxx_waitset.cpp
@@ -21,7 +21,7 @@
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>

--- a/iceoryx_examples/request_response/server_cxx_basic.cpp
+++ b/iceoryx_examples/request_response/server_cxx_basic.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](const auto& request) {

--- a/iceoryx_examples/request_response/server_cxx_listener.cpp
+++ b/iceoryx_examples/request_response/server_cxx_listener.cpp
@@ -20,7 +20,7 @@
 #include "iceoryx_posh/popo/listener.hpp"
 #include "iceoryx_posh/popo/server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -76,7 +76,7 @@ int main()
     //! [attach listener]
 
     //! [wait for termination]
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     //! [wait for termination]
 
     //! [cleanup]

--- a/iceoryx_examples/request_response/server_cxx_untyped.cpp
+++ b/iceoryx_examples/request_response/server_cxx_untyped.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_server.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <iostream>
@@ -36,7 +36,7 @@ int main()
     //! [create server]
 
     //! [process requests in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take request]
         server.take().and_then([&](auto& requestPayload) {

--- a/iceoryx_examples/singleprocess/README.md
+++ b/iceoryx_examples/singleprocess/README.md
@@ -72,7 +72,7 @@ iox::runtime::PoshRuntimeSingleProcess runtime("singleProcessDemo");
 ```cpp
 std::thread publisherThread(publisher), subscriberThread(subscriber);
 
-iox::posix::waitForTerminationRequest();
+iox::waitForTerminationRequest();
 
 publisherThread.join();
 subscriberThread.join();
@@ -105,7 +105,7 @@ After that, we are sending numbers in ascending order with a 100ms interval in a
 ```cpp
 uint64_t counter{0};
 constexpr const char GREEN_RIGHT_ARROW[] = "\033[32m->\033[m ";
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 {
     publisher.loan().and_then([&](auto& sample) {
         sample->counter = counter++;
@@ -136,7 +136,7 @@ until someone terminates the application.
 <!--[geoffrey][iceoryx_examples/singleprocess/single_process.cpp][receive]-->
 ```cpp
 constexpr const char ORANGE_LEFT_ARROW[] = "\033[33m<-\033[m ";
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 {
     if (iox::SubscribeState::SUBSCRIBED == subscriber.getSubscriptionState())
     {

--- a/iceoryx_examples/singleprocess/single_process.cpp
+++ b/iceoryx_examples/singleprocess/single_process.cpp
@@ -24,7 +24,7 @@
 #include "iceoryx_posh/runtime/posh_runtime_single_process.hpp"
 #include "iox/detail/convert.hpp"
 #include "iox/logging.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -59,7 +59,7 @@ void publisher()
     //! [send]
     uint64_t counter{0};
     constexpr const char GREEN_RIGHT_ARROW[] = "\033[32m->\033[m ";
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         publisher.loan().and_then([&](auto& sample) {
             sample->counter = counter++;
@@ -83,7 +83,7 @@ void subscriber()
 
     //! [receive]
     constexpr const char ORANGE_LEFT_ARROW[] = "\033[33m<-\033[m ";
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         if (iox::SubscribeState::SUBSCRIBED == subscriber.getSubscriptionState())
         {
@@ -136,7 +136,7 @@ int main()
     //! [run]
     std::thread publisherThread(publisher), subscriberThread(subscriber);
 
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
 
     publisherThread.join();
     subscriberThread.join();

--- a/iceoryx_examples/user_header/README.md
+++ b/iceoryx_examples/user_header/README.md
@@ -58,9 +58,9 @@ and the iceoryx includes for publisher and runtime.
 ```cpp
 #include "user_header_and_payload_types.hpp"
 
-#include "iceoryx_dust/posix_wrapper/signal_watcher.hpp"
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_watcher.hpp"
 ```
 
 Next, the iceoryx runtime is initialized. With this call, the application will be registered at `RouDi`,
@@ -87,7 +87,7 @@ if you prefer a more traditional approach.
 uint64_t timestamp = 42;
 uint64_t fibonacciLast = 0;
 uint64_t fibonacciCurrent = 1;
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 {
     auto fibonacciNext = fibonacciCurrent + fibonacciLast;
     fibonacciLast = fibonacciCurrent;
@@ -231,7 +231,7 @@ The main loop is quite simple. The publisher is periodically polled and the data
 Again, the user-header is accessed by the `getUserHeader` method of the sample.
 <!-- [geoffrey] [iceoryx_examples/user_header/subscriber_cxx_api.cpp] [poll subscriber for samples in a loop] -->
 ```cpp
-while (!iox::posix::hasTerminationRequested())
+while (!iox::hasTerminationRequested())
 {
     subscriber.take().and_then([&](auto& sample) {
         std::cout << APP_NAME << " got value: " << sample->fibonacci << " with timestamp "

--- a/iceoryx_examples/user_header/publisher_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -40,7 +40,7 @@ int main()
     uint64_t timestamp = 42;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/publisher_untyped_cxx_api.cpp
@@ -17,7 +17,7 @@
 //! [iceoryx includes]
 #include "user_header_and_payload_types.hpp"
 
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [include differs from typed C++ API]
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 //! [include differs from typed C++ API]
@@ -42,7 +42,7 @@ int main()
     uint64_t timestamp = 73;
     uint64_t fibonacciLast = 0;
     uint64_t fibonacciCurrent = 1;
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         auto fibonacciNext = fibonacciCurrent + fibonacciLast;
         fibonacciLast = fibonacciCurrent;

--- a/iceoryx_examples/user_header/subscriber_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take sample]
         subscriber.take().and_then([&](auto& sample) {

--- a/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
+++ b/iceoryx_examples/user_header/subscriber_untyped_cxx_api.cpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
 #include <atomic>
@@ -37,7 +37,7 @@ int main()
     //! [create subscriber]
 
     //! [poll subscriber for samples in a loop]
-    while (!iox::posix::hasTerminationRequested())
+    while (!iox::hasTerminationRequested())
     {
         //! [take chunk]
         subscriber.take().and_then([&](auto& userPayload) {

--- a/iceoryx_examples/waitset/ice_waitset_publisher.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_publisher.cpp
@@ -16,7 +16,7 @@
 
 #include "iceoryx_posh/popo/publisher.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -27,7 +27,7 @@ void sending()
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-publisher-waitset");
     iox::popo::Publisher<CounterTopic> myPublisher({"Radar", "FrontLeft", "Counter"});
 
-    for (uint32_t counter = 0U; !iox::posix::hasTerminationRequested(); ++counter)
+    for (uint32_t counter = 0U; !iox::hasTerminationRequested(); ++counter)
     {
         myPublisher.publishCopyOf(CounterTopic{counter})
             .and_then([&] { std::cout << "Sending: " << counter << std::endl; })

--- a/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
+++ b/iceoryx_hoofs/cmake/IceoryxPlatform.cmake
@@ -80,7 +80,7 @@ function(iox_create_lsan_runtime_blacklist BLACKLIST_FILE_PATH)
     # count      bytes template
     #     8        642 libacl.so.1
     #     1         24 iox::posix::UnixDomainSocket::timedReceive
-    #     1         24 iox::posix::MessageQueue::receive
+    #     1         24 iox::MessageQueue::receive
     if(NOT EXISTS ${BLACKLIST_FILE_PATH})
         file(WRITE  ${BLACKLIST_FILE_PATH} "# This file is auto-generated from iceoryx_hoofs/cmake/IceoryxPlatform.cmake\n")
         file(APPEND ${BLACKLIST_FILE_PATH} "#leak:libacl.so.1\n")

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/ipc_interface_base.hpp
@@ -33,8 +33,8 @@
 #include "iox/relative_pointer.hpp"
 
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
-#include "iox/posix/message_queue.hpp"
-#include "iox/posix/named_pipe.hpp"
+#include "iox/message_queue.hpp"
+#include "iox/named_pipe.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -50,9 +50,9 @@ namespace iox
 namespace platform
 {
 #if defined(_WIN32)
-using IoxIpcChannelType = iox::posix::NamedPipe;
+using IoxIpcChannelType = iox::NamedPipe;
 #elif defined(__FREERTOS__)
-using IoxIpcChannelType = iox::posix::NamedPipe;
+using IoxIpcChannelType = iox::NamedPipe;
 #else
 using IoxIpcChannelType = iox::posix::UnixDomainSocket;
 #endif

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
@@ -48,7 +48,7 @@ class RouDiApp
 
   protected:
     /// @brief waits for the next signal to RouDi daemon
-    IOX_DEPRECATED_SINCE(3, "Please use iox::posix::waitForTerminationRequest() from 'iox/posix/signal_watcher.hpp'")
+    IOX_DEPRECATED_SINCE(3, "Please use iox::posix::waitForTerminationRequest() from 'iox/signal_watcher.hpp'")
     bool waitForSignal() noexcept;
 
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};

--- a/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/iceoryx_roudi_app.cpp
@@ -20,8 +20,8 @@
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
 #include "iceoryx_posh/roudi/iceoryx_roudi_components.hpp"
 #include "iox/optional.hpp"
-#include "iox/posix/signal_watcher.hpp"
 #include "iox/scoped_static.hpp"
+#include "iox/signal_watcher.hpp"
 
 namespace iox
 {
@@ -50,7 +50,7 @@ uint8_t IceOryxRouDiApp::run() noexcept
                                                            m_compatibilityCheckLevel,
                                                            m_processKillDelay,
                                                            m_processTeminationDelay});
-        iox::posix::waitForTerminationRequest();
+        iox::waitForTerminationRequest();
     }
     return EXIT_SUCCESS;
 }

--- a/iceoryx_posh/source/roudi/application/roudi_app.cpp
+++ b/iceoryx_posh/source/roudi/application/roudi_app.cpp
@@ -25,7 +25,7 @@
 #include "iceoryx_posh/roudi/cmd_line_args.hpp"
 #include "iox/logging.hpp"
 #include "iox/optional.hpp"
-#include "iox/posix/signal_watcher.hpp"
+#include "iox/signal_watcher.hpp"
 
 namespace iox
 {
@@ -79,7 +79,7 @@ bool RouDiApp::checkAndOptimizeConfig(const RouDiConfig_t& config) noexcept
 
 bool RouDiApp::waitForSignal() noexcept
 {
-    iox::posix::waitForTerminationRequest();
+    iox::waitForTerminationRequest();
     return true;
 }
 

--- a/iceoryx_posh/source/runtime/ipc_interface_base.cpp
+++ b/iceoryx_posh/source/runtime/ipc_interface_base.cpp
@@ -242,7 +242,7 @@ bool IpcInterface<posix::UnixDomainSocket>::ipcChannelMapsToFile() noexcept
 }
 
 template <>
-bool IpcInterface<posix::NamedPipe>::ipcChannelMapsToFile() noexcept
+bool IpcInterface<NamedPipe>::ipcChannelMapsToFile() noexcept
 {
     return true;
 }
@@ -263,8 +263,8 @@ void IpcInterface<IpcChannelType>::cleanupOutdatedIpcChannel(const RuntimeName_t
 }
 
 template class IpcInterface<posix::UnixDomainSocket>;
-template class IpcInterface<posix::NamedPipe>;
-template class IpcInterface<posix::MessageQueue>;
+template class IpcInterface<NamedPipe>;
+template class IpcInterface<MessageQueue>;
 
 } // namespace runtime
 } // namespace iox

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -22,7 +22,7 @@
 #include "iceoryx_posh/internal/runtime/ipc_message.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp"
 #include "iox/duration.hpp"
-#include "iox/posix/message_queue.hpp"
+#include "iox/message_queue.hpp"
 #include "iox/std_string_support.hpp"
 
 

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
@@ -18,8 +18,8 @@
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
 #include "iceoryx_platform/platform_settings.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_interface_base.hpp"
-#include "iox/posix/message_queue.hpp"
-#include "iox/posix/named_pipe.hpp"
+#include "iox/message_queue.hpp"
+#include "iox/named_pipe.hpp"
 #include "iox/std_chrono_support.hpp"
 
 #include "test.hpp"


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Like decided in the developer meetup today, `posix` is not part of the include path and namespace.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1391 
