### PR TITLE
iox-#2060 Fix clang-tidy warning for legacy 'byte' alias

### DIFF
--- a/iceoryx_hoofs/legacy/include/iceoryx_hoofs/iceoryx_hoofs_types.hpp
+++ b/iceoryx_hoofs/legacy/include/iceoryx_hoofs/iceoryx_hoofs_types.hpp
@@ -20,6 +20,8 @@
 #include "iox/detail/deprecation_marker.hpp"
 #include "iox/iceoryx_hoofs_types.hpp"
 
+#include <cstddef>
+
 IOX_DEPRECATED_HEADER_SINCE(3, "Please include 'iox/iceoryx_hoofs_types.hpp' instead.")
 
 namespace iox
@@ -29,7 +31,7 @@ namespace iox
 namespace cxx
 {
 /// @deprecated use 'std::byte' instead of 'iox::cxx::byte_t'
-using byte_t IOX_DEPRECATED_SINCE(3, "Please use 'std::byte' instead.") = byte;
+using byte_t IOX_DEPRECATED_SINCE(3, "Please use 'std::byte' instead.") = std::byte;
 
 } // namespace cxx
 namespace log


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [ ] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The nightly clang-tidy full scan fails after the legacy header were added to the scan list. This PR fixes the problem with the latest scan.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #2060
