### PR TITLE
iox-#1391 Move shared memory and signal handler header to new location

### DIFF
--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -12,17 +12,11 @@
 ./iceoryx_hoofs/test/moduletests/test_concurrent_*
 ./iceoryx_hoofs/test/stresstests/sofi/test_stress_sofi.cpp
 
-./iceoryx_hoofs/include/iceoryx_hoofs/posix_wrapper/*
-./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/*
-
 ./iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/mocks/logger_mock.hpp
 ./iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/fatal_failure*
 ./iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/testing_logger.hpp
 ./iceoryx_hoofs/testing/testing_logger.cpp
 
-./iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/*
-./iceoryx_hoofs/source/posix_wrapper/*
-./iceoryx_hoofs/source/posix_wrapper/shared_memory_object/*
 ./iceoryx_hoofs/test/moduletests/test_posix*
 
 ./iceoryx_hoofs/include/iceoryx_hoofs/error_reporting/**/*

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -377,7 +377,7 @@
     auto signalGuard = iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler);
 
     // after
-    auto signalGuard = iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler);
+    auto signalGuard = iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler);
     if (signalGuard.has_error()) {
         // perform error handling
     }

--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -32,7 +32,6 @@
 
 using namespace iox;
 using namespace iox::popo;
-using namespace iox::posix;
 using namespace iox::mepoo;
 using namespace iox::runtime;
 using namespace iox::testing;

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -51,7 +51,6 @@ using namespace ::testing;
 using namespace iox::capro;
 using namespace iox::cxx;
 using namespace iox::mepoo;
