### PR TITLE
Move `move_and_copy_helper` to `iceoryx/design`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,10 @@ necessary, do the following:
 1. Contact the maintainers beforehand by opening an issue to discuss the necessity
 1. If accepted, add the new header to `tools/scripts/used-headers.txt` for the CI to pass
 
+### Eliminating code duplication
+
+1. In some cases, the code in the constructor and assignment operations may be largely duplicated. It is encouraged to move this duplicated code into a separate function (e.g., `copy_and_move_impl`) for better reuse. Additionally, the `MoveAndCopyHelper` in `iceoryx/design` (refer to [MoveAndCopyHelper](./doc/design/move_and_copy_helper.md)) offers some functionalities that make this process easier.
+
 ## Folder structure
 
 The folder structure boils down to:

--- a/doc/design/move_and_copy_helper.md
+++ b/doc/design/move_and_copy_helper.md
@@ -1,0 +1,131 @@
+# Move And Copy Helper
+
+## Summary and problem description
+
+Currently, some classes in our codebase use assignment in the constructor (ctor) to avoid code duplication, as seen in issue #1517 . However, it's noted in issue #1686 that self-assignment cannot happen in the ctor. Therefore, an alternative approach should be adopted to replace the current implementation.
+
+One method involves placing the shared logical code within a separate function, hereafter referred to as `copy_and_move_impl`. This function is then called within the ctor and assignment operations, using template parameters to specify the method of member initialization.
+
+## Premise
+
+When a class performs highly consistent tasks during construction (ctor) and assignment, implementers often extract the repetitive parts into a separate `copy_and_move_impl`. However, there are inevitably minor differences between move, copy, and ctor, assignment (for example, during ctor, specific variables need to be initialized to avoid garbage values affecting subsequent behaviors, etc...). In these cases, the `MoveAndCopyHelper` can be used to simplify the code.
+
+## Terminology
+
+- `MoveAndCopyOperations`: an enum class, including
+    - `CopyConstructor`
+    - `MoveConstructor`
+    - `CopyAssignment`
+    - `MoveAssignment`
+
+## Goals
+
+The purpose of the `MoveAndCopyHelper` is:
+- To allow special constructors to indicate the source of the call (e.g., CopyConstructor) when calling `copy_and_move_impl`.
+- To provide a consistent way of expressing data exchange in `copy_and_move_impl`.
+- To offer a way to ignore `MoveAndCopyOperations` and forcibly use ctor or assignment, facilitating users' needs in special circumstances.
+
+## Design
+
+- Provide the enum class `MoveAndCopyOperations` to describe the expected behavior of member variables during initialization (e.g., using copy or move). Passing this enum as a template parameter to `copy_and_move_impl` ensures whether special constructors are called as expected.
+- Provide functions like `transfer` to ensure that the exchange process of member variables conforms to `MoveAndCopyOperations`.
+
+### Code example
+
+```cpp
+// header
+
+#include "iox/move_and_copy_helper.hpp"
+
+#define TMP 1024
+
+class Test
+{
+  public:
+    Test();
+    Test(const Test&);
+    Test(Test&&);
+    Test& operator=(const Test&);
+    Test& operator=(Test&&);
+
+    uint64_t size();
+
+  private:
+    int m_data[TMP];
+    uint64_t m_size{0};
+}
+
+// implementation
+Test::Test(const Test& rhs)
+{
+    copy_and_move_impl<MoveAndCopyOperations::CopyConstructor>(rhs);
+}
+
+Test::Test(Test&& rhs)
+{
+     copy_and_move_impl<MoveAndCopyOperations::MoveConstructor>(rhs);
+}
+
+Test& Test::operator=(const Test& rhs)
+{
+    if (this != &rhs)
+    {
+        copy_and_move_impl<MoveAndCopyOperations::CopyAssignment>(rhs);
+    }
+    return *this;
+}
+
+Test& Test::operator=(Test&& rhs)
+{
+    if (this != &rhs)
+    {
+        copy_and_move_impl<MoveAndCopyOperations::MoveAssignment>(std::move(rhs));
+    }
+    return *this;
+}
+
+void Test::size()
+{
+    return m_size;
+}
+
+template <MoveAndCopyOperations Opt, typename RhsType>
+void Test::copy_and_move_impl(RhsType&& rhs)
+{
+    // you can set alias to simplify code
+    using Helper = MoveAndCopyHelper<Opt>;
+
+    // you can determine the current `Opt` at compile time for compile-time branching decisions.
+    constexpr bool is_ctor = Helper::is_ctor();
+    constexpr bool is_move = Helper::is_move();
+
+    // for ctor operation
+    if constexpr (is_ctor)
+    {
+        // reset something if needed
+        reset_something();
+    }
+
+    // transfer data example
+    for (uint64_t i = 0; i < rhs.size(); ++i)
+    {
+        if constexpr (is_move)
+        {
+            Helper::transfer(m_data[i], std::move(rhs.data[i]));
+        }
+        else
+        {
+            Helper::transfer(m_data[i], rhs.data[i]);
+        }
+    }
+}
+
+For more examples, see
+
+- `iceoryx_dust/container/detail/fixed_position_container.inl`
+
+```
+
+## Open issues
+
+[#2113 Move MoveAndCopyHelper to iceoryx_hoofs/design](https://github.com/eclipse-iceoryx/iceoryx/issues/2113)

--- a/doc/design/move_and_copy_helper.md
+++ b/doc/design/move_and_copy_helper.md
@@ -2,7 +2,7 @@
 
 ## Summary and problem description
 
-Currently, some classes in our codebase use assignment in the constructor (ctor) to avoid code duplication, as seen in issue #1517 . However, it's noted in issue #1686 that self-assignment cannot happen in the ctor. Therefore, an alternative approach should be adopted to replace the current implementation.
+Currently, some classes in our codebase use assignment in the constructor (ctor) to avoid code duplication, as seen in issue [#1517](https://github.com/eclipse-iceoryx/iceoryx/issues/1517) . However, it's noted in issue [#1686](https://github.com/eclipse-iceoryx/iceoryx/issues/1686) that self-assignment cannot happen in the ctor. Therefore, an alternative approach should be adopted to replace the current implementation.
 
 One method involves placing the shared logical code within a separate function, hereafter referred to as `copy_and_move_impl`. This function is then called within the ctor and assignment operations, using template parameters to specify the method of member initialization.
 
@@ -13,6 +13,7 @@ When a class performs highly consistent tasks during construction (ctor) and ass
 ## Terminology
 
 - `MoveAndCopyOperations`: an enum class, including
+
     - `CopyConstructor`
     - `MoveConstructor`
     - `CopyAssignment`
@@ -119,12 +120,11 @@ void Test::copy_and_move_impl(RhsType&& rhs)
         }
     }
 }
