### PR TITLE
iox-#1391 Rename 'posixCall' to 'IOX_POSIX_CALL' and move header to 'iox/posix_call.hpp'

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -1255,3 +1255,13 @@
 
     With the switch to C++17 `[[maybe_unused]]`, `[[fallthrough]]` and `[[no_discard]]`
     are available and should be used instead of the macros.
+
+56. `posixCall` macro is renamed to `IOX_POSIX_CALL`
+
+    ```cpp
+    // before
+    iox::posix::posixCall(open)("/hypnotoad");
+
+    // after
+    IOX_POSIX_CALL(open)("/hypnotoad");
+    ```

--- a/iceoryx_dust/utility/include/iox/detail/convert.hpp
+++ b/iceoryx_dust/utility/include/iox/detail/convert.hpp
@@ -19,7 +19,7 @@
 #ifndef IOX_DUST_UTILITY_CONVERT_HPP
 #define IOX_DUST_UTILITY_CONVERT_HPP
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iox/posix_call.hpp"
 #include "iox/string.hpp"
 
 #include <climits>

--- a/iceoryx_dust/utility/include/iox/detail/convert.inl
+++ b/iceoryx_dust/utility/include/iox/detail/convert.inl
@@ -163,7 +163,7 @@ inline bool convert::fromString<float>(const char* v, float& dest) noexcept
         return false;
     }
 
-    return !posix::posixCall(strtof)(v, nullptr)
+    return !IOX_POSIX_CALL(strtof)(v, nullptr)
                 .failureReturnValue(HUGE_VALF, -HUGE_VALF)
                 .evaluate()
                 .and_then([&](auto& r) { dest = r.value; })
@@ -178,7 +178,7 @@ inline bool convert::fromString<double>(const char* v, double& dest) noexcept
         return false;
     }
 
-    return !posix::posixCall(strtod)(v, nullptr)
+    return !IOX_POSIX_CALL(strtod)(v, nullptr)
                 .failureReturnValue(HUGE_VAL, -HUGE_VAL)
                 .evaluate()
                 .and_then([&](auto& r) { dest = r.value; })
@@ -193,7 +193,7 @@ inline bool convert::fromString<long double>(const char* v, long double& dest) n
         return false;
     }
 
-    return !posix::posixCall(strtold)(v, nullptr)
+    return !IOX_POSIX_CALL(strtold)(v, nullptr)
                 .failureReturnValue(HUGE_VALL, -HUGE_VALL)
                 .evaluate()
                 .and_then([&](auto& r) { dest = r.value; })
@@ -208,7 +208,7 @@ inline bool convert::fromString<uint64_t>(const char* v, uint64_t& dest) noexcep
         return false;
     }
 
-    auto call = posix::posixCall(strtoull)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULLONG_MAX).evaluate();
+    auto call = IOX_POSIX_CALL(strtoull)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULLONG_MAX).evaluate();
 
     if (call.has_error())
     {
@@ -259,7 +259,7 @@ inline bool convert::fromString<uint32_t>(const char* v, uint32_t& dest) noexcep
         return false;
     }
 
-    auto call = posix::posixCall(strtoull)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULLONG_MAX).evaluate();
+    auto call = IOX_POSIX_CALL(strtoull)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULLONG_MAX).evaluate();
 
     if (call.has_error())
     {
@@ -284,7 +284,7 @@ inline bool convert::fromString<uint16_t>(const char* v, uint16_t& dest) noexcep
         return false;
     }
 
-    auto call = posix::posixCall(strtoul)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULONG_MAX).evaluate();
+    auto call = IOX_POSIX_CALL(strtoul)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULONG_MAX).evaluate();
 
     if (call.has_error())
     {
@@ -309,7 +309,7 @@ inline bool convert::fromString<uint8_t>(const char* v, uint8_t& dest) noexcept
         return false;
     }
 
-    auto call = posix::posixCall(strtoul)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULONG_MAX).evaluate();
+    auto call = IOX_POSIX_CALL(strtoul)(v, nullptr, STRTOULL_BASE).failureReturnValue(ULONG_MAX).evaluate();
 
     if (call.has_error())
     {
@@ -334,8 +334,7 @@ inline bool convert::fromString<int64_t>(const char* v, int64_t& dest) noexcept
         return false;
     }
 
-    auto call =
-        posix::posixCall(strtoll)(v, nullptr, STRTOULL_BASE).failureReturnValue(LLONG_MAX, LLONG_MIN).evaluate();
+    auto call = IOX_POSIX_CALL(strtoll)(v, nullptr, STRTOULL_BASE).failureReturnValue(LLONG_MAX, LLONG_MIN).evaluate();
     if (call.has_error())
     {
         return false;
@@ -359,8 +358,7 @@ inline bool convert::fromString<int32_t>(const char* v, int32_t& dest) noexcept
         return false;
     }
 
-    auto call =
-        posix::posixCall(strtoll)(v, nullptr, STRTOULL_BASE).failureReturnValue(LLONG_MAX, LLONG_MIN).evaluate();
+    auto call = IOX_POSIX_CALL(strtoll)(v, nullptr, STRTOULL_BASE).failureReturnValue(LLONG_MAX, LLONG_MIN).evaluate();
     if (call.has_error())
     {
         return false;
@@ -384,7 +382,7 @@ inline bool convert::fromString<int16_t>(const char* v, int16_t& dest) noexcept
         return false;
     }
 
-    auto call = posix::posixCall(strtol)(v, nullptr, STRTOULL_BASE).failureReturnValue(LONG_MAX, LONG_MIN).evaluate();
+    auto call = IOX_POSIX_CALL(strtol)(v, nullptr, STRTOULL_BASE).failureReturnValue(LONG_MAX, LONG_MIN).evaluate();
     if (call.has_error())
     {
         return false;
@@ -408,7 +406,7 @@ inline bool convert::fromString<int8_t>(const char* v, int8_t& dest) noexcept
         return false;
     }
 
-    auto call = posix::posixCall(strtol)(v, nullptr, STRTOULL_BASE).failureReturnValue(LONG_MAX, LONG_MIN).evaluate();
+    auto call = IOX_POSIX_CALL(strtol)(v, nullptr, STRTOULL_BASE).failureReturnValue(LONG_MAX, LONG_MIN).evaluate();
     if (call.has_error())
     {
         return false;
@@ -432,7 +430,7 @@ inline bool convert::fromString<bool>(const char* v, bool& dest) noexcept
         return false;
     }
 
-    return !posix::posixCall(strtoul)(v, nullptr, STRTOULL_BASE)
+    return !IOX_POSIX_CALL(strtoul)(v, nullptr, STRTOULL_BASE)
                 .failureReturnValue(ULONG_MAX)
                 .evaluate()
                 .and_then([&](auto& r) { dest = static_cast<bool>(r.value); })

--- a/iceoryx_hoofs/README.md
+++ b/iceoryx_hoofs/README.md
@@ -138,7 +138,7 @@ The module structure is a logical grouping. It is replicated for `concurrent` an
 | class                 | internal | description                                                         |
 |:---------------------:|:--------:|:--------------------------------------------------------------------|
 |`Builder`              |          | Macro which generates a setter method useful for a builder pattern. |
