### PR TITLE
iox-#2137 Merge 'ListenerImpl' back to 'Listener'

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -112,6 +112,7 @@
 - Add public functions to create an 'access_rights' object from integer values [#2108](https://github.com/eclipse-iceoryx/iceoryx/issues/2108)
 - Fix `historyRequest` may be larger than `queueCapacity` during creating a subscriber [#2121](https://github.com/eclipse-iceoryx/iceoryx/issues/2121)
 - Unable to acquire file status due to an unknown failure [#2023](https://github.com/eclipse-iceoryx/iceoryx/issues/2023)
+- Bug in 'ListenerImpl' [#2137](https://github.com/eclipse-iceoryx/iceoryx/issues/2137)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/notification_attorney.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/notification_attorney.hpp
@@ -33,8 +33,7 @@ class NotificationAttorney
 {
     template <uint64_t>
     friend class WaitSet;
-    template <uint64_t>
-    friend class ListenerImpl;
+    friend class Listener;
 
   private:
     template <typename T, typename... Targs>

--- a/iceoryx_posh/source/popo/listener.cpp
+++ b/iceoryx_posh/source/popo/listener.cpp
@@ -21,13 +21,88 @@ namespace iox
 namespace popo
 {
 Listener::Listener() noexcept
+    : Listener(*runtime::PoshRuntime::getInstance().getMiddlewareConditionVariable())
 {
 }
 
-Listener::Listener(ConditionVariableData& conditionVariableData) noexcept
-    : Parent(conditionVariableData)
+Listener::Listener(ConditionVariableData& conditionVariable) noexcept
+    : m_conditionVariableData(&conditionVariable)
+    , m_conditionListener(conditionVariable)
 {
+    m_thread = std::thread(&Listener::threadLoop, this);
 }
+
+Listener::~Listener() noexcept
+{
+    m_wasDtorCalled.store(true, std::memory_order_relaxed);
+    m_conditionListener.destroy();
+
+    m_thread.join();
+    m_conditionVariableData->m_toBeDestroyed.store(true, std::memory_order_relaxed);
+}
+
+uint64_t Listener::size() const noexcept
+{
+    return m_indexManager.indicesInUse();
+}
+
+void Listener::threadLoop() noexcept
+{
+    while (m_wasDtorCalled.load(std::memory_order_relaxed) == false)
+    {
+        auto activateNotificationIds = m_conditionListener.wait();
+
+        for (auto& id : activateNotificationIds)
+        {
+            m_events[id]->executeCallback();
+        }
+    }
+}
+
+void Listener::removeTrigger(const uint64_t index) noexcept
+{
+    if (index >= MAX_NUMBER_OF_EVENTS)
+    {
+        return;
+    }
+
+    if (m_events[index]->reset())
+    {
+        m_indexManager.push(static_cast<uint32_t>(index));
+    }
+}
+
+///////////////////////
+// BEGIN IndexManager_t
+///////////////////////
+Listener::IndexManager_t::IndexManager_t() noexcept
+{
+    m_loffli.init(m_loffliStorage, MAX_NUMBER_OF_EVENTS);
+}
+
+bool Listener::IndexManager_t::pop(uint32_t& value) noexcept
+{
+    if (m_loffli.pop(value))
+    {
+        ++m_indicesInUse;
+        return true;
+    }
+    return false;
+}
+
+void Listener::IndexManager_t::push(const uint32_t index) noexcept
+{
+    IOX_EXPECTS(m_loffli.push(index));
+    --m_indicesInUse;
+}
+
+uint64_t Listener::IndexManager_t::indicesInUse() const noexcept
+{
+    return m_indicesInUse.load(std::memory_order_relaxed);
+}
+/////////////////////
+// END IndexManager_t
+/////////////////////
 
 namespace internal
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Once we tried to fix an issue with compile time defined sizes of the `Listener` in the C binding by splitting the `Listener` into two classes. This did not fix the problem but we forgot to unify those classes again and `ListenerImpl` is not meant to be used on its own. This PRs reverts the split and unifies the code into one class.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] ~~Unit tests have been written for new behavior~~
- [x] Public API changes are documented via doxygen
- [x] ~~Copyright owner are updated in the changed files~~
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2137
