### PR TITLE
iox-#2108 Public API to create 'access_rights' from value

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -107,6 +107,7 @@
 - FixedPositionContainer fails to compile on QNX QCC [#2084](https://github.com/eclipse-iceoryx/iceoryx/issues/2084)
 - Chunk fails to be released when more than 4 GiB of chunks have been allocated [#2087](https://github.com/eclipse-iceoryx/iceoryx/issues/2087)
 - Fix clang-tidy errors from full-scan nightly build [#2060](https://github.com/eclipse-iceoryx/iceoryx/issues/2060)
+- Add public functions to create an 'access_rights' object from integer values [#2108](https://github.com/eclipse-iceoryx/iceoryx/issues/2108)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
+++ b/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
@@ -1,5 +1,4 @@
 // Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
-// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -187,15 +186,6 @@ inline bool doesEndWithPathSeparator(const iox::string<StringCapacity>& name) no
         }
     }
     return false;
-}
-
-inline constexpr access_rights access_rights::from_value_sanitized(const access_rights::value_type value) noexcept
-{
-    if ((value & detail::UNKNOWN) == detail::UNKNOWN)
-    {
-        return access_rights{detail::UNKNOWN};
-    }
-    return access_rights{static_cast<value_type>(value & detail::MASK)};
 }
 
 inline constexpr access_rights::value_type access_rights::value() const noexcept

--- a/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
+++ b/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -188,53 +189,62 @@ inline bool doesEndWithPathSeparator(const iox::string<StringCapacity>& name) no
     return false;
 }
 
-constexpr access_rights::value_type access_rights::value() const noexcept
+inline constexpr access_rights access_rights::from_value_sanitized(const access_rights::value_type value) noexcept
+{
+    if (value != detail::UNKNOWN)
+    {
+        return access_rights{static_cast<value_type>(value & detail::MASK)};
+    }
+    return access_rights{value};
+}
+
+inline constexpr access_rights::value_type access_rights::value() const noexcept
 {
     return m_value;
 }
 
