### PR TITLE
iox-#1391 Move 'VariantQueue' to iceoryx_posh

### DIFF
--- a/iceoryx_binding_c/source/c_client.cpp
+++ b/iceoryx_binding_c/source/c_client.cpp
@@ -24,7 +24,6 @@ using namespace iox;
 using namespace iox::popo;
 using namespace iox::runtime;
 using namespace iox::capro;
-using namespace iox::cxx;
 
 extern "C" {
 #include "iceoryx_binding_c/client.h"

--- a/iceoryx_binding_c/source/c_publisher.cpp
+++ b/iceoryx_binding_c/source/c_publisher.cpp
@@ -26,7 +26,6 @@
 
 
 using namespace iox;
-using namespace iox::cxx;
 using namespace iox::popo;
 using namespace iox::capro;
 using namespace iox::mepoo;

--- a/iceoryx_binding_c/source/c_request_header.cpp
+++ b/iceoryx_binding_c/source/c_request_header.cpp
@@ -20,7 +20,6 @@ using namespace iox;
 using namespace iox::popo;
 using namespace iox::runtime;
 using namespace iox::capro;
-using namespace iox::cxx;
 
 extern "C" {
 #include "iceoryx_binding_c/request_header.h"

--- a/iceoryx_binding_c/source/c_response_header.cpp
+++ b/iceoryx_binding_c/source/c_response_header.cpp
@@ -20,7 +20,6 @@ using namespace iox;
 using namespace iox::popo;
 using namespace iox::runtime;
 using namespace iox::capro;
-using namespace iox::cxx;
 
 extern "C" {
 #include "iceoryx_binding_c/response_header.h"

--- a/iceoryx_binding_c/source/c_server.cpp
+++ b/iceoryx_binding_c/source/c_server.cpp
@@ -24,7 +24,6 @@ using namespace iox;
 using namespace iox::popo;
 using namespace iox::runtime;
 using namespace iox::capro;
-using namespace iox::cxx;
 
 extern "C" {
 #include "iceoryx_binding_c/server.h"

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -28,7 +28,6 @@
 
 
 using namespace iox;
-using namespace iox::cxx;
 using namespace iox::popo;
 using namespace iox::capro;
 using namespace iox::mepoo;

--- a/iceoryx_binding_c/test/moduletests/test_client.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_client.cpp
@@ -28,7 +28,6 @@
 using namespace iox::popo;
 using namespace iox::capro;
 using namespace iox;
-using namespace iox::cxx;
 using namespace iox::testing;
 
 extern "C" {
@@ -117,7 +116,7 @@ class iox_client_test : public Test
     iox_client_storage_t sutStorage;
 
     ServerChunkQueueData_t serverChunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                                iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+                                                iox::popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
     ChunkQueuePopper<ServerChunkQueueData_t> serverRequestQueue{&serverChunkQueueData};
 
     static constexpr const char SERVICE[] = "allGlory";

--- a/iceoryx_binding_c/test/moduletests/test_listener.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_listener.cpp
@@ -141,7 +141,7 @@ class iox_listener_test : public Test
         m_subscriberPortData.resize(MAX_NUMBER_OF_EVENTS_PER_LISTENER + 1U,
                                     TEST_SERVICE_DESCRIPTION,
                                     "myApp",
-                                    iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                    iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
                                     subscriberOptions);
         m_subscriber.resize(MAX_NUMBER_OF_EVENTS_PER_LISTENER + 1U);
         for (uint64_t i = 0U; i < MAX_NUMBER_OF_EVENTS_PER_LISTENER + 1U; ++i)

--- a/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_notification_info.cpp
@@ -49,7 +49,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 
 class iox_notification_info_test : public Test
@@ -115,7 +114,7 @@ class iox_notification_info_test : public Test
     SubscriberOptions m_subscriberOptions{MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, 0U};
     iox::popo::SubscriberPortData m_portPtr{TEST_TheHoff_DESCRIPTION,
                                             "myApp",
-                                            iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                            iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
                                             m_subscriberOptions};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     cpp2c_Subscriber m_subscriber;

--- a/iceoryx_binding_c/test/moduletests/test_publisher.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_publisher.cpp
@@ -44,7 +44,6 @@ using namespace ::testing;
 using namespace iox::testing;
 using namespace iox::roudi_env;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 
 class iox_pub_test : public Test
@@ -103,7 +102,7 @@ class iox_pub_test : public Test
 
     using ChunkQueueData_t = popo::ChunkQueueData<DefaultChunkQueueConfig, popo::ThreadSafePolicy>;
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
 
     BumpAllocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;

--- a/iceoryx_binding_c/test/moduletests/test_server.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_server.cpp
@@ -28,7 +28,6 @@
 using namespace iox::popo;
 using namespace iox::capro;
 using namespace iox;
-using namespace iox::cxx;
 using namespace iox::testing;
 
 extern "C" {
@@ -111,7 +110,7 @@ class iox_server_test : public Test
     iox_server_storage_t sutStorage;
 
     ClientChunkQueueData_t clientResponseQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                                   iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+                                                   iox::popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
     ChunkQueuePopper<ClientChunkQueueData_t> clientResponseQueue{&clientResponseQueueData};
 
     static constexpr const char SERVICE[] = "TheHoff";

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -49,7 +49,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 
 class iox_sub_test : public Test
@@ -114,7 +113,7 @@ class iox_sub_test : public Test
     iox::popo::SubscriberOptions subscriberOptions{MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, 0U};
     iox::popo::SubscriberPortData m_portPtr{TEST_SERVICE_DESCRIPTION,
                                             "myApp",
-                                            iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                            iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
                                             subscriberOptions};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     std::unique_ptr<cpp2c_Subscriber> m_subscriber{new cpp2c_Subscriber};

--- a/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_wait_set.cpp
@@ -65,7 +65,7 @@ class iox_ws_test : public Test
         {
             m_portDataVector.emplace_back(TEST_SERVICE_DESCRIPTION,
                                           "someAppName",
-                                          iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                          iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
                                           m_subscriberOptions);
             m_subscriberVector.emplace_back();
             m_subscriberVector[i].m_portData = &m_portDataVector[i];

--- a/iceoryx_hoofs/README.md
+++ b/iceoryx_hoofs/README.md
@@ -105,7 +105,6 @@ The module structure is a logical grouping. It is replicated for `concurrent` an
 |`SpscSofi`                          | i        | Single producer, single consumer lock-free safely overflowing FiFo (SpscSofi).                                                                                                                                                         |
 |`MpmcResizeableLockFreeQueue`       |          | Resizeable variant of the `MpmcLockfreeQueue`                                                                                                                                                                                          |
 |`stack`                             |          | Stack implementation with simple push/pop interface.                                                                                                                                                                               |
-|`VariantQueue`                      |          | A queue which wraps multiple variants of Queues (SpscFifo, SpscSofi, MpmcResizeableLockFreeQueue) - will be moved to `iceoryx_posh` -                                                                                                           |
 
 #### Attribute overview of the available buffers
 

--- a/iceoryx_hoofs/container/include/iox/forward_list.hpp
+++ b/iceoryx_hoofs/container/include/iox/forward_list.hpp
@@ -35,7 +35,7 @@ namespace iox
 ///         Capacity must at least be 1, (unintended) negative initialization is rejected with compile assertion
 ///         limitation: concurrency concerns have to be handled by client side.
 ///
-///         overview of cxx::forward_list deviations to std::forward_list(C++11)
+///         overview of forward_list deviations to std::forward_list(C++11)
 ///         - list declaration with mandatory max list size argument
 ///         - member functions don't throw exception but will trigger different failure handling
 ///         - push_front returns a bool (instead of void) informing on successful insertion (true)

--- a/iceoryx_hoofs/container/include/iox/list.hpp
+++ b/iceoryx_hoofs/container/include/iox/list.hpp
@@ -35,7 +35,7 @@ namespace iox
 ///         Capacity must at least be 1, (unintended) negative initialization is rejected with compile assertion
 ///         limitation: concurrency concerns have to be handled by client side.
 ///
-///         overview of cxx::forward_list deviations to std::forward_list(C++11)
+///         overview of list deviations to std::list(C++11)
 ///         - list declaration with mandatory max list size argument
 ///         - member functions don't throw exception but will trigger different failure handling
 ///         - push_front/~_back returns a bool (instead of void) informing on successful insertion (true)

--- a/iceoryx_hoofs/filesystem/include/iox/file_reader.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/file_reader.hpp
@@ -26,14 +26,14 @@ namespace iox
 /// can be decided by means of the ErrorMode argument.
 ///
 /// @code
-///     cxx::FileReader reader("filename");
+///     iox::FileReader reader("filename");
 ///     std::string str;
 ///     if(reader.isOpen()) {
 ///         reader.readLine(str);
 ///     }
 ///
 ///     // Terminates program execution, if file cannot be opened (or found):
-///     cxx::FileReader reader("filename", "path/to/file", cxx::FileReader::ErrorMode::Terminate);
+///     iox::FileReader reader("filename", "path/to/file", iox::FileReader::ErrorMode::Terminate);
 /// @endcode
 class FileReader
 {

--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -78,12 +78,12 @@ class Ownership
     gid_t gid() const noexcept;
 
     /// @brief Constructs a ownership object from a uid and a gid.
-    /// @returns If the user or group does not exist it returns 'cxx::nullopt' otherwise an Ownership object
+    /// @returns If the user or group does not exist it returns 'iox::nullopt' otherwise an Ownership object
     ///             with existing user and group
     static optional<Ownership> from_user_and_group(const uid_t uid, const gid_t gid) noexcept;
 
     /// @brief Constructs a ownership object from a user name and a group name.
-    /// @returns If the user or group does not exist it returns 'cxx::nullopt' otherwise an Ownership object
+    /// @returns If the user or group does not exist it returns 'iox::nullopt' otherwise an Ownership object
     ///             with existing user and group
     static optional<Ownership> from_user_and_group(const UserName& user_name, const GroupName& group_name) noexcept;
 

--- a/iceoryx_hoofs/posix/time/include/iox/deadline_timer.hpp
+++ b/iceoryx_hoofs/posix/time/include/iox/deadline_timer.hpp
@@ -28,7 +28,7 @@ namespace iox
 /// it uses the intialized duration], reset timer to a customized duration, check if the timer is active and user can
 /// also get to know about the remaining time before the timer goes off
 /// @code
-///     iox::cxx::deadline_timer deadlineTimer(1000_ms);
+///     iox::deadline_timer deadlineTimer(1000_ms);
 ///
 ///     // to check if the timer is active
 ///     if( deadlineTimer.hasExpired()){

--- a/iceoryx_hoofs/test/moduletests/test_cli_cli_definition.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cli_cli_definition.cpp
@@ -29,7 +29,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 
 /// This test is only some kind of compilation test to verify that the

--- a/iceoryx_hoofs/test/moduletests/test_cli_command_line_parser.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_cli_command_line_parser.cpp
@@ -34,7 +34,6 @@ namespace
 using namespace ::testing;
 using namespace iox::cli;
 using namespace iox;
-using namespace iox::cxx;
 
 class CommandLineParser_test : public Test
 {

--- a/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
+++ b/iceoryx_hoofs/test/moduletests/test_design_functional_interface_common.hpp
@@ -27,7 +27,7 @@ namespace test_design_functional_interface
 ///
 ///        The idea is to have a test setup which is so generic that a user
 ///        which would like to enrich its class with the functional interface
-///        has to write only a test factory in 'test_cxx_functional_types.hpp'
+///        has to write only a test factory in 'test_design_functional_interface_types.hpp'
 ///        for its specific type and then can add its type to the typelist and
 ///        the tests are generated for them.
 template <typename T>

--- a/iceoryx_hoofs/test/moduletests/test_posix_file.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file.cpp
@@ -30,7 +30,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 using namespace iox::units;
 using namespace iox::units::duration_literals;

--- a/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
@@ -22,7 +22,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 
 /// NOLINTJUSTIFICATION compile time string literal used only in tests

--- a/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_named_semaphore.cpp
@@ -21,7 +21,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 
 class NamedSemaphoreTest : public Test

--- a/iceoryx_hoofs/test/moduletests/test_posix_thread.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_thread.cpp
@@ -24,7 +24,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 using namespace iox::units;
 using namespace iox::units::duration_literals;

--- a/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_unnamed_semaphore.cpp
@@ -21,7 +21,6 @@
 namespace
 {
 using namespace ::testing;
-using namespace iox::cxx;
 using namespace iox;
 
 class UnnamedSemaphoreTest : public Test

--- a/iceoryx_hoofs/test/moduletests/test_utility_std_string_support.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_std_string_support.cpp
@@ -567,7 +567,7 @@ TYPED_TEST(StdString_test, FindEmptyStdStringInEmptyStringWorks)
 }
 
 /// @note template <typename T>
-/// iox::cxx::optional<uint64_t> find_first_of(const T& t, uint64_t pos = 0) const noexcept
+/// iox::optional<uint64_t> find_first_of(const T& t, uint64_t pos = 0) const noexcept
 TYPED_TEST(StdString_test, FindFirstOfFailsForEmptyStdStringInEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "207671e4-cef3-40d2-8984-e8ae5c2b42ec");
@@ -646,7 +646,7 @@ TEST(String100, FindNotIncludedStdStringFails)
 }
 
 /// @note template <typename T>
-/// iox::cxx::optional<uint64_t> find_last_of(const T& t, uint64_t pos = 0) const noexcept
+/// iox::optional<uint64_t> find_last_of(const T& t, uint64_t pos = 0) const noexcept
 TYPED_TEST(StdString_test, FindLastOfFailsForEmptyStdStringInEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "15f72273-8b90-407f-b7d0-07372f3cee29");

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_expected.cpp
@@ -22,7 +22,6 @@
 #include "test.hpp"
 
 using namespace ::testing;
-using namespace ::iox::cxx;
 using namespace ::iox;
 using namespace ::iox::testing;
 

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_string.cpp
@@ -2457,7 +2457,7 @@ TYPED_TEST(stringTyped_test, AppendCharDoesNotChangeStringWhenCapacityIsExceeded
     EXPECT_THAT(this->testSubject.c_str(), StrEq(temp.substr(0, STRINGCAP)));
 }
 
-/// @note iox::cxx::optional<string<Capacity>> substr(uint64_t pos = 0) const noexcept;
+/// @note iox::optional<string<Capacity>> substr(uint64_t pos = 0) const noexcept;
 TYPED_TEST(stringTyped_test, SubstrWithDefaultPosAndSizeResultsInWholeString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "da66bb36-2a1c-435b-8a47-874eb12315ef");
@@ -2495,7 +2495,7 @@ TEST(String100, SubstrWithDefaultSizeWorks)
     EXPECT_THAT(testSubstring.c_str(), StrEq(testStdSubstring));
 }
 
-/// @note iox::cxx::optional<string<Capacity>> substr(uint64_t pos, uint64_t count) const noexcept
+/// @note iox::optional<string<Capacity>> substr(uint64_t pos, uint64_t count) const noexcept
 TEST(String100, SubstrWithValidPosAndSizeWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3cd90af2-97f4-4767-854d-d3ca726bd348");
@@ -2554,7 +2554,7 @@ TYPED_TEST(stringTyped_test, SubstrWithInvalidPosFails)
 }
 
 /// @note template <typename T>
-/// iox::cxx::optional<uint64_t> find(const T& t, uint64_t pos = 0) const noexcept
+/// iox::optional<uint64_t> find(const T& t, uint64_t pos = 0) const noexcept
 TYPED_TEST(stringTyped_test, FindEmptyStringInEmptyStringWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3ceb4ed6-1395-445e-afe4-94f6c9b2cee8");
@@ -2655,7 +2655,7 @@ TEST(String100, FindNotIncludedStringLiteralFails)
 }
 
 /// @note template <typename T>
-/// iox::cxx::optional<uint64_t> find_first_of(const T& t, uint64_t pos = 0) const noexcept
+/// iox::optional<uint64_t> find_first_of(const T& t, uint64_t pos = 0) const noexcept
 TYPED_TEST(stringTyped_test, FindFirstOfFailsForEmptyStringInEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "21f90f13-6b15-4ce1-9258-c21154b6043c");
@@ -2771,7 +2771,7 @@ TEST(String100, FindFirstOfForNotIncludedStringLiteralFails)
 }
 
 /// @note template <typename T>
-/// iox::cxx::optional<uint64_t> find_last_of(const T& t, uint64_t pos = 0) const noexcept
+/// iox::optional<uint64_t> find_last_of(const T& t, uint64_t pos = 0) const noexcept
 TYPED_TEST(stringTyped_test, FindLastOfFailsForEmptyStringInEmptyString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "7e09947d-762f-4d7f-a1ab-65696877da06");

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/timing_test.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/timing_test.hpp
@@ -27,8 +27,8 @@
 ///        repetitions all results of the test are successful then the timing
 ///        test itself is successful.
 ///
-///        You can get to know them in praxis in the test_cxx_deadline_timer.cpp
-///        unit test for instance.
+///        The test_time_deadline_timer.cpp has is a good source to get an idea
+///        on how to use it in unit test.
 ///
 /// @code
 /// class MyClass_test : public Test {};

--- a/iceoryx_hoofs/utility/include/iox/into.hpp
+++ b/iceoryx_hoofs/utility/include/iox/into.hpp
@@ -71,8 +71,6 @@ struct extract_into_type<lossy<T>>
 ///
 /// namespace iox
 /// {
-/// namespace cxx
-/// {
 /// template <>
 /// constexpr HighLevel from<LowLevel, HighLevel>(LowLevel e) noexcept
 /// {
@@ -86,7 +84,6 @@ struct extract_into_type<lossy<T>>
 ///         return HighLevel::Timeout;
 ///     }
 /// }
-/// } // namespace cxx
 /// } // namespace iox
 /// @endcode
 /// @tparam SourceType is the 'from' type

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
@@ -288,7 +288,7 @@ inline void optional<T>::destruct_value() noexcept
     value().~T();
     m_hasValue = false;
 }
-// AXIVION Next Construct AutosarC++19_03-M17.0.3 : make_optional is defined within iox::cxx which prevents easy misuse
+// AXIVION Next Construct AutosarC++19_03-M17.0.3 : make_optional is defined within the iox namespace which prevents easy misuse
 template <typename OptionalBaseType, typename... Targs>
 inline optional<OptionalBaseType> make_optional(Targs&&... args) noexcept
 {

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -18,7 +18,6 @@
 #ifndef IOX_POSH_ICEORYX_POSH_TYPES_HPP
 #define IOX_POSH_ICEORYX_POSH_TYPES_HPP
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_platform/platform_settings.hpp"
 #include "iceoryx_posh/iceoryx_posh_deployment.hpp"
 #include "iox/duration.hpp"

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp
@@ -17,10 +17,10 @@
 #ifndef IOX_POSH_POPO_BUILDING_BLOCKS_CHUNK_QUEUE_DATA_HPP
 #define IOX_POSH_POPO_BUILDING_BLOCKS_CHUNK_QUEUE_DATA_HPP
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_posh/internal/mepoo/shm_safe_unmanaged_chunk.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/condition_notifier.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/condition_variable_data.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 #include "iceoryx_posh/popo/port_queue_policies.hpp"
 #include "iox/detail/unique_id.hpp"
 #include "iox/relative_pointer.hpp"
@@ -38,12 +38,12 @@ struct ChunkQueueData : public LockingPolicy
     using LockGuard_t = std::lock_guard<const ThisType_t>;
     using ChunkQueueDataProperties_t = ChunkQueueDataProperties;
 
-    ChunkQueueData(const QueueFullPolicy policy, const cxx::VariantQueueTypes queueType) noexcept;
+    ChunkQueueData(const QueueFullPolicy policy, const VariantQueueTypes queueType) noexcept;
 
     UniqueId m_uniqueId{};
 
     static constexpr uint64_t MAX_CAPACITY = ChunkQueueDataProperties_t::MAX_QUEUE_CAPACITY;
-    cxx::VariantQueue<mepoo::ShmSafeUnmanagedChunk, MAX_CAPACITY> m_queue;
+    VariantQueue<mepoo::ShmSafeUnmanagedChunk, MAX_CAPACITY> m_queue;
     std::atomic_bool m_queueHasLostChunks{false};
 
     RelativePointer<ConditionVariableData> m_conditionVariableDataPtr;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.inl
@@ -22,8 +22,8 @@ namespace iox
 namespace popo
 {
 template <typename ChunkQueueProperties, typename LockingPolicy>
-inline ChunkQueueData<ChunkQueueProperties, LockingPolicy>::ChunkQueueData(
-    const QueueFullPolicy policy, const cxx::VariantQueueTypes queueType) noexcept
+inline ChunkQueueData<ChunkQueueProperties, LockingPolicy>::ChunkQueueData(const QueueFullPolicy policy,
+                                                                           const VariantQueueTypes queueType) noexcept
     : m_queue(queueType)
     , m_queueFullPolicy(policy)
 {

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp
@@ -17,9 +17,9 @@
 #ifndef IOX_POSH_POPO_BUILDING_BLOCKS_CHUNK_RECEIVER_DATA_HPP
 #define IOX_POSH_POPO_BUILDING_BLOCKS_CHUNK_RECEIVER_DATA_HPP
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_queue_data.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 #include "iceoryx_posh/internal/popo/used_chunk_list.hpp"
 #include "iceoryx_posh/mepoo/memory_info.hpp"
 
@@ -30,7 +30,7 @@ namespace popo
 template <uint32_t MaxChunksHeldSimultaneously, typename ChunkQueueDataType>
 struct ChunkReceiverData : public ChunkQueueDataType
 {
-    explicit ChunkReceiverData(const cxx::VariantQueueTypes queueType,
+    explicit ChunkReceiverData(const VariantQueueTypes queueType,
                                const QueueFullPolicy queueFullPolicy,
                                const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.inl
@@ -23,7 +23,7 @@ namespace popo
 {
 template <uint32_t MaxChunksHeldSimultaneously, typename ChunkQueueDataType>
 inline ChunkReceiverData<MaxChunksHeldSimultaneously, ChunkQueueDataType>::ChunkReceiverData(
-    const cxx::VariantQueueTypes queueType,
+    const VariantQueueTypes queueType,
     const QueueFullPolicy queueFullPolicy,
     const mepoo::MemoryInfo& memoryInfo) noexcept
     : ChunkQueueDataType(queueFullPolicy, queueType)

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_CXX_VARIANT_QUEUE_HPP
-#define IOX_HOOFS_CXX_VARIANT_QUEUE_HPP
+
+#ifndef IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_HPP
+#define IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_HPP
 
 #include "iox/detail/mpmc_resizeable_lockfree_queue.hpp"
 #include "iox/detail/spsc_fifo.hpp"
@@ -27,14 +28,14 @@
 
 namespace iox
 {
-namespace cxx
+namespace popo
 {
 /// @brief list of the supported underlying queue types
 /// @note  if a new queue type is added the following steps have to be
 ///         performed:
 ///         1. add queue type here
 ///         2. add queue type in m_fifo data member variant type
-///         3. increase numberOfQueueTypes in test_cxx_variant_queue test
+///         3. increase numberOfQueueTypes in test_popo_variant_queue test
 enum class VariantQueueTypes : uint64_t
 {
     FiFo_SingleProducerSingleConsumer = 0,
@@ -51,8 +52,8 @@ enum class VariantQueueTypes : uint64_t
 /// @param[in] ValueType type which should be stored
 /// @param[in] Capacity capacity of the underlying fifo
 /// @code
-///     cxx::VariantQueue<int, 5> nonOverflowingQueue(cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer);
-///     cxx::VariantQueue<int, 5> overflowingQueue(cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer);
+///     popo::VariantQueue<int, 5> nonOverflowingQueue(popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer);
+///     popo::VariantQueue<int, 5> overflowingQueue(popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer);
 ///
 ///     // overflow case
 ///     auto status = nonOverflowingQueue.push(123);
@@ -116,9 +117,9 @@ class VariantQueue
     const VariantQueueTypes m_type;
     fifo_t m_fifo;
 };
-} // namespace cxx
+} // namespace popo
 } // namespace iox
 
-#include "iceoryx_hoofs/internal/cxx/variant_queue.inl"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.inl"
 
-#endif // IOX_HOOFS_CXX_VARIANT_QUEUE_HPP
+#endif // IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_HPP

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/variant_queue.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/variant_queue.inl
@@ -15,14 +15,15 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-#ifndef IOX_HOOFS_CXX_VARIANT_QUEUE_INL
-#define IOX_HOOFS_CXX_VARIANT_QUEUE_INL
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
+#ifndef IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_INL
+#define IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_INL
+
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 
 namespace iox
 {
-namespace cxx
+namespace popo
 {
 template <typename ValueType, uint64_t Capacity>
 inline VariantQueue<ValueType, Capacity>::VariantQueue(const VariantQueueTypes type) noexcept
@@ -259,7 +260,7 @@ inline uint64_t VariantQueue<ValueType, Capacity>::capacity() const noexcept
     return 0U;
 }
 
-} // namespace cxx
+} // namespace popo
 } // namespace iox
 
-#endif // IOX_HOOFS_CXX_VARIANT_QUEUE_INL
+#endif // IOX_POSH_POPO_BUILDING_BLOCKS_VARIANT_QUEUE_INL

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -18,8 +18,8 @@
 #ifndef IOX_POSH_POPO_PORTS_SUBSCRIBER_PORT_DATA_HPP
 #define IOX_POSH_POPO_PORTS_SUBSCRIBER_PORT_DATA_HPP
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_posh/capro/service_description.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
 #include "iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp"
 #include "iceoryx_posh/popo/subscriber_options.hpp"
@@ -36,7 +36,7 @@ struct SubscriberPortData : public BasePortData
 {
     SubscriberPortData(const capro::ServiceDescription& serviceDescription,
                        const RuntimeName_t& runtimeName,
-                       cxx::VariantQueueTypes queueType,
+                       const VariantQueueTypes queueType,
                        const SubscriberOptions& subscriberOptions,
                        const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/mepoo/mepoo_config.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/mepoo/mepoo_config.hpp
@@ -51,7 +51,7 @@ struct MePooConfig
     MePooConfig() noexcept = default;
 
     /// @brief Get function for receiving memory pool configuration
-    /// @return cxx::vector of config information size and count of chunks
+    /// @return iox::vector of config information size and count of chunks
     const MePooConfigContainerType* getMemPoolConfig() const noexcept;
 
     /// @brief Function for adding new entry

--- a/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.inl
@@ -31,8 +31,8 @@ inline iox::popo::SubscriberPortData* PortPool::constructSubscriber(const capro:
         serviceDescription,
         runtimeName,
         (subscriberOptions.queueFullPolicy == popo::QueueFullPolicy::DISCARD_OLDEST_DATA)
-            ? cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer
-            : cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+            ? popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer
+            : popo::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
         subscriberOptions,
         memoryInfo);
     if (port == getSubscriberPortDataList().end())
@@ -53,8 +53,8 @@ inline iox::popo::SubscriberPortData* PortPool::constructSubscriber(const capro:
         serviceDescription,
         runtimeName,
         (subscriberOptions.queueFullPolicy == popo::QueueFullPolicy::DISCARD_OLDEST_DATA)
-            ? cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer
-            : cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer,
+            ? popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer
+            : popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer,
         subscriberOptions,
         memoryInfo);
     if (port == getSubscriberPortDataList().end())

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -67,7 +67,7 @@ class PoshRuntime
     ///
     /// @param[in] name used for registering the process with the RouDi daemon.
     ///            Must be a valid platform-independent file name, see
-    ///            iox::cxx::isValidPathEntry
+    ///            iox::isValidPathEntry
     ///
     /// @return active runtime
     static PoshRuntime& initRuntime(const RuntimeName_t& name) noexcept;

--- a/iceoryx_posh/source/popo/ports/client_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_data.cpp
@@ -21,10 +21,10 @@ namespace iox
 {
 namespace popo
 {
-cxx::VariantQueueTypes getResponseQueueType(const QueueFullPolicy policy) noexcept
+VariantQueueTypes getResponseQueueType(const QueueFullPolicy policy) noexcept
 {
-    return policy == QueueFullPolicy::DISCARD_OLDEST_DATA ? cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer
-                                                          : cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer;
+    return policy == QueueFullPolicy::DISCARD_OLDEST_DATA ? VariantQueueTypes::SoFi_MultiProducerSingleConsumer
+                                                          : VariantQueueTypes::FiFo_MultiProducerSingleConsumer;
 }
 
 constexpr uint64_t ClientPortData::HISTORY_CAPACITY_ZERO;

--- a/iceoryx_posh/source/popo/ports/server_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_data.cpp
@@ -21,10 +21,10 @@ namespace iox
 {
 namespace popo
 {
-cxx::VariantQueueTypes getRequestQueueType(const QueueFullPolicy policy) noexcept
+VariantQueueTypes getRequestQueueType(const QueueFullPolicy policy) noexcept
 {
-    return policy == QueueFullPolicy::DISCARD_OLDEST_DATA ? cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer
-                                                          : cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer;
+    return policy == QueueFullPolicy::DISCARD_OLDEST_DATA ? VariantQueueTypes::SoFi_MultiProducerSingleConsumer
+                                                          : VariantQueueTypes::FiFo_MultiProducerSingleConsumer;
 }
 
 constexpr uint64_t ServerPortData::HISTORY_REQUEST_OF_ZERO;

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -24,7 +24,7 @@ namespace popo
 {
 SubscriberPortData::SubscriberPortData(const capro::ServiceDescription& serviceDescription,
                                        const RuntimeName_t& runtimeName,
-                                       cxx::VariantQueueTypes queueType,
+                                       const VariantQueueTypes queueType,
                                        const SubscriberOptions& subscriberOptions,
                                        const mepoo::MemoryInfo& memoryInfo) noexcept
     : BasePortData(serviceDescription, runtimeName, subscriberOptions.nodeName)

--- a/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
@@ -33,7 +33,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::popo;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 
 struct DummySample
@@ -216,11 +215,11 @@ class ChunkBuildingBlocks_IntegrationTest : public Test
     ChunkDistributor_t m_chunkDistributor{&m_chunkDistributorData};
     ChunkQueueData_t m_chunkQueueData{
         QueueFullPolicy::DISCARD_OLDEST_DATA,
-        iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer}; // SoFi intentionally not used
+        iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer}; // SoFi intentionally not used
     ChunkQueuePopper_t m_popper{&m_chunkQueueData};
 
     // Objects used by subscribing thread
-    ChunkReceiverData_t m_chunkReceiverData{iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer,
+    ChunkReceiverData_t m_chunkReceiverData{iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer,
                                             QueueFullPolicy::DISCARD_OLDEST_DATA}; // SoFi intentionally not used
     ChunkReceiver<ChunkReceiverData_t> m_chunkReceiver{&m_chunkReceiverData};
 };

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -37,7 +37,6 @@ namespace
 using namespace ::testing;
 using namespace iox::popo;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox;
 using namespace iox::mepoo;
 

--- a/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
+++ b/iceoryx_posh/test/integrationtests/test_service_discovery.cpp
@@ -40,7 +40,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::runtime;
-using namespace iox::cxx;
 using namespace iox::popo;
 using namespace iox::capro;
 using namespace iox::roudi_env;

--- a/iceoryx_posh/test/moduletests/test_base_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_base_port.cpp
@@ -78,7 +78,7 @@ SubscriberPortData* createPortData()
 {
     return new SubscriberPortData(SERVICE_DESCRIPTION,
                                   RUNTIME_NAME_FOR_SUBSCRIBER_PORTS,
-                                  iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+                                  iox::popo::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
                                   SubscriberOptions());
 }
 template <>

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -39,7 +39,7 @@ TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
     IdString_t testInstanceID{"3"};
     ServiceDescription sd(testServiceID, testEventID, testInstanceID);
     iox::popo::SubscriberPortData recData{
-        sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, iox::popo::SubscriberOptions()};
+        sd, "foo", iox::popo::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, iox::popo::SubscriberOptions()};
 
     CaproMessage testObj(CaproMessageType::OFFER, sd, CaproServiceType::PUBLISHER, &recData);
 

--- a/iceoryx_posh/test/moduletests/test_popo_base_client.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_client.cpp
@@ -29,7 +29,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 using namespace iox::popo;
 using namespace iox::runtime;

--- a/iceoryx_posh/test/moduletests/test_popo_base_server.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_server.cpp
@@ -29,7 +29,6 @@ namespace
 using namespace ::testing;
 using namespace iox;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 using namespace iox::popo;
 using namespace iox::runtime;

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_distributor.cpp
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_hoofs/error_handling/error_handling.hpp"
 #include "iceoryx_hoofs/testing/barrier.hpp"
 #include "iceoryx_hoofs/testing/fatal_failure.hpp"
@@ -27,6 +26,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_queue_popper.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_queue_pusher.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 #include "test.hpp"
 
@@ -37,7 +37,6 @@ namespace
 using namespace ::testing;
 using namespace iox::testing;
 using namespace iox::popo;
-using namespace iox::cxx;
 using namespace iox::mepoo;
 
 using ChunkDistributorTestSubjects = Types<ThreadSafePolicy, SingleThreadedPolicy>;

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_queue.cpp
@@ -71,18 +71,18 @@ class ChunkQueue_testBase
     static constexpr uint32_t RESIZED_CAPACITY{5U};
 };
 
-template <typename PolicyType, iox::cxx::VariantQueueTypes VariantQueueType>
+template <typename PolicyType, iox::popo::VariantQueueTypes VariantQueueType>
 struct TypeDefinitions
 {
     using PolicyType_t = PolicyType;
-    static const iox::cxx::VariantQueueTypes variantQueueType{VariantQueueType};
+    static const iox::popo::VariantQueueTypes variantQueueType{VariantQueueType};
 };
 
 using ChunkQueueSubjects =
-    Types<TypeDefinitions<ThreadSafePolicy, iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer>,
-          TypeDefinitions<ThreadSafePolicy, iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer>,
-          TypeDefinitions<SingleThreadedPolicy, iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer>,
-          TypeDefinitions<SingleThreadedPolicy, iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer>>;
+    Types<TypeDefinitions<ThreadSafePolicy, iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer>,
+          TypeDefinitions<ThreadSafePolicy, iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer>,
+          TypeDefinitions<SingleThreadedPolicy, iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer>,
+          TypeDefinitions<SingleThreadedPolicy, iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer>>;
 
 TYPED_TEST_SUITE(ChunkQueue_test, ChunkQueueSubjects, );
 
@@ -95,7 +95,7 @@ class ChunkQueue_test : public Test, public ChunkQueue_testBase
 
     using ChunkQueueData_t = ChunkQueueData<iox::DefaultChunkQueueConfig, typename TestTypes::PolicyType_t>;
 
-    iox::cxx::VariantQueueTypes m_variantQueueType{TestTypes::variantQueueType};
+    iox::popo::VariantQueueTypes m_variantQueueType{TestTypes::variantQueueType};
     ChunkQueueData_t m_chunkData{QueueFullPolicy::DISCARD_OLDEST_DATA, m_variantQueueType};
     ChunkQueuePopper<ChunkQueueData_t> m_popper{&m_chunkData};
     ChunkQueuePusher<ChunkQueueData_t> m_pusher{&m_chunkData};
@@ -121,12 +121,12 @@ TYPED_TEST(ChunkQueue_test, UniqueIdIsMonotonicallyIncreasing)
     ChunkQueueData_t m_chunkData1{QueueFullPolicy::DISCARD_OLDEST_DATA, this->m_variantQueueType};
     {
         ChunkQueueData_t m_chunkData2{QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer};
         EXPECT_THAT(static_cast<UniqueId::value_type>(m_chunkData2.m_uniqueId),
                     static_cast<UniqueId::value_type>(m_chunkData1.m_uniqueId) + 1);
     }
     ChunkQueueData_t m_chunkData3{QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                  iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                  iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     EXPECT_THAT(static_cast<UniqueId::value_type>(m_chunkData3.m_uniqueId),
                 static_cast<UniqueId::value_type>(m_chunkData1.m_uniqueId) + 2);
 }
@@ -138,7 +138,7 @@ TYPED_TEST(ChunkQueue_test, PushOneChunk)
     this->m_pusher.push(chunk);
     EXPECT_THAT(this->m_popper.empty(), Eq(false));
     /// @note size not implemented on FIFO
-    if (this->m_variantQueueType != iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer)
+    if (this->m_variantQueueType != iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer)
     {
         EXPECT_THAT(this->m_popper.size(), Eq(1U));
     }
@@ -153,7 +153,7 @@ TYPED_TEST(ChunkQueue_test, PopOneChunk)
     EXPECT_THAT(this->m_popper.tryPop().has_value(), Eq(true));
     EXPECT_THAT(this->m_popper.empty(), Eq(true));
     /// @note size not implemented on FIFO
-    if (this->m_variantQueueType != iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer)
+    if (this->m_variantQueueType != iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer)
     {
         EXPECT_THAT(this->m_popper.size(), Eq(0U));
     }
@@ -279,7 +279,7 @@ class ChunkQueueFiFo_test : public Test, public ChunkQueue_testBase
     using ChunkQueueData_t = ChunkQueueData<iox::DefaultChunkQueueConfig, PolicyType>;
 
     ChunkQueueData_t m_chunkData{QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                 iox::cxx::VariantQueueTypes::FiFo_SingleProducerSingleConsumer};
+                                 iox::popo::VariantQueueTypes::FiFo_SingleProducerSingleConsumer};
     ChunkQueuePopper<ChunkQueueData_t> m_popper{&m_chunkData};
     ChunkQueuePusher<ChunkQueueData_t> m_pusher{&m_chunkData};
 };
@@ -343,7 +343,7 @@ class ChunkQueueSoFi_test : public Test, public ChunkQueue_testBase
     using ChunkQueueData_t = ChunkQueueData<iox::DefaultChunkQueueConfig, PolicyType>;
 
     ChunkQueueData_t m_chunkData{QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                 iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                 iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     ChunkQueuePopper<ChunkQueueData_t> m_popper{&m_chunkData};
     ChunkQueuePusher<ChunkQueueData_t> m_pusher{&m_chunkData};
 };

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_receiver.cpp
@@ -88,7 +88,7 @@ class ChunkReceiver_test : public Test
         iox::popo::ChunkReceiverData<iox::MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, ChunkQueueData_t>;
     using ChunkQueuePopper_t = iox::popo::ChunkQueuePopper<ChunkQueueData_t>;
 
-    ChunkReceiverData_t m_chunkReceiverData{iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+    ChunkReceiverData_t m_chunkReceiverData{iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
                                             iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA};
     iox::popo::ChunkReceiver<ChunkReceiverData_t> m_chunkReceiver{&m_chunkReceiverData};
 

--- a/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_chunk_sender.cpp
@@ -105,7 +105,7 @@ class ChunkSender_test : public Test
         iox::popo::ChunkSenderData<iox::MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY, ChunkDistributorData_t>;
 
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     ChunkSenderData_t m_chunkSenderData{
         &m_memoryManager, iox::popo::ConsumerTooSlowPolicy::DISCARD_OLDEST_DATA, 0}; // must be 0 for test
     ChunkSenderData_t m_chunkSenderDataWithHistory{

--- a/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_client_port.cpp
@@ -210,7 +210,7 @@ class ClientPort_test : public Test
     static constexpr uint32_t USER_PAYLOAD_ALIGNMENT{8U};
 
     ServerChunkQueueData_t serverChunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                                iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+                                                iox::popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
     ChunkQueuePopper<ServerChunkQueueData_t> serverRequestQueue{&serverChunkQueueData};
 
     SutClientPort clientPortWithConnectOnCreate{

--- a/iceoryx_posh/test/moduletests/test_popo_listener.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_listener.cpp
@@ -37,7 +37,6 @@ namespace
 using namespace ::testing;
 
 using namespace iox::popo;
-using namespace iox::cxx;
 using namespace iox::units::duration_literals;
 
 namespace

--- a/iceoryx_posh/test/moduletests/test_popo_listener_waitset_attachments.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_listener_waitset_attachments.cpp
@@ -29,7 +29,6 @@ namespace
 {
 using namespace ::testing;
 using namespace ::iox::popo;
-using namespace ::iox::cxx;
 using namespace ::iox;
 using namespace ::iox::capro;
 using namespace ::iox::mepoo;

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -331,7 +331,7 @@ TEST_F(PublisherPort_test, subscribeWhenNotOfferedReturnsNACK)
 {
     ::testing::Test::RecordProperty("TEST_ID", "71148938-58f1-4189-8461-8bab912e32c6");
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;
@@ -350,7 +350,7 @@ TEST_F(PublisherPort_test, unsubscribeWhenNotSubscribedReturnsNACK)
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::UNSUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;
@@ -369,7 +369,7 @@ TEST_F(PublisherPort_test, subscribeWhenOfferedReturnsACKAndWeHaveSubscribers)
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;
@@ -389,7 +389,7 @@ TEST_F(PublisherPort_test, unsubscribeWhenSubscribedReturnsACKAndWeHaveNoMoreSub
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;
@@ -415,7 +415,7 @@ TEST_F(PublisherPort_test, subscribeManyIsFine)
     uint64_t dummy;
     uint64_t* dummyPtr = &dummy;
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = reinterpret_cast<ChunkQueueData_t*>(dummyPtr);
@@ -441,7 +441,7 @@ TEST_F(PublisherPort_test, subscribeTillOverflowReturnsNACK)
     uint64_t dummy;
     uint64_t* dummyPtr = &dummy;
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = reinterpret_cast<ChunkQueueData_t*>(dummyPtr);
@@ -466,7 +466,7 @@ TEST_F(PublisherPort_test, sendWhenSubscribedDeliversAChunk)
     m_sutNoOfferOnCreateUserSide.offer();
     m_sutNoOfferOnCreateRouDiSide.tryGetCaProMessage();
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;
@@ -512,7 +512,7 @@ TEST_F(PublisherPort_test, subscribeWithHistoryLikeTheARAField)
     sutWithHistoryRouDiSide.tryGetCaProMessage();
     // 3. subscribe with a history request
     ChunkQueueData_t m_chunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                      iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+                                      iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::SUB,
                                           iox::capro::ServiceDescription("a", "b", "c"));
     caproMessage.m_chunkQueueData = &m_chunkQueueData;

--- a/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
+++ b/iceoryx_posh/test/moduletests/test_popo_server_port_common.hpp
@@ -226,7 +226,7 @@ class ServerPort_test : public Test
     static constexpr uint32_t USER_PAYLOAD_ALIGNMENT{8U};
 
     ClientChunkQueueData_t clientChunkQueueData{iox::popo::QueueFullPolicy::DISCARD_OLDEST_DATA,
-                                                iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+                                                iox::popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
     ChunkQueuePopper<ClientChunkQueueData_t> clientResponseQueue{&clientChunkQueueData};
 
     SutServerPort serverPortWithOfferOnCreate{

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
@@ -62,7 +62,7 @@ class SubscriberPortSingleProducer_test : public Test
     iox::popo::SubscriberPortData m_subscriberPortDataSingleProducer{
         TEST_SERVICE_DESCRIPTION,
         "myApp",
-        iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+        iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
         m_noSubscribeOnCreateOptions};
     iox::popo::SubscriberPortUser m_sutUserSideSingleProducer{&m_subscriberPortDataSingleProducer};
     iox::popo::SubscriberPortSingleProducer m_sutRouDiSideSingleProducer{&m_subscriberPortDataSingleProducer};
@@ -71,7 +71,7 @@ class SubscriberPortSingleProducer_test : public Test
     iox::popo::SubscriberPortData m_subscriberPortDataDefaultOptions{
         TEST_SERVICE_DESCRIPTION,
         "myApp",
-        iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+        iox::popo::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
         m_defaultSubscriberOptions};
     iox::popo::SubscriberPortUser m_sutUserSideDefaultOptions{&m_subscriberPortDataDefaultOptions};
     iox::popo::SubscriberPortSingleProducer m_sutRouDiSideDefaultOptions{&m_subscriberPortDataDefaultOptions};
@@ -382,7 +382,7 @@ class SubscriberPortMultiProducer_test : public Test
     iox::popo::SubscriberPortData m_subscriberPortDataMultiProducer{
         SubscriberPortSingleProducer_test::TEST_SERVICE_DESCRIPTION,
         "myApp",
-        iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer,
+        iox::popo::VariantQueueTypes::SoFi_MultiProducerSingleConsumer,
         iox::popo::SubscriberOptions()};
     iox::popo::SubscriberPortUser m_sutUserSideMultiProducer{&m_subscriberPortDataMultiProducer};
     iox::popo::SubscriberPortMultiProducer m_sutRouDiSideMultiProducer{&m_subscriberPortDataMultiProducer};

--- a/iceoryx_posh/test/moduletests/test_popo_variant_queue.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_variant_queue.cpp
@@ -15,14 +15,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "iceoryx_hoofs/cxx/variant_queue.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/variant_queue.hpp"
 #include "test.hpp"
 
 namespace
 {
 using namespace ::testing;
 using namespace iox;
-using namespace iox::cxx;
+using namespace iox::popo;
 
 
 template <typename T>

--- a/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_waitset.cpp
@@ -35,7 +35,6 @@ using namespace ::testing;
 
 using namespace iox::popo;
 using namespace iox::popo::detail;
-using namespace iox::cxx;
 using namespace iox;
 using namespace iox::units::duration_literals;
 

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -38,7 +38,6 @@ namespace
 using namespace ::testing;
 using namespace iox::runtime;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox;
 using namespace iox::popo;
 using namespace iox::roudi_env;

--- a/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_cmd_line_parser_config_file_option.cpp
@@ -27,7 +27,6 @@ namespace
 {
 using namespace ::testing;
 
-using namespace iox::cxx;
 using namespace iox::config;
 
 class CmdLineParserConfigFileOption_test : public Test

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -351,10 +351,10 @@ TEST_F(PortIntrospection_test, addAndRemoveSubscriber)
     // test adding of ports
     // remark: duplicate subscriber insertions are not possible
     iox::popo::SubscriberPortData recData1{
-        service1, runtimeName1, iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, subscriberOptions1};
+        service1, runtimeName1, iox::popo::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, subscriberOptions1};
     MockSubscriberPortUser port1(&recData1);
     iox::popo::SubscriberPortData recData2{
-        service2, runtimeName2, iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, subscriberOptions2};
+        service2, runtimeName2, iox::popo::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, subscriberOptions2};
     MockSubscriberPortUser port2(&recData2);
     EXPECT_THAT(m_introspectionAccess.addSubscriber(recData1), Eq(true));
     EXPECT_THAT(m_introspectionAccess.addSubscriber(recData1), Eq(false));

--- a/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_portmanager_fixture.hpp
@@ -41,7 +41,6 @@ namespace iox_test_roudi_portmanager
 using namespace ::testing;
 using namespace iox;
 using namespace iox::capro;
-using namespace iox::cxx;
 using namespace iox::popo;
 using namespace iox::roudi;
 using namespace iox::roudi_env;

--- a/iceoryx_posh/test/moduletests/test_version_info.cpp
+++ b/iceoryx_posh/test/moduletests/test_version_info.cpp
@@ -23,7 +23,6 @@ namespace
 {
 using namespace ::testing;
 using namespace iox::version;
-using namespace iox::cxx;
 
 class VersionInfo_test : public Test
 {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR moves the `VariantQueue` to the port building blocks, the only place where it is used. Additionally, the documentation and namespace usage of `cxx` is cleaned up.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1391
