### PR TITLE
iox-#1032 Refactor 'IOX_REQUIRE'

### DIFF
--- a/doc/design/error_reporting.md
+++ b/doc/design/error_reporting.md
@@ -165,7 +165,7 @@ the case that it does not hold
 ```cpp
 int x;
 // ...
-IOX_REQUIRE(x>=0, Code::OutOfBounds);
+IOX_REQUIRE(x>=0, "required condition violation message");
 ```
 
 The condition is required to hold and this requirement is always checked.

--- a/iceoryx_hoofs/reporting/include/iox/assertions.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/assertions.hpp
@@ -44,18 +44,28 @@
         iox::er::forwardPanic(CURRENT_SOURCE_LOCATION, message);                                                       \
     } while (false)
 
-/// @brief report fatal error if expr evaluates to false
-/// @note for conditions that may actually happen during correct use
-/// @param expr boolean expression that must hold
-/// @param error error object (or code)
-#define IOX_REQUIRE(expr, error) IOX_REPORT_FATAL_IF(!(expr), error)
-
 //************************************************************************************************
 //* For documentation of intent, defensive programming and debugging
 //*
 //* There are no error codes/errors required here on purpose, as it would make the use cumbersome.
 //* Instead a special internal error type is used.
 //************************************************************************************************
+
+/// @brief report fatal required condition violation if expr evaluates to false
+/// @note for conditions that may actually happen during correct use
+/// @param expr boolean expression that must hold
+/// @param message message to be forwarded in case of violation
+#define IOX_REQUIRE(expr, message)                                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (!(expr))                                                                                                   \
+        {                                                                                                              \
+            iox::er::forwardFatalError(iox::er::Violation::createRequiredConditionViolation(),                         \
+                                       iox::er::REQUIRED_CONDITION_VIOLATION,                                          \
+                                       CURRENT_SOURCE_LOCATION,                                                        \
+                                       message); /* @todo iox-#1032 add strigified 'expr' as '#expr' */                \
+        }                                                                                                              \
+    } while (false)
 
 /// @brief if enabled: report fatal precondition violation if expr evaluates to false
 /// @param expr boolean expression that must hold upon entry of the function it appears in

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/error_kind.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/error_kind.hpp
@@ -37,6 +37,11 @@ struct FatalKind
     static constexpr char const* name = "Fatal Error";
 };
 
+struct RequiredConditionViolationKind
+{
+    static constexpr char const* name = "Required Condition Violation";
+};
+
 struct PreconditionViolationKind
 {
     static constexpr char const* name = "Precondition Violation";
@@ -59,6 +64,11 @@ struct IsFatal : public std::false_type
 // This enforces that these errors are always fatal in the sense that they cause panic and abort.
 template <>
 struct IsFatal<FatalKind> : public std::true_type
+{
+};
+
+template <>
+struct IsFatal<RequiredConditionViolationKind> : public std::true_type
 {
 };
 
@@ -87,6 +97,12 @@ bool constexpr isFatal<FatalKind>(FatalKind)
 }
 
 template <>
+bool constexpr isFatal<RequiredConditionViolationKind>(RequiredConditionViolationKind)
+{
+    return IsFatal<RequiredConditionViolationKind>::value;
+}
+
+template <>
 bool constexpr isFatal<PreconditionViolationKind>(PreconditionViolationKind)
 {
     return IsFatal<PreconditionViolationKind>::value;
@@ -100,6 +116,9 @@ bool constexpr isFatal<AssumptionViolationKind>(AssumptionViolationKind)
 
 // indicates serious condition, unable to continue
 constexpr FatalKind FATAL;
+
+// indicates a bug (contract breach by caller)
+constexpr RequiredConditionViolationKind REQUIRED_CONDITION_VIOLATION;
 
 // indicates a bug (contract breach by caller)
 constexpr PreconditionViolationKind PRECONDITION_VIOLATION;

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/errors.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/errors.hpp
@@ -70,6 +70,11 @@ class Violation
         return !(*this == rhs);
     }
 