-|`posixCall`            |          | Wrapper around C and POSIX function calls which performs a full error handling. Additionally, this wrapper makes sure that `EINTR` handling is performed correctly by repeating the system call. |
+|`IOX_POSIX_CALL`       |          | Wrapper around C and POSIX function calls which performs a full error handling. Additionally, this wrapper makes sure that `EINTR` handling is performed correctly by repeating the system call. |
 |`functional_interface` |          | Constructs to easily add functional interfaces like `and_then` to object container.                                                                                                                                                   |
 |`NewType<T, Policies>` |          | C++11 implementation of [Haskells NewType-pattern](https://wiki.haskell.org/Newtype).                                                                                                                                                 |
 |`StaticLifetimeGuard`  |          | Static instance manager which solves the singleton lifetime problem. |

--- a/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/thread.hpp
@@ -16,11 +16,11 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_PTHREAD_HPP
 #define IOX_HOOFS_POSIX_WRAPPER_PTHREAD_HPP
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/pthread.hpp"
 #include "iox/builder.hpp"
 #include "iox/expected.hpp"
 #include "iox/function.hpp"
+#include "iox/posix_call.hpp"
 #include "iox/string.hpp"
 
 #include <atomic>

--- a/iceoryx_hoofs/legacy/include/iceoryx_hoofs/cxx/vector.hpp
+++ b/iceoryx_hoofs/legacy/include/iceoryx_hoofs/cxx/vector.hpp
@@ -19,7 +19,7 @@
 #include "iox/detail/deprecation_marker.hpp"
 #include "iox/vector.hpp"
 
-IOX_DEPRECATED_HEADER_SINCE(3, "Please include 'iox/.hpp' instead.")
+IOX_DEPRECATED_HEADER_SINCE(3, "Please include 'iox/vector.hpp' instead.")
 
 namespace iox
 {

--- a/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_HPP
+#define IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_HPP
+
+#include "iox/detail/deprecation_marker.hpp"
+#include "iox/posix_call.hpp"
+
+IOX_DEPRECATED_HEADER_SINCE(3, "Please include 'iox/posix_call.hpp' instead.")
+
+namespace iox
+{
+/// @todo iox-#1593 Deprecate namespace with
+/// namespace IOX_DEPRECATED_SINCE(3, "Please use the 'iox' namespace directly and the corresponding header.")
+namespace posix
+{
+/// @deprecated use corresponding constant from 'iox/posix_call.hpp'
+IOX_DEPRECATED_SINCE(3, "Please use 'POSIX_CALL_ERROR_STRING_SIZE' from 'iox/posix_call.hpp' instead.")
+static constexpr uint32_t POSIX_CALL_ERROR_STRING_SIZE = iox::POSIX_CALL_ERROR_STRING_SIZE;
+/// @deprecated use corresponding constant from 'iox/posix_call.hpp'
+IOX_DEPRECATED_SINCE(3, "Please use 'POSIX_CALL_EINTR_REPETITIONS' from 'iox/posix_call.hpp' instead.")
+static constexpr uint64_t POSIX_CALL_EINTR_REPETITIONS = iox::POSIX_CALL_EINTR_REPETITIONS;
+/// @deprecated use corresponding constant from 'iox/posix_call.hpp'
+IOX_DEPRECATED_SINCE(3, "Please use 'POSIX_CALL_INVALID_ERRNO' from 'iox/posix_call.hpp' instead.")
+static constexpr int32_t POSIX_CALL_INVALID_ERRNO = iox::POSIX_CALL_INVALID_ERRNO;
+
+namespace internal
+{
+// NOLINTJUSTIFICATION just a forwarding function to ensure backwards compatibility
+// NOLINTBEGIN(readability-function-size)
+template <typename ReturnType, typename... FunctionArguments>
+IOX_DEPRECATED_SINCE(3, "Please use 'IOX_POSIX_CALL' from 'iox/posix_call.hpp' instead.")
+PosixCallBuilder<ReturnType, FunctionArguments...> createPosixCallBuilder(ReturnType (*posixCall)(FunctionArguments...),
+                                                                          const char* posixFunctionName,
+                                                                          const char* file,
+                                                                          const int32_t line,
+                                                                          const char* callingFunction) noexcept
+{
+    return iox::detail::createPosixCallBuilder(posixCall, posixFunctionName, file, line, callingFunction);
+}
+// NOLINTEND(readability-function-size)
+} // namespace internal
+
+/// @deprecated use 'IOX_POSIX_CALL' from 'iox/posix_call.hpp' instead of 'iox::posix::posixCall'
+/// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
+///                     name
+/// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define posixCall(f)                                                                                                   \
+    internal::createPosixCallBuilder(                                                                                  \
+        &(f),                                                                                                          \
+        (#f),                                                                                                          \
+        __FILE__,                                                                                                      \
+        __LINE__,                                                                                                      \
+        __PRETTY_FUNCTION__) // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
+// needed for source code location, safely wrapped in macro
+
+} // namespace posix
+} // namespace iox
+
+#endif // IOX_HOOFS_POSIX_WRAPPER_POSIX_CALL_HPP

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -16,7 +16,7 @@
 
 #include "iox/file_management_interface.hpp"
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -25,7 +25,7 @@ namespace details
 expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
 {
     iox_stat file_status = {};
-    auto result = posix::posixCall(iox_fstat)(fildes, &file_status).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_fstat)(fildes, &file_status).failureReturnValue(-1).evaluate();
 
     if (result.has_error())
     {
@@ -50,7 +50,7 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
 
 expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, const gid_t gid) noexcept
 {
-    auto result = posix::posixCall(iox_fchown)(fildes, uid, gid).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_fchown)(fildes, uid, gid).failureReturnValue(-1).evaluate();
 
     if (result.has_error())
     {
@@ -84,7 +84,7 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
 
 expected<void, FileSetPermissionError> set_permissions(const int fildes, const access_rights perms) noexcept
 {
-    auto result = posix::posixCall(iox_fchmod)(fildes, perms.value()).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_fchmod)(fildes, perms.value()).failureReturnValue(-1).evaluate();
 
     if (result.has_error())
     {

--- a/iceoryx_hoofs/posix/filesystem/source/file.cpp
+++ b/iceoryx_hoofs/posix/filesystem/source/file.cpp
@@ -15,12 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iox/file.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/errno.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/stdio.hpp"
 #include "iox/attributes.hpp"
 #include "iox/filesystem.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -43,9 +43,9 @@ expected<File, FileCreationError> FileBuilder::create(const FilePath& name) noex
 // NOLINTBEGIN(readability-function-size,readability-function-cognitive-complexity)
 expected<File, FileCreationError> FileBuilder::open(const FilePath& name) noexcept
 {
-    auto result = posix::posixCall(iox_open)(name.as_string().c_str(),
-                                             convertToOflags(m_access_mode, m_open_mode),
-                                             static_cast<iox_mode_t>(m_permissions.value()))
+    auto result = IOX_POSIX_CALL(iox_open)(name.as_string().c_str(),
+                                           convertToOflags(m_access_mode, m_open_mode),
+                                           static_cast<iox_mode_t>(m_permissions.value()))
                       .failureReturnValue(-1)
                       .evaluate();
 
@@ -163,7 +163,7 @@ void File::close_fd() noexcept
         return;
     }
 
-    auto result = posix::posixCall(iox_close)(m_file_descriptor).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_close)(m_file_descriptor).failureReturnValue(-1).evaluate();
     m_file_descriptor = INVALID_FILE_DESCRIPTOR;
 
     if (!result.has_error())
@@ -194,7 +194,7 @@ void File::close_fd() noexcept
 
 expected<bool, FileAccessError> File::does_exist(const FilePath& file) noexcept
 {
-    auto result = posix::posixCall(iox_access)(file.as_string().c_str(), F_OK).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_access)(file.as_string().c_str(), F_OK).failureReturnValue(-1).evaluate();
 
     if (!result.has_error())
     {
@@ -227,7 +227,7 @@ expected<bool, FileAccessError> File::does_exist(const FilePath& file) noexcept
 
 expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
 {
-    auto result = posix::posixCall(iox_remove)(file.as_string().c_str())
+    auto result = IOX_POSIX_CALL(iox_remove)(file.as_string().c_str())
                       .failureReturnValue(-1)
                       .suppressErrorMessagesForErrnos(ENOENT)
                       .evaluate();
@@ -272,7 +272,7 @@ expected<bool, FileRemoveError> File::remove(const FilePath& file) noexcept
 
 expected<void, FileOffsetError> File::set_offset(const uint64_t offset) const noexcept
 {
-    auto result = posix::posixCall(iox_lseek)(m_file_descriptor, static_cast<iox_off_t>(offset), IOX_SEEK_SET)
+    auto result = IOX_POSIX_CALL(iox_lseek)(m_file_descriptor, static_cast<iox_off_t>(offset), IOX_SEEK_SET)
                       .failureReturnValue(-1)
                       .evaluate();
 
@@ -329,7 +329,7 @@ File::read_at(const uint64_t offset, uint8_t* const buffer, const uint64_t buffe
         return err(FileReadError::OffsetFailure);
     }
 
-    auto result = posix::posixCall(iox_read)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_read)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
 
     if (!result.has_error())
     {
@@ -383,7 +383,7 @@ File::write_at(const uint64_t offset, const uint8_t* const buffer, const uint64_
         return err(FileWriteError::OffsetFailure);
     }
 
-    auto result = posix::posixCall(iox_write)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_write)(m_file_descriptor, buffer, buffer_len).failureReturnValue(-1).evaluate();
 
     if (!result.has_error())
     {

--- a/iceoryx_hoofs/posix/time/source/deadline_timer.cpp
+++ b/iceoryx_hoofs/posix/time/source/deadline_timer.cpp
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iox/deadline_timer.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iox/posix_call.hpp"
 
 #include "iceoryx_platform/time.hpp"
 
@@ -58,7 +58,7 @@ iox::units::Duration deadline_timer::remainingTime() const noexcept
 iox::units::Duration deadline_timer::getCurrentMonotonicTime() noexcept
 {
     timespec time_since_epoch{0, 0};
-    IOX_ENSURES_WITH_MSG(!posix::posixCall(clock_gettime)(CLOCK_MONOTONIC, &time_since_epoch)
+    IOX_ENSURES_WITH_MSG(!IOX_POSIX_CALL(clock_gettime)(CLOCK_MONOTONIC, &time_since_epoch)
                               .failureReturnValue(-1)
                               .evaluate()
                               .has_error(),

--- a/iceoryx_hoofs/reporting/source/log/building_blocks/console_logger.cpp
+++ b/iceoryx_hoofs/reporting/source/log/building_blocks/console_logger.cpp
@@ -58,7 +58,7 @@ void ConsoleLogger::createLogMessageHeader(const char* file,
                                            LogLevel logLevel) noexcept
 {
     timespec timestamp{0, 0};
-    // intentionally avoid using 'iox::posixCall' here to keep the logger dependency free
+    // intentionally avoid using 'IOX_POSIX_CALL' here to keep the logger dependency free
     if (clock_gettime(CLOCK_REALTIME, &timestamp) != 0)
     {
         timestamp = {0, 0};

--- a/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/named_semaphore.cpp
@@ -15,8 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/named_semaphore.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -31,7 +31,7 @@ static string<NamedSemaphore::Name_t::capacity() + 1> createNameWithSlash(const 
 
 static expected<void, SemaphoreError> unlink(const NamedSemaphore::Name_t& name) noexcept
 {
-    auto result = posixCall(iox_sem_unlink)(createNameWithSlash(name).c_str())
+    auto result = IOX_POSIX_CALL(iox_sem_unlink)(createNameWithSlash(name).c_str())
                       .failureReturnValue(-1)
                       .ignoreErrnos(ENOENT)
                       .evaluate();
@@ -57,7 +57,7 @@ static expected<bool, SemaphoreError>
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const NamedSemaphore::Name_t& name) noexcept
 {
-    auto result = posixCall(iox_sem_open)(createNameWithSlash(name).c_str(), 0)
+    auto result = IOX_POSIX_CALL(iox_sem_open)(createNameWithSlash(name).c_str(), 0)
                       .failureReturnValue(IOX_SEM_FAILED)
                       .ignoreErrnos(ENOENT)
                       .evaluate();
@@ -109,10 +109,10 @@ static expected<void, SemaphoreError> createSemaphore(optional<NamedSemaphore>& 
                                                       const access_rights permissions,
                                                       const uint32_t initialValue) noexcept
 {
-    auto result = posixCall(iox_sem_open_ext)(createNameWithSlash(name).c_str(),
-                                              convertToOflags(openMode),
-                                              permissions.value(),
-                                              static_cast<unsigned int>(initialValue))
+    auto result = IOX_POSIX_CALL(iox_sem_open_ext)(createNameWithSlash(name).c_str(),
+                                                   convertToOflags(openMode),
+                                                   permissions.value(),
+                                                   static_cast<unsigned int>(initialValue))
                       .failureReturnValue(IOX_SEM_FAILED)
                       .evaluate();
 
@@ -230,7 +230,7 @@ NamedSemaphore::NamedSemaphore(iox_sem_t* handle, const Name_t& name, const bool
 
 NamedSemaphore::~NamedSemaphore() noexcept
 {
-    if (posixCall(iox_sem_close)(m_handle).failureReturnValue(-1).evaluate().has_error())
+    if (IOX_POSIX_CALL(iox_sem_close)(m_handle).failureReturnValue(-1).evaluate().has_error())
     {
         IOX_LOG(ERROR, "This should never happen. Unable to close named semaphore \"" << m_name << '"');
     }

--- a/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/posix_access_rights.cpp
@@ -16,13 +16,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/grp.hpp"
 #include "iceoryx_platform/platform_correction.hpp"
 #include "iceoryx_platform/pwd.hpp"
 #include "iceoryx_platform/types.hpp"
 #include "iceoryx_platform/unistd.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 #include "iox/uninitialized_array.hpp"
 
 #include <limits>
@@ -63,7 +63,7 @@ PosixGroup PosixGroup::getGroupOfCurrentProcess() noexcept
 
 optional<gid_t> PosixGroup::getGroupID(const PosixGroup::groupName_t& name) noexcept
 {
-    auto getgrnamCall = posixCall(getgrnam)(name.c_str()).failureReturnValue(nullptr).evaluate();
+    auto getgrnamCall = IOX_POSIX_CALL(getgrnam)(name.c_str()).failureReturnValue(nullptr).evaluate();
 
     if (getgrnamCall.has_error())
     {
@@ -76,7 +76,7 @@ optional<gid_t> PosixGroup::getGroupID(const PosixGroup::groupName_t& name) noex
 
 optional<PosixGroup::groupName_t> PosixGroup::getGroupName(gid_t id) noexcept
 {
-    auto getgrgidCall = posixCall(getgrgid)(id).failureReturnValue(nullptr).evaluate();
+    auto getgrgidCall = IOX_POSIX_CALL(getgrgid)(id).failureReturnValue(nullptr).evaluate();
 
     if (getgrgidCall.has_error())
     {
@@ -110,7 +110,7 @@ bool PosixGroup::doesExist() const noexcept
 
 optional<uid_t> PosixUser::getUserID(const userName_t& name) noexcept
 {
-    auto getpwnamCall = posixCall(getpwnam)(name.c_str()).failureReturnValue(nullptr).evaluate();
+    auto getpwnamCall = IOX_POSIX_CALL(getpwnam)(name.c_str()).failureReturnValue(nullptr).evaluate();
 
     if (getpwnamCall.has_error())
     {
@@ -122,7 +122,7 @@ optional<uid_t> PosixUser::getUserID(const userName_t& name) noexcept
 
 optional<PosixUser::userName_t> PosixUser::getUserName(uid_t id) noexcept
 {
-    auto getpwuidCall = posixCall(getpwuid)(id).failureReturnValue(nullptr).evaluate();
+    auto getpwuidCall = IOX_POSIX_CALL(getpwuid)(id).failureReturnValue(nullptr).evaluate();
 
     if (getpwuidCall.has_error())
     {
@@ -140,7 +140,7 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
         return groupVector_t();
     }
 
-    auto getpwnamCall = posixCall(getpwnam)(userName->c_str()).failureReturnValue(nullptr).evaluate();
+    auto getpwnamCall = IOX_POSIX_CALL(getpwnam)(userName->c_str()).failureReturnValue(nullptr).evaluate();
     if (getpwnamCall.has_error())
     {
         IOX_LOG(ERROR, "Error: getpwnam call failed");
@@ -151,9 +151,10 @@ PosixUser::groupVector_t PosixUser::getGroups() const noexcept
     UninitializedArray<gid_t, MaxNumberOfGroups> groups{}; // groups is initialized in iox_getgrouplist
     auto numGroups = MaxNumberOfGroups;
 
-    auto getgrouplistCall = posixCall(iox_getgrouplist)(userName->c_str(), userDefaultGroup, &groups[0], &numGroups)
-                                .failureReturnValue(-1)
-                                .evaluate();
+    auto getgrouplistCall =
+        IOX_POSIX_CALL(iox_getgrouplist)(userName->c_str(), userDefaultGroup, &groups[0], &numGroups)
+            .failureReturnValue(-1)
+            .evaluate();
     if (getgrouplistCall.has_error())
     {
         IOX_LOG(ERROR, "Error: Could not obtain group list");

--- a/iceoryx_hoofs/source/posix_wrapper/scheduler.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/scheduler.cpp
@@ -16,8 +16,8 @@
 
 #include "iceoryx_hoofs/posix_wrapper/scheduler.hpp"
 #include "iceoryx_hoofs/cxx/requires.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -25,7 +25,7 @@ namespace posix
 {
 int32_t getSchedulerPriorityMinimum(const Scheduler scheduler) noexcept
 {
-    auto result = posixCall(sched_get_priority_min)(static_cast<int>(scheduler)).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(sched_get_priority_min)(static_cast<int>(scheduler)).failureReturnValue(-1).evaluate();
     if (result.has_error())
     {
         IOX_LOG(ERROR,
@@ -44,7 +44,7 @@ int32_t getSchedulerPriorityMinimum(const Scheduler scheduler) noexcept
 
 int32_t getSchedulerPriorityMaximum(const Scheduler scheduler) noexcept
 {
-    auto result = posixCall(sched_get_priority_max)(static_cast<int>(scheduler)).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(sched_get_priority_max)(static_cast<int>(scheduler)).failureReturnValue(-1).evaluate();
     if (result.has_error())
     {
         IOX_LOG(ERROR,

--- a/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/semaphore_interface.cpp
@@ -16,9 +16,9 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/semaphore_interface.hpp"
 #include "iceoryx_hoofs/posix_wrapper/named_semaphore.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -55,7 +55,7 @@ iox_sem_t* SemaphoreInterface<SemaphoreChild>::getHandle() noexcept
 template <typename SemaphoreChild>
 expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::post() noexcept
 {
-    auto result = posixCall(iox_sem_post)(getHandle()).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_sem_post)(getHandle()).failureReturnValue(-1).evaluate();
 
     if (result.has_error())
     {
@@ -70,7 +70,7 @@ expected<SemaphoreWaitState, SemaphoreError>
 SemaphoreInterface<SemaphoreChild>::timedWait(const units::Duration& timeout) noexcept
 {
     const timespec timeoutAsTimespec = timeout.timespec(units::TimeSpecReference::Epoch);
-    auto result = posixCall(iox_sem_timedwait)(getHandle(), &timeoutAsTimespec)
+    auto result = IOX_POSIX_CALL(iox_sem_timedwait)(getHandle(), &timeoutAsTimespec)
                       .failureReturnValue(-1)
                       .ignoreErrnos(ETIMEDOUT)
                       .evaluate();
@@ -86,7 +86,7 @@ SemaphoreInterface<SemaphoreChild>::timedWait(const units::Duration& timeout) no
 template <typename SemaphoreChild>
 expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWait() noexcept
 {
-    auto result = posixCall(iox_sem_trywait)(getHandle()).failureReturnValue(-1).ignoreErrnos(EAGAIN).evaluate();
+    auto result = IOX_POSIX_CALL(iox_sem_trywait)(getHandle()).failureReturnValue(-1).ignoreErrnos(EAGAIN).evaluate();
 
     if (result.has_error())
     {
@@ -99,7 +99,7 @@ expected<bool, SemaphoreError> SemaphoreInterface<SemaphoreChild>::tryWait() noe
 template <typename SemaphoreChild>
 expected<void, SemaphoreError> SemaphoreInterface<SemaphoreChild>::wait() noexcept
 {
-    auto result = posixCall(iox_sem_wait)(getHandle()).failureReturnValue(-1).evaluate();
+    auto result = IOX_POSIX_CALL(iox_sem_wait)(getHandle()).failureReturnValue(-1).evaluate();
 
     if (result.has_error())
     {

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object/memory_map.cpp
@@ -16,9 +16,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 #include <bitset>
 
@@ -30,12 +30,12 @@ expected<MemoryMap, MemoryMapError> MemoryMapBuilder::create() noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A5.2.3, CertC++-EXP55 : Incompatibility with POSIX definition of mmap
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) low-level memory management
-    auto result = posixCall(mmap)(const_cast<void*>(m_baseAddressHint),
-                                  m_length,
-                                  convertToProtFlags(m_accessMode),
-                                  static_cast<int32_t>(m_flags),
-                                  m_fileDescriptor,
-                                  m_offset)
+    auto result = IOX_POSIX_CALL(mmap)(const_cast<void*>(m_baseAddressHint),
+                                       m_length,
+                                       convertToProtFlags(m_accessMode),
+                                       static_cast<int32_t>(m_flags),
+                                       m_fileDescriptor,
+                                       m_offset)
 
                       // NOLINTJUSTIFICATION cast required, type of error MAP_FAILED defined by POSIX to be void*
                       // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, performance-no-int-to-ptr)
@@ -176,7 +176,7 @@ bool MemoryMap::destroy() noexcept
 {
     if (m_baseAddress != nullptr)
     {
-        auto unmapResult = posixCall(munmap)(m_baseAddress, m_length).failureReturnValue(-1).evaluate();
+        auto unmapResult = IOX_POSIX_CALL(munmap)(m_baseAddress, m_length).failureReturnValue(-1).evaluate();
         m_baseAddress = nullptr;
         m_length = 0U;
 

--- a/iceoryx_hoofs/source/posix_wrapper/system_configuration.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/system_configuration.cpp
@@ -17,8 +17,8 @@
 
 #include "iceoryx_hoofs/internal/posix_wrapper/system_configuration.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -28,7 +28,7 @@ uint64_t pageSize() noexcept
 {
     // sysconf fails when one provides an invalid name parameter. _SC_PAGESIZE
     // is a valid name parameter therefore it should never fail.
-    return static_cast<uint64_t>(posix::posixCall(sysconf)(_SC_PAGESIZE)
+    return static_cast<uint64_t>(IOX_POSIX_CALL(sysconf)(_SC_PAGESIZE)
                                      .failureReturnValue(-1)
                                      .evaluate()
                                      .or_else([](auto& r) {

--- a/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/unnamed_semaphore.cpp
@@ -15,8 +15,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/unnamed_semaphore.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -35,9 +35,9 @@ UnnamedSemaphoreBuilder::create(optional<UnnamedSemaphore>& uninitializedSemapho
 
     uninitializedSemaphore.emplace();
 
-    auto result = posixCall(iox_sem_init)(&uninitializedSemaphore.value().m_handle,
-                                          (m_isInterProcessCapable) ? 1 : 0,
-                                          static_cast<unsigned int>(m_initialValue))
+    auto result = IOX_POSIX_CALL(iox_sem_init)(&uninitializedSemaphore.value().m_handle,
+                                               (m_isInterProcessCapable) ? 1 : 0,
+                                               static_cast<unsigned int>(m_initialValue))
                       .failureReturnValue(-1)
                       .evaluate();
 
@@ -67,7 +67,7 @@ UnnamedSemaphore::~UnnamedSemaphore() noexcept
 {
     if (m_destroyHandle)
     {
-        auto result = posixCall(iox_sem_destroy)(getHandle()).failureReturnValue(-1).evaluate();
+        auto result = IOX_POSIX_CALL(iox_sem_destroy)(getHandle()).failureReturnValue(-1).evaluate();
         if (result.has_error())
         {
             switch (result.error().errnum)

--- a/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_access_control.cpp
@@ -17,9 +17,9 @@
 
 #if defined(__linux__)
 #include "iceoryx_hoofs/internal/posix_wrapper/access_control.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/pwd.hpp"
 #include "iceoryx_platform/stat.hpp"
+#include "iox/posix_call.hpp"
 #include "test.hpp"
 
 #include <memory>
@@ -63,7 +63,7 @@ std::unique_ptr<PwUidResult> iox_getpwuid(const uid_t uid)
 {
     passwd* resultPtr = nullptr;
     std::unique_ptr<PwUidResult> result = std::make_unique<PwUidResult>();
-    auto call = posixCall(getpwuid_r)(uid, &result->pwd, &result->buff[0], PwUidResult::BUFFER_SIZE, &resultPtr)
+    auto call = IOX_POSIX_CALL(getpwuid_r)(uid, &result->pwd, &result->buff[0], PwUidResult::BUFFER_SIZE, &resultPtr)
                     .returnValueMatchesErrno()
                     .evaluate();
     if (call.has_error())

--- a/iceoryx_hoofs/test/moduletests/test_posix_access_rights.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_access_rights.cpp
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_hoofs/posix_wrapper/posix_access_rights.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iox/posix_call.hpp"
 #include "test.hpp"
 
 #include <cstdlib>
@@ -37,13 +37,11 @@ class PosixAccessRights_test : public Test
         fileStream.open(TestFileName, std::fstream::out | std::fstream::trunc);
         fileStream.close();
 
-        iox::posix::posixCall(system)(("groups > " + TestFileName).c_str())
-            .failureReturnValue(-1)
-            .evaluate()
-            .or_else([](auto& r) {
-                IOX_LOG(ERROR, "system call failed with error: " << r.getHumanReadableErrnum());
-                std::terminate();
-            });
+        IOX_POSIX_CALL(system)
+        (("groups > " + TestFileName).c_str()).failureReturnValue(-1).evaluate().or_else([](auto& r) {
+            IOX_LOG(ERROR, "system call failed with error: " << r.getHumanReadableErrnum());
+            std::terminate();
+        });
     }
 
     void TearDown() override

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_hoofs/testing/testing_logger.hpp"
+#include "iox/posix_call.hpp"
 #include "test.hpp"
 #include <gtest/gtest.h>
 
@@ -61,7 +61,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_GoodCase)
     constexpr int RETURN_VALUE = 1;
     constexpr int ERRNO_VALUE = 2;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE)
         .evaluate()
         .and_then([&](auto& r) {
@@ -81,7 +82,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValue_BadCase)
     constexpr int RETURN_VALUE = 3;
     constexpr int ERRNO_VALUE = 4;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE + 1)
         .evaluate()
         .and_then([](auto&) { EXPECT_TRUE(false); })
@@ -104,7 +106,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_GoodCase)
     constexpr int RETURN_VALUE = 5;
     constexpr int ERRNO_VALUE = 6;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE + 1)
         .evaluate()
         .and_then([&](auto& r) {
@@ -124,7 +127,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValue_BadCase)
     constexpr int RETURN_VALUE = 7;
     constexpr int ERRNO_VALUE = 8;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE)
         .evaluate()
         .and_then([](auto&) { EXPECT_TRUE(false); })
@@ -147,7 +151,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_Good
     constexpr int RETURN_VALUE = 9;
     constexpr int ERRNO_VALUE = 10;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE + 1)
         .ignoreErrnos(ERRNO_VALUE)
         .evaluate()
@@ -168,7 +173,8 @@ TEST_F(PosixCall_test, CallingFunctionWithSuccessReturnValueAndIgnoredErrno_BadC
     constexpr int RETURN_VALUE = 11;
     constexpr int ERRNO_VALUE = 12;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE + 1)
         .ignoreErrnos(ERRNO_VALUE + 1)
         .evaluate()
@@ -192,7 +198,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_Good
     constexpr int RETURN_VALUE = 13;
     constexpr int ERRNO_VALUE = 14;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE)
         .ignoreErrnos(ERRNO_VALUE)
         .evaluate()
@@ -213,7 +220,8 @@ TEST_F(PosixCall_test, CallingFunctionWithFailureReturnValueAndIgnoredErrno_BadC
     constexpr int RETURN_VALUE = 15;
     constexpr int ERRNO_VALUE = 16;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE)
         .ignoreErrnos(ERRNO_VALUE + 1)
         .evaluate()
@@ -237,7 +245,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWorks)
     constexpr int RETURN_VALUE = 17;
     constexpr int ERRNO_VALUE = 18;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
         .evaluate()
@@ -258,7 +267,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsNotListedFails
     constexpr int RETURN_VALUE = 19;
     constexpr int ERRNO_VALUE = 20;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 17, ERRNO_VALUE + 1337, ERRNO_VALUE - 2)
         .evaluate()
@@ -279,7 +289,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsFirstInListSuc
     constexpr int RETURN_VALUE = 21;
     constexpr int ERRNO_VALUE = 22;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE, ERRNO_VALUE - 91, ERRNO_VALUE + 137, ERRNO_VALUE + 17, ERRNO_VALUE - 29)
         .evaluate()
@@ -300,7 +311,8 @@ TEST_F(PosixCall_test, IgnoringMultipleErrnosWhereOccurringErrnoIsLastInListSucc
     constexpr int RETURN_VALUE = 23;
     constexpr int ERRNO_VALUE = 24;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 918, ERRNO_VALUE + 8137, ERRNO_VALUE + 187, ERRNO_VALUE - 289, ERRNO_VALUE)
         .evaluate()
@@ -321,7 +333,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
     constexpr int RETURN_VALUE = 117;
     constexpr int ERRNO_VALUE = 118;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE)
         .ignoreErrnos(ERRNO_VALUE - 10)
@@ -344,7 +357,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
     constexpr int RETURN_VALUE = 217;
     constexpr int ERRNO_VALUE = 218;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 10)
         .ignoreErrnos(ERRNO_VALUE)
@@ -367,7 +381,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsWorksWhenErrnoIs
     constexpr int RETURN_VALUE = 317;
     constexpr int ERRNO_VALUE = 318;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 10)
         .ignoreErrnos(ERRNO_VALUE + 17)
@@ -390,7 +405,8 @@ TEST_F(PosixCall_test, IgnoringErrnosByMultipleIgnoreErrnosCallsFails)
     constexpr int RETURN_VALUE = 417;
     constexpr int ERRNO_VALUE = 418;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE - 10)
         .ignoreErrnos(ERRNO_VALUE + 13)
@@ -413,7 +429,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithNonPresentErrnoPrintsErrorMessage
     constexpr int RETURN_VALUE = 111;
     constexpr int ERRNO_VALUE = 112;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
         .evaluate()
@@ -434,7 +451,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingWithPresentErrnoDoesNotPrintErrorMess
     constexpr int RETURN_VALUE = 113;
     constexpr int ERRNO_VALUE = 114;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE)
         .evaluate()
@@ -455,7 +473,8 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithNoPresentErrnoPrintsError
     constexpr int RETURN_VALUE = 115;
     constexpr int ERRNO_VALUE = 116;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10, ERRNO_VALUE + 16, ERRNO_VALUE + 17)
         .evaluate()
@@ -476,7 +495,8 @@ TEST_F(PosixCall_test, SuppressMultipleErrnoLoggingWithPresentErrnoDoesNotPrintE
     constexpr int RETURN_VALUE = 117;
     constexpr int ERRNO_VALUE = 118;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10, ERRNO_VALUE, ERRNO_VALUE + 17)
         .evaluate()
@@ -497,7 +517,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithNonPresentErrnoPri
     constexpr int RETURN_VALUE = 119;
     constexpr int ERRNO_VALUE = 120;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE + 13)
@@ -520,7 +541,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingByMultipleCallsWithPresentErrnoDoesNo
     constexpr int RETURN_VALUE = 121;
     constexpr int ERRNO_VALUE = 122;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE - 10)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE)
@@ -543,7 +565,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfIgnoredErrnoDoesNotPrintErrorMessag
     constexpr int RETURN_VALUE = 123;
     constexpr int ERRNO_VALUE = 124;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE)
@@ -565,7 +588,8 @@ TEST_F(PosixCall_test, SuppressErrnoLoggingOfNotIgnoredErrnoDoesNotPrintErrorMes
     constexpr int RETURN_VALUE = 123;
     constexpr int ERRNO_VALUE = 124;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(1)
         .ignoreErrnos(ERRNO_VALUE + 10)
         .suppressErrorMessagesForErrnos(ERRNO_VALUE)
@@ -584,9 +608,9 @@ TEST_F(PosixCall_test, RecallingFunctionWithEintrWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c613542f-dead-409e-9630-f05486faa8f3");
 
-    eintrRepetition = iox::posix::POSIX_CALL_EINTR_REPETITIONS;
-    iox::posix::posixCall(testEintr)()
-        .successReturnValue(0)
+    eintrRepetition = iox::POSIX_CALL_EINTR_REPETITIONS;
+    IOX_POSIX_CALL(testEintr)
+    ().successReturnValue(0)
         .evaluate()
         .and_then([](auto& r) {
             EXPECT_THAT(r.value, Eq(0));
@@ -604,15 +628,12 @@ TEST_F(PosixCall_test, FunctionReturnsEINTRTooOftenResultsInFailure)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a63b36d3-bccc-4d5c-9fad-502dd6f163f1");
 
-    eintrRepetition = iox::posix::POSIX_CALL_EINTR_REPETITIONS + 1;
-    iox::posix::posixCall(testEintr)()
-        .successReturnValue(0)
-        .evaluate()
-        .and_then([](auto&) { EXPECT_TRUE(false); })
-        .or_else([](auto& r) {
-            EXPECT_THAT(r.value, Eq(1));
-            EXPECT_THAT(r.errnum, Eq(EINTR));
-        });
+    eintrRepetition = iox::POSIX_CALL_EINTR_REPETITIONS + 1;
+    IOX_POSIX_CALL(testEintr)
+    ().successReturnValue(0).evaluate().and_then([](auto&) { EXPECT_TRUE(false); }).or_else([](auto& r) {
+        EXPECT_THAT(r.value, Eq(1));
+        EXPECT_THAT(r.errnum, Eq(EINTR));
+    });
 
     EXPECT_THAT(eintrRepetition, Eq(1));
     iox::testing::TestingLogger::checkLogMessageIfLogLevelIsSupported(
@@ -626,7 +647,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
     constexpr int RETURN_VALUE = 25;
     constexpr int ERRNO_VALUE = 26;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE, RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto& r) {
@@ -646,7 +668,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
     constexpr int RETURN_VALUE = 27;
     constexpr int ERRNO_VALUE = 28;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto& r) {
@@ -666,7 +689,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
     constexpr int RETURN_VALUE = 29;
     constexpr int ERRNO_VALUE = 30;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2, RETURN_VALUE)
         .evaluate()
         .and_then([&](auto& r) {
@@ -686,7 +710,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleSuccessReturnValuesWhereGoodVa
     constexpr int RETURN_VALUE = 31;
     constexpr int ERRNO_VALUE = 32;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .successReturnValue(RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
@@ -706,7 +731,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
     constexpr int RETURN_VALUE = 33;
     constexpr int ERRNO_VALUE = 34;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE, RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
@@ -726,7 +752,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
     constexpr int RETURN_VALUE = 35;
     constexpr int ERRNO_VALUE = 36;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE - 1, RETURN_VALUE, RETURN_VALUE + 1, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
@@ -746,7 +773,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
     constexpr int RETURN_VALUE = 37;
     constexpr int ERRNO_VALUE = 38;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2, RETURN_VALUE)
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })
@@ -766,7 +794,8 @@ TEST_F(PosixCall_test, CallingFunctionWithMultipleFailureReturnValuesWhereFailur
     constexpr int RETURN_VALUE = 39;
     constexpr int ERRNO_VALUE = 40;
 
-    iox::posix::posixCall(testFunction)(RETURN_VALUE, ERRNO_VALUE)
+    IOX_POSIX_CALL(testFunction)
+    (RETURN_VALUE, ERRNO_VALUE)
         .failureReturnValue(RETURN_VALUE - 1, RETURN_VALUE + 1, RETURN_VALUE + 2)
         .evaluate()
         .and_then([&](auto& r) {
@@ -785,7 +814,8 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
 
     constexpr int RETURN_VALUE = 0;
 
-    iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
+    IOX_POSIX_CALL(returnValueIsErrno)
+    (RETURN_VALUE)
         .returnValueMatchesErrno()
         .evaluate()
         .and_then([&](auto& r) {
@@ -804,7 +834,8 @@ TEST_F(PosixCall_test, ErrnoIsSetFromReturnValueWhenFunctionHandlesErrnosInRetur
 
     constexpr int RETURN_VALUE = 42;
 
-    iox::posix::posixCall(returnValueIsErrno)(RETURN_VALUE)
+    IOX_POSIX_CALL(returnValueIsErrno)
+    (RETURN_VALUE)
         .returnValueMatchesErrno()
         .evaluate()
         .and_then([&](auto&) { EXPECT_TRUE(false); })

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory.cpp
@@ -18,10 +18,10 @@
 #include "test.hpp"
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/mman.hpp"
 #include "iceoryx_platform/stat.hpp"
 #include "iceoryx_platform/unistd.hpp"
+#include "iox/posix_call.hpp"
 
 #include <fcntl.h>
 
@@ -63,9 +63,9 @@ class SharedMemory_Test : public Test
     createRawSharedMemory(const iox::posix::SharedMemory::Name_t& name)
     {
         // NOLINTBEGIN(hicpp-signed-bitwise) enum types defined by POSIX are required
-        auto result = iox::posix::posixCall(iox_shm_open)((std::string("/") + name.c_str()).c_str(),
-                                                          O_RDWR | O_CREAT,
-                                                          S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
+        auto result = IOX_POSIX_CALL(iox_shm_open)((std::string("/") + name.c_str()).c_str(),
+                                                   O_RDWR | O_CREAT,
+                                                   S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP)
                           .failureReturnValue(SharedMemory::INVALID_HANDLE)
                           .evaluate();
         // NOLINTEND(hicpp-signed-bitwise)

--- a/iceoryx_hoofs/test/moduletests/test_time_unit_duration.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_time_unit_duration.cpp
@@ -15,10 +15,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_hoofs/testing/mocks/logger_mock.hpp"
 #include "iceoryx_hoofs/testing/testing_logger.hpp"
 #include "iox/duration.hpp"
+#include "iox/posix_call.hpp"
 #include "test.hpp"
 #include <ctime>
 #include <iostream>
@@ -1080,13 +1080,13 @@ TEST(Duration_test, ConvertTimespecWithMonotonicReference)
     constexpr int64_t NANOSECONDS{66};
 
     struct timespec referenceTimeForMonotonicEpoch = {};
-    ASSERT_FALSE((iox::posix::posixCall(clock_gettime)(CLOCK_MONOTONIC, &referenceTimeForMonotonicEpoch)
+    ASSERT_FALSE((IOX_POSIX_CALL(clock_gettime)(CLOCK_MONOTONIC, &referenceTimeForMonotonicEpoch)
                       .failureReturnValue(-1)
                       .evaluate()
                       .has_error()));
 
     struct timespec referenceTimeForUnixEpoch = {};
-    ASSERT_FALSE((iox::posix::posixCall(clock_gettime)(CLOCK_REALTIME, &referenceTimeForUnixEpoch)
+    ASSERT_FALSE((IOX_POSIX_CALL(clock_gettime)(CLOCK_REALTIME, &referenceTimeForUnixEpoch)
                       .failureReturnValue(-1)
                       .evaluate()
                       .has_error()));

--- a/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_unix_domain_sockets.cpp
@@ -17,9 +17,9 @@
 
 #if !defined(_WIN32)
 #include "iceoryx_hoofs/internal/posix_wrapper/unix_domain_socket.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_hoofs/testing/timing_test.hpp"
 #include "iceoryx_platform/socket.hpp"
+#include "iox/posix_call.hpp"
 
 #include "test.hpp"
 
@@ -70,15 +70,17 @@ class UnixDomainSocket_test : public Test
         sockAddr.sun_family = AF_LOCAL;
         strncpy(&(sockAddr.sun_path[0]), name.c_str(), name.size());
 
-        iox::posix::posixCall(iox_socket)(AF_LOCAL, SOCK_DGRAM, 0)
+        IOX_POSIX_CALL(iox_socket)
+        (AF_LOCAL, SOCK_DGRAM, 0)
             .failureReturnValue(ERROR_CODE)
             .evaluate()
             .and_then([&](auto& r) {
-                iox::posix::posixCall(iox_bind)(r.value,
-                                                // NOLINTJUSTIFICATION enforced by POSIX API
-                                                // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-                                                reinterpret_cast<struct sockaddr*>(&sockAddr),
-                                                sizeof(sockAddr))
+                IOX_POSIX_CALL(iox_bind)
+                (r.value,
+                 // NOLINTJUSTIFICATION enforced by POSIX API
+                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+                 reinterpret_cast<struct sockaddr*>(&sockAddr),
+                 sizeof(sockAddr))
                     .failureReturnValue(ERROR_CODE)
                     .evaluate()
                     .or_else([&](auto&) {

--- a/iceoryx_hoofs/time/source/duration.cpp
+++ b/iceoryx_hoofs/time/source/duration.cpp
@@ -19,7 +19,7 @@
 #include "iceoryx_platform/platform_correction.hpp"
 #include "iox/logging.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -53,7 +53,7 @@ struct timespec Duration::timespec(const TimeSpecReference reference) const noex
     // AXIVION Next Construct AutosarC++19_03-M5.0.3: False positive! CLOCK_REALTIME and CLOCK_MONOTONIC are of type clockid_t
     const clockid_t clockId{(reference == TimeSpecReference::Epoch) ? CLOCK_REALTIME : CLOCK_MONOTONIC};
     IOX_ENSURES_WITH_MSG(
-        !posix::posixCall(clock_gettime)(clockId, &referenceTime).failureReturnValue(-1).evaluate().has_error(),
+        !IOX_POSIX_CALL(clock_gettime)(clockId, &referenceTime).failureReturnValue(-1).evaluate().has_error(),
         "An error which should never happen occured during 'clock_gettime'!");
 
     const auto targetTime = Duration(referenceTime) + *this;

--- a/iceoryx_posh/source/roudi/process_manager.cpp
+++ b/iceoryx_posh/source/roudi/process_manager.cpp
@@ -17,13 +17,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/internal/roudi/process_manager.hpp"
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/signal.hpp"
 #include "iceoryx_platform/types.hpp"
 #include "iceoryx_platform/wait.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iox/detail/convert.hpp"
 #include "iox/logging.hpp"
+#include "iox/posix_call.hpp"
 #include "iox/relative_pointer.hpp"
 #include "iox/std_chrono_support.hpp"
 #include "iox/vector.hpp"
@@ -166,8 +166,8 @@ bool ProcessManager::requestShutdownOfProcess(Process& process, ShutdownPolicy s
 {
     static constexpr int32_t ERROR_CODE = -1;
 
-    return !posix::posixCall(kill)(static_cast<pid_t>(process.getPid()),
-                                   (shutdownPolicy == ShutdownPolicy::SIG_KILL) ? SIGKILL : SIGTERM)
+    return !IOX_POSIX_CALL(kill)(static_cast<pid_t>(process.getPid()),
+                                 (shutdownPolicy == ShutdownPolicy::SIG_KILL) ? SIGKILL : SIGTERM)
                 .failureReturnValue(ERROR_CODE)
                 .ignoreErrnos(ESRCH)
                 .evaluate()
@@ -180,7 +180,7 @@ bool ProcessManager::requestShutdownOfProcess(Process& process, ShutdownPolicy s
 bool ProcessManager::probeProcessAliveWithSigTerm(const Process& process) noexcept
 {
     static constexpr int32_t ERROR_CODE = -1;
-    auto checkCommand = posix::posixCall(kill)(static_cast<pid_t>(process.getPid()), SIGTERM)
+    auto checkCommand = IOX_POSIX_CALL(kill)(static_cast<pid_t>(process.getPid()), SIGTERM)
                             .failureReturnValue(ERROR_CODE)
                             .ignoreErrnos(ESRCH)
                             .evaluate()

--- a/iceoryx_posh/source/runtime/heartbeat.cpp
+++ b/iceoryx_posh/source/runtime/heartbeat.cpp
@@ -16,9 +16,9 @@
 
 #include "iceoryx_posh/internal/runtime/heartbeat.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_platform/time.hpp"
 #include "iox/duration.hpp"
+#include "iox/posix_call.hpp"
 
 namespace iox
 {
@@ -54,7 +54,7 @@ uint64_t Heartbeat::milliseconds_since_epoch() noexcept
     };
 
     IOX_ENSURES_WITH_MSG(
-        !posix::posixCall(clock_gettime)(CLOCK_MONOTONIC, &timepoint).failureReturnValue(-1).evaluate().has_error(),
+        !IOX_POSIX_CALL(clock_gettime)(CLOCK_MONOTONIC, &timepoint).failureReturnValue(-1).evaluate().has_error(),
         "An error which should never happen occured during 'clock_gettime'!");
 
     return units::Duration(timepoint).toMilliseconds();

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -18,11 +18,11 @@
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "test.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/posix_call.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_message.hpp"
 #include "iceoryx_posh/internal/runtime/ipc_runtime_interface.hpp"
 #include "iox/duration.hpp"
 #include "iox/message_queue.hpp"
+#include "iox/posix_call.hpp"
 #include "iox/std_string_support.hpp"
 
 
@@ -144,7 +144,8 @@ TEST_F(CMqInterfaceStartupRace_test, ObsoleteRouDiMq)
         checkRegRequest(msg);
 
         // simulate the restart of RouDi with the mqueue cleanup
-        posix::posixCall(system)(DeleteRouDiMessageQueue).failureReturnValue(-1).evaluate().or_else([](auto& r) {
+        IOX_POSIX_CALL(system)
+        (DeleteRouDiMessageQueue).failureReturnValue(-1).evaluate().or_else([](auto& r) {
             std::cerr << "system call failed with error: " << r.getHumanReadableErrnum();
             exit(EXIT_FAILURE);
         });
@@ -195,7 +196,8 @@ TEST_F(CMqInterfaceStartupRace_test, ObsoleteRouDiMqWithFullMq)
         std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
         // simulate the restart of RouDi with the mqueue cleanup
-        posix::posixCall(system)(DeleteRouDiMessageQueue).failureReturnValue(-1).evaluate().or_else([](auto& r) {
+        IOX_POSIX_CALL(system)
+        (DeleteRouDiMessageQueue).failureReturnValue(-1).evaluate().or_else([](auto& r) {
             std::cerr << "system call failed with error: " << r.getHumanReadableErrnum();
             exit(EXIT_FAILURE);
         });

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -228,16 +228,14 @@ void IntrospectionApp::waitForUserInput(int32_t timeoutMs)
     fileDesc.fd = STDIN_FILENO;
     fileDesc.events = POLLIN;
     constexpr size_t nFileDesc = 1u;
-    iox::posix::posixCall(poll)(&fileDesc, nFileDesc, timeoutMs)
-        .failureReturnValue(-1)
-        .evaluate()
-        .and_then([&](auto eventCount) {
-            if (static_cast<size_t>(eventCount.value) == nFileDesc && fileDesc.revents == POLLIN)
-            {
-                this->updateDisplayYX();
-                this->refreshTerminal();
-            }
-        });
+    IOX_POSIX_CALL(poll)
+    (&fileDesc, nFileDesc, timeoutMs).failureReturnValue(-1).evaluate().and_then([&](auto eventCount) {
+        if (static_cast<size_t>(eventCount.value) == nFileDesc && fileDesc.revents == POLLIN)
+        {
+            this->updateDisplayYX();
+            this->refreshTerminal();
+        }
+    });
 }
 
 void IntrospectionApp::prettyPrint(const std::string& str, const PrettyOptions pr)
@@ -792,8 +790,8 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
         }
     }
 
-    iox::posix::posixCall(getchar)().failureReturnValue(EOF).evaluate().expect(
-        "unable to exit the introspection client since getchar failed");
+    IOX_POSIX_CALL(getchar)
+    ().failureReturnValue(EOF).evaluate().expect("unable to exit the introspection client since getchar failed");
     closeTerminal();
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the `posixCall` to `iox/posix_call.hpp` and renames the macro to `IOX_POSIX_CALL`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1391
