### PR TITLE
iox-#2023 Fix bad file descriptor error

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -111,6 +111,7 @@
 - Fix clang-tidy errors from full-scan nightly build [#2060](https://github.com/eclipse-iceoryx/iceoryx/issues/2060)
 - Add public functions to create an 'access_rights' object from integer values [#2108](https://github.com/eclipse-iceoryx/iceoryx/issues/2108)
 - Fix `historyRequest` may be larger than `queueCapacity` during creating a subscriber [#2121](https://github.com/eclipse-iceoryx/iceoryx/issues/2121)
+- Unable to acquire file status due to an unknown failure [#2023](https://github.com/eclipse-iceoryx/iceoryx/issues/2023)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -33,6 +33,7 @@ enum class FileStatError
 {
     IoFailure,
     FileTooLarge,
+    BadFileDescriptor,
     UnknownError,
 };
 
@@ -44,6 +45,7 @@ enum class FileSetOwnerError
     PermissionDenied,
     ReadOnlyFilesystem,
     InvalidUidOrGid,
+    BadFileDescriptor,
     UnknownError,
 };
 
@@ -52,6 +54,7 @@ enum class FileSetPermissionError
 {
     PermissionDenied,
     ReadOnlyFilesystem,
+    BadFileDescriptor,
     UnknownError,
 };
 

--- a/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
+++ b/iceoryx_hoofs/posix/design/source/file_management_interface.cpp
@@ -32,6 +32,9 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileStatError::BadFileDescriptor);
         case EIO:
             IOX_LOG(ERROR, "Unable to acquire file status since an io failure occurred while reading.");
             return err(FileStatError::IoFailure);
@@ -41,7 +44,7 @@ expected<iox_stat, FileStatError> get_file_status(const int fildes) noexcept
                     "corresponding structure.");
             return err(FileStatError::FileTooLarge);
         default:
-            IOX_LOG(ERROR, "Unable to acquire file status due to an unknown failure");
+            IOX_LOG(ERROR, "Unable to acquire file status due to an unknown failure. errno: " << result.error().errnum);
             return err(FileStatError::UnknownError);
         }
     }
@@ -57,6 +60,9 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileSetOwnerError::BadFileDescriptor);
         case EPERM:
             IOX_LOG(ERROR, "Unable to set owner due to insufficient permissions.");
             return err(FileSetOwnerError::PermissionDenied);
@@ -75,7 +81,7 @@ expected<void, FileSetOwnerError> set_owner(const int fildes, const uid_t uid, c
             IOX_LOG(ERROR, "Unable to set owner since an interrupt was received.");
             return err(FileSetOwnerError::Interrupt);
         default:
-            IOX_LOG(ERROR, "Unable to set owner since an unknown error occurred.");
+            IOX_LOG(ERROR, "Unable to set owner since an unknown error occurred. errno: " << result.error().errnum);
             return err(FileSetOwnerError::UnknownError);
         }
     }