+    static Violation createRequiredConditionViolation()
+    {
+        return Violation(ErrorCode(ErrorCode::REQUIRED_CONDITION_VIOLATION));
+    }
+
     static Violation createPreconditionViolation()
     {
         return Violation(ErrorCode(ErrorCode::PRECONDITION_VIOLATION));

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/macros.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/macros.hpp
@@ -61,7 +61,10 @@
     {                                                                                                                  \
         if (expr)                                                                                                      \
         {                                                                                                              \
-            iox::er::forwardNonFatalError(iox::er::toError(error), kind, CURRENT_SOURCE_LOCATION);                     \
+            iox::er::forwardNonFatalError(                                                                             \
+                iox::er::toError(error),                                                                               \
+                kind,                                                                                                  \
+                CURRENT_SOURCE_LOCATION); /* @todo iox-#1032 add strigified 'expr' as '#expr' */                       \
         }                                                                                                              \
     } while (false)
 

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/types.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/types.hpp
@@ -33,8 +33,9 @@ struct ErrorCode
 
     type value;
 
-    static constexpr type ASSUMPTION_VIOLATION{0};
-    static constexpr type PRECONDITION_VIOLATION{1};
+    static constexpr type REQUIRED_CONDITION_VIOLATION{0};
+    static constexpr type ASSUMPTION_VIOLATION{1};
+    static constexpr type PRECONDITION_VIOLATION{2};
 
     constexpr explicit ErrorCode(uint32_t value)
         : value(value)

--- a/iceoryx_hoofs/test/moduletests/error_reporting/test_error_reporting_macros.cpp
+++ b/iceoryx_hoofs/test/moduletests/error_reporting/test_error_reporting_macros.cpp
@@ -128,7 +128,7 @@ TEST_F(ErrorReportingMacroApi_test, reportConditionalNoError)
     IOX_TESTING_EXPECT_OK();
 }
 
-TEST_F(ErrorReportingMacroApi_test, requireConditionSatisfied)
+TEST_F(ErrorReportingMacroApi_test, checkRequireConditionSatisfied)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3c684878-20f8-426f-bb8b-7576b567d04f");
     auto f = []() { IOX_REQUIRE(true, ""); };
@@ -138,7 +138,7 @@ TEST_F(ErrorReportingMacroApi_test, requireConditionSatisfied)
     IOX_TESTING_EXPECT_OK();
 }
 
-TEST_F(ErrorReportingMacroApi_test, requireConditionNotSatisfied)
+TEST_F(ErrorReportingMacroApi_test, checkRequireConditionViolate)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb62d315-8854-401b-82af-6161ae45a34e");
     auto f = []() { IOX_REQUIRE(false, ""); };
@@ -146,6 +146,7 @@ TEST_F(ErrorReportingMacroApi_test, requireConditionNotSatisfied)
     runInTestThread(f);
 
     IOX_TESTING_EXPECT_PANIC();
+    IOX_TESTING_EXPECT_REQUIRED_CONDITION_VIOLATION();
 }
 
 TEST_F(ErrorReportingMacroApi_test, checkPreconditionSatisfied)

--- a/iceoryx_hoofs/test/moduletests/error_reporting/test_error_reporting_macros.cpp
+++ b/iceoryx_hoofs/test/moduletests/error_reporting/test_error_reporting_macros.cpp
@@ -131,7 +131,7 @@ TEST_F(ErrorReportingMacroApi_test, reportConditionalNoError)
 TEST_F(ErrorReportingMacroApi_test, requireConditionSatisfied)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3c684878-20f8-426f-bb8b-7576b567d04f");
-    auto f = []() { IOX_REQUIRE(true, MyCodeA::OutOfBounds); };
+    auto f = []() { IOX_REQUIRE(true, ""); };
 
     runInTestThread(f);
 
@@ -141,12 +141,11 @@ TEST_F(ErrorReportingMacroApi_test, requireConditionSatisfied)
 TEST_F(ErrorReportingMacroApi_test, requireConditionNotSatisfied)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb62d315-8854-401b-82af-6161ae45a34e");
-    auto f = []() { IOX_REQUIRE(false, MyCodeA::OutOfBounds); };
+    auto f = []() { IOX_REQUIRE(false, ""); };
 
     runInTestThread(f);
 
     IOX_TESTING_EXPECT_PANIC();
-    IOX_TESTING_EXPECT_ERROR(MyCodeA::OutOfBounds);
 }
 
 TEST_F(ErrorReportingMacroApi_test, checkPreconditionSatisfied)

