### PR TITLE
iox-#2121 Fix history request is out of limit.

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -109,6 +109,7 @@
 - Chunk fails to be released when more than 4 GiB of chunks have been allocated [#2087](https://github.com/eclipse-iceoryx/iceoryx/issues/2087)
 - Fix clang-tidy errors from full-scan nightly build [#2060](https://github.com/eclipse-iceoryx/iceoryx/issues/2060)
 - Add public functions to create an 'access_rights' object from integer values [#2108](https://github.com/eclipse-iceoryx/iceoryx/issues/2108)
+- Fix `historyRequest` may be larger than `queueCapacity` during creating a subscriber [#2121](https://github.com/eclipse-iceoryx/iceoryx/issues/2121)
 
 **Refactoring:**
 

--- a/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_impl.cpp
@@ -234,12 +234,12 @@ PoshRuntimeImpl::getMiddlewareSubscriber(const capro::ServiceDescription& servic
         options.queueCapacity = 1U;
     }
 
-    if (subscriberOptions.historyRequest > subscriberOptions.queueCapacity)
+    if (subscriberOptions.historyRequest > options.queueCapacity)
     {
         IOX_LOG(WARN,
                 "Requested historyRequest for "
                     << service << " is larger than queueCapacity. Clamping historyRequest to queueCapacity!");
-        options.historyRequest = subscriberOptions.queueCapacity;
+        options.historyRequest = options.queueCapacity;
     }
 
     if (options.nodeName.empty())

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -526,6 +526,22 @@ TEST_F(PoshRuntime_test, GetMiddlewareSubscriberWithHistoryRequestLargerThanQueu
     EXPECT_EQ(EXPECTED_HISTORY_REQUEST, subscriberPort->m_options.historyRequest);
 }
 
+
+TEST_F(PoshRuntime_test,
+       GetMiddlewareSubscriberWithHistoryRequestLargerThanClampedQueueCapacityClampsToClampedQueueCapacity)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "9746468f-d191-43d9-b973-542fa8a66101");
+    iox::popo::SubscriberOptions subscriberOptions;
+    constexpr uint64_t MAX_QUEUE_CAPACITY = iox::popo::SubscriberPortUser::MemberType_t::ChunkQueueData_t::MAX_CAPACITY;
+    subscriberOptions.queueCapacity = MAX_QUEUE_CAPACITY + 1;
+    subscriberOptions.historyRequest = MAX_QUEUE_CAPACITY + 2;
+
+    auto subscriberPort = m_runtime->getMiddlewareSubscriber(
+        iox::capro::ServiceDescription("91", "1", "2"), subscriberOptions, iox::runtime::PortConfigInfo(33U, 11U, 22U));
+
+    EXPECT_EQ(MAX_QUEUE_CAPACITY, subscriberPort->m_options.queueCapacity);
+    EXPECT_EQ(MAX_QUEUE_CAPACITY, subscriberPort->m_options.historyRequest);
+}
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberDefaultArgs)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e06b999c-e237-4e32-b826-a5ffdb6bb737");


### PR DESCRIPTION
…ting the Roudi daemon to create a subscriber.

## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- fixes #2121 