@@ -91,6 +97,9 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
     {
         switch (result.error().errnum)
         {
+        case EBADF:
+            IOX_LOG(ERROR, "The provided file descriptor is invalid.");
+            return err(FileSetPermissionError::BadFileDescriptor);
         case EPERM:
             IOX_LOG(ERROR, "Unable to adjust permissions due to insufficient permissions.");
             return err(FileSetPermissionError::PermissionDenied);
@@ -98,7 +107,8 @@ expected<void, FileSetPermissionError> set_permissions(const int fildes, const a
             IOX_LOG(ERROR, "Unable to adjust permissions since it is a read-only filesystem.");
             return err(FileSetPermissionError::ReadOnlyFilesystem);
         default:
-            IOX_LOG(ERROR, "Unable to adjust permissions since an unknown error occurred.");
+            IOX_LOG(ERROR,
+                    "Unable to adjust permissions since an unknown error occurred. errno: " << result.error().errnum);
             return err(FileSetPermissionError::UnknownError);
         }
     }

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,28 +43,28 @@ class MePooSegment
 
     PosixGroup getWriterGroup() const noexcept;
     PosixGroup getReaderGroup() const noexcept;
-    const SharedMemoryObjectType& getSharedMemoryObject() const noexcept;
+
     MemoryManagerType& getMemoryManager() noexcept;
 
     uint64_t getSegmentId() const noexcept;
+
+    uint64_t getSegmentSize() const noexcept;
 
   protected:
     SharedMemoryObjectType createSharedMemoryObject(const MePooConfig& mempoolConfig,
                                                     const PosixGroup& writerGroup) noexcept;
 
   protected:
-    SharedMemoryObjectType m_sharedMemoryObject;
-    MemoryManagerType m_memoryManager;
     PosixGroup m_readerGroup;
     PosixGroup m_writerGroup;
-    uint64_t m_segmentId;
+    uint64_t m_segmentId{0};
+    uint64_t m_segmentSize{0};
     iox::mepoo::MemoryInfo m_memoryInfo;
+    SharedMemoryObjectType m_sharedMemoryObject;
+    MemoryManagerType m_memoryManager;
 
     static constexpr access_rights SEGMENT_PERMISSIONS =
         perms::owner_read | perms::owner_write | perms::group_read | perms::group_write;
-
-  private:
-    void setSegmentId(const uint64_t segmentId) noexcept;
 };
 } // namespace mepoo
 } // namespace iox

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -43,7 +43,7 @@ inline MePooSegment<SharedMemoryObjectType, MemoryManagerType>::MePooSegment(
     : m_readerGroup(readerGroup)
     , m_writerGroup(writerGroup)
     , m_memoryInfo(memoryInfo)
-    , m_sharedMemoryObject(std::move(createSharedMemoryObject(mempoolConfig, writerGroup)))
+    , m_sharedMemoryObject(createSharedMemoryObject(mempoolConfig, writerGroup))
 {
     using namespace detail;
     PosixAcl acl;

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/mepoo_segment.inl
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,10 +40,10 @@ inline MePooSegment<SharedMemoryObjectType, MemoryManagerType>::MePooSegment(
     const PosixGroup& readerGroup,
     const PosixGroup& writerGroup,
     const iox::mepoo::MemoryInfo& memoryInfo) noexcept
-    : m_sharedMemoryObject(std::move(createSharedMemoryObject(mempoolConfig, writerGroup)))
-    , m_readerGroup(readerGroup)
+    : m_readerGroup(readerGroup)
     , m_writerGroup(writerGroup)
     , m_memoryInfo(memoryInfo)
+    , m_sharedMemoryObject(std::move(createSharedMemoryObject(mempoolConfig, writerGroup)))
 {
     using namespace detail;
     PosixAcl acl;
@@ -85,13 +86,13 @@ inline SharedMemoryObjectType MePooSegment<SharedMemoryObjectType, MemoryManager
                 {
                     errorHandler(PoshError::MEPOO__SEGMENT_INSUFFICIENT_SEGMENT_IDS);
                 }
-                this->setSegmentId(static_cast<uint64_t>(maybeSegmentId.value()));
+                this->m_segmentId = static_cast<uint64_t>(maybeSegmentId.value());
+                this->m_segmentSize = sharedMemoryObject.get_size().expect("Failed to get SHM size.");
 
                 IOX_LOG(DEBUG,
-                        "Roudi registered payload data segment "
-                            << iox::log::hex(sharedMemoryObject.getBaseAddress()) << " with size "
-                            << sharedMemoryObject.get_size().expect("Failed to get SHM size.") << " to id "
-                            << m_segmentId);
+                        "Roudi registered payload data segment " << iox::log::hex(sharedMemoryObject.getBaseAddress())
+                                                                 << " with size " << m_segmentSize << " to id "
+                                                                 << m_segmentId);
             })
             .or_else([](auto&) { errorHandler(PoshError::MEPOO__SEGMENT_UNABLE_TO_CREATE_SHARED_MEMORY_OBJECT); })
             .value());
@@ -116,22 +117,15 @@ inline MemoryManagerType& MePooSegment<SharedMemoryObjectType, MemoryManagerType
 }
 
 template <typename SharedMemoryObjectType, typename MemoryManagerType>
-inline const SharedMemoryObjectType&
-MePooSegment<SharedMemoryObjectType, MemoryManagerType>::getSharedMemoryObject() const noexcept
-{
-    return m_sharedMemoryObject;
-}
-
-template <typename SharedMemoryObjectType, typename MemoryManagerType>
 inline uint64_t MePooSegment<SharedMemoryObjectType, MemoryManagerType>::getSegmentId() const noexcept
 {
     return m_segmentId;
 }
 
 template <typename SharedMemoryObjectType, typename MemoryManagerType>
-inline void MePooSegment<SharedMemoryObjectType, MemoryManagerType>::setSegmentId(const uint64_t segmentId) noexcept
+inline uint64_t MePooSegment<SharedMemoryObjectType, MemoryManagerType>::getSegmentSize() const noexcept
 {
-    m_segmentId = segmentId;
+    return m_segmentSize;
 }
 
 } // namespace mepoo

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
@@ -55,13 +55,11 @@ class SegmentManager
     {
       public:
         SegmentMapping(const ShmName_t& sharedMemoryName,
-                       const void* const startAddress,
                        uint64_t size,
                        bool isWritable,
                        uint64_t segmentId,
                        const iox::mepoo::MemoryInfo& memoryInfo = iox::mepoo::MemoryInfo()) noexcept
             : m_sharedMemoryName(sharedMemoryName)
-            , m_startAddress(startAddress)
             , m_size(size)
             , m_isWritable(isWritable)
             , m_segmentId(segmentId)
@@ -71,7 +69,6 @@ class SegmentManager
         }
 
         ShmName_t m_sharedMemoryName{""};
