### PR TITLE
iox-#2023 Improve error messages

### DIFF
--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -33,6 +33,7 @@ enum class FileStatError
 {
     IoFailure,
     FileTooLarge,
+    BadFileDescriptor,
     UnknownError,
 };
 
@@ -44,6 +45,7 @@ enum class FileSetOwnerError
     PermissionDenied,
     ReadOnlyFilesystem,
     InvalidUidOrGid,
+    BadFileDescriptor,
     UnknownError,
 };
 
@@ -52,6 +54,7 @@ enum class FileSetPermissionError
 {
     PermissionDenied,
     ReadOnlyFilesystem,
+    BadFileDescriptor,
     UnknownError,
 };
 

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -32,6 +32,9 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileStatError::BadFileDescriptor);
         case EIO:
             IOX_LOG(ERROR, "Unable to acquire file status since an io failure occurred while reading.");
             return err(FileStatError::IoFailure);
@@ -41,7 +44,7 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
                     "corresponding structure.");
             return err(FileStatError::FileTooLarge);
         default:
-            IOX_LOG(ERROR, "Unable to acquire file status due to an unknown failure");
+            IOX_LOG(ERROR, "Unable to acquire file status due to an unknown failure. errno: " << result.error().errnum);
             return err(FileStatError::UnknownError);
         }
     }
@@ -57,6 +60,9 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileSetOwnerError::BadFileDescriptor);
         case EPERM:
             IOX_LOG(ERROR, "Unable to set owner due to insufficient permissions.");
             return err(FileSetOwnerError::PermissionDenied);
@@ -75,7 +81,7 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
             IOX_LOG(ERROR, "Unable to set owner since an interrupt was received.");
             return err(FileSetOwnerError::Interrupt);
         default:
-            IOX_LOG(ERROR, "Unable to set owner since an unknown error occurred.");
+            IOX_LOG(ERROR, "Unable to set owner since an unknown error occurred. errno: " << result.error().errnum);
             return err(FileSetOwnerError::UnknownError);
         }
     }
@@ -91,6 +97,9 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileSetPermissionError::BadFileDescriptor);
         case EPERM:
             IOX_LOG(ERROR, "Unable to adjust permissions due to insufficient permissions.");
             return err(FileSetPermissionError::PermissionDenied);
@@ -98,7 +107,8 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
             IOX_LOG(ERROR, "Unable to adjust permissions since it is a read-only filesystem.");
             return err(FileSetPermissionError::ReadOnlyFilesystem);
         default:
-            IOX_LOG(ERROR, "Unable to adjust permissions since an unknown error occurred.");
+            IOX_LOG(ERROR,
+                    "Unable to adjust permissions since an unknown error occurred. errno: " << result.error().errnum);
             return err(FileSetPermissionError::UnknownError);
         }
     }


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds the errno to the error message in the default case in the error translation switch statement. In addition it explicitly prints error messages for invalid file descriptors.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Relates to #2023 