+```
 
 For more examples, see
 
 - `iceoryx_dust/container/detail/fixed_position_container.inl`
-
-```
 
 ## Open issues
 

--- a/doc/design/move_and_copy_helper.md
+++ b/doc/design/move_and_copy_helper.md
@@ -31,6 +31,14 @@ The purpose of the `MoveAndCopyHelper` is:
 - Provide the enum class `MoveAndCopyOperations` to describe the expected behavior of member variables during initialization (e.g., using copy or move). Passing this enum as a template parameter to `copy_and_move_impl` ensures whether special constructors are called as expected.
 - Provide functions like `transfer` to ensure that the exchange process of member variables conforms to `MoveAndCopyOperations`.
 
+### Scenario
+
+Presently, there are three functions: `transfer`, `create_new`, and `assign`. The scenarios outlined below briefly describe the appropriate usage for each function.
+
+- `transfer`: This is a general-purpose function for data transfer. It is recommended for use in cases where you are not dealing with potentially uninitialized memory.
+- `create_new`: In certain instances, particularly during constructor operations, some class members are lazy initialization. For these members, the copy or move constructor must be employed, even when they are being accessed via the assignment operator.
+- `assign`: TBD.
+
 ### Code example
 
 ```cpp

--- a/doc/design/move_and_copy_helper.md
+++ b/doc/design/move_and_copy_helper.md
@@ -109,8 +109,8 @@ void Test::copy_and_move_impl(RhsType&& rhs)
     using Helper = MoveAndCopyHelper<Opt>;
 
     // you can determine the current 'Opt' at compile time for compile-time branching decisions.
-    constexpr bool is_ctor = Helper::is_ctor();
-    constexpr bool is_move = Helper::is_move();
+    constexpr bool is_ctor = Helper::is_ctor;
+    constexpr bool is_move = Helper::is_move;
 
     // // self assignment check if needed
     // if constexpr (!is_ctor)
@@ -131,7 +131,10 @@ void Test::copy_and_move_impl(RhsType&& rhs)
     // transfer data example
     for (uint64_t i = 0; i < rhs.size(); ++i)
     {
-        // @Method 1
+        // @Recommended method
+        Helper::transfer(m_data[i], Helper::move_or_copy(rhs.data[i]));
+
+        // @Alternative method
         // if constexpr (is_move)
         // {
         //     Helper::transfer(m_data[i], std::move(rhs.data[i]));
@@ -140,9 +143,6 @@ void Test::copy_and_move_impl(RhsType&& rhs)
         // {
         //     Helper::transfer(m_data[i], rhs.data[i]);
         // }
-
-        // @Method 2
-        Helper::transfer(m_data[i], Helper::move_or_copy(rhs.data[i]));
     }
 }
 ```

--- a/doc/design/move_and_copy_helper.md
+++ b/doc/design/move_and_copy_helper.md
@@ -33,6 +33,7 @@ The purpose of the `MoveAndCopyHelper` is:
 
 ### Scenario
 
+#### Transfer
 Presently, there are three functions: `transfer`, `create_new`, and `assign`. The scenarios outlined below briefly describe the appropriate usage for each function.
 
 - `transfer`: This is a general-purpose function for data transfer. It is recommended for use in cases where you are not dealing with potentially uninitialized memory.
@@ -107,7 +108,7 @@ void Test::copy_and_move_impl(RhsType&& rhs)
     // you can set alias to simplify code
     using Helper = MoveAndCopyHelper<Opt>;
 
-    // you can determine the current `Opt` at compile time for compile-time branching decisions.
+    // you can determine the current 'Opt' at compile time for compile-time branching decisions.
     constexpr bool is_ctor = Helper::is_ctor();
     constexpr bool is_move = Helper::is_move();
 