-        const void* m_startAddress{nullptr};
         uint64_t m_size{0};
         bool m_isWritable{false};
         uint64_t m_segmentId{0};

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,11 +69,7 @@ SegmentManager<SegmentType>::getSegmentMappings(const PosixUser& user) noexcept
                 if (!foundInWriterGroup)
                 {
                     mappingContainer.emplace_back(
-                        segment.getWriterGroup().getName(),
-                        segment.getSharedMemoryObject().getBaseAddress(),
-                        segment.getSharedMemoryObject().get_size().expect("failed to get SHM size"),
-                        true,
-                        segment.getSegmentId());
+                        segment.getWriterGroup().getName(), segment.getSegmentSize(), true, segment.getSegmentId());
                     foundInWriterGroup = true;
                 }
                 else
@@ -91,15 +88,11 @@ SegmentManager<SegmentType>::getSegmentMappings(const PosixUser& user) noexcept
             // only add segments which are not yet added as writer
             if (segment.getReaderGroup() == groupID
                 && std::find_if(mappingContainer.begin(), mappingContainer.end(), [&](const SegmentMapping& mapping) {
-                       return mapping.m_startAddress == segment.getSharedMemoryObject().getBaseAddress();
+                       return mapping.m_segmentId == segment.getSegmentId();
                    }) == mappingContainer.end())
             {
                 mappingContainer.emplace_back(
-                    segment.getWriterGroup().getName(),
-                    segment.getSharedMemoryObject().getBaseAddress(),
-                    segment.getSharedMemoryObject().get_size().expect("Failed to get SHM size."),
-                    false,
-                    segment.getSegmentId());
+                    segment.getWriterGroup().getName(), segment.getSegmentSize(), false, segment.getSegmentId());
             }
         }
     }

--- a/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
+++ b/iceoryx_posh/test/moduletests/test_mepoo_segment.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2023 by Mathias Kraus <elboberido@m-hias.de>. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -168,25 +169,13 @@ TEST_F(MePooSegment_test, SharedMemoryCreationParameter)
         MePooSegment_test::SharedMemoryObject_MOCK::createFct();
 }
 
-TEST_F(MePooSegment_test, GetSharedMemoryObject)
+TEST_F(MePooSegment_test, GetSegmentSize)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "e1c12dd0-fd7d-4be3-918b-08d16a68c8e0");
+    ::testing::Test::RecordProperty("TEST_ID", "0eee50c0-251e-4313-bb35-d83a0de27ce2");
     GTEST_SKIP_FOR_ADDITIONAL_USER() << "This test requires the -DTEST_WITH_ADDITIONAL_USER=ON cmake argument";
 
-    uint64_t memorySizeInBytes{0};
-    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator = [&](const detail::PosixSharedMemory::Name_t,
-                                                                        const uint64_t f_memorySizeInBytes,
-                                                                        const iox::AccessMode,
-                                                                        const iox::OpenMode,
-                                                                        const void*,
-                                                                        const iox::access_rights) {
-        memorySizeInBytes = f_memorySizeInBytes;
-    };
-    SUT sut{mepooConfig, m_managementAllocator, PosixGroup{"iox_roudi_test1"}, PosixGroup{"iox_roudi_test2"}};
-    MePooSegment_test::SharedMemoryObject_MOCK::createVerificator =
-        MePooSegment_test::SharedMemoryObject_MOCK::createFct();
-
-    EXPECT_THAT(sut.getSharedMemoryObject().get_size().expect("Failed to get SHM size"), Eq(memorySizeInBytes));
+    auto sut = createSut();
+    EXPECT_THAT(sut->getSegmentSize(), Eq(MemoryManager::requiredChunkMemorySize(mepooConfig)));
 }
 
 TEST_F(MePooSegment_test, GetReaderGroup)


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

As it turned out, a file descriptor opened in `RouDi` was accessed from the `PoshRuntime`. It worked by accident most of the time since file descriptors are not randomized and the `PoshRuntime` just happened to have a matching valid file descriptor. If `RouDi` was started as a subprocess and inherited some file descriptors, the `PoshRuntime` did not have a matching file descriptor and the `fstat` call failed with `EBADF`

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2023