--- a/iceoryx_hoofs/testing/error_reporting/testing_support.cpp
+++ b/iceoryx_hoofs/testing/error_reporting/testing_support.cpp
@@ -31,6 +31,12 @@ bool hasError()
     return ErrorHandler::instance().hasError();
 }
 
+bool hasRequiredConditionViolation()
+{
+    auto code = iox::er::ErrorCode{iox::er::ErrorCode::REQUIRED_CONDITION_VIOLATION};
+    return ErrorHandler::instance().hasViolation(code);
+}
+
 bool hasPreconditionViolation()
 {
     auto code = iox::er::ErrorCode{iox::er::ErrorCode::PRECONDITION_VIOLATION};
@@ -45,7 +51,7 @@ bool hasAssumptionViolation()
 
 bool hasViolation()
 {
-    return hasPreconditionViolation() || hasAssumptionViolation();
+    return hasRequiredConditionViolation() || hasPreconditionViolation() || hasAssumptionViolation();
 }
 
 bool isInNormalState()

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/error_reporting/testing_support.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/error_reporting/testing_support.hpp
@@ -50,6 +50,9 @@ bool hasPanicked();
 /// @brief indicates whether the test error handler registered any error
 bool hasError();
 
+/// @brief indicates whether the test error handler registered a required condition violation
+bool hasRequiredConditionViolation();
+
 /// @brief indicates whether the test error handler registered a precondition violation
 bool hasPreconditionViolation();
 
@@ -120,11 +123,11 @@ inline void runInTestThread(Function&& testFunction, Args&&... args)
 
 #define IOX_TESTING_ASSERT_NO_ERROR() ASSERT_FALSE(iox::testing::hasError())
 
-#define IOX_TESTING_ASSERT_VIOLATION()                                                                                 \
-    ASSERT_TRUE(iox::testing::hasPreconditionViolation() || iox::testing::hasAssumptionViolation())
+#define IOX_TESTING_ASSERT_VIOLATION() ASSERT_TRUE(iox::testing::hasViolation())
 
-#define IOX_TESTING_ASSERT_NO_VIOLATION()                                                                              \
-    ASSERT_FALSE(iox::testing::hasPreconditionViolation() || iox::testing::hasAssumptionViolation())
+#define IOX_TESTING_ASSERT_NO_VIOLATION() ASSERT_FALSE(iox::testing::hasViolation())
+
+#define IOX_TESTING_ASSERT_REQUIRED_CONDITION_VIOLATION() ASSERT_TRUE(iox::testing::hasRequiredConditionViolation())
 
 #define IOX_TESTING_ASSERT_PRECONDITION_VIOLATION() ASSERT_TRUE(iox::testing::hasPreconditionViolation())
 
@@ -142,11 +145,11 @@ inline void runInTestThread(Function&& testFunction, Args&&... args)
 
 #define IOX_TESTING_EXPECT_NO_ERROR() EXPECT_FALSE(iox::testing::hasError())
 
-#define IOX_TESTING_EXPECT_VIOLATION()                                                                                 \
-    EXPECT_TRUE(iox::testing::hasPreconditionViolation() || iox::testing::hasAssumptionViolation())
+#define IOX_TESTING_EXPECT_VIOLATION() EXPECT_TRUE(iox::testing::hasViolation())
 
-#define IOX_TESTING_EXPECT_NO_VIOLATION()                                                                              \
-    EXPECT_FALSE(iox::testing::hasPreconditionViolation() || iox::testing::hasAssumptionViolation())
+#define IOX_TESTING_EXPECT_NO_VIOLATION() EXPECT_FALSE(iox::testing::hasViolation())
+
+#define IOX_TESTING_EXPECT_REQUIRED_CONDITION_VIOLATION() EXPECT_TRUE(iox::testing::hasRequiredConditionViolation())
 
 #define IOX_TESTING_EXPECT_PRECONDITION_VIOLATION() EXPECT_TRUE(iox::testing::hasPreconditionViolation())
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Currently `IOX_REQUIRE` can only be used with an error code which makes it semantically similar to `IOX_REPORT_FATAL_IF`. On the other hand, there is no assertion macro which cannot be deactivated via compile time switch. I think it makes more sense to have an `IOX_REQUIRE` which acts like an `IOX_ASSUME` but cannot turned off by a compile time switch.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1032
