### PR TITLE
iox-#2082 faster vector on POD data

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -55,6 +55,7 @@
 - Switch to C++17 on all platforms [#2066](https://github.com/eclipse-iceoryx/iceoryx/issues/2066)
 - Implement `unsafe_raw_access` in `iox::string` and add `BufferInfo` struct [#1431](https://github.com/eclipse-iceoryx/iceoryx/issues/1431)
 - Add the introspection to the ROS release [\#2099](https://github.com/eclipse-iceoryx/iceoryx/issues/2099)
+- Fast POD data in `iox::vector` [#2082](https://github.com/eclipse-iceoryx/iceoryx/issues/2082)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/container/include/iox/detail/vector.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/vector.inl
@@ -19,7 +19,9 @@
 
 #include "iox/vector.hpp"
 
+#include <cstring> // std::memcpy, std::memmove
 #include <iostream>
+#include <type_traits>
 
 namespace iox
 {
@@ -52,10 +54,14 @@ inline vector<T, Capacity>::vector(const uint64_t count) noexcept
     }
 
     m_size = std::min(count, Capacity);
-    for (uint64_t i{0U}; i < m_size; ++i)
+    // If the type is a trivial class without member initialization the constructor would not initialize the data
+    if constexpr (!(std::is_trivial<T>::value && std::is_class<T>::value))
     {
-        // AXIVION Next Line AutosarC++19_03-A18.5.2, FaultDetection-IndirectAssignmentOverflow : False positive, it is a placement new. Size guaranteed by T.
-        new (&at(i)) T();
+        for (uint64_t i{0U}; i < m_size; ++i)
+        {
+            // AXIVION Next Line AutosarC++19_03-A18.5.2, FaultDetection-IndirectAssignmentOverflow : False positive, it is a placement new. Size guaranteed by T.
+            new (&at_unchecked(i)) T();
+        }
     }
 }
 
@@ -84,19 +90,28 @@ inline vector<T, Capacity>& vector<T, Capacity>::operator=(const vector& rhs) no
     {
         uint64_t i{0U};
         const uint64_t rhsSize{rhs.size()};
-        const uint64_t minSize{algorithm::minVal(m_size, rhsSize)};
 
-        // copy using copy assignment
-        for (; i < minSize; ++i)
+        if constexpr (std::is_trivially_copyable<T>::value)
         {
-            // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
-            at(i) = rhs.at(i);
+            std::memcpy(data(), rhs.data(), rhsSize * sizeof(T));
+            i = rhsSize;
         }
-
-        // copy using copy ctor
-        for (; i < rhsSize; ++i)
+        else
         {
-            IOX_DISCARD_RESULT(emplace_back(rhs.at(i)));
+            const uint64_t minSize{algorithm::minVal(m_size, rhsSize)};
+
+            // copy using copy assignment
+            for (; i < minSize; ++i)
+            {
+                // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
+                at(i) = rhs.at(i);
+            }
+
+            // copy using copy ctor
+            for (; i < rhsSize; ++i)
+            {
+                IOX_DISCARD_RESULT(emplace_back(rhs.at(i)));
+            }
         }
 
         // delete remaining elements
@@ -114,19 +129,28 @@ inline vector<T, Capacity>& vector<T, Capacity>::operator=(vector&& rhs) noexcep
     {
         uint64_t i{0U};
         const uint64_t rhsSize{rhs.size()};
-        const uint64_t minSize{algorithm::minVal(m_size, rhsSize)};
 
-        // move using move assignment
-        for (; i < minSize; ++i)
+        if constexpr (std::is_trivially_copyable<T>::value)
         {
-            // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
-            at(i) = std::move(rhs.at(i));
+            std::memcpy(data(), rhs.data(), rhsSize * sizeof(T));
+            i = rhsSize;
         }
-
-        // move using move ctor
-        for (; i < rhsSize; ++i)
+        else
         {
-            IOX_DISCARD_RESULT(emplace_back(std::move(rhs.at(i))));
+            const uint64_t minSize{algorithm::minVal(m_size, rhsSize)};
+
+            // move using move assignment
+            for (; i < minSize; ++i)
+            {
+                // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
+                at(i) = std::move(rhs.at(i));
+            }
+
+            // move using move ctor
+            for (; i < rhsSize; ++i)
+            {
+                IOX_DISCARD_RESULT(emplace_back(std::move(rhs.at(i))));
+            }
         }
 
         // delete remaining elements
@@ -168,8 +192,15 @@ inline bool vector<T, Capacity>::emplace_back(Targs&&... args) noexcept
 {
     if (m_size < Capacity)
     {
-        // AXIVION Next Line AutosarC++19_03-A5.0.1, FaultDetection-IndirectAssignmentOverflow: Size guaranteed by T. Evaluation order is inconsequential.
-        new (&at(m_size++)) T(std::forward<Targs>(args)...);
+        if constexpr (std::is_trivial<T>::value)
+        {
+            at_unchecked(m_size++) = T{std::forward<Targs>(args)...};
+        }
+        else
+        {
+            // AXIVION Next Line AutosarC++19_03-A5.0.1, FaultDetection-IndirectAssignmentOverflow: Size guaranteed by T. Evaluation order is inconsequential.
+            new (&at_unchecked(m_size++)) T{std::forward<Targs>(args)...};
+        }
         return true;
     }
     return false;
@@ -189,14 +220,26 @@ inline bool vector<T, Capacity>::emplace(const uint64_t position, Targs&&... arg
     {
         return emplace_back(std::forward<Targs>(args)...);
     }
-    IOX_DISCARD_RESULT(emplace_back(std::move(at_unchecked(sizeBeforeEmplace - 1U))));
-    for (uint64_t i{sizeBeforeEmplace - 1U}; i > position; --i)
+    if constexpr (std::is_trivial<T>::value)
     {
-        at_unchecked(i) = std::move(at_unchecked(i - 1U));
+        resize(size() + 1U);
+        const uint64_t dataLen{sizeBeforeEmplace - position};
+        std::memmove(data() + position + 1U, data() + position, dataLen * sizeof(T));
+        at_unchecked(position) = T{std::forward<Targs>(args)...};
     }
-
-    at(position).~T();
-    new (&at(position)) T(std::forward<Targs>(args)...);
+    else
+    {
+        IOX_DISCARD_RESULT(emplace_back(std::move(at_unchecked(sizeBeforeEmplace - 1U))));
+        for (uint64_t i{sizeBeforeEmplace - 1U}; i > position; --i)
+        {
+            at_unchecked(i) = std::move(at_unchecked(i - 1U));
+        }
+        if constexpr (!std::is_trivially_destructible<T>::value)
+        {
+            at_unchecked(position).~T();
+        }
+        new (&at_unchecked(position)) T(std::forward<Targs>(args)...);
+    }
     return true;
 }
 
@@ -218,7 +261,14 @@ inline bool vector<T, Capacity>::pop_back() noexcept
 {
     if (m_size > 0U)
     {
-        at_unchecked(--m_size).~T();
+        if constexpr (std::is_trivial<T>::value)
+        {
+            m_size--;
+        }
+        else
+        {
+            at_unchecked(--m_size).~T();
+        }
         return true;
     }
     return false;
@@ -359,13 +409,26 @@ inline bool vector<T, Capacity>::erase(iterator position) noexcept
         // AXIVION Next Line AutosarC++19_03-M5.0.9 : False positive. Pointer arithmetic occurs here.
         uint64_t index{static_cast<uint64_t>(position - begin())};
         uint64_t n{index};
-        while ((n + 1U) < size())
+        if constexpr (std::is_trivially_copyable<T>::value)
         {
-            // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
-            at(n) = std::move(at(n + 1U));
-            ++n;
+            if constexpr (!(std::is_trivially_destructible<T>::value))
+            {
+                at_unchecked(n).~T();
+            }
+            uint64_t dataLen{size() - n - 1U};
+            std::memmove(data() + n, data() + n + 1U, dataLen * sizeof(T));
         }
-        at(n).~T();
+        else
+        {
+            while ((n + 1U) < size())
+            {
+                // AXIVION Next Line AutosarC++19_03-A5.0.1 : Expands to basic variable assignment. Evaluation order is inconsequential.
+                at_unchecked(n) = std::move(at(n + 1U));
+                ++n;
+            }
+            at_unchecked(n).~T();
+        }
+
         m_size--;
         return true;
     }
@@ -391,9 +454,16 @@ inline const T& vector<T, Capacity>::at_unchecked(const uint64_t index) const no
 template <typename T, uint64_t Capacity>
 inline void vector<T, Capacity>::clearFrom(const uint64_t startPosition) noexcept
 {
-    while (m_size > startPosition)
+    if constexpr (std::is_trivially_destructible<T>::value)
     {
-        at_unchecked(--m_size).~T();
+        m_size = startPosition;
+    }
+    else
+    {
+        while (m_size > startPosition)
+        {
+            at_unchecked(--m_size).~T();
+        }
     }
 }
 


### PR DESCRIPTION
Optimize the vector class by specializing it for plain old data (POD) types, thereby eliminating the need for explicit constructors, destructors, and copy operators in the vector operations.

## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes https://github.com/eclipse-iceoryx/iceoryx/issues/2082