-constexpr bool operator==(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr bool operator==(const access_rights lhs, const access_rights rhs) noexcept
 {
     return lhs.value() == rhs.value();
 }
 
-constexpr bool operator!=(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr bool operator!=(const access_rights lhs, const access_rights rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
-constexpr access_rights operator|(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator|(const access_rights lhs, const access_rights rhs) noexcept
 {
     return access_rights(lhs.value() | rhs.value());
 }
 
-constexpr access_rights operator&(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator&(const access_rights lhs, const access_rights rhs) noexcept
 {
     return access_rights(lhs.value() & rhs.value());
 }
 
-constexpr access_rights operator^(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator^(const access_rights lhs, const access_rights rhs) noexcept
 {
     return access_rights(lhs.value() ^ rhs.value());
 }
 
-constexpr access_rights operator~(const access_rights value) noexcept
+inline constexpr access_rights operator~(const access_rights value) noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A4.7.1, AutosarC++19_03-M0.3.1, FaultDetection-IntegerOverflow : Cast is safe and required due to integer promotion
     return access_rights(static_cast<access_rights::value_type>(~value.value()));
 }
 
-constexpr access_rights operator|=(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator|=(const access_rights lhs, const access_rights rhs) noexcept
 {
     return operator|(lhs, rhs);
 }
 
-constexpr access_rights operator&=(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator&=(const access_rights lhs, const access_rights rhs) noexcept
 {
     return operator&(lhs, rhs);
 }
 
-constexpr access_rights operator^=(const access_rights lhs, const access_rights rhs) noexcept
+inline constexpr access_rights operator^=(const access_rights lhs, const access_rights rhs) noexcept
 {
     return operator^(lhs, rhs);
 }

--- a/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
+++ b/iceoryx_hoofs/filesystem/include/iox/detail/filesystem.inl
@@ -191,11 +191,11 @@ inline bool doesEndWithPathSeparator(const iox::string<StringCapacity>& name) no
 
 inline constexpr access_rights access_rights::from_value_sanitized(const access_rights::value_type value) noexcept
 {
-    if (value != detail::UNKNOWN)
+    if ((value & detail::UNKNOWN) == detail::UNKNOWN)
     {
-        return access_rights{static_cast<value_type>(value & detail::MASK)};
+        return access_rights{detail::UNKNOWN};
     }
-    return access_rights{value};
+    return access_rights{static_cast<value_type>(value & detail::MASK)};
 }
 
 inline constexpr access_rights::value_type access_rights::value() const noexcept

--- a/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -116,136 +117,55 @@ class access_rights final
 
     ~access_rights() noexcept = default;
 
+    /// @brief Creates an 'access_rights' object from a sanitized value, ensuring that only the bits defined in
+    /// 'iox::perms::mask' are set when the value is not 'iox::perm::unknown'.
+    /// @param[in] value for the 'access_rights'
+    /// @return the 'access_rights' object
+    static constexpr access_rights from_value_sanitized(const value_type value) noexcept;
+
+    /// @brief Creates an 'access_rights' object from an unchecked value. The user has to ensure that only the bits
+    /// defined in 'iox::perms::mask' are set when the value is not 'iox::perm::unknown'.
+    /// @param[in] value for the 'access_rights'
+    /// @return the 'access_rights' object
+    static constexpr access_rights unsafe_from_value_unchecked(const value_type value) noexcept
+    {
+        // the code cannot be moved to the '*.inl' file since the function is used in the 'perms' namespace to define
+        // the 'access_rights' constants
+        return access_rights{value};
+    }
+
     constexpr value_type value() const noexcept;
 
     struct detail
     {
         // AXIVION DISABLE STYLE AutosarC++19_03-M2.13.2 : Filesystem permissions are defined in octal representation
 
-        // the code cannot be moved to the '*.inl' file since the functions are used in the 'perms' namespace to define
-        // the respective constants
+        static constexpr value_type NONE{0};
 
-        /// @note Implementation detail! Please use 'iox::perms::none'.
-        static constexpr access_rights none() noexcept
-        {
-            constexpr value_type VALUE{0};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type OWNER_READ{0400};
+        static constexpr value_type OWNER_WRITE{0200};
+        static constexpr value_type OWNER_EXEC{0100};
+        static constexpr value_type OWNER_ALL{0700};
 
-        /// @note Implementation detail! Please use 'iox::perms::owner_read'.
-        static constexpr access_rights owner_read() noexcept
-        {
-            constexpr value_type VALUE{0400};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::owner_write'.
-        static constexpr access_rights owner_write() noexcept
-        {
-            constexpr value_type VALUE{0200};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::owner_exec'.
-        static constexpr access_rights owner_exec() noexcept
-        {
-            constexpr value_type VALUE{0100};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::owner_all'.
-        static constexpr access_rights owner_all() noexcept
-        {
-            constexpr value_type VALUE{0700};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type GROUP_READ{040};
+        static constexpr value_type GROUP_WRITE{020};
+        static constexpr value_type GROUP_EXEC{010};
+        static constexpr value_type GROUP_ALL{070};
 
-        /// @note Implementation detail! Please use 'iox::perms::group_read'.
-        static constexpr access_rights group_read() noexcept
-        {
-            constexpr value_type VALUE{040};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::group_write'.
-        static constexpr access_rights group_write() noexcept
-        {
-            constexpr value_type VALUE{020};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::group_exec'.
-        static constexpr access_rights group_exec() noexcept
-        {
-            constexpr value_type VALUE{010};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::group_all'.
-        static constexpr access_rights group_all() noexcept
-        {
-            constexpr value_type VALUE{070};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type OTHERS_READ{04};
+        static constexpr value_type OTHERS_WRITE{02};
+        static constexpr value_type OTHERS_EXEC{01};
+        static constexpr value_type OTHERS_ALL{07};
 
-        /// @note Implementation detail! Please use 'iox::perms::others_read'.
-        static constexpr access_rights others_read() noexcept
-        {
-            constexpr value_type VALUE{04};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::others_write'.
-        static constexpr access_rights others_write() noexcept
-        {
-            constexpr value_type VALUE{02};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::others_exec'.
-        static constexpr access_rights others_exec() noexcept
-        {
-            constexpr value_type VALUE{01};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::others_all'.
-        static constexpr access_rights others_all() noexcept
-        {
-            constexpr value_type VALUE{07};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type ALL{0777};
 
-        /// @note Implementation detail! Please use 'iox::perms::all'.
-        static constexpr access_rights all() noexcept
-        {
-            constexpr value_type VALUE{0777};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type SET_UID{04000};
+        static constexpr value_type SET_GID{02000};
+        static constexpr value_type STICKY_BIT{01000};
 
-        /// @note Implementation detail! Please use 'iox::perms::set_uid'.
-        static constexpr access_rights set_uid() noexcept
-        {
-            constexpr value_type VALUE{04000};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::set_gid'.
-        static constexpr access_rights set_gid() noexcept
-        {
-            constexpr value_type VALUE{02000};
-            return access_rights{VALUE};
-        }
-        /// @note Implementation detail! Please use 'iox::perms::sticky_bit'.
-        static constexpr access_rights sticky_bit() noexcept
-        {
-            constexpr value_type VALUE{01000};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type MASK{07777};
 
-        /// @note Implementation detail! Please use 'iox::perms::mask'.
-        static constexpr access_rights mask() noexcept
-        {
-            constexpr value_type VALUE{07777};
-            return access_rights{VALUE};
-        }
-
-        /// @note Implementation detail! Please use 'iox::perms::unknown'.
-        static constexpr access_rights unknown() noexcept
-        {
-            constexpr value_type VALUE{0xFFFFU};
-            return access_rights{VALUE};
-        }
+        static constexpr value_type UNKNOWN{0xFFFFU};
 
         // AXIVION ENABLE STYLE AutosarC++19_03-M2.13.2
     };
@@ -278,55 +198,55 @@ namespace perms
 // AXIVION DISABLE STYLE AutosarC++19_03-A2.10.5 : Name reuse is intentional since they refer to the same value. Additionally, different namespaces are used.
 
 /// @brief Deny everything
-static constexpr access_rights none{access_rights::detail::none()};
+static constexpr auto none{access_rights::unsafe_from_value_unchecked(access_rights::detail::NONE)};
 
 /// @brief owner has read permission
-static constexpr access_rights owner_read{access_rights::detail::owner_read()};
+static constexpr auto owner_read{access_rights::unsafe_from_value_unchecked(access_rights::detail::OWNER_READ)};
 /// @brief owner has write permission
-static constexpr access_rights owner_write{access_rights::detail::owner_write()};
+static constexpr auto owner_write{access_rights::unsafe_from_value_unchecked(access_rights::detail::OWNER_WRITE)};
 /// @brief owner has execution permission
-static constexpr access_rights owner_exec{access_rights::detail::owner_exec()};
+static constexpr auto owner_exec{access_rights::unsafe_from_value_unchecked(access_rights::detail::OWNER_EXEC)};
 /// @brief owner has all permissions
-static constexpr access_rights owner_all{access_rights::detail::owner_all()};
+static constexpr auto owner_all{access_rights::unsafe_from_value_unchecked(access_rights::detail::OWNER_ALL)};
 
 /// @brief group has read permission
-static constexpr access_rights group_read{access_rights::detail::group_read()};
+static constexpr auto group_read{access_rights::unsafe_from_value_unchecked(access_rights::detail::GROUP_READ)};
 /// @brief group has write permission
-static constexpr access_rights group_write{access_rights::detail::group_write()};
+static constexpr auto group_write{access_rights::unsafe_from_value_unchecked(access_rights::detail::GROUP_WRITE)};
 /// @brief group has execution permission
-static constexpr access_rights group_exec{access_rights::detail::group_exec()};
+static constexpr auto group_exec{access_rights::unsafe_from_value_unchecked(access_rights::detail::GROUP_EXEC)};
 /// @brief group has all permissions
-static constexpr access_rights group_all{access_rights::detail::group_all()};
+static constexpr auto group_all{access_rights::unsafe_from_value_unchecked(access_rights::detail::GROUP_ALL)};
 
 /// @brief others have read permission
-static constexpr access_rights others_read{access_rights::detail::others_read()};
+static constexpr auto others_read{access_rights::unsafe_from_value_unchecked(access_rights::detail::OTHERS_READ)};
 /// @brief others have write permission
-static constexpr access_rights others_write{access_rights::detail::others_write()};
+static constexpr auto others_write{access_rights::unsafe_from_value_unchecked(access_rights::detail::OTHERS_WRITE)};
 /// @brief others have execution permission
-static constexpr access_rights others_exec{access_rights::detail::others_exec()};
+static constexpr auto others_exec{access_rights::unsafe_from_value_unchecked(access_rights::detail::OTHERS_EXEC)};
 /// @brief others have all permissions
-static constexpr access_rights others_all{access_rights::detail::others_all()};
+static constexpr auto others_all{access_rights::unsafe_from_value_unchecked(access_rights::detail::OTHERS_ALL)};
 
 /// @brief all permissions for everyone
-static constexpr access_rights all{access_rights::detail::all()};
+static constexpr auto all{access_rights::unsafe_from_value_unchecked(access_rights::detail::ALL)};
 
 /// @brief set uid bit
 /// @note introduction into setgit/setuid: https://en.wikipedia.org/wiki/Setuid
 // AXIVION Next Construct AutosarC++19_03-M2.10.1: The constant is in a namespace and mimics the C++17 STL equivalent
-static constexpr access_rights set_uid{access_rights::detail::set_uid()};
+static constexpr auto set_uid{access_rights::unsafe_from_value_unchecked(access_rights::detail::SET_UID)};
 /// @brief set gid bit
 /// @note introduction into setgit/setuid: https://en.wikipedia.org/wiki/Setuid
 // AXIVION Next Construct AutosarC++19_03-M2.10.1: The constant is in a namespace and mimics the C++17 STL equivalent
-static constexpr access_rights set_gid{access_rights::detail::set_gid()};
+static constexpr auto set_gid{access_rights::unsafe_from_value_unchecked(access_rights::detail::SET_GID)};
 /// @brief set sticky bit
 /// @note sticky bit introduction: https://en.wikipedia.org/wiki/Sticky_bit
-static constexpr access_rights sticky_bit{access_rights::detail::sticky_bit()};
+static constexpr auto sticky_bit{access_rights::unsafe_from_value_unchecked(access_rights::detail::STICKY_BIT)};
 
 /// @brief all permissions for everyone as well as uid, gid and sticky bit
-static constexpr access_rights mask{access_rights::detail::mask()};
+static constexpr auto mask{access_rights::unsafe_from_value_unchecked(access_rights::detail::MASK)};
 
 /// @brief unknown permissions
-static constexpr access_rights unknown{access_rights::detail::unknown()};
+static constexpr auto unknown{access_rights::unsafe_from_value_unchecked(access_rights::detail::UNKNOWN)};
 
 // AXIVION ENABLE STYLE AutosarC++19_03-A2.10.5
 } // namespace perms

--- a/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
@@ -189,8 +189,6 @@ class access_rights final
     friend constexpr access_rights operator^=(const access_rights lhs, const access_rights rhs) noexcept;
 
   private:
-    template <typename>
-    friend struct FileManagementInterface;
     explicit constexpr access_rights(value_type value) noexcept
         : m_value(value)
     {

--- a/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
@@ -118,13 +118,15 @@ class access_rights final
     ~access_rights() noexcept = default;
 
     /// @brief Creates an 'access_rights' object from a sanitized value, ensuring that only the bits defined in
-    /// 'iox::perms::mask' are set when the value is not 'iox::perm::unknown'.
+    /// 'iox::perms::mask' are set when the 'iox::perm::unknown' bit is not set. If the 'iox::perm::unknown' bit is set
+    /// all other bits will be reset.
     /// @param[in] value for the 'access_rights'
     /// @return the 'access_rights' object
     static constexpr access_rights from_value_sanitized(const value_type value) noexcept;
 
     /// @brief Creates an 'access_rights' object from an unchecked value. The user has to ensure that only the bits
-    /// defined in 'iox::perms::mask' are set when the value is not 'iox::perm::unknown'.
+    /// defined in 'iox::perms::mask' are set when the 'iox::perm::unknown' bit is not set. If the 'iox::perm::unknown'
+    /// bit is set all other bits should be reset.
     /// @param[in] value for the 'access_rights'
     /// @return the 'access_rights' object
     static constexpr access_rights unsafe_from_value_unchecked(const value_type value) noexcept
@@ -165,7 +167,12 @@ class access_rights final
 
         static constexpr value_type MASK{07777};
 
-        static constexpr value_type UNKNOWN{0xFFFFU};
+        // intentionally different from 'std::filesystem::perms::unknown' to prevent unexpected results. Combining a
+        // permission set to 'std::filesystem::perms::unknown' with other permission flags using bitwise OR may result
+        // in a value that is not representative of a valid permission state. By setting the value to '0x8000' only the
+        // MSB is 1 and all bits representing permissions are set to 0 and a bitwise OR will therefore also always
+        // result in a 0.
+        static constexpr value_type UNKNOWN{0x8000U};
 
         // AXIVION ENABLE STYLE AutosarC++19_03-M2.13.2
     };

--- a/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
@@ -46,7 +46,7 @@ inline expected<access_rights, FileStatError> FileManagementInterface<Derived>::
     // st_mode also contains the file type, since we only would like to acquire the permissions
     // we have to remove the file type
     auto permissions_only = static_cast<access_rights::value_type>(result->st_mode & iox::perms::all.value());
-    return ok(access_rights::unsafe_from_value_unchecked(permissions_only));
+    return ok(access_rights::from_value_sanitized(permissions_only));
 }
 
 template <typename Derived>

--- a/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/file_management_interface.inl
@@ -45,8 +45,8 @@ inline expected<access_rights, FileStatError> FileManagementInterface<Derived>::
 
     // st_mode also contains the file type, since we only would like to acquire the permissions
     // we have to remove the file type
-    constexpr uint16_t ONLY_FILE_PERMISSIONS = 0777;
-    return ok(access_rights(static_cast<access_rights::value_type>(result->st_mode & ONLY_FILE_PERMISSIONS)));
+    auto permissions_only = static_cast<access_rights::value_type>(result->st_mode & iox::perms::all.value());
+    return ok(access_rights::unsafe_from_value_unchecked(permissions_only));
 }
 
 template <typename Derived>

--- a/iceoryx_hoofs/test/moduletests/test_filesystem_filesystem.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_filesystem_filesystem.cpp
@@ -591,23 +591,6 @@ TEST(filesystem_test_isValidPathEntry, StringWithRelativeComponentsIsInvalidWhen
                                   iox::RelativePathComponents::REJECT));
 }
 
-TEST(filesystem_test, accessRightsFromValueSanitizedWorksForValueUnknown)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "6e510e0e-1a0c-40a3-bab0-941a78d745d8");
-    constexpr auto TEST_VALUE = access_rights::detail::UNKNOWN;
-
-    EXPECT_THAT(access_rights::from_value_sanitized(TEST_VALUE).value(), Eq(TEST_VALUE));
-}
-
-TEST(filesystem_test, accessRightsFromValueSanitizedWorksForValueUnknownWithExtraBitsSet)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "1af33cc5-c870-4fef-ad23-6525296d6792");
-    constexpr auto TEST_VALUE_SANITIZED = access_rights::detail::UNKNOWN;
-    constexpr auto TEST_VALUE = TEST_VALUE_SANITIZED | static_cast<access_rights::value_type>(0x0101U);
-
-    EXPECT_THAT(access_rights::from_value_sanitized(TEST_VALUE).value(), Eq(TEST_VALUE_SANITIZED));
-}
-
 TEST(filesystem_test, accessRightsFromValueSanitizedWorksForValueInRangeOfPermsMask)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5a6c2ece-9cd7-4779-ad0b-16372aebd407");
@@ -619,18 +602,10 @@ TEST(filesystem_test, accessRightsFromValueSanitizedWorksForValueInRangeOfPermsM
 TEST(filesystem_test, accessRightsFromValueSanitizedWorksForValueOutOfRangeOfPermsMask)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8a291709-a75c-4afa-96d8-d57a0d40696c");
-    constexpr auto TEST_VALUE_SANITIZED = access_rights::detail::OWNER_EXEC;
+    constexpr auto TEST_VALUE_SANITIZED = access_rights::detail::OWNER_WRITE;
     constexpr auto TEST_VALUE = TEST_VALUE_SANITIZED | static_cast<access_rights::value_type>(010000);
 
     EXPECT_THAT(access_rights::from_value_sanitized(TEST_VALUE).value(), Eq(TEST_VALUE_SANITIZED));
-}
-
-TEST(filesystem_test, accessRightsUnsafeFromValueUncheckedWorkForAnyValue)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "5f34cef3-f778-4eed-bb78-42decdb8f7bb");
-    constexpr auto TEST_VALUE = access_rights::detail::OWNER_WRITE | static_cast<access_rights::value_type>(010000);
-
-    EXPECT_THAT(access_rights::unsafe_from_value_unchecked(TEST_VALUE).value(), Eq(TEST_VALUE));
 }
 
 TEST(filesystem_test, permsBinaryOrEqualToBinaryOrOfUnderlyingType)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds two static public functions to `access_rights` in order the remove the friend declaration to `FileManagementInterface` and give the user an option to create an `access_rights` object when dealing with low level libc functions.

Additionally, `iox::perms::unknown` is redefined from `0xFFFF` to `0x8000` to prevent unexpected results when used with bitwise OR. I think it was a bad decision from the C++ committee to use `0xFFFF` to indicate an unknown state which includes bits from known valid states.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2108