@@ -130,14 +131,18 @@ void Test::copy_and_move_impl(RhsType&& rhs)
     // transfer data example
     for (uint64_t i = 0; i < rhs.size(); ++i)
     {
-        if constexpr (is_move)
-        {
-            Helper::transfer(m_data[i], std::move(rhs.data[i]));
-        }
-        else
-        {
-            Helper::transfer(m_data[i], rhs.data[i]);
-        }
+        // @Method 1
+        // if constexpr (is_move)
+        // {
+        //     Helper::transfer(m_data[i], std::move(rhs.data[i]));
+        // }
+        // else
+        // {
+        //     Helper::transfer(m_data[i], rhs.data[i]);
+        // }
+
+        // @Method 2
+        Helper::transfer(m_data[i], Helper::move_or_copy(rhs.data[i]));
     }
 }
 ```

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -93,8 +93,8 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
     // alias helper struct
     using Helper = MoveAndCopyHelper<Opt>;
 
-    constexpr bool is_ctor = Helper::is_ctor();
-    constexpr bool is_move = Helper::is_move();
+    constexpr bool is_ctor = Helper::is_ctor;
+    constexpr bool is_move = Helper::is_move;
 
     // status array is not yet initialized for constructor creation
     if constexpr (is_ctor)
@@ -114,27 +114,13 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
         {
             // When the slot is in the 'USED' state, it is safe to proceed with either construction (ctor) or assignment
             // operation. Therefore, creation can be carried out according to the option specified by Opt.
-            if constexpr (is_move)
-            {
-                Helper::transfer(m_data[i], std::move(*rhs_it));
-            }
-            else
-            {
-                Helper::transfer(m_data[i], *rhs_it);
-            }
+            Helper::transfer(m_data[i], Helper::move_or_copy_it(rhs_it));
         }
         else
         {
             // When the slot is in the 'FREE' state, it is unsafe to proceed with assignment operation.
             // Therefore, we need to force helper to use ctor create to make sure that the 'FREE' slots get initialized.
-            if constexpr (is_move)
-            {
-                Helper::create_new(m_data[i], std::move(*rhs_it));
-            }
-            else
-            {
-                Helper::create_new(m_data[i], *rhs_it);
-            }
+            Helper::create_new(m_data[i], Helper::move_or_copy_it(rhs_it));
         }
 
         m_status[i] = SlotStatus::USED;

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -129,11 +129,11 @@ inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rh
             // Therefore, we need to force helper to use ctor create to make sure that the 'FREE' slots get initialized.
             if constexpr (is_move)
             {
-                Helper::ctor_create(m_data[i], std::move(*rhs_it));
+                Helper::create_new(m_data[i], std::move(*rhs_it));
             }
             else
             {
-                Helper::ctor_create(m_data[i], *rhs_it);
+                Helper::create_new(m_data[i], *rhs_it);
             }
         }
 

--- a/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
+++ b/iceoryx_dust/container/include/iox/detail/fixed_position_container.inl
@@ -18,7 +18,6 @@
 #ifndef IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_INL
 #define IOX_DUST_CONTAINER_DETAIL_FIXED_POSITION_CONTAINER_INL
 
-#include "iox/detail/fixed_position_container_helper.hpp"
 #include "iox/fixed_position_container.hpp"
 
 namespace iox
@@ -56,13 +55,13 @@ inline FixedPositionContainer<T, CAPACITY>::~FixedPositionContainer() noexcept
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(const FixedPositionContainer& rhs) noexcept
 {
-    copy_and_move_impl<detail::MoveAndCopyOperations::CopyConstructor>(rhs);
+    copy_and_move_impl<MoveAndCopyOperations::CopyConstructor>(rhs);
 }
 
 template <typename T, uint64_t CAPACITY>
 inline FixedPositionContainer<T, CAPACITY>::FixedPositionContainer(FixedPositionContainer&& rhs) noexcept
 {
-    copy_and_move_impl<detail::MoveAndCopyOperations::MoveConstructor>(std::move(rhs));
+    copy_and_move_impl<MoveAndCopyOperations::MoveConstructor>(std::move(rhs));
 }
 
 template <typename T, uint64_t CAPACITY>
@@ -71,7 +70,7 @@ FixedPositionContainer<T, CAPACITY>::operator=(const FixedPositionContainer& rhs
 {
     if (this != &rhs)
     {
-        copy_and_move_impl<detail::MoveAndCopyOperations::CopyAssignment>(rhs);
+        copy_and_move_impl<MoveAndCopyOperations::CopyAssignment>(rhs);
     }
     return *this;
 }
@@ -82,17 +81,17 @@ FixedPositionContainer<T, CAPACITY>::operator=(FixedPositionContainer&& rhs) noe
 {
     if (this != &rhs)
     {
-        copy_and_move_impl<detail::MoveAndCopyOperations::MoveAssignment>(std::move(rhs));
+        copy_and_move_impl<MoveAndCopyOperations::MoveAssignment>(std::move(rhs));
     }
     return *this;
 }
 
 template <typename T, uint64_t CAPACITY>
-template <detail::MoveAndCopyOperations Opt, typename RhsType>
+template <MoveAndCopyOperations Opt, typename RhsType>
 inline void FixedPositionContainer<T, CAPACITY>::copy_and_move_impl(RhsType&& rhs) noexcept
 {
     // alias helper struct
-    using Helper = detail::MoveAndCopyHelper<Opt>;
+    using Helper = MoveAndCopyHelper<Opt>;
 
     constexpr bool is_ctor = Helper::is_ctor();
     constexpr bool is_move = Helper::is_move();

--- a/iceoryx_dust/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_dust/container/include/iox/fixed_position_container.hpp
@@ -19,7 +19,7 @@
 
 #include "iceoryx_hoofs/cxx/requires.hpp"
 #include "iox/algorithm.hpp"
-#include "iox/detail/fixed_position_container_helper.hpp"
+#include "iox/move_and_copy_helper.hpp"
 #include "iox/uninitialized_array.hpp"
 
 #include <cstdint>
@@ -316,7 +316,7 @@ class FixedPositionContainer final
     };
 
   private:
-    template <detail::MoveAndCopyOperations Opt, typename RhsType>
+    template <MoveAndCopyOperations Opt, typename RhsType>
     void copy_and_move_impl(RhsType&& rhs) noexcept;
 
   private:

--- a/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
+++ b/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved. reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_DESIGN_MOVE_AND_COPY_HELPER_INL
+#define IOX_HOOFS_DESIGN_MOVE_AND_COPY_HELPER_INL
+
+#include "iox/move_and_copy_helper.hpp"
+
+namespace iox
+{
+
+template <MoveAndCopyOperations Opt>
+template <typename T, typename V>
+inline void MoveAndCopyHelper<Opt>::transfer(T& dest, V&& src) noexcept
+{
+    if constexpr (is_ctor())
+    {
+        ctor_create(dest, std::forward<V>(src));
+    }
+    else
+    {
+        assignment_create(dest, std::forward<V>(src));
+    }
+}
+
+template <MoveAndCopyOperations Opt>
+template <typename T, typename V>
+inline void MoveAndCopyHelper<Opt>::ctor_create(T& dest, V&& src) noexcept
+{
+    if constexpr (is_move())
+    {
+        static_assert(std::is_rvalue_reference_v<decltype(src)>, "src should be rvalue reference");
+        static_assert(std::is_convertible_v<V, T>, "src type is not convertible to dest type");
+        new (&dest) T(std::forward<V>(src));
+    }
+    else
+    {
+        static_assert(std::is_lvalue_reference_v<decltype(src)>, "src should be lvalue reference");
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should has 'const' modifier");
+        static_assert(std::is_convertible_v<V, T>, "src type is not convertible to dest type");
+        new (&dest) T(src);
+    }
+}
+
+template <MoveAndCopyOperations Opt>
+template <typename T, typename V>
+inline void MoveAndCopyHelper<Opt>::assignment_create(T& dest, V&& src) noexcept
+{
+    if constexpr (is_move())
+    {
+        static_assert(std::is_rvalue_reference_v<decltype(src)>, "src should be rvalue reference");
+        dest = std::forward<V>(src);
+    }
+    else
+    {
+        static_assert(std::is_lvalue_reference_v<decltype(src)>, "src should be lvalue reference");
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should has 'const' modifier");
+        dest = src;
+    }
+}
+
+template <MoveAndCopyOperations Opt>
+inline constexpr bool MoveAndCopyHelper<Opt>::is_ctor() noexcept
+{
+    return Opt == MoveAndCopyOperations::CopyConstructor || Opt == MoveAndCopyOperations::MoveConstructor;
+}
+
+template <MoveAndCopyOperations Opt>
+inline constexpr bool MoveAndCopyHelper<Opt>::is_move() noexcept
+{
+    return Opt == MoveAndCopyOperations::MoveAssignment || Opt == MoveAndCopyOperations::MoveConstructor;
+}
+
+} // namespace iox
+#endif

--- a/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
+++ b/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
@@ -28,17 +28,17 @@ inline void MoveAndCopyHelper<Opt>::transfer(T& dest, V&& src) noexcept
 {
     if constexpr (is_ctor())
     {
-        ctor_create(dest, std::forward<V>(src));
+        create_new(dest, std::forward<V>(src));
     }
     else
     {
-        assignment_create(dest, std::forward<V>(src));
+        assign(dest, std::forward<V>(src));
     }
 }
 
 template <MoveAndCopyOperations Opt>
 template <typename T, typename V>
-inline void MoveAndCopyHelper<Opt>::ctor_create(T& dest, V&& src) noexcept
+inline void MoveAndCopyHelper<Opt>::create_new(T& dest, V&& src) noexcept
 {
     if constexpr (is_move())
     {
@@ -49,7 +49,7 @@ inline void MoveAndCopyHelper<Opt>::ctor_create(T& dest, V&& src) noexcept
     else
     {
         static_assert(std::is_lvalue_reference_v<decltype(src)>, "src should be lvalue reference");
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should has 'const' modifier");
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should have 'const' modifier");
         static_assert(std::is_convertible_v<V, T>, "src type is not convertible to dest type");
         new (&dest) T(src);
     }
@@ -57,7 +57,7 @@ inline void MoveAndCopyHelper<Opt>::ctor_create(T& dest, V&& src) noexcept
 
 template <MoveAndCopyOperations Opt>
 template <typename T, typename V>
-inline void MoveAndCopyHelper<Opt>::assignment_create(T& dest, V&& src) noexcept
+inline void MoveAndCopyHelper<Opt>::assign(T& dest, V&& src) noexcept
 {
     if constexpr (is_move())
     {
@@ -67,7 +67,7 @@ inline void MoveAndCopyHelper<Opt>::assignment_create(T& dest, V&& src) noexcept
     else
     {
         static_assert(std::is_lvalue_reference_v<decltype(src)>, "src should be lvalue reference");
-        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should has 'const' modifier");
+        static_assert(std::is_const_v<std::remove_reference_t<decltype(src)>>, "src should have 'const' modifier");
         dest = src;
     }
 }

--- a/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
+++ b/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved. reserved.
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
+++ b/iceoryx_hoofs/design/include/iox/detail/move_and_copy_helper.inl
@@ -21,54 +21,11 @@
 
 namespace iox
 {
-
-/// @brief MoveAndCopyHelperBase is a template structure used to create or assign objects based on the provided
-/// operation type (Opt). All of methods in this class are general for MoveAndCopyOperations. Any function that depends
-/// on specific MoveAndCopyOperations should move to partial specialization region.
-/// @tparam Opt The operation type that determines how objects are created or assigned.
-template <MoveAndCopyOperations Opt>
-class MoveAndCopyHelperBase
-{
-  public:
-    /// @brief Creates or assigns an object to 'dest' based on the specail operation type.
-    /// @tparam T The type of the object to be created or assigned.
-    /// @tparam V The type of the source object, kept as a universal reference to preserve its lvalue or rvalue nature.
-    /// @param[out] dest The destination object where the new object is created or to which the source object is
-    /// assigned.
-    /// @param[in] src The source object, either for copy or move operations.
-    template <typename T, typename V>
-    static void transfer(T& dest, V&& src) noexcept;
-
-    /// @brief Force to use constructor to create an object at the destination.
-    /// @tparam T The type of the object to be constructed.
-    /// @tparam V The type of the source object, used for move or copy construction.
-    /// @param[out] dest The destination object where the new object is constructed.
-    /// @param[in] src The source object, either for move or copy construction.
-    template <typename T, typename V>
-    static void ctor_create(T& dest, V&& src) noexcept;
-
-    /// @brief Force to use assignment to assign an object to the destination.
-    /// @tparam T The type of the destination object.
-    /// @tparam V The type of the source object, used for move or copy assignment.
-    /// @param dest The destination object where the source object is assigned.
-    /// @param src The source object, either for move or copy assignment.
-    template <typename T, typename V>
-    static void assignment_create(T& dest, V&& src) noexcept;
-
-    /// @brief Checks if the current special operation is a constructor call.
-    /// @return True if the operation is a copy or move constructor, false otherwise.
-    static constexpr bool is_ctor() noexcept;
-
-    /// @brief Checks if the current special operation is a move operation.
-    /// @return True if the operation is a move constructor or move assignment, false otherwise.
-    static constexpr bool is_move() noexcept;
-};
-
 template <MoveAndCopyOperations Opt>
 template <typename T, typename V>
-inline void MoveAndCopyHelperBase<Opt>::transfer(T& dest, V&& src) noexcept
+inline void MoveAndCopyHelper<Opt>::transfer(T& dest, V&& src) noexcept
 {
-    if constexpr (is_ctor())
+    if constexpr (is_ctor)
     {
         create_new(dest, std::forward<V>(src));
     }
@@ -80,9 +37,9 @@ inline void MoveAndCopyHelperBase<Opt>::transfer(T& dest, V&& src) noexcept
 
 template <MoveAndCopyOperations Opt>
 template <typename T, typename V>
-inline void MoveAndCopyHelperBase<Opt>::ctor_create(T& dest, V&& src) noexcept
+inline void MoveAndCopyHelper<Opt>::create_new(T& dest, V&& src) noexcept
 {
-    if constexpr (is_move())
+    if constexpr (is_move)
     {
         static_assert(std::is_rvalue_reference_v<decltype(src)>, "src should be rvalue reference");
         static_assert(std::is_convertible_v<V, T>, "src type is not convertible to dest type");
@@ -99,9 +56,9 @@ inline void MoveAndCopyHelperBase<Opt>::ctor_create(T& dest, V&& src) noexcept
 
 template <MoveAndCopyOperations Opt>
 template <typename T, typename V>
-inline void MoveAndCopyHelperBase<Opt>::assignment_create(T& dest, V&& src) noexcept
+inline void MoveAndCopyHelper<Opt>::assign(T& dest, V&& src) noexcept
 {
-    if constexpr (is_move())
+    if constexpr (is_move)
     {
         static_assert(std::is_rvalue_reference_v<decltype(src)>, "src should be rvalue reference");
         dest = std::forward<V>(src);
@@ -113,120 +70,5 @@ inline void MoveAndCopyHelperBase<Opt>::assignment_create(T& dest, V&& src) noex
         dest = src;
     }
 }
-
-template <MoveAndCopyOperations Opt>
-inline constexpr bool MoveAndCopyHelperBase<Opt>::is_ctor() noexcept
-{
-    return Opt == MoveAndCopyOperations::CopyConstructor || Opt == MoveAndCopyOperations::MoveConstructor;
-}
-
-template <MoveAndCopyOperations Opt>
-inline constexpr bool MoveAndCopyHelperBase<Opt>::is_move() noexcept
-{
-    return Opt == MoveAndCopyOperations::MoveAssignment || Opt == MoveAndCopyOperations::MoveConstructor;
-}
-
-/// @brief The partial specialization region for MoveAndCopyHelper.
-/* partial specialization */
-
-template <>
-struct MoveAndCopyHelper<MoveAndCopyOperations::CopyConstructor>
-    : public MoveAndCopyHelperBase<MoveAndCopyOperations::CopyConstructor>
-{
-    template <typename T>
-    static constexpr auto move_or_copy(const T& value) noexcept -> decltype(value)
-    {
-        return value;
-    }
-
-    template <typename Iterator>
-    static constexpr auto move_or_copy_it(Iterator& it) noexcept -> decltype(*it)
-    {
-        return *it;
-    }
-};
-
-template <>
-struct MoveAndCopyHelper<MoveAndCopyOperations::CopyAssignment>
-    : public MoveAndCopyHelperBase<MoveAndCopyOperations::CopyConstructor>
-{
-    /// @brief This function aims to simplified the constexpr if branches due to the 'transfer' parameters.
-    /// @tparam T
-    /// @param[in] value The target value which is going to transfer
-    /// @return Const lvalue reference of value
-    /// @example
-    /// An example of simplifying the usage of 'if constexpr' branches in a loop.
-    /// The original code:
-    /// \code{.cpp}
-    /// for (uint64_t i = 0; i < rhs.size(); ++i)
-    /// {
-    ///     if constexpr (is_move)
-    ///     {
-    ///         Helper::transfer(m_data[i], std::move(rhs.data[i]));
-    ///     }
-    ///     else
-    ///     {
-    ///         Helper::transfer(m_data[i], rhs.data[i]);
-    ///     }
-    /// }
-    /// \endcode
-    /// can be simplified to:
-    /// \code{.cpp}
-    /// for (uint64_t i = 0; i < rhs.size(); ++i)
-    /// {
-    ///     Helper::transfer(m_data[i], Helper::move_or_copy(rhs.data[i]));
-    /// }
-    /// \endcode
-    template <typename T>
-    static inline constexpr auto move_or_copy(const T& value) noexcept -> decltype(value)
-    {
-        return value;
-    }
-
-    /// @brief The iterator as input version of move_or_copy
-    /// @tparam Iterator The iterator type
-    /// @param[in] it
-    /// @return
-    template <typename Iterator>
-    static inline constexpr auto move_or_copy_it(Iterator& it) noexcept -> decltype(*it)
-    {
-        return *it;
-    }
-};
-
-template <>
-struct MoveAndCopyHelper<MoveAndCopyOperations::MoveConstructor>
-    : public MoveAndCopyHelperBase<MoveAndCopyOperations::MoveConstructor>
-{
-    template <typename T>
-    static inline constexpr auto move_or_copy(T&& value) noexcept -> decltype(std::move(std::forward<T>(value)))
-    {
-        return std::move(std::forward<T>(value));
-    }
-
-    template <typename Iterator>
-    static inline constexpr auto move_or_copy_it(Iterator& it) noexcept -> decltype(std::move(*it))
-    {
-        return std::move(*it);
-    }
-};
-
-template <>
-struct MoveAndCopyHelper<MoveAndCopyOperations::MoveAssignment>
-    : public MoveAndCopyHelperBase<MoveAndCopyOperations::MoveAssignment>
-{
-    template <typename T>
-    static inline constexpr auto move_or_copy(T&& value) noexcept -> decltype(std::move(std::forward<T>(value)))
-    {
-        return std::move(std::forward<T>(value));
-    }
-
-    template <typename Iterator>
-    static inline constexpr auto move_or_copy_it(Iterator& it) noexcept -> decltype(std::move(*it))
-    {
-        return std::move(*it);
-    }
-};
-
 } // namespace iox
 #endif

--- a/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
+++ b/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
@@ -31,8 +31,140 @@ enum class MoveAndCopyOperations
     MoveAssignment,
 };
 
+/// @brief MoveAndCopyHelper is a template structure used to create or assign objects based on the provided
+/// operation type (Opt). All of methods in this class are general for MoveAndCopyOperations. Any function that depends
+/// on specific MoveAndCopyOperations should move to partial specialization region.
+/// @tparam Opt The operation type that determines how objects are created or assigned.
 template <MoveAndCopyOperations Opt>
-struct MoveAndCopyHelper;
+class MoveAndCopyHelper
+{
+  public:
+    /// @brief Creates or assigns an object to 'dest' based on the specail operation type.
+    /// @tparam T The type of the object to be created or assigned.
+    /// @tparam V The type of the source object, kept as a universal reference to preserve its lvalue or rvalue nature.
+    /// @param[out] dest The destination object where the new object is created or to which the source object is
+    /// assigned.
+    /// @param[in] src The source object, either for copy or move operations.
+    template <typename T, typename V>
+    static void transfer(T& dest, V&& src) noexcept;
+
+    /// @brief Force to use constructor to create an object at the destination.
+    /// @tparam T The type of the object to be constructed.
+    /// @tparam V The type of the source object, used for move or copy construction.
+    /// @param[out] dest The destination object where the new object is constructed.
+    /// @param[in] src The source object, either for move or copy construction.
+    template <typename T, typename V>
+    static void create_new(T& dest, V&& src) noexcept;
+
+    /// @brief Force to use assignment to assign an object to the destination.
+    /// @tparam T The type of the destination object.
+    /// @tparam V The type of the source object, used for move or copy assignment.
+    /// @param dest The destination object where the source object is assigned.
+    /// @param src The source object, either for move or copy assignment.
+    template <typename T, typename V>
+    static void assign(T& dest, V&& src) noexcept;
+
+    /// @brief Moves a value if the condition specified by 'enable_if_t' is met.
+    /// @details This overload of 'move_or_copy' is enabled when 'Opt' is either 'MoveAssignment' or 'MoveConstructor'.
+    ///          It moves the given value, providing an efficient way to transfer resources.
+    /// @tparam T The type of the value to be moved.
+    /// @tparam enable_if A SFINAE condition that enables this overload for move operations.
+    /// @param[in] src The source value to be moved.
+    /// @return A reference to the moved value.
+    /// @note This overload is selected when the template parameter 'Opt' indicates a move operation.
+    /// @example
+    /// An example of simplifying the usage of 'if constexpr' branches in a loop.
+    /// The original code:
+    /// \code{.cpp}
+    /// for (uint64_t i = 0; i < rhs.size(); ++i)
+    /// {
+    ///     if constexpr (is_move)
+    ///     {
+    ///         Helper::transfer(m_data[i], std::move(rhs.data[i]));
+    ///     }
+    ///     else
+    ///     {
+    ///         Helper::transfer(m_data[i], rhs.data[i]);
+    ///     }
+    /// }
+    /// \endcode
+    /// can be simplified to:
+    /// \code{.cpp}
+    /// for (uint64_t i = 0; i < rhs.size(); ++i)
+    /// {
+    ///     Helper::transfer(m_data[i], Helper::move_or_copy(rhs.data[i]));
+    /// }
+    /// \endcode
+    template <typename T,
+              typename = std::enable_if_t<Opt == MoveAndCopyOperations::MoveAssignment
+                                              || Opt == MoveAndCopyOperations::MoveConstructor,
+                                          T>>
+    static inline T&& move_or_copy(T&& src) noexcept
+    {
+        return std::move(std::forward<T>(src));
+    }
+
+    /// @brief Copies a value if the condition specified by 'enable_if_t' is not met for move operations.
+    /// @details This overload of 'move_or_copy' is enabled for cases other than 'MoveAssignment' or 'MoveConstructor'.
+    ///          It simply copies the given value.
+    /// @tparam T The type of the value to be copied.
+    /// @tparam enable_if A SFINAE condition that enables this overload for copy operations.
+    /// @param[in] src The source value to be copied.
+    /// @return A const reference to the copied value.
+    /// @note This overload is selected when the template parameter 'Opt' does not indicate a move operation.
+    template <typename T,
+              typename = std::enable_if_t<(Opt != MoveAndCopyOperations::MoveAssignment
+                                           && Opt != MoveAndCopyOperations::MoveConstructor),
+                                          T>>
+    static inline const T& move_or_copy(const T& src) noexcept
+    {
+        return src;
+    }
+
+    /// @brief Moves a value pointed by an iterator if the condition specified by 'enable_if_t' is met.
+    /// @details This overload of 'move_or_copy_it' is enabled when 'Opt' is either 'MoveAssignment' or
+    /// 'MoveConstructor'.
+    ///          It moves the value pointed by the given iterator.
+    /// @tparam Iterator The type of the iterator.
+    /// @tparam enable_if A SFINAE condition that enables this overload for move operations.
+    /// @param[in] it The iterator pointing to the value to be moved.
+    /// @return A moved value from the iterator's pointee.
+    /// @note This overload is selected for move operations based on 'Opt'.
+    /// @note If the decltype syntax missed, move ctor will be called twice
+    template <typename Iterator,
+              typename = std::enable_if_t<Opt == MoveAndCopyOperations::MoveAssignment
+                                              || Opt == MoveAndCopyOperations::MoveConstructor,
+                                          Iterator>>
+    static inline auto move_or_copy_it(Iterator& it) noexcept -> decltype(std::move(*it))
+    {
+        return std::move(*it);
+    }
+
+    /// @brief Accesses a value pointed by an iterator if the condition specified by 'enable_if_t' is not met for move
+    /// operations.
+    /// @details This overload of 'move_or_copy_it' is enabled for cases other than 'MoveAssignment' or
+    /// 'MoveConstructor'.
+    ///          It provides direct access to the value pointed by the iterator.
+    /// @tparam Iterator The type of the iterator.
+    /// @tparam enable_if A SFINAE condition that enables this overload for direct access operations.
+    /// @param[in] it The iterator pointing to the value to be accessed.
+    /// @return A direct access to the value from the iterator's pointee.
+    /// @note This overload is selected for direct access operations when 'Opt' does not indicate a move operation.
+    template <typename Iterator,
+              typename = std::enable_if_t<Opt != MoveAndCopyOperations::MoveAssignment
+                                              && Opt != MoveAndCopyOperations::MoveConstructor,
+                                          Iterator>>
+    static inline auto move_or_copy_it(Iterator& it) noexcept -> decltype(*it)
+    {
+        return *it;
+    }
+
+  public:
+    static constexpr bool is_ctor =
+        Opt == MoveAndCopyOperations::CopyConstructor || Opt == MoveAndCopyOperations::MoveConstructor;
+    static constexpr bool is_move =
+        Opt == MoveAndCopyOperations::MoveAssignment || Opt == MoveAndCopyOperations::MoveConstructor;
+};
 
 } // namespace iox
 

--- a/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
+++ b/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved. reserved.
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
+++ b/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
@@ -53,7 +53,7 @@ class MoveAndCopyHelper final
     /// @param[out] dest The destination object where the new object is constructed.
     /// @param[in] src The source object, either for move or copy construction.
     template <typename T, typename V>
-    static void ctor_create(T& dest, V&& src) noexcept;
+    static void create_new(T& dest, V&& src) noexcept;
 
     /// @brief Force to use assignment to assign an object to the destination.
     /// @tparam T The type of the destination object.
@@ -61,7 +61,7 @@ class MoveAndCopyHelper final
     /// @param dest The destination object where the source object is assigned.
     /// @param src The source object, either for move or copy assignment.
     template <typename T, typename V>
-    static void assignment_create(T& dest, V&& src) noexcept;
+    static void assign(T& dest, V&& src) noexcept;
 
     /// @brief Checks if the current special operation is a constructor call.
     /// @return True if the operation is a copy or move constructor, false otherwise.

--- a/iceoryx_hoofs/test/moduletests/test_design_move_and_copy_helper.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_move_and_copy_helper.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 by Dennis Liu <dennis48161025@gmail.com>. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "iceoryx_hoofs/testing/lifetime_and_assignment_tracker.hpp"
+#include "iox/move_and_copy_helper.hpp"
+#include "test.hpp"
+
+namespace
+{
+using namespace ::testing;
+using namespace iox;
+using namespace iox::testing;
+
+struct MoveAndCopyHelper_test : public Test
+{
+    using DataType = uint64_t;
+    static constexpr DataType DEFAULT_VALUE{10};
+    static constexpr DataType EMPTY_VALUE{0};
+
+    using MoveOnlySut = MoveOnlyLifetimeAndAssignmentTracker<DataType, 0>;
+    using MoveCopyableSut = LifetimeAndAssignmentTracker<DataType, 0>;
+
+    using Operation = iox::MoveAndCopyOperations;
+    using CopyCtorHelper = iox::MoveAndCopyHelper<Operation::CopyConstructor>;
+    using MoveCtorHelper = iox::MoveAndCopyHelper<Operation::MoveConstructor>;
+    using CopyAssignmentHelper = iox::MoveAndCopyHelper<Operation::CopyAssignment>;
+    using MoveAssignmentHelper = iox::MoveAndCopyHelper<Operation::MoveAssignment>;
+
+    void SetUp() override
+    {
+        sut.value = DEFAULT_VALUE;
+        move_only_sut.value = DEFAULT_VALUE;
+
+        stats.reset();
+        move_only_stats.reset();
+    }
+
+    MoveCopyableSut sut{DEFAULT_VALUE};
+    MoveCopyableSut::Statistics& stats = MoveCopyableSut::stats;
+
+    MoveOnlySut move_only_sut{DEFAULT_VALUE};
+    MoveOnlySut::Statistics& move_only_stats = MoveOnlySut::move_only_stats;
+};
+
+// BEGIN test move_or_copy for MoveCopyableSut
+
+TEST_F(MoveAndCopyHelper_test, CopyCtorHelperCanApplyOnMoveCopyableSut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "23308260-7a28-4169-8816-3be9e4ef965f");
+
+    MoveCopyableSut copy_sut{CopyCtorHelper::move_or_copy(sut)};
+
+    EXPECT_THAT(stats.copyCTor, 1U);
+    EXPECT_THAT(stats.moveCTor, 0U);
+    EXPECT_THAT(stats.copyAssignment, 0U);
+    EXPECT_THAT(stats.moveAssignment, 0U);
+
+    EXPECT_THAT(sut.value, DEFAULT_VALUE);
+    EXPECT_THAT(copy_sut.value, DEFAULT_VALUE);
+}
+
+TEST_F(MoveAndCopyHelper_test, CopyAssignmentHelperCanApplyOnMoveCopyableSut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a25b15ad-ef66-4cd9-a9f8-3da9a15fa7fc");
+
+    MoveCopyableSut copy_sut{EMPTY_VALUE};
+    copy_sut = CopyAssignmentHelper::move_or_copy(sut);
+
+    EXPECT_THAT(stats.copyCTor, 0U);
+    EXPECT_THAT(stats.moveCTor, 0U);
+    EXPECT_THAT(stats.copyAssignment, 1U);
+    EXPECT_THAT(stats.moveAssignment, 0U);
+
+    EXPECT_THAT(sut.value, DEFAULT_VALUE);
+    EXPECT_THAT(copy_sut.value, DEFAULT_VALUE);
+}
+
+TEST_F(MoveAndCopyHelper_test, MoveCtorHelperCanApplyOnMoveCopyableSut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a2aa6625-0483-447d-8aa1-4de9cd53c91e");
+
+    MoveCopyableSut move_sut{MoveCtorHelper::move_or_copy(sut)};
+
+    EXPECT_THAT(stats.copyCTor, 0U);
+    EXPECT_THAT(stats.moveCTor, 1U);
+    EXPECT_THAT(stats.copyAssignment, 0U);
+    EXPECT_THAT(stats.moveAssignment, 0U);
+
+    EXPECT_THAT(move_sut.value, DEFAULT_VALUE);
+}
+
+TEST_F(MoveAndCopyHelper_test, MoveAssignmentHelperCanApplyOnMoveCopyableSut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5945174f-739c-4cb2-a485-4473baaf52e4");
+
+    MoveCopyableSut move_sut{EMPTY_VALUE};
+    move_sut = MoveAssignmentHelper::move_or_copy(sut);
+
+    EXPECT_THAT(stats.copyCTor, 0U);
+    EXPECT_THAT(stats.moveCTor, 0U);
+    EXPECT_THAT(stats.copyAssignment, 0U);
+    EXPECT_THAT(stats.moveAssignment, 1U);
+
+    EXPECT_THAT(move_sut.value, DEFAULT_VALUE);
+}
+
+// END test move_or_copy for MoveCopyableSut
+
+
+// BEGIN test move_or_copy for MoveOnlySut
+
+TEST_F(MoveAndCopyHelper_test, MoveCtorHelperCanApplyOnMoveOnlySut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "54f03825-4fa2-4bb4-89b9-aafd7ddfc420");
+
+    MoveOnlySut moved_move_only_sut{MoveCtorHelper::move_or_copy(move_only_sut)};
+
+    EXPECT_THAT(move_only_stats.copyCTor, 0U);
+    EXPECT_THAT(move_only_stats.moveCTor, 1U);
+    EXPECT_THAT(move_only_stats.copyAssignment, 0U);
+    EXPECT_THAT(move_only_stats.moveAssignment, 0U);
+
+    EXPECT_THAT(moved_move_only_sut.value, DEFAULT_VALUE);
+}
+
+TEST_F(MoveAndCopyHelper_test, MoveAssignmentHelperCanApplyOnMoveOnlySut)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "4c70e8d5-d5b1-4d8e-83a6-d68c2ede89a0");
+
+    MoveOnlySut moved_move_only_sut{EMPTY_VALUE};
+    moved_move_only_sut = MoveCtorHelper::move_or_copy(move_only_sut);
+
+    EXPECT_THAT(move_only_stats.copyCTor, 0U);
+    EXPECT_THAT(move_only_stats.moveCTor, 0U);
+    EXPECT_THAT(move_only_stats.copyAssignment, 0U);
+    EXPECT_THAT(move_only_stats.moveAssignment, 1U);
+
+    EXPECT_THAT(moved_move_only_sut.value, DEFAULT_VALUE);
+}
+
+// END test move_or_copy for MoveOnlySut
+
+} // namespace

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/lifetime_and_assignment_tracker.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/lifetime_and_assignment_tracker.hpp
@@ -135,9 +135,122 @@ class LifetimeAndAssignmentTracker
     T value = DEFAULT_VALUE;
 };
 
+template <typename T = uint64_t, T DEFAULT_VALUE = 0>
+class MoveOnlyLifetimeAndAssignmentTracker
+{
+  public:
+    MoveOnlyLifetimeAndAssignmentTracker()
+    {
+        move_only_stats.cTor++;
+        move_only_stats.classValue = value;
+    }
+
+    // NOLINTNEXTLINE(hicpp-explicit-conversions) we want to use this class in tests transparently to a 'T'
+    MoveOnlyLifetimeAndAssignmentTracker(const T value)
+        : value(value)
+    {
+        move_only_stats.customCTor++;
+        move_only_stats.classValue = value;
+    }
+
+    MoveOnlyLifetimeAndAssignmentTracker(const MoveOnlyLifetimeAndAssignmentTracker& rhs)
+        : value(rhs.value)
+    {
+        move_only_stats.copyCTor++;
+        move_only_stats.classValue = value;
+    }
+
+    MoveOnlyLifetimeAndAssignmentTracker(MoveOnlyLifetimeAndAssignmentTracker&& rhs) noexcept
+        : value(rhs.value)
+    {
+        move_only_stats.moveCTor++;
+        move_only_stats.classValue = value;
+    }
+
+    MoveOnlyLifetimeAndAssignmentTracker& operator=(const MoveOnlyLifetimeAndAssignmentTracker& rhs)
+    {
+        if (this != &rhs)
+        {
+            move_only_stats.copyAssignment++;
+            value = rhs.value;
+            move_only_stats.classValue = value;
+        }
+        return *this;
+    }
+
+    MoveOnlyLifetimeAndAssignmentTracker& operator=(MoveOnlyLifetimeAndAssignmentTracker&& rhs) noexcept
+    {
+        if (this != &rhs)
+        {
+            move_only_stats.moveAssignment++;
+            value = rhs.value;
+            move_only_stats.classValue = value;
+        }
+        return *this;
+    }
+
+    bool operator==(const MoveOnlyLifetimeAndAssignmentTracker& rhs) const
+    {
+        return value == rhs.value;
+    }
+
+    ~MoveOnlyLifetimeAndAssignmentTracker()
+    {
+        move_only_stats.dTor++;
+        move_only_stats.classValue = value;
+        move_only_stats.dTorOrder.emplace_back(value);
+    }
+
+    T& ref()
+    {
+        return value;
+    }
+
+    const T& ref() const
+    {
+        return value;
+    }
+
+    struct Statistics
+    {
+        uint64_t cTor{0};
+        uint64_t customCTor{0};
+        uint64_t copyCTor{0};
+        uint64_t moveCTor{0};
+        uint64_t moveAssignment{0};
+        uint64_t copyAssignment{0};
+        uint64_t dTor{0};
+        T classValue{0};
+
+        std::vector<T> dTorOrder;
+
+        void reset()
+        {
+            cTor = 0;
+            customCTor = 0;
+            copyCTor = 0;
+            moveCTor = 0;
+            moveAssignment = 0;
+            copyAssignment = 0;
+            dTor = 0;
+            classValue = 0;
+            dTorOrder.clear();
+        }
+    };
+
+    //NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) only used for tests
+    static Statistics move_only_stats;
+
+    T value = DEFAULT_VALUE;
+};
+
 template <typename T, T DEFAULT_VALUE>
 typename LifetimeAndAssignmentTracker<T, DEFAULT_VALUE>::Statistics
     LifetimeAndAssignmentTracker<T, DEFAULT_VALUE>::stats{};
+
+template <typename T, T DEFAULT_VALUE>
+typename MoveOnlyLifetimeAndAssignmentTracker<T, DEFAULT_VALUE>::Statistics
+    MoveOnlyLifetimeAndAssignmentTracker<T, DEFAULT_VALUE>::move_only_stats{};
 } // namespace testing
 } // namespace iox
 

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/lifetime_and_assignment_tracker.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/lifetime_and_assignment_tracker.hpp
@@ -153,12 +153,7 @@ class MoveOnlyLifetimeAndAssignmentTracker
         move_only_stats.classValue = value;
     }
 
-    MoveOnlyLifetimeAndAssignmentTracker(const MoveOnlyLifetimeAndAssignmentTracker& rhs)
-        : value(rhs.value)
-    {
-        move_only_stats.copyCTor++;
-        move_only_stats.classValue = value;
-    }
+    MoveOnlyLifetimeAndAssignmentTracker(const MoveOnlyLifetimeAndAssignmentTracker& rhs) = delete;
 
     MoveOnlyLifetimeAndAssignmentTracker(MoveOnlyLifetimeAndAssignmentTracker&& rhs) noexcept
         : value(rhs.value)
@@ -167,16 +162,7 @@ class MoveOnlyLifetimeAndAssignmentTracker
         move_only_stats.classValue = value;
     }
 
-    MoveOnlyLifetimeAndAssignmentTracker& operator=(const MoveOnlyLifetimeAndAssignmentTracker& rhs)
-    {
-        if (this != &rhs)
-        {
-            move_only_stats.copyAssignment++;
-            value = rhs.value;
-            move_only_stats.classValue = value;
-        }
-        return *this;
-    }
+    MoveOnlyLifetimeAndAssignmentTracker& operator=(const MoveOnlyLifetimeAndAssignmentTracker& rhs) = delete;
 
     MoveOnlyLifetimeAndAssignmentTracker& operator=(MoveOnlyLifetimeAndAssignmentTracker&& rhs) noexcept
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Move the helper into design according to the discussion in #2105.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #2105 
- Closes #2113
- Closes #2117