-using namespace iox::posix;
 
 class iox_notification_info_test : public Test
 {

--- a/iceoryx_binding_c/test/moduletests/test_publisher.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_publisher.cpp
@@ -46,7 +46,6 @@ using namespace iox::roudi_env;
 using namespace iox::capro;
 using namespace iox::cxx;
 using namespace iox::mepoo;
-using namespace iox::posix;
 
 class iox_pub_test : public Test
 {

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -51,7 +51,6 @@ using namespace ::testing;
 using namespace iox::capro;
 using namespace iox::cxx;
 using namespace iox::mepoo;
-using namespace iox::posix;
 
 class iox_sub_test : public Test
 {

--- a/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
+++ b/iceoryx_dust/posix/ipc/include/iox/named_pipe.hpp
@@ -19,7 +19,6 @@
 #define IOX_DUST_POSIX_IPC_NAMED_PIPE_HPP
 
 #include "iceoryx_hoofs/concurrent/lockfree_queue.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_platform/semaphore.hpp"
 #include "iox/builder.hpp"
 #include "iox/duration.hpp"
@@ -27,6 +26,7 @@
 #include "iox/iceoryx_dust_deployment.hpp"
 #include "iox/optional.hpp"
 #include "iox/posix_ipc_channel.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/string.hpp"
 #include "iox/uninitialized_array.hpp"
 #include "iox/unnamed_semaphore.hpp"
@@ -108,7 +108,7 @@ class NamedPipe
     friend class NamedPipeBuilder;
 
     class NamedPipeData;
-    NamedPipe(posix::SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
+    NamedPipe(PosixSharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept;
 
     template <typename Prefix>
     static PosixIpcChannelName_t mapToSharedMemoryName(const Prefix& p, const PosixIpcChannelName_t& name) noexcept;
@@ -150,7 +150,7 @@ class NamedPipe
     };
 
   private:
-    posix::SharedMemoryObject m_sharedMemory;
+    PosixSharedMemoryObject m_sharedMemory;
     NamedPipeData* m_data = nullptr;
 };
 

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -27,9 +27,6 @@
 
 namespace iox
 {
-using posix::SharedMemoryObject;
-using posix::SharedMemoryObjectBuilder;
-
 /// NOLINTJUSTIFICATION see declaration in header
 /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
@@ -77,7 +74,7 @@ expected<NamedPipe, PosixIpcChannelError> NamedPipeBuilder::create() const noexc
 
     auto namedPipeShmName = NamedPipe::mapToSharedMemoryName(NamedPipe::NAMED_PIPE_PREFIX, m_name);
     auto sharedMemoryResult =
-        SharedMemoryObjectBuilder()
+        PosixSharedMemoryObjectBuilder()
             .name(namedPipeShmName)
             .memorySizeInBytes(sizeof(NamedPipe::NamedPipeData) + alignof(NamedPipe::NamedPipeData))
             .accessMode(AccessMode::READ_WRITE)
@@ -125,7 +122,7 @@ expected<NamedPipe, PosixIpcChannelError> NamedPipeBuilder::create() const noexc
     return ok(NamedPipe{std::move(sharedMemory), data});
 }
 
-NamedPipe::NamedPipe(SharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept
+NamedPipe::NamedPipe(PosixSharedMemoryObject&& sharedMemory, NamedPipeData* data) noexcept
     : m_sharedMemory(std::move(sharedMemory))
     , m_data(data)
 {

--- a/iceoryx_dust/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_dust/posix/ipc/source/named_pipe.cpp
@@ -27,7 +27,6 @@
 
 namespace iox
 {
-using posix::SharedMemory;
 using posix::SharedMemoryObject;
 using posix::SharedMemoryObjectBuilder;
 
@@ -190,7 +189,7 @@ expected<void, PosixIpcChannelError> NamedPipe::destroy() noexcept
 
 expected<bool, PosixIpcChannelError> NamedPipe::unlinkIfExists(const PosixIpcChannelName_t& name) noexcept
 {
-    auto result = SharedMemory::unlinkIfExist(mapToSharedMemoryName(NAMED_PIPE_PREFIX, name));
+    auto result = detail::PosixSharedMemory::unlinkIfExist(mapToSharedMemoryName(NAMED_PIPE_PREFIX, name));
     if (result.has_error())
     {
         return err(PosixIpcChannelError::INTERNAL_LOGIC_ERROR);

--- a/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
+++ b/iceoryx_dust/posix/sync/include/iox/signal_watcher.hpp
@@ -16,8 +16,8 @@
 #ifndef IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
 #define IOX_DUST_POSIX_WRAPPER_SIGNAL_WATCHER_HPP
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iox/optional.hpp"
+#include "iox/signal_handler.hpp"
 #include "iox/unnamed_semaphore.hpp"
 
 #include <atomic>
@@ -28,7 +28,7 @@ namespace iox
 ///        signal has occurred or ask the watcher if it has occurred.
 /// @code
 ///   // can be used to loop until SIGINT or SIGTERM has occurred
-///   #include <iceoryx_hoofs/posix/signal_watcher.hpp>
+///   #include <iox/signal_watcher.hpp>
 ///   void loopUntilTerminationRequested()
 ///   {
 ///       while(!iox::hasTerminationRequested())
@@ -71,8 +71,8 @@ class SignalWatcher
     mutable optional<UnnamedSemaphore> m_semaphore;
 
     std::atomic_bool m_hasSignalOccurred{false};
-    posix::SignalGuard m_sigTermGuard;
-    posix::SignalGuard m_sigIntGuard;
+    SignalGuard m_sigTermGuard;
+    SignalGuard m_sigIntGuard;
 };
 
 /// @brief convenience function, calls SignalWatcher::getInstance().waitForSignal();

--- a/iceoryx_dust/posix/sync/source/signal_watcher.cpp
+++ b/iceoryx_dust/posix/sync/source/signal_watcher.cpp
@@ -43,9 +43,9 @@ void internalSignalHandler(int) noexcept
 
 SignalWatcher::SignalWatcher() noexcept
     : m_sigTermGuard(
-        registerSignalHandler(posix::Signal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
+        registerSignalHandler(PosixSignal::TERM, internalSignalHandler).expect("Unable to register Signal::TERM"))
     , m_sigIntGuard(
-          registerSignalHandler(posix::Signal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
+          registerSignalHandler(PosixSignal::INT, internalSignalHandler).expect("Unable to register Signal::INT"))
 {
     UnnamedSemaphoreBuilder()
         .isInterProcessCapable(false)

--- a/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
+++ b/iceoryx_dust/test/moduletests/test_posix_sync_signal_watcher.cpp
@@ -24,7 +24,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox;
-using namespace iox::posix;
 
 class SignalWatcherTester : public SignalWatcher
 {

--- a/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
+++ b/iceoryx_examples/icediscovery/iox_wait_for_service.cpp
@@ -71,9 +71,9 @@ int main()
     discoverySigHandlerAccess = &discovery;
 
     auto sigTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
     auto sigIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
 
     //! [define search query]
     auto query = [&]() {

--- a/iceoryx_examples/request_response/README.md
+++ b/iceoryx_examples/request_response/README.md
@@ -35,10 +35,10 @@ At first, the includes for the client port, request-response types, WaitSet, and
 ```cpp
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "iox/signal_watcher.hpp"
 ```
 

--- a/iceoryx_examples/request_response/client_cxx_waitset.cpp
+++ b/iceoryx_examples/request_response/client_cxx_waitset.cpp
@@ -17,10 +17,10 @@
 //! [iceoryx includes]
 #include "request_and_response_types.hpp"
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/client.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "iox/signal_watcher.hpp"
 //! [iceoryx includes]
 
@@ -55,9 +55,9 @@ static void signalHandler(int sig [[maybe_unused]])
 int main()
 {
     auto sigTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, signalHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, signalHandler).expect("failed to register SIGTERM");
     auto sigIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, signalHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, signalHandler).expect("failed to register SIGINT");
 
     //! [initialize runtime]
     iox::runtime::PoshRuntime::initRuntime(APP_NAME);

--- a/iceoryx_examples/waitset/ice_waitset_basic.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_basic.cpp
@@ -14,12 +14,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iox/optional.hpp"
+#include "iox/signal_handler.hpp"
 #include "topic_data.hpp"
 
 #include <atomic>
@@ -45,9 +45,9 @@ int main()
 {
     // register signal handler to handle termination of the loop
     auto signalGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
     auto signalTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
 
     // initialize runtime
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-waitset-basic");

--- a/iceoryx_examples/waitset/ice_waitset_gateway.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_gateway.cpp
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -69,9 +69,9 @@ int main()
 {
     // register sigHandler
     auto signalIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
     auto signalTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
 
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-waitset-gateway");
 

--- a/iceoryx_examples/waitset/ice_waitset_grouping.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_grouping.cpp
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/untyped_subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -44,9 +44,9 @@ int main()
 {
     // register sigHandler
     auto signalIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
     auto signalTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
 
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-waitset-grouping");
     //! [create waitset]

--- a/iceoryx_examples/waitset/ice_waitset_individual.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_individual.cpp
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -42,9 +42,9 @@ int main()
 {
     // register sigHandler
     auto signalIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
     auto signalTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
 
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-waitset-individual");
 

--- a/iceoryx_examples/waitset/ice_waitset_timer_driven_execution.cpp
+++ b/iceoryx_examples/waitset/ice_waitset_timer_driven_execution.cpp
@@ -14,11 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 #include "iceoryx_posh/popo/user_trigger.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
+#include "iox/signal_handler.hpp"
 #include "topic_data.hpp"
 
 #include <chrono>
@@ -53,9 +53,9 @@ int main()
 {
     // register sigHandler
     auto signalIntGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::INT, sigHandler).expect("failed to register SIGINT");
+        iox::registerSignalHandler(iox::PosixSignal::INT, sigHandler).expect("failed to register SIGINT");
     auto signalTermGuard =
-        iox::posix::registerSignalHandler(iox::posix::Signal::TERM, sigHandler).expect("failed to register SIGTERM");
+        iox::registerSignalHandler(iox::PosixSignal::TERM, sigHandler).expect("failed to register SIGTERM");
 
     iox::runtime::PoshRuntime::initRuntime("iox-cpp-waitset-sync");
 

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -107,7 +107,6 @@ iox_add_library(
         source/cxx/requires.cpp
         source/error_handling/error_handler.cpp
         source/error_handling/error_handling.cpp
-        source/posix_wrapper/signal_handler.cpp
         source/error_reporting/custom/default/default_error_handler.cpp
         time/source/duration.cpp
         utility/source/unique_id.cpp
@@ -124,6 +123,7 @@ iox_add_library(
         posix/filesystem/source/posix_acl.cpp
         posix/sync/source/mutex.cpp
         posix/sync/source/named_semaphore.cpp
+        posix/sync/source/signal_handler.cpp
         posix/sync/source/semaphore_interface.cpp
         posix/sync/source/thread.cpp
         posix/sync/source/unnamed_semaphore.cpp

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -108,7 +108,6 @@ iox_add_library(
         source/error_handling/error_handler.cpp
         source/error_handling/error_handling.cpp
         source/posix_wrapper/shared_memory_object.cpp
-        source/posix_wrapper/shared_memory_object/memory_map.cpp
         source/posix_wrapper/shared_memory_object/shared_memory.cpp
         source/posix_wrapper/signal_handler.cpp
         source/error_reporting/custom/default/default_error_handler.cpp
@@ -118,6 +117,7 @@ iox_add_library(
         posix/auth/source/posix_group.cpp
         posix/auth/source/posix_user.cpp
         posix/design/source/file_management_interface.cpp
+        posix/ipc/source/posix_memory_map.cpp
         posix/ipc/source/unix_domain_socket.cpp
         posix/filesystem/source/file.cpp
         posix/filesystem/source/file_lock.cpp

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -107,7 +107,6 @@ iox_add_library(
         source/cxx/requires.cpp
         source/error_handling/error_handler.cpp
         source/error_handling/error_handling.cpp
-        source/posix_wrapper/shared_memory_object.cpp
         source/posix_wrapper/signal_handler.cpp
         source/error_reporting/custom/default/default_error_handler.cpp
         time/source/duration.cpp
@@ -118,6 +117,7 @@ iox_add_library(
         posix/design/source/file_management_interface.cpp
         posix/ipc/source/posix_memory_map.cpp
         posix/ipc/source/posix_shared_memory.cpp
+        posix/ipc/source/posix_shared_memory_object.cpp
         posix/ipc/source/unix_domain_socket.cpp
         posix/filesystem/source/file.cpp
         posix/filesystem/source/file_lock.cpp

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -108,7 +108,6 @@ iox_add_library(
         source/error_handling/error_handler.cpp
         source/error_handling/error_handling.cpp
         source/posix_wrapper/shared_memory_object.cpp
-        source/posix_wrapper/shared_memory_object/shared_memory.cpp
         source/posix_wrapper/signal_handler.cpp
         source/error_reporting/custom/default/default_error_handler.cpp
         time/source/duration.cpp
@@ -118,6 +117,7 @@ iox_add_library(
         posix/auth/source/posix_user.cpp
         posix/design/source/file_management_interface.cpp
         posix/ipc/source/posix_memory_map.cpp
+        posix/ipc/source/posix_shared_memory.cpp
         posix/ipc/source/unix_domain_socket.cpp
         posix/filesystem/source/file.cpp
         posix/filesystem/source/file_lock.cpp

--- a/iceoryx_hoofs/README.md
+++ b/iceoryx_hoofs/README.md
@@ -32,8 +32,7 @@ The module structure is a logical grouping. It is replicated for `concurrent` an
 |`RelativePointer`                   |          | Pointer which can be stored in shared memory                                                                                                                                                                             |
 |`ScopeGuard`                        |          | This is an abstraction of the C++ RAII idiom. Sometimes you have constructs where you would like to perform a certain task on creation and then again when they are getting out of scope, this is where `ScopeGuard` comes in. It is like a `std::lock_guard` or a `std::shared_ptr` but more generic. |
 |`scoped_static`                     |          | Helper function to limit lifetime of static or global variables to a scope                                                                                                                                               |
-|`shared_memory_object/Allocator`    | i        | Helper class for the `SharedMemoryObject`.                                                                                                                                                                               |
-|`BumpAllocator`                     | i        | Implementation of a bump allocator                                                                                                                                                                                       |
+|`BumpAllocator`                     |          | Implementation of a bump allocator                                                                                                                                                                                       |
 
 ### Container (container)
 
@@ -115,10 +114,10 @@ The module structure is a logical grouping. It is replicated for `concurrent` an
 
 | class                              | internal | description                                                                                                                                                                                                              |
 |:----------------------------------:|:--------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|`UnixDomainSocket`                  | i        | Interface for unix domain sockets.                                                                                                                                                                                       |
-|`SharedMemoryObject`                | i        | Creates and maps existing shared memory into the application.                                                                                                                                                            |
-|`shared_memory_object/MemoryMap`    | i        | Abstraction of `mmap`, `munmap` and helper class for the `SharedMemoryObject`.                                                                                                                                           |
-|`shared_memory_object/SharedMemory` | i        | Abstraction of shared memory, see [ManPage shm_overview](https://www.man7.org/linux/man-pages/man7/shm_overview.7.html) and helper class for the `SharedMemoryObject`.                                                   |
+|`UnixDomainSocket`                  |          | Interface for unix domain sockets.                                                                                                                                                                                       |
+|`PosixSharedMemoryObject`           |          | Creates and maps existing shared memory into the application.                                                                                                                                                            |
+|`PosixMemoryMap`                    | i        | Abstraction of `mmap`, `munmap` and helper class for the `PosixSharedMemoryObject`.                                                                                                                                           |
+|`PosixSharedMemory`                 | i        | Abstraction of shared memory, see [ManPage shm_overview](https://www.man7.org/linux/man-pages/man7/shm_overview.7.html) and helper class for the `PosixSharedMemoryObject`.                                                   |
 
 ### Threads & sychronisation (sync)
 

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -17,11 +17,11 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
 #define IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
 #include "iceoryx_platform/stat.hpp"
 #include "iox/builder.hpp"
 #include "iox/bump_allocator.hpp"
 #include "iox/detail/posix_memory_map.hpp"
+#include "iox/detail/posix_shared_memory.hpp"
 #include "iox/file_management_interface.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/optional.hpp"
@@ -82,13 +82,13 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     friend class SharedMemoryObjectBuilder;
 
   private:
-    SharedMemoryObject(SharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept;
+    SharedMemoryObject(detail::PosixSharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept;
 
     friend struct FileManagementInterface<SharedMemoryObject>;
     shm_handle_t get_file_handle() const noexcept;
 
   private:
-    SharedMemory m_sharedMemory;
+    detail::PosixSharedMemory m_sharedMemory;
     detail::PosixMemoryMap m_memoryMap;
 };
 
@@ -97,7 +97,7 @@ class SharedMemoryObjectBuilder
     /// @brief A valid file name for the shared memory with the restriction that
     ///        no leading dot is allowed since it is not compatible with every
     ///        file system
-    IOX_BUILDER_PARAMETER(SharedMemory::Name_t, name, "")
+    IOX_BUILDER_PARAMETER(detail::PosixSharedMemory::Name_t, name, "")
 
     /// @brief Defines the size of the shared memory
     IOX_BUILDER_PARAMETER(uint64_t, memorySizeInBytes, 0U)

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp
@@ -17,11 +17,11 @@
 #ifndef IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
 #define IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp"
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
 #include "iceoryx_platform/stat.hpp"
 #include "iox/builder.hpp"
 #include "iox/bump_allocator.hpp"
+#include "iox/detail/posix_memory_map.hpp"
 #include "iox/file_management_interface.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/optional.hpp"
@@ -82,14 +82,14 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     friend class SharedMemoryObjectBuilder;
 
   private:
-    SharedMemoryObject(SharedMemory&& sharedMemory, MemoryMap&& memoryMap) noexcept;
+    SharedMemoryObject(SharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept;
 
     friend struct FileManagementInterface<SharedMemoryObject>;
     shm_handle_t get_file_handle() const noexcept;
 
   private:
     SharedMemory m_sharedMemory;
-    MemoryMap m_memoryMap;
+    detail::PosixMemoryMap m_memoryMap;
 };
 
 class SharedMemoryObjectBuilder

--- a/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/signal_handler.hpp
+++ b/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/signal_handler.hpp
@@ -1,0 +1,52 @@
+
+// Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IOX_HOOFS_POSIX_WRAPPER_SIGNAL_HANDLER_HPP
+#define IOX_HOOFS_POSIX_WRAPPER_SIGNAL_HANDLER_HPP
+
+#include "iox/detail/deprecation_marker.hpp"
+#include "iox/signal_handler.hpp"
+
+IOX_DEPRECATED_HEADER_SINCE(3, "Please include 'iox/signal_handler.hpp' instead.")
+
+namespace iox
+{
+namespace posix
+{
+using SignalHandlerCallback_t IOX_DEPRECATED_SINCE(
+    3, "Please use 'iox::SignalHandlerCallback_t' from 'iox/signal_handler.hpp' instead.") = SignalHandlerCallback_t;
+
+using Signal IOX_DEPRECATED_SINCE(3,
+                                  "Please use 'iox::PosixSignal' from 'iox/signal_handler.hpp' instead.") = PosixSignal;
+
+using SignalGuardError IOX_DEPRECATED_SINCE(
+    3, "Please use 'iox::SignalGuardError' from 'iox/signal_handler.hpp' instead.") = SignalGuardError;
+
+using SignalGuard
+    IOX_DEPRECATED_SINCE(3, "Please use 'iox::SignalGuard' from 'iox/signal_handler.hpp' instead.") = SignalGuard;
+
+IOX_DEPRECATED_SINCE(3, "Please use 'iox::registerSignalHandler' from 'iox/signal_handler.hpp' instead.")
+inline expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signal,
+                                                                     const SignalHandlerCallback_t callback) noexcept
+{
+    return iox::registerSignalHandler(signal, callback);
+}
+
+} // namespace posix
+} // namespace iox
+
+#endif // IOX_HOOFS_POSIX_SYNC_SIGNAL_HANDLER_HPP

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_MEMORY_MAP_HPP
-#define IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_MEMORY_MAP_HPP
+
+#ifndef IOX_HOOFS_POSIX_IPC_POSIX_MEMORY_MAP_HPP
+#define IOX_HOOFS_POSIX_IPC_POSIX_MEMORY_MAP_HPP
 
 #include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
 #include "iceoryx_platform/mman.hpp"
@@ -25,11 +26,10 @@
 
 namespace iox
 {
-namespace posix
+namespace detail
 {
-class SharedMemoryObject;
 
-enum class MemoryMapError
+enum class PosixMemoryMapError
 {
     ACCESS_FAILED,
     UNABLE_TO_LOCK,
@@ -46,7 +46,7 @@ enum class MemoryMapError
 };
 
 /// @brief Flags defining how the mapped data should be handled
-enum class MemoryMapFlags : int32_t
+enum class PosixMemoryMapFlags : int32_t
 {
     /// @brief changes are shared
     SHARE_CHANGES = MAP_SHARED,
@@ -63,9 +63,9 @@ enum class MemoryMapFlags : int32_t
     PRIVATE_CHANGES_AND_FORCE_BASE_ADDRESS_HINT = MAP_PRIVATE | MAP_FIXED,
 };
 
-class MemoryMap;
-/// @brief The builder of a MemoryMap object
-class MemoryMapBuilder
+class PosixMemoryMap;
+/// @brief The builder of a 'PosixMemoryMap' object
+class PosixMemoryMapBuilder
 {
     /// @brief The base address suggestion to which the memory should be mapped. But
     ///        there is no guarantee that it is really mapped at this position.
@@ -84,40 +84,40 @@ class MemoryMapBuilder
     IOX_BUILDER_PARAMETER(AccessMode, accessMode, AccessMode::READ_WRITE)
 
     /// @brief Sets the flags defining how the mapped data should be handled
-    IOX_BUILDER_PARAMETER(MemoryMapFlags, flags, MemoryMapFlags::SHARE_CHANGES)
+    IOX_BUILDER_PARAMETER(PosixMemoryMapFlags, flags, PosixMemoryMapFlags::SHARE_CHANGES)
 
     /// @brief Offset of the memory location
     IOX_BUILDER_PARAMETER(off_t, offset, 0)
 
   public:
-    /// @brief creates a valid MemoryMap object. If the construction failed the expected
-    ///        contains an enum value describing the error.
-    /// @return expected containing MemoryMap on success otherwise MemoryMapError
-    expected<MemoryMap, MemoryMapError> create() noexcept;
+    /// @brief creates a valid 'PosixMemoryMap' object. If the construction failed the
+    ///        expected contains an enum value describing the error.
+    /// @return expected containing 'PosixMemoryMap' on success otherwise 'PosixMemoryMapError'
+    expected<PosixMemoryMap, PosixMemoryMapError> create() noexcept;
 };
 
-/// @brief C++ abstraction of mmap and munmap. When a MemoryMap object is
+/// @brief C++ abstraction of mmap and munmap. When a 'PosixMemoryMap' object is
 ///        created the configured memory is mapped into the process space until
 ///        that object goes out of scope - then munmap is called and the memory
 ///        region is removed from the process space.
-class MemoryMap
+class PosixMemoryMap
 {
   public:
     /// @brief copy operations are removed since we are handling a system resource
-    MemoryMap(const MemoryMap&) = delete;
-    MemoryMap& operator=(const MemoryMap&) = delete;
+    PosixMemoryMap(const PosixMemoryMap&) = delete;
+    PosixMemoryMap& operator=(const PosixMemoryMap&) = delete;
 
     /// @brief move constructor
     /// @param[in] rhs the source object
-    MemoryMap(MemoryMap&& rhs) noexcept;
+    PosixMemoryMap(PosixMemoryMap&& rhs) noexcept;
 
     /// @brief move assignment operator
     /// @param[in] rhs the source object
     /// @return reference to *this
-    MemoryMap& operator=(MemoryMap&& rhs) noexcept;
+    PosixMemoryMap& operator=(PosixMemoryMap&& rhs) noexcept;
 
     /// @brief destructor, calls munmap when the underlying memory is mapped
-    ~MemoryMap() noexcept;
+    ~PosixMemoryMap() noexcept;
 
     /// @brief returns the base address, if the object was moved it returns nullptr
     const void* getBaseAddress() const noexcept;
@@ -125,17 +125,17 @@ class MemoryMap
     /// @brief returns the base address, if the object was moved it returns nullptr
     void* getBaseAddress() noexcept;
 
-    friend class MemoryMapBuilder;
+    friend class PosixMemoryMapBuilder;
 
   private:
-    MemoryMap(void* const baseAddress, const uint64_t length) noexcept;
+    PosixMemoryMap(void* const baseAddress, const uint64_t length) noexcept;
     bool destroy() noexcept;
-    static MemoryMapError errnoToEnum(const int32_t errnum) noexcept;
+    static PosixMemoryMapError errnoToEnum(const int32_t errnum) noexcept;
 
     void* m_baseAddress{nullptr};
     uint64_t m_length{0U};
 };
-} // namespace posix
+} // namespace detail
 } // namespace iox
 
-#endif // IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_MEMORY_MAP_HPP
+#endif // IOX_HOOFS_POSIX_IPC_POSIX_MEMORY_MAP_HPP

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
@@ -18,9 +18,10 @@
 #ifndef IOX_HOOFS_POSIX_IPC_POSIX_MEMORY_MAP_HPP
 #define IOX_HOOFS_POSIX_IPC_POSIX_MEMORY_MAP_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/shared_memory.hpp"
 #include "iceoryx_platform/mman.hpp"
 #include "iox/builder.hpp"
+#include "iox/expected.hpp"
+#include "iox/filesystem.hpp"
 
 #include <cstdint>
 

--- a/iceoryx_hoofs/posix/ipc/include/iox/posix_shared_memory_object.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/posix_shared_memory_object.hpp
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
-#define IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
+
+#ifndef IOX_HOOFS_POSIX_ICP_POSIX_SHARED_MEMORY_OBJECT_HPP
+#define IOX_HOOFS_POSIX_ICP_POSIX_SHARED_MEMORY_OBJECT_HPP
 
 #include "iceoryx_platform/stat.hpp"
 #include "iox/builder.hpp"
@@ -30,10 +31,8 @@
 
 namespace iox
 {
-namespace posix
-{
 
-enum class SharedMemoryObjectError
+enum class PosixSharedMemoryObjectError
 {
     SHARED_MEMORY_CREATION_FAILED,
     MAPPING_SHARED_MEMORY_FAILED,
@@ -42,7 +41,7 @@ enum class SharedMemoryObjectError
     INTERNAL_LOGIC_FAILURE,
 };
 
-enum class SharedMemoryAllocationError
+enum class PosixSharedMemoryAllocationError
 {
     REQUESTED_MEMORY_AFTER_FINALIZED_ALLOCATION,
     NOT_ENOUGH_MEMORY,
@@ -50,21 +49,21 @@ enum class SharedMemoryAllocationError
 
 };
 
-class SharedMemoryObjectBuilder;
+class PosixSharedMemoryObjectBuilder;
 
 /// @brief Creates a shared memory segment and maps it into the process space.
 ///        One can use optionally the allocator to acquire memory.
-class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
+class PosixSharedMemoryObject : public FileManagementInterface<PosixSharedMemoryObject>
 {
   public:
-    using Builder = SharedMemoryObjectBuilder;
+    using Builder = PosixSharedMemoryObjectBuilder;
 
     static constexpr const void* const NO_ADDRESS_HINT = nullptr;
-    SharedMemoryObject(const SharedMemoryObject&) = delete;
-    SharedMemoryObject& operator=(const SharedMemoryObject&) = delete;
-    SharedMemoryObject(SharedMemoryObject&&) noexcept = default;
-    SharedMemoryObject& operator=(SharedMemoryObject&&) noexcept = default;
-    ~SharedMemoryObject() noexcept = default;
+    PosixSharedMemoryObject(const PosixSharedMemoryObject&) = delete;
+    PosixSharedMemoryObject& operator=(const PosixSharedMemoryObject&) = delete;
+    PosixSharedMemoryObject(PosixSharedMemoryObject&&) noexcept = default;
+    PosixSharedMemoryObject& operator=(PosixSharedMemoryObject&&) noexcept = default;
+    ~PosixSharedMemoryObject() noexcept = default;
 
     /// @brief Returns start- or base-address of the shared memory.
     const void* getBaseAddress() const noexcept;
@@ -79,12 +78,12 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     ///        existing shared memory was opened.
     bool hasOwnership() const noexcept;
 
-    friend class SharedMemoryObjectBuilder;
+    friend class PosixSharedMemoryObjectBuilder;
 
   private:
-    SharedMemoryObject(detail::PosixSharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept;
+    PosixSharedMemoryObject(detail::PosixSharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept;
 
-    friend struct FileManagementInterface<SharedMemoryObject>;
+    friend struct FileManagementInterface<PosixSharedMemoryObject>;
     shm_handle_t get_file_handle() const noexcept;
 
   private:
@@ -92,7 +91,7 @@ class SharedMemoryObject : public FileManagementInterface<SharedMemoryObject>
     detail::PosixMemoryMap m_memoryMap;
 };
 
-class SharedMemoryObjectBuilder
+class PosixSharedMemoryObjectBuilder
 {
     /// @brief A valid file name for the shared memory with the restriction that
     ///        no leading dot is allowed since it is not compatible with every
@@ -119,9 +118,8 @@ class SharedMemoryObjectBuilder
     IOX_BUILDER_PARAMETER(access_rights, permissions, perms::none)
 
   public:
-    expected<SharedMemoryObject, SharedMemoryObjectError> create() noexcept;
+    expected<PosixSharedMemoryObject, PosixSharedMemoryObjectError> create() noexcept;
 };
-} // namespace posix
 } // namespace iox
 
-#endif // IOX_HOOFS_POSIX_WRAPPER_SHARED_MEMORY_OBJECT_HPP
+#endif // IOX_HOOFS_POSIX_ICP_POSIX_SHARED_MEMORY_OBJECT_HPP

--- a/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/unistd.hpp"
@@ -30,9 +30,8 @@
 
 namespace iox
 {
-namespace posix
+namespace detail
 {
-constexpr const void* const SharedMemoryObject::NO_ADDRESS_HINT;
 constexpr uint64_t SIGBUS_ERROR_MESSAGE_LENGTH = 1024U + platform::IOX_MAX_SHM_NAME_LENGTH;
 
 /// NOLINTJUSTIFICATION global variables are only accessible from within this compilation unit
@@ -51,11 +50,13 @@ static void memsetSigbusHandler(int) noexcept
     IOX_DISCARD_RESULT(result);
     _exit(EXIT_FAILURE);
 }
+} // namespace detail
+constexpr const void* const PosixSharedMemoryObject::NO_ADDRESS_HINT;
 
 // NOLINTJUSTIFICATION the function size is related to the error handling and the cognitive complexity
 // results from the expanded log macro
 // NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
-expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder::create() noexcept
+expected<PosixSharedMemoryObject, PosixSharedMemoryObjectError> PosixSharedMemoryObjectBuilder::create() noexcept
 {
     auto printErrorDetails = [this] {
         auto logBaseAddressHint = [this](log::LogStream& stream) noexcept -> log::LogStream& {
@@ -90,7 +91,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     {
         printErrorDetails();
         IOX_LOG(ERROR, "Unable to create SharedMemoryObject since we could not acquire a SharedMemory resource");
-        return err(SharedMemoryObjectError::SHARED_MEMORY_CREATION_FAILED);
+        return err(PosixSharedMemoryObjectError::SHARED_MEMORY_CREATION_FAILED);
     }
 
     const auto realSizeResult = sharedMemory->get_size();
@@ -100,7 +101,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         IOX_LOG(ERROR,
                 "Unable to create SharedMemoryObject since we could not acquire the memory size of the "
                 "underlying object.");
-        return err(SharedMemoryObjectError::UNABLE_TO_VERIFY_MEMORY_SIZE);
+        return err(PosixSharedMemoryObjectError::UNABLE_TO_VERIFY_MEMORY_SIZE);
     }
 
     const auto realSize = *realSizeResult;
@@ -110,7 +111,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         IOX_LOG(ERROR,
                 "Unable to create SharedMemoryObject since a size of "
                     << m_memorySizeInBytes << " was requested but the object has only a size of " << realSize);
-        return err(SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE);
+        return err(PosixSharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE);
     }
 
     auto memoryMap = detail::PosixMemoryMapBuilder()
@@ -126,7 +127,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     {
         printErrorDetails();
         IOX_LOG(ERROR, "Failed to map created shared memory into process!");
-        return err(SharedMemoryObjectError::MAPPING_SHARED_MEMORY_FAILED);
+        return err(PosixSharedMemoryObjectError::MAPPING_SHARED_MEMORY_FAILED);
     }
 
     if (sharedMemory->hasOwnership())
@@ -136,21 +137,21 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         {
             // this lock is required for the case that multiple threads are creating multiple
             // shared memory objects concurrently
-            std::lock_guard<std::mutex> lock(sigbusHandlerMutex);
-            auto memsetSigbusGuard = registerSignalHandler(Signal::BUS, memsetSigbusHandler);
+            std::lock_guard<std::mutex> lock(detail::sigbusHandlerMutex);
+            auto memsetSigbusGuard = registerSignalHandler(posix::Signal::BUS, detail::memsetSigbusHandler);
             if (memsetSigbusGuard.has_error())
             {
                 printErrorDetails();
                 IOX_LOG(ERROR, "Failed to temporarily override SIGBUS to safely zero the shared memory");
-                return err(SharedMemoryObjectError::INTERNAL_LOGIC_FAILURE);
+                return err(PosixSharedMemoryObjectError::INTERNAL_LOGIC_FAILURE);
             }
 
             // NOLINTJUSTIFICATION snprintf required to populate char array so that it can be used signal safe in
             //                     a possible signal call
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
             IOX_DISCARD_RESULT(snprintf(
-                &sigbusErrorMessage[0],
-                SIGBUS_ERROR_MESSAGE_LENGTH,
+                &detail::sigbusErrorMessage[0],
+                detail::SIGBUS_ERROR_MESSAGE_LENGTH,
                 "While setting the acquired shared memory to zero a fatal SIGBUS signal appeared caused by memset. The "
                 "shared memory object with the following properties [ name = %s, sizeInBytes = %llu, access mode = %s, "
                 "open mode = %s, baseAddressHint = %p, permissions = %u ] maybe requires more memory than it is "
@@ -168,39 +169,38 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
                 "Acquired " << m_memorySizeInBytes << " bytes successfully in the shared memory [" << m_name << "]");
     }
 
-    return ok(SharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
+    return ok(PosixSharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
 }
 
-SharedMemoryObject::SharedMemoryObject(detail::PosixSharedMemory&& sharedMemory,
-                                       detail::PosixMemoryMap&& memoryMap) noexcept
+PosixSharedMemoryObject::PosixSharedMemoryObject(detail::PosixSharedMemory&& sharedMemory,
+                                                 detail::PosixMemoryMap&& memoryMap) noexcept
     : m_sharedMemory(std::move(sharedMemory))
     , m_memoryMap(std::move(memoryMap))
 {
 }
 
-const void* SharedMemoryObject::getBaseAddress() const noexcept
+const void* PosixSharedMemoryObject::getBaseAddress() const noexcept
 {
     return m_memoryMap.getBaseAddress();
 }
 
-void* SharedMemoryObject::getBaseAddress() noexcept
+void* PosixSharedMemoryObject::getBaseAddress() noexcept
 {
     return m_memoryMap.getBaseAddress();
 }
 
-shm_handle_t SharedMemoryObject::get_file_handle() const noexcept
+shm_handle_t PosixSharedMemoryObject::get_file_handle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }
 
-shm_handle_t SharedMemoryObject::getFileHandle() const noexcept
+shm_handle_t PosixSharedMemoryObject::getFileHandle() const noexcept
 {
     return m_sharedMemory.getHandle();
 }
 
-bool SharedMemoryObject::hasOwnership() const noexcept
+bool PosixSharedMemoryObject::hasOwnership() const noexcept
 {
     return m_sharedMemory.hasOwnership();
 }
-} // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
@@ -16,12 +16,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iox/posix_shared_memory_object.hpp"
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/unistd.hpp"
 #include "iox/attributes.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/logging.hpp"
+#include "iox/signal_handler.hpp"
 
 #include <bitset>
 #include <cstdlib>
@@ -138,7 +138,7 @@ expected<PosixSharedMemoryObject, PosixSharedMemoryObjectError> PosixSharedMemor
             // this lock is required for the case that multiple threads are creating multiple
             // shared memory objects concurrently
             std::lock_guard<std::mutex> lock(detail::sigbusHandlerMutex);
-            auto memsetSigbusGuard = registerSignalHandler(posix::Signal::BUS, detail::memsetSigbusHandler);
+            auto memsetSigbusGuard = registerSignalHandler(PosixSignal::BUS, detail::memsetSigbusHandler);
             if (memsetSigbusGuard.has_error())
             {
                 printErrorDetails();

--- a/iceoryx_hoofs/posix/sync/include/iox/signal_handler.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/signal_handler.hpp
@@ -13,21 +13,20 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_POSIX_WRAPPER_SIGNAL_HANDLER_HPP
-#define IOX_HOOFS_POSIX_WRAPPER_SIGNAL_HANDLER_HPP
+
+#ifndef IOX_HOOFS_POSIX_SYNC_SIGNAL_HANDLER_HPP
+#define IOX_HOOFS_POSIX_SYNC_SIGNAL_HANDLER_HPP
 
 #include "iceoryx_platform/signal.hpp"
 #include "iox/expected.hpp"
 
 namespace iox
 {
-namespace posix
-{
 using SignalHandlerCallback_t = void (*)(int);
 
 /// @brief Corresponds to the SIG* macros defined in signal.h. The integer values
 ///        are equal to the corresponding macro value.
-enum class Signal : int
+enum class PosixSignal : int
 {
     BUS = SIGBUS,
     INT = SIGINT,
@@ -68,15 +67,15 @@ class SignalGuard
     SignalGuard& operator=(const SignalGuard& rhs) = delete;
     SignalGuard& operator=(SignalGuard&& rhs) = delete;
 
-    friend expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal,
+    friend expected<SignalGuard, SignalGuardError> registerSignalHandler(const PosixSignal,
                                                                          const SignalHandlerCallback_t) noexcept;
 
   private:
     void restorePreviousAction() noexcept;
-    SignalGuard(const Signal signal, const struct sigaction& previousAction) noexcept;
+    SignalGuard(const PosixSignal signal, const struct sigaction& previousAction) noexcept;
 
   private:
-    Signal m_signal;
+    PosixSignal m_signal;
     struct sigaction m_previousAction = {};
     bool m_doRestorePreviousAction{false};
 };
@@ -87,12 +86,12 @@ class SignalGuard
 ///             until the SignalGuard goes out of scope and restores the previous callback. If you override the
 ///             callbacks multiple times and the created SignalGuards goes out of scope in a different order then the
 ///             callback is restored which was active when the last SignalGuard which is going out of scope was created.
-/// @param[in] Signal the signal to which the callback should be attached
+/// @param[in] signal the 'PosixSignal' to which the callback should be attached
 /// @param[in] callback the callback which should be called when the signal is raised.
 /// @return SignalGuard on success - when it goes out of scope the previous signal action is restored. On error
 ///         SignalGuardError is returned which describes the error.
-expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signal,
+expected<SignalGuard, SignalGuardError> registerSignalHandler(const PosixSignal signal,
                                                               const SignalHandlerCallback_t callback) noexcept;
-} // namespace posix
 } // namespace iox
-#endif
+
+#endif // IOX_HOOFS_POSIX_SYNC_SIGNAL_HANDLER_HPP

--- a/iceoryx_hoofs/posix/sync/include/iox/thread.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/thread.hpp
@@ -48,7 +48,7 @@ enum class ThreadError
 
 /// @brief POSIX thread wrapper class. Following RAII, the thread is joined on destruction.
 /// @code
-/// #include "iceoryx_hoofs/posix_wrapper/thread.hpp"
+/// #include "iox/thread.hpp"
 ///
 /// iox::function<void()> callable = []() { /* ... */ };
 /// optional<Thread> myThread;

--- a/iceoryx_hoofs/posix/sync/source/signal_handler.cpp
+++ b/iceoryx_hoofs/posix/sync/source/signal_handler.cpp
@@ -14,15 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
+#include "iox/signal_handler.hpp"
 #include "iox/logging.hpp"
 #include "iox/posix_call.hpp"
 
 namespace iox
 {
-namespace posix
-{
-SignalGuard::SignalGuard(const Signal signal, const struct sigaction& previousAction) noexcept
+SignalGuard::SignalGuard(const PosixSignal signal, const struct sigaction& previousAction) noexcept
     : m_signal{signal}
     , m_previousAction{previousAction}
     , m_doRestorePreviousAction(true)
@@ -54,7 +52,7 @@ void SignalGuard::restorePreviousAction() noexcept
     }
 }
 
-expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signal,
+expected<SignalGuard, SignalGuardError> registerSignalHandler(const PosixSignal signal,
                                                               const SignalHandlerCallback_t callback) noexcept
 {
     struct sigaction action = {};
@@ -93,5 +91,4 @@ expected<SignalGuard, SignalGuardError> registerSignalHandler(const Signal signa
 
     return ok(SignalGuard(signal, previousAction));
 }
-} // namespace posix
 } // namespace iox

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -113,12 +113,12 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
         return err(SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE);
     }
 
-    auto memoryMap = MemoryMapBuilder()
+    auto memoryMap = detail::PosixMemoryMapBuilder()
                          .baseAddressHint((m_baseAddressHint) ? *m_baseAddressHint : nullptr)
                          .length(realSize)
                          .fileDescriptor(sharedMemory->getHandle())
                          .accessMode(m_accessMode)
-                         .flags(MemoryMapFlags::SHARE_CHANGES)
+                         .flags(detail::PosixMemoryMapFlags::SHARE_CHANGES)
                          .offset(0)
                          .create();
 
@@ -171,7 +171,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     return ok(SharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
 }
 
-SharedMemoryObject::SharedMemoryObject(SharedMemory&& sharedMemory, MemoryMap&& memoryMap) noexcept
+SharedMemoryObject::SharedMemoryObject(SharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept
     : m_sharedMemory(std::move(sharedMemory))
     , m_memoryMap(std::move(memoryMap))
 {

--- a/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_hoofs/source/posix_wrapper/shared_memory_object.cpp
@@ -78,7 +78,7 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
                     << ", permissions = " << iox::log::oct(m_permissions.value()) << " ]");
     };
 
-    auto sharedMemory = SharedMemoryBuilder()
+    auto sharedMemory = detail::PosixSharedMemoryBuilder()
                             .name(m_name)
                             .accessMode(m_accessMode)
                             .openMode(m_openMode)
@@ -171,7 +171,8 @@ expected<SharedMemoryObject, SharedMemoryObjectError> SharedMemoryObjectBuilder:
     return ok(SharedMemoryObject(std::move(*sharedMemory), std::move(*memoryMap)));
 }
 
-SharedMemoryObject::SharedMemoryObject(SharedMemory&& sharedMemory, detail::PosixMemoryMap&& memoryMap) noexcept
+SharedMemoryObject::SharedMemoryObject(detail::PosixSharedMemory&& sharedMemory,
+                                       detail::PosixMemoryMap&& memoryMap) noexcept
     : m_sharedMemory(std::move(sharedMemory))
     , m_memoryMap(std::move(memoryMap))
 {

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -15,9 +15,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iox/memory.hpp"
 #include "iox/posix_group.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/posix_user.hpp"
 #include "test.hpp"
 
@@ -41,7 +41,7 @@ class SharedMemoryObject_Test : public Test
 TEST_F(SharedMemoryObject_Test, CTorWithValidArguments)
 {
     ::testing::Test::RecordProperty("TEST_ID", "bbda60d2-d741-407e-9a9f-f0ca74d985a8");
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("validShmMem")
                    .memorySizeInBytes(100)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -54,7 +54,7 @@ TEST_F(SharedMemoryObject_Test, CTorWithValidArguments)
 TEST_F(SharedMemoryObject_Test, CTorOpenNonExistingSharedMemoryObject)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d80278c3-1dd8-409d-9162-f7f900892526");
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("pummeluff")
                    .memorySizeInBytes(100)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -68,7 +68,7 @@ TEST_F(SharedMemoryObject_Test, AllocateMemoryInSharedMemoryAndReadIt)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6169ac70-a08e-4a19-80e4-57f0d5f89233");
     const uint64_t MEMORY_SIZE = 16;
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(MEMORY_SIZE)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -85,7 +85,7 @@ TEST_F(SharedMemoryObject_Test, AllocateMemoryInSharedMemoryAndReadIt)
         data_ptr[i] = static_cast<uint8_t>(i * 2 + 1);
     }
 
-    auto sut2 = iox::posix::SharedMemoryObjectBuilder()
+    auto sut2 = PosixSharedMemoryObjectBuilder()
                     .name("shmAllocate")
                     .memorySizeInBytes(MEMORY_SIZE)
                     .openMode(iox::OpenMode::OPEN_EXISTING)
@@ -105,7 +105,7 @@ TEST_F(SharedMemoryObject_Test, OpenFailsWhenActualMemorySizeIsSmallerThanReques
 {
     ::testing::Test::RecordProperty("TEST_ID", "bb58b45e-8366-42ae-bd30-8d7415791dd4");
     const uint64_t MEMORY_SIZE = 16U << 20U; // 16 MB
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(1)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -114,21 +114,21 @@ TEST_F(SharedMemoryObject_Test, OpenFailsWhenActualMemorySizeIsSmallerThanReques
                    .create()
                    .expect("failed to create sut");
 
-    auto sut2 = iox::posix::SharedMemoryObjectBuilder()
+    auto sut2 = PosixSharedMemoryObjectBuilder()
                     .name("shmAllocate")
                     .memorySizeInBytes(MEMORY_SIZE)
                     .openMode(iox::OpenMode::OPEN_EXISTING)
                     .create();
 
     ASSERT_TRUE(sut2.has_error());
-    EXPECT_THAT(sut2.error(), Eq(posix::SharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE));
+    EXPECT_THAT(sut2.error(), Eq(PosixSharedMemoryObjectError::REQUESTED_SIZE_EXCEEDS_ACTUAL_SIZE));
 }
 
 TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0c8b41eb-74fd-4796-9e5e-fe6707f3c46c");
     const uint64_t MEMORY_SIZE = 1024;
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(MEMORY_SIZE * sizeof(uint64_t))
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -145,7 +145,7 @@ TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)
         data_ptr[i] = i * 2 + 1;
     }
 
-    auto sut2 = iox::posix::SharedMemoryObjectBuilder()
+    auto sut2 = PosixSharedMemoryObjectBuilder()
                     .name("shmAllocate")
                     .memorySizeInBytes(1)
                     .openMode(iox::OpenMode::OPEN_EXISTING)
@@ -167,7 +167,7 @@ TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)
 TEST_F(SharedMemoryObject_Test, AcquiringOwnerWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a9859b5e-555b-4cff-b418-74168a9fd85a");
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(8)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -186,7 +186,7 @@ TEST_F(SharedMemoryObject_Test, AcquiringPermissionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2b36bc3b-16a0-4c18-a1cb-6815812c6616");
     const auto permissions = perms::owner_all | perms::group_write | perms::group_read | perms::others_exec;
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(8)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -202,7 +202,7 @@ TEST_F(SharedMemoryObject_Test, AcquiringPermissionsWorks)
 TEST_F(SharedMemoryObject_Test, SettingOwnerWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "da85be28-7e21-4207-9077-698a2ec188d6");
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(8)
                    .accessMode(iox::AccessMode::READ_WRITE)
@@ -221,7 +221,7 @@ TEST_F(SharedMemoryObject_Test, SettingOwnerWorks)
 TEST_F(SharedMemoryObject_Test, SettingPermissionsWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "412abc8a-d1f8-4ceb-86db-f2790d2da58f");
-    auto sut = iox::posix::SharedMemoryObjectBuilder()
+    auto sut = PosixSharedMemoryObjectBuilder()
                    .name("shmAllocate")
                    .memorySizeInBytes(8)
                    .accessMode(iox::AccessMode::READ_WRITE)

--- a/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
@@ -14,29 +14,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/posix_wrapper/signal_handler.hpp"
+#include "iox/signal_handler.hpp"
 #include "test.hpp"
 #include <atomic>
 
 namespace
 {
 using namespace ::testing;
-using namespace iox::posix;
+using namespace iox;
 
 std::atomic_int signalOfCallback1{0};
 std::atomic_int signalOfCallback2{0};
 
-template <Signal SignalValue>
+template <PosixSignal SignalValue>
 struct SignalType
 {
-    static constexpr Signal VALUE = SignalValue;
+    static constexpr PosixSignal VALUE = SignalValue;
 };
 
 template <typename T>
 class SignalHandler_test : public Test
 {
   public:
-    static constexpr Signal SIGNAL_VALUE = T::VALUE;
+    static constexpr PosixSignal SIGNAL_VALUE = T::VALUE;
 
     void SetUp() override
     {
@@ -73,15 +73,17 @@ class SignalHandler_test : public Test
     static constexpr int INVALID_SIGNAL = std::numeric_limits<int>::max();
 };
 
-using Implementations =
-    Types<SignalType<Signal::INT>, SignalType<Signal::BUS>, SignalType<Signal::TERM>, SignalType<Signal::HUP>>;
+using Implementations = Types<SignalType<PosixSignal::INT>,
+                              SignalType<PosixSignal::BUS>,
+                              SignalType<PosixSignal::TERM>,
+                              SignalType<PosixSignal::HUP>>;
 
 TYPED_TEST_SUITE(SignalHandler_test, Implementations, );
 
 TYPED_TEST(SignalHandler_test, RegisteringSignalGuardCallbackWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7836be02-28ab-43b7-b7a7-7c43c4830eb4");
-    Signal signalValue = TestFixture::SIGNAL_VALUE;
+    PosixSignal signalValue = TestFixture::SIGNAL_VALUE;
     auto signalGuard [[maybe_unused]] = registerSignalHandler(signalValue, this->signalHandler1);
 
     ASSERT_EQ(raise(static_cast<int>(signalValue)), 0);
@@ -93,7 +95,7 @@ TYPED_TEST(SignalHandler_test, RegisteringSignalGuardCallbackWorks)
 TYPED_TEST(SignalHandler_test, WhenSignalGuardGoesOutOfScopePreviousStateIsRestored)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8d2efc2b-837b-446d-ba16-fbca9a539b82");
-    Signal signalValue = TestFixture::SIGNAL_VALUE;
+    PosixSignal signalValue = TestFixture::SIGNAL_VALUE;
     this->registerSignal(static_cast<int>(signalValue), this->signalHandler2);
     {
         auto signalGuard [[maybe_unused]] = registerSignalHandler(signalValue, this->signalHandler1);
@@ -108,7 +110,7 @@ TYPED_TEST(SignalHandler_test, WhenSignalGuardGoesOutOfScopePreviousStateIsResto
 TYPED_TEST(SignalHandler_test, MoveConstructedSignalGuardCallbackWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8fcf886b-babb-41ab-a8ee-6ba123224aef");
-    Signal signalValue = TestFixture::SIGNAL_VALUE;
+    PosixSignal signalValue = TestFixture::SIGNAL_VALUE;
     auto signalGuard = registerSignalHandler(signalValue, this->signalHandler1);
     ASSERT_FALSE(signalGuard.has_error());
 
@@ -123,7 +125,7 @@ TYPED_TEST(SignalHandler_test, MoveConstructedSignalGuardCallbackWorks)
 TYPED_TEST(SignalHandler_test, MoveConstructedSignalGuardRestoresPreviousState)
 {
     ::testing::Test::RecordProperty("TEST_ID", "718c396f-ab2f-4ea3-bb90-f67f7ab131d8");
-    Signal signalValue = TestFixture::SIGNAL_VALUE;
+    PosixSignal signalValue = TestFixture::SIGNAL_VALUE;
     this->registerSignal(static_cast<int>(signalValue), this->signalHandler2);
 
     {

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
@@ -17,7 +17,6 @@
 #ifndef IOX_POSH_MEPOO_MEPOO_SEGMENT_HPP
 #define IOX_POSH_MEPOO_MEPOO_SEGMENT_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/mepoo/memory_info.hpp"
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
@@ -25,12 +24,13 @@
 #include "iox/detail/posix_acl.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/posix_group.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 
 namespace iox
 {
 namespace mepoo
 {
-template <typename SharedMemoryObjectType = posix::SharedMemoryObject, typename MemoryManagerType = MemoryManager>
+template <typename SharedMemoryObjectType = PosixSharedMemoryObject, typename MemoryManagerType = MemoryManager>
 class MePooSegment
 {
   public:

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
@@ -17,7 +17,6 @@
 #ifndef IOX_POSH_ROUDI_PORT_MANAGER_HPP
 #define IOX_POSH_ROUDI_PORT_MANAGER_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/capro/capro_message.hpp"
@@ -41,6 +40,7 @@
 #include "iceoryx_posh/roudi/port_pool.hpp"
 #include "iceoryx_posh/runtime/port_config_info.hpp"
 #include "iox/optional.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/type_traits.hpp"
 
 #include <mutex>

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_user.hpp
@@ -17,10 +17,10 @@
 #ifndef IOX_POSH_RUNTIME_SHARED_MEMORY_USER_HPP
 #define IOX_POSH_RUNTIME_SHARED_MEMORY_USER_HPP
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/optional.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/relative_pointer.hpp"
 #include "iox/vector.hpp"
 
@@ -47,8 +47,8 @@ class SharedMemoryUser
                           const UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept;
 
   private:
-    optional<posix::SharedMemoryObject> m_shmObject;
-    vector<posix::SharedMemoryObject, MAX_SHM_SEGMENTS> m_dataShmObjects;
+    optional<PosixSharedMemoryObject> m_shmObject;
+    vector<PosixSharedMemoryObject, MAX_SHM_SEGMENTS> m_dataShmObjects;
     static constexpr access_rights SHM_SEGMENT_PERMISSIONS =
         perms::owner_read | perms::owner_write | perms::group_read | perms::group_write;
 };

--- a/iceoryx_posh/include/iceoryx_posh/roudi/memory/posix_shm_memory_provider.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/memory/posix_shm_memory_provider.hpp
@@ -19,11 +19,11 @@
 
 #include "iceoryx_posh/roudi/memory/memory_provider.hpp"
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iox/expected.hpp"
 #include "iox/filesystem.hpp"
 #include "iox/optional.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/string.hpp"
 
 #include <cstdint>
@@ -62,7 +62,7 @@ class PosixShmMemoryProvider : public MemoryProvider
     ShmName_t m_shmName;
     AccessMode m_accessMode{AccessMode::READ_ONLY};
     OpenMode m_openMode{OpenMode::OPEN_EXISTING};
-    optional<posix::SharedMemoryObject> m_shmObject;
+    optional<PosixSharedMemoryObject> m_shmObject;
 
     static constexpr access_rights SHM_MEMORY_PERMISSIONS =
         perms::owner_read | perms::owner_write | perms::group_read | perms::group_write;

--- a/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/roudi_app.hpp
@@ -48,7 +48,7 @@ class RouDiApp
 
   protected:
     /// @brief waits for the next signal to RouDi daemon
-    IOX_DEPRECATED_SINCE(3, "Please use iox::posix::waitForTerminationRequest() from 'iox/signal_watcher.hpp'")
+    IOX_DEPRECATED_SINCE(3, "Please use iox::waitForTerminationRequest() from 'iox/signal_watcher.hpp'")
     bool waitForSignal() noexcept;
 
     iox::log::LogLevel m_logLevel{iox::log::LogLevel::WARN};

--- a/iceoryx_posh/roudi_env/source/roudi_env.cpp
+++ b/iceoryx_posh/roudi_env/source/roudi_env.cpp
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/roudi_env/roudi_env.hpp"
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object/memory_map.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/unique_port_id.hpp"
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"

--- a/iceoryx_posh/source/mepoo/mepoo_segment.cpp
+++ b/iceoryx_posh/source/mepoo/mepoo_segment.cpp
@@ -20,6 +20,6 @@ namespace iox
 {
 namespace mepoo
 {
-template class MePooSegment<posix::SharedMemoryObject, MemoryManager>;
+template class MePooSegment<PosixSharedMemoryObject, MemoryManager>;
 } // namespace mepoo
 } // namespace iox

--- a/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/source/roudi/memory/posix_shm_memory_provider.cpp
@@ -54,7 +54,7 @@ expected<void*, MemoryProviderError> PosixShmMemoryProvider::createMemory(const 
         return err(MemoryProviderError::MEMORY_ALIGNMENT_EXCEEDS_PAGE_SIZE);
     }
 
-    if (!posix::SharedMemoryObjectBuilder()
+    if (!PosixSharedMemoryObjectBuilder()
              .name(m_shmName)
              .memorySizeInBytes(size)
              .accessMode(m_accessMode)

--- a/iceoryx_posh/source/runtime/shared_memory_user.cpp
+++ b/iceoryx_posh/source/runtime/shared_memory_user.cpp
@@ -31,7 +31,7 @@ SharedMemoryUser::SharedMemoryUser(const size_t topicSize,
                                    const uint64_t segmentId,
                                    const UntypedRelativePointer::offset_t segmentManagerAddressOffset) noexcept
 {
-    posix::SharedMemoryObjectBuilder()
+    PosixSharedMemoryObjectBuilder()
         .name(roudi::SHM_NAME)
         .memorySizeInBytes(topicSize)
         .accessMode(AccessMode::READ_WRITE)
@@ -72,7 +72,7 @@ void SharedMemoryUser::openDataSegments(const uint64_t segmentId,
     for (const auto& segment : segmentMapping)
     {
         auto accessMode = segment.m_isWritable ? AccessMode::READ_WRITE : AccessMode::READ_ONLY;
-        posix::SharedMemoryObjectBuilder()
+        PosixSharedMemoryObjectBuilder()
             .name(segment.m_sharedMemoryName)
             .memorySizeInBytes(segment.m_size)
             .accessMode(accessMode)

--- a/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
+++ b/iceoryx_posh/test/integrationtests/test_mq_interface_startup_race.cpp
@@ -35,7 +35,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::units;
-using namespace iox::posix;
 using namespace iox::units::duration_literals;
 
 using iox::runtime::IpcInterfaceBase;

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_hoofs/testing/test_definitions.hpp"
 #include "iceoryx_platform/fcntl.hpp"
 #include "iceoryx_platform/stat.hpp"
@@ -25,6 +24,7 @@
 #include "iox/bump_allocator.hpp"
 #include "iox/expected.hpp"
 #include "iox/posix_group.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "test.hpp"
 
 
@@ -36,7 +36,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::mepoo;
-using namespace iox::posix;
 
 class MePooSegment_test : public Test
 {
@@ -110,7 +109,7 @@ class MePooSegment_test : public Test
         IOX_BUILDER_PARAMETER(iox::access_rights, permissions, iox::perms::none)
 
       public:
-        iox::expected<SharedMemoryObject_MOCK, SharedMemoryObjectError> create() noexcept
+        iox::expected<SharedMemoryObject_MOCK, PosixSharedMemoryObjectError> create() noexcept
         {
             return iox::ok(SharedMemoryObject_MOCK(m_name,
                                                    m_memorySizeInBytes,

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -45,13 +45,13 @@ class MePooSegment_test : public Test
     struct SharedMemoryObject_MOCK
     {
         using Builder = SharedMemoryObject_MOCKBuilder;
-        using createFct = std::function<void(const SharedMemory::Name_t,
+        using createFct = std::function<void(const detail::PosixSharedMemory::Name_t,
                                              const uint64_t,
                                              const iox::AccessMode,
                                              const iox::OpenMode,
                                              const void*,
                                              const iox::access_rights)>;
-        SharedMemoryObject_MOCK(const SharedMemory::Name_t& name,
+        SharedMemoryObject_MOCK(const detail::PosixSharedMemory::Name_t& name,
                                 const uint64_t memorySizeInBytes,
                                 const AccessMode accessMode,
                                 const OpenMode openMode,
@@ -97,7 +97,7 @@ class MePooSegment_test : public Test
 
     class SharedMemoryObject_MOCKBuilder
     {
-        IOX_BUILDER_PARAMETER(SharedMemory::Name_t, name, "")
+        IOX_BUILDER_PARAMETER(detail::PosixSharedMemory::Name_t, name, "")
 
         IOX_BUILDER_PARAMETER(uint64_t, memorySizeInBytes, 0U)
 
@@ -154,13 +154,13 @@ TEST_F(MePooSegment_test, SharedMemoryCreationParameter)
     ::testing::Test::RecordProperty("TEST_ID", "0fcfefd4-3a84-43a5-9805-057a60239184");
     GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
 
-    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [](const SharedMemory::Name_t f_name,
+    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [](const detail::PosixSharedMemory::Name_t f_name,
                                                                        const uint64_t,
                                                                        const iox::AccessMode f_accessMode,
                                                                        const iox::OpenMode openMode,
                                                                        const void*,
                                                                        const iox::access_rights) {
-        EXPECT_THAT(f_name, Eq(SharedMemory::Name_t("iox_roudi_test2")));
+        EXPECT_THAT(f_name, Eq(detail::PosixSharedMemory::Name_t("iox_roudi_test2")));
         EXPECT_THAT(f_accessMode, Eq(iox::AccessMode::READ_WRITE));
         EXPECT_THAT(openMode, Eq(iox::OpenMode::PURGE_AND_CREATE));
     };
@@ -175,7 +175,7 @@ TEST_F(MePooSegment_test, GetSharedMemoryObject)
     GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
 
     uint64_t memorySizeInBytes{0};
-    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [&](const SharedMemory::Name_t,
+    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [&](const detail::PosixSharedMemory::Name_t,
                                                                         const uint64_t f_memorySizeInBytes,
                                                                         const iox::AccessMode,
                                                                         const iox::OpenMode,

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment_management.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/internal/posix_wrapper/shared_memory_object.hpp"
 #include "iceoryx_hoofs/testing/test_definitions.hpp"
 #include "iceoryx_posh/error_handling/error_handling.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
@@ -24,6 +23,7 @@
 #include "iceoryx_posh/mepoo/segment_config.hpp"
 #include "iox/bump_allocator.hpp"
 #include "iox/posix_group.hpp"
+#include "iox/posix_shared_memory_object.hpp"
 #include "iox/posix_user.hpp"
 #include "test.hpp"
 
@@ -33,7 +33,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::mepoo;
-using namespace iox::posix;
 
 class MePooSegmentMock
 {

--- a/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
@@ -38,7 +38,7 @@ class PosixShmMemoryProvider_Test : public Test
     void SetUp() override
     {
         /// @note just in the case a test left something behind we remove the shared memory if it exists
-        IOX_DISCARD_RESULT(iox::posix::SharedMemory::unlinkIfExist(TEST_SHM_NAME));
+        IOX_DISCARD_RESULT(iox::posix::PosixSharedMemory::unlinkIfExist(TEST_SHM_NAME));
     }
 
     void TearDown() override

--- a/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_posix_shm_memory_provider.cpp
@@ -38,7 +38,7 @@ class PosixShmMemoryProvider_Test : public Test
     void SetUp() override
     {
         /// @note just in the case a test left something behind we remove the shared memory if it exists
-        IOX_DISCARD_RESULT(iox::posix::PosixSharedMemory::unlinkIfExist(TEST_SHM_NAME));
+        IOX_DISCARD_RESULT(iox::detail::PosixSharedMemory::unlinkIfExist(TEST_SHM_NAME));
     }
 
     void TearDown() override
@@ -47,7 +47,7 @@ class PosixShmMemoryProvider_Test : public Test
 
     bool shmExists()
     {
-        return !iox::posix::SharedMemoryObjectBuilder()
+        return !iox::PosixSharedMemoryObjectBuilder()
                     .name(TEST_SHM_NAME)
                     .memorySizeInBytes(8)
                     .accessMode(iox::AccessMode::READ_ONLY)

--- a/iceoryx_posh/test/moduletests/test_roudi_process.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process.cpp
@@ -31,7 +31,6 @@ using namespace iox;
 using namespace iox::roudi;
 using namespace iox::popo;
 using namespace iox::runtime;
-using namespace iox::posix;
 
 class IpcInterfaceUser_Mock : public iox::roudi::Process
 {

--- a/iceoryx_posh/test/moduletests/test_roudi_process_manager.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_manager.cpp
@@ -35,7 +35,6 @@ using namespace iox;
 using namespace iox::roudi;
 using namespace iox::popo;
 using namespace iox::runtime;
-using namespace iox::posix;
 using namespace iox::roudi_env;
 using namespace iox::version;
 

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface.cpp
@@ -30,7 +30,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox;
-using namespace iox::posix;
 using namespace iox::units::duration_literals;
 
 #if defined(__APPLE__)

--- a/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
+++ b/iceoryx_posh/test/moduletests/test_runtime_ipc_interface_creator.cpp
@@ -27,7 +27,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox;
-using namespace iox::posix;
 using namespace iox::runtime;
 using namespace iox::testing;
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the last constructs from `posix_wrapper` to the new module location. These are the shared memory header and the signal handler.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1391
