### PR TITLE
iox-#2052 Refactor copy_and_move_impl

### DIFF
--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -18,10 +18,8 @@
 #ifndef IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_INL
 #define IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_INL
 
-#include "iox/fixed_position_container.hpp"
-#if __cplusplus < 201703L
 #include "iox/detail/fixed_position_container_helper.hpp"
-#endif
+#include "iox/fixed_position_container.hpp"
 
 namespace iox
 {
@@ -58,23 +56,13 @@ inline FixedPositionContainer<T, CAPACITY>::~FixedPositionContainer() noexcept
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(const FixedPositionContainer& rhs) noexcept
 {
-    for (IndexType i = 0; i < CAPACITY; ++i)
-    {
-        m_status[i] = SlotStatus::FREE;
-    }
-
-    *this = rhs;
+    copy_and_move_impl<detail::SpecialCreationOperations::CopyConstructor>(rhs);
 }
 
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(FixedPositionContainer&& rhs) noexcept
 {
-    for (IndexType i = 0; i < CAPACITY; ++i)
-    {
-        m_status[i] = SlotStatus::FREE;
-    }
-
-    *this = std::move(rhs);
+    copy_and_move_impl<detail::SpecialCreationOperations::MoveConstructor>(std::move(rhs));
 }
 
 template <typename T, uint64_t CAPACITY>
@@ -83,7 +71,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& rhs
 {
     if (this != &rhs)
     {
-        copy_and_move_impl(rhs);
+        copy_and_move_impl<detail::SpecialCreationOperations::CopyAssignment>(rhs);
     }
     return *this;
 }
@@ -94,73 +82,79 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
 {
     if (this != &rhs)
     {
-        copy_and_move_impl(std::move(rhs));
-
-        // clear rhs
-        rhs.clear();
+        copy_and_move_impl<detail::SpecialCreationOperations::MoveAssignment>(std::move(rhs));
     }
     return *this;
 }
 
 template <typename T, uint64_t CAPACITY>
-template <typename RhsType>
+template <detail::SpecialCreationOperations Opt, typename RhsType>
 inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rhs) noexcept
 {
-    // we already make sure rhs is always passed by std::move() for move case, therefore
-    // the result of "decltype(rhs)" is same as "decltype(std::forward<RhsType>(rhs))"
-    static_assert(std::is_rvalue_reference<decltype(rhs)>::value
-                      || (std::is_lvalue_reference<decltype(rhs)>::value
-                          && std::is_const<std::remove_reference_t<decltype(rhs)>>::value),
-                  "RhsType must be const lvalue reference or rvalue reference");
+    static_assert(
+        std::is_rvalue_reference_v<
+            decltype(rhs)> || (std::is_lvalue_reference_v<decltype(rhs)> && std::is_const_v<std::remove_reference_t<decltype(rhs)>>),
+        "RhsType must be const lvalue reference or rvalue reference");
 
-    constexpr bool is_move = std::is_rvalue_reference<decltype(rhs)>::value;
+    // alias helper struct
+    using Helper = detail::SpecialCreationHelper<Opt>;
+
+    constexpr bool is_ctor = Helper::is_ctor();
+    constexpr bool is_move = Helper::is_move();
+
+    if constexpr (is_ctor)
+    {
+        for (IndexType i = 0; i < CAPACITY; ++i)
+        {
+            m_status[i] = SlotStatus::FREE;
+        }
+    }
 
     IndexType i{Index::FIRST};
     auto rhs_it = (std::forward<RhsType>(rhs)).begin();
 
-    // transfer src data to destination
     for (; rhs_it.to_index() != Index::INVALID; ++i, ++rhs_it)
     {
         if (m_status[i] == SlotStatus::USED)
         {
-#if __cplusplus >= 201703L
+            // When the slot is in the 'USED' state, it is safe to proceed with either construction (ctor) or assignment
+            // operation. Therefore, creation can be carried out according to the option specified by Opt.
+
+            // TODO: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // Helper::create(m_data[i], Helper::move_or_copy_it(rhs_it));
+
             if constexpr (is_move)
             {
-                m_data[i] = std::move(*rhs_it);
+                Helper::create(m_data[i], std::move(*rhs_it));
             }
             else
             {
-                m_data[i] = *rhs_it;
+                Helper::create(m_data[i], *rhs_it);
             }
-#else
-            // We introduce a helper struct primarily due to the test case
-            // e1cc7c9f-c1b5-4047-811b-004302af5c00. It demands compile-time if-else branching
-            // for classes that are either non-copyable or non-moveable.
-            // Note: With C++17's 'if constexpr', the need for these helper structs can be eliminated.
-            detail::AssignmentHelper<is_move>::assign(m_data[i], detail::MoveHelper<is_move>::move_or_copy(rhs_it));
-#endif
         }
-        // use ctor to avoid UB for non-initialized free slots
         else
         {
-#if __cplusplus >= 201703L
+            // When the slot is in the 'FREE' state, it is unsafe to proceed with assignment operation.
+            // Therefore, we need to force helper to use ctor create to make sure that the 'FREE' slots get initialized.
+
+            // TODO: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // Helper::ctor_create(m_data[i], Helper::move_or_copy_it(rhs_it));
+
             if constexpr (is_move)
             {
-                new (&m_data[i]) T(std::move(*rhs_it));
+                Helper::ctor_create(m_data[i], std::move(*rhs_it));
             }
             else
             {
-                new (&m_data[i]) T(*rhs_it);
+                Helper::ctor_create(m_data[i], *rhs_it);
             }
-#else
-            // Same as above
-            detail::CtorHelper<is_move>::construct(m_data[i], detail::MoveHelper<is_move>::move_or_copy(rhs_it));
-#endif
         }
+
         m_status[i] = SlotStatus::USED;
         m_next[i] = static_cast<IndexType>(i + 1U);
     }
 
+    // reset rest
     for (; i < CAPACITY; ++i)
     {
         if (m_status[i] == SlotStatus::USED)
@@ -174,6 +168,7 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
         m_next[i] = next;
     }
 
+    // correct m_next
     m_next[Index::LAST] = Index::INVALID;
     if (!rhs.empty())
     {
@@ -183,6 +178,12 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
     m_begin_free = static_cast<IndexType>(rhs.m_size);
     m_begin_used = rhs.empty() ? Index::INVALID : Index::FIRST;
     m_size = rhs.m_size;
+
+    // reset rhs if is_move is true
+    if constexpr (is_move)
+    {
+        rhs.clear();
+    }
 }
 
 template <typename T, uint64_t CAPACITY>

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -120,7 +120,7 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
             // When the slot is in the 'USED' state, it is safe to proceed with either construction (ctor) or assignment
             // operation. Therefore, creation can be carried out according to the option specified by Opt.
 
-            // @todo iox-2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // @todo iox-#2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
             // Helper::create(m_data[i], Helper::move_or_copy_it(rhs_it));
 
             if constexpr (is_move)
@@ -137,7 +137,7 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
             // When the slot is in the 'FREE' state, it is unsafe to proceed with assignment operation.
             // Therefore, we need to force helper to use ctor create to make sure that the 'FREE' slots get initialized.
 
-            // @todo iox-2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // @todo iox-#2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
             // Helper::ctor_create(m_data[i], Helper::move_or_copy_it(rhs_it));
 
             if constexpr (is_move)

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -92,8 +92,8 @@ template <detail::SpecialCreationOperations Opt, typename RhsType>
 inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rhs) noexcept
 {
     static_assert(
-        std::is_rvalue_reference_v<
-            decltype(rhs)> || (std::is_lvalue_reference_v<decltype(rhs)> && std::is_const_v<std::remove_reference_t<decltype(rhs)>>),
+        std::is_rvalue_reference<decltype(rhs)>::value
+            || (std::is_lvalue_reference_v<decltype(rhs)> && std::is_const_v<std::remove_reference_t<decltype(rhs)>>),
         "RhsType must be const lvalue reference or rvalue reference");
 
     // alias helper struct
@@ -120,7 +120,7 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
             // When the slot is in the 'USED' state, it is safe to proceed with either construction (ctor) or assignment
             // operation. Therefore, creation can be carried out according to the option specified by Opt.
 
-            // TODO: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // @todo iox-2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
             // Helper::create(m_data[i], Helper::move_or_copy_it(rhs_it));
 
             if constexpr (is_move)
@@ -137,7 +137,7 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
             // When the slot is in the 'FREE' state, it is unsafe to proceed with assignment operation.
             // Therefore, we need to force helper to use ctor create to make sure that the 'FREE' slots get initialized.
 
-            // TODO: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
+            // @todo iox-2052: moveCtor will failed if using move_or_copy_it. Twice time moveCtor will be called.
             // Helper::ctor_create(m_data[i], Helper::move_or_copy_it(rhs_it));
 
             if constexpr (is_move)

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
@@ -74,7 +74,7 @@ struct SpecialCreationHelper
         }
         else
         {
-            // @todo iox-2052: enable this when move_or_copy_it / move_or_copy works
+            // @todo iox-#2052: enable this when move_or_copy_it / move_or_copy works
             // static_assert(std::is_lvalue_reference_v<decltype(src.get())>, "src should be lvalue reference");
             // static_assert(std::is_const_v<std::remove_reference_t<decltype(src.get())>>, "src should has const
             // modifier"); static_assert(std::is_convertible_v<V, T>, "Source type is not convertible to destination
@@ -102,7 +102,7 @@ struct SpecialCreationHelper
         }
         else
         {
-            // @todo iox-2052: enable this when move_or_copy_it / move_or_copy works
+            // @todo iox-#2052: enable this when move_or_copy_it / move_or_copy works
             // static_assert(std::is_lvalue_reference_v<decltype(src.get())>, "src should be lvalue reference");
             // static_assert(std::is_const_v<std::remove_reference_t<decltype(src.get())>>, "src should has const
             // modifier"); dest = src.get();

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container_helper.hpp
@@ -74,7 +74,7 @@ struct SpecialCreationHelper
         }
         else
         {
-            // TODO: enable this when move_or_copy_it / move_or_copy works
+            // @todo iox-2052: enable this when move_or_copy_it / move_or_copy works
             // static_assert(std::is_lvalue_reference_v<decltype(src.get())>, "src should be lvalue reference");
             // static_assert(std::is_const_v<std::remove_reference_t<decltype(src.get())>>, "src should has const
             // modifier"); static_assert(std::is_convertible_v<V, T>, "Source type is not convertible to destination
@@ -102,7 +102,7 @@ struct SpecialCreationHelper
         }
         else
         {
-            // TODO: enable this when move_or_copy_it / move_or_copy works
+            // @todo iox-2052: enable this when move_or_copy_it / move_or_copy works
             // static_assert(std::is_lvalue_reference_v<decltype(src.get())>, "src should be lvalue reference");
             // static_assert(std::is_const_v<std::remove_reference_t<decltype(src.get())>>, "src should has const
             // modifier"); dest = src.get();

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -19,6 +19,7 @@
 
 #include "iceoryx_hoofs/cxx/requires.hpp"
 #include "iox/algorithm.hpp"
+#include "iox/detail/fixed_position_container_helper.hpp"
 #include "iox/uninitialized_array.hpp"
 
 #include <cstdint>
@@ -315,7 +316,7 @@ class FixedPositionContainer final
     };
 
   private:
-    template <typename RhsType>
+    template <detail::SpecialCreationOperations Opt, typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 
   private:

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -316,7 +316,7 @@ class FixedPositionContainer final
     };
 
   private:
-    template <detail::SpecialCreationOperations Opt, typename RhsType>
+    template <detail::MoveAndCopyOperations Opt, typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 
   private:


### PR DESCRIPTION
Refactor `FixedPositionContainer::copy_and_move_impl` by new struct `SpecialCreationHelper` and enum class `SpecialCreationOperations` with C++17 features.

## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
I implement a prototype named `SpecialCreationHelper` according to  [previous discussion](https://github.com/eclipse-iceoryx/iceoryx/pull/2069#issuecomment-1804246731).
If it looks good to you, I'll create another issue to move the helper class to `design` module.

Btw, I have no idea if `move_or_copy` and `move_or_copy_it` are needed or not. These functions currently cause twice time `moveCtor` calls problem (See [example](https://godbolt.org/z/o1TW3866Y)). Currently, I directly use `if constexpr` to pass correct value. If you think they are unnecessary, I will delete related comment and code.
 
## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References
- #2069 
- Closes #2052 
