### PR TITLE
Add edge test cases for 'convert::from_string'

### DIFF
--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -303,58 +303,102 @@ TEST_F(convert_test, fromString_LongInt_Fail)
     ASSERT_THAT(result.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_MinMaxShort)
+/// EDGE CASES START
+/// inc: increment, dec: decrement
+
+TEST_F(convert_test, fromString_EdgeCase_SignedShort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "98e33efd-ba39-4b88-8307-358be30e4e73");
-    std::string source = "32767";
-    auto gg = iox::convert::from_string<int16_t>(source.c_str());
-    EXPECT_THAT(iox::convert::from_string<int16_t>(source.c_str()).has_value(), Eq(true));
-    source = "32768";
-    EXPECT_THAT(iox::convert::from_string<int16_t>(source.c_str()).has_value(), Eq(false));
-    source = "-32768";
-    EXPECT_THAT(iox::convert::from_string<int16_t>(source.c_str()).has_value(), Eq(true));
+
+    std::string source = "-32768";
+    auto short_min = iox::convert::from_string<short>(source.c_str());
+    ASSERT_THAT(short_min.has_value(), Eq(true));
+    EXPECT_THAT(short_min.value(), Eq(-32768));
+
     source = "-32769";
-    EXPECT_THAT(iox::convert::from_string<int16_t>(source.c_str()).has_value(), Eq(false));
+    auto short_min_dec_1 = iox::convert::from_string<short>(source.c_str());
+    ASSERT_THAT(short_min_dec_1.has_value(), Eq(false));
+
+    source = "32767";
+    auto short_max = iox::convert::from_string<short>(source.c_str());
+    ASSERT_THAT(short_max.has_value(), Eq(true));
+    EXPECT_THAT(short_max.value(), Eq(32767));
+
+    source = "32768";
+    auto short_max_inc_1 = iox::convert::from_string<short>(source.c_str());
+    ASSERT_THAT(short_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_MinMaxUNSIGNED_Short)
-{
-    ::testing::Test::RecordProperty("TEST_ID", "f9196939-ae5d-4c27-85bf-b3b084343261");
-    std::string source = "65535";
-    EXPECT_THAT(iox::convert::from_string<uint16_t>(source.c_str()).has_value(), Eq(true));
-    source = "65536";
-    EXPECT_THAT(iox::convert::from_string<uint16_t>(source.c_str()).has_value(), Eq(false));
-    source = "0";
-    EXPECT_THAT(iox::convert::from_string<uint16_t>(source.c_str()).has_value(), Eq(true));
-    source = "-1";
-    EXPECT_THAT(iox::convert::from_string<uint16_t>(source.c_str()).has_value(), Eq(false));
-}
-
-TEST_F(convert_test, fromString_MinMaxInt)
+TEST_F(convert_test, fromString_EdgeCase_SignedInt)
 {
     ::testing::Test::RecordProperty("TEST_ID", "abf0fda5-044e-4f1b-bb1e-31b701578a3d");
-    std::string source = "2147483647";
-    EXPECT_THAT(iox::convert::from_string<int32_t>(source.c_str()).has_value(), Eq(true));
-    source = "2147483648";
-    EXPECT_THAT(iox::convert::from_string<int32_t>(source.c_str()).has_value(), Eq(false));
-    source = "-2147483648";
-    EXPECT_THAT(iox::convert::from_string<int32_t>(source.c_str()).has_value(), Eq(true));
+
+    std::string source = "-2147483648";
+    auto int_min = iox::convert::from_string<int>(source.c_str());
+    ASSERT_THAT(int_min.has_value(), Eq(true));
+    EXPECT_THAT(int_min.value(), Eq(-2147483648));
+
     source = "-2147483649";
-    EXPECT_THAT(iox::convert::from_string<int32_t>(source.c_str()).has_value(), Eq(false));
+    auto int_min_dec_1 = iox::convert::from_string<int>(source.c_str());
+    ASSERT_THAT(int_min_dec_1.has_value(), Eq(false));
+
+    source = "2147483647";
+    auto int_max = iox::convert::from_string<int>(source.c_str());
+    ASSERT_THAT(int_max.has_value(), Eq(true));
+    EXPECT_THAT(int_max.value(), Eq(2147483647));
+
+    source = "2147483648";
+    auto int_max_inc_1 = iox::convert::from_string<int>(source.c_str());
+    ASSERT_THAT(int_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_MinMaxUNSIGNED_Int)
+TEST_F(convert_test, fromString_EdgeCase_UnSignedShort)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "f9196939-ae5d-4c27-85bf-b3b084343261");
+
+    std::string source = "0";
+    auto unshort_min = iox::convert::from_string<unsigned short>(source.c_str());
+    ASSERT_THAT(unshort_min.has_value(), Eq(true));
+    EXPECT_THAT(unshort_min.value(), Eq(0));
+
+    source = "-1";
+    auto unshort_min_dec_1 = iox::convert::from_string<unsigned short>(source.c_str());
+    ASSERT_THAT(unshort_min_dec_1.has_value(), Eq(false));
+
+    source = "65535";
+    auto unshort_max = iox::convert::from_string<unsigned short>(source.c_str());
+    ASSERT_THAT(unshort_max.has_value(), Eq(true));
+    EXPECT_THAT(unshort_max.value(), Eq(65535));
+
+    source = "65536";
+    auto unshort_max_inc_1 = iox::convert::from_string<unsigned short>(source.c_str());
+    ASSERT_THAT(unshort_max_inc_1.has_value(), Eq(false));
+}
+
+TEST_F(convert_test, fromString_EdgeCase_UnSignedInt)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c2a832ef-3e86-4303-a98c-63c7b11ea789");
-    std::string source = "4294967295";
-    EXPECT_THAT(iox::convert::from_string<uint32_t>(source.c_str()).has_value(), Eq(true));
-    source = "4294967296";
-    EXPECT_THAT(iox::convert::from_string<uint32_t>(source.c_str()).has_value(), Eq(false));
-    source = "0";
-    EXPECT_THAT(iox::convert::from_string<uint32_t>(source.c_str()).has_value(), Eq(true));
+
+    std::string source = "0";
+    auto unint_min = iox::convert::from_string<unsigned int>(source.c_str());
+    ASSERT_THAT(unint_min.has_value(), Eq(true));
+    EXPECT_THAT(unint_min.value(), Eq(0));
+
     source = "-1";
-    EXPECT_THAT(iox::convert::from_string<uint32_t>(source.c_str()).has_value(), Eq(false));
+    auto unint_min_dec_1 = iox::convert::from_string<unsigned int>(source.c_str());
+    ASSERT_THAT(unint_min_dec_1.has_value(), Eq(false));
+
+    source = "4294967295";
+    auto unint_max = iox::convert::from_string<unsigned int>(source.c_str());
+    ASSERT_THAT(unint_max.has_value(), Eq(true));
+    EXPECT_THAT(unint_max.value(), Eq(4294967295));
+
+    source = "4294967296";
+    auto unint_max_inc_1 = iox::convert::from_string<unsigned int>(source.c_str());
+    ASSERT_THAT(unint_max_inc_1.has_value(), Eq(false));
 }
+
+/// EDGE CASES END
 
 TEST_F(convert_test, fromString_cxxString)
 {

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -322,12 +322,12 @@ TEST_F(convert_test, fromString_SignedChar_EdgeCase_InRange_Success)
     std::string source = "-128";
     auto signed_char_min = iox::convert::from_string<signed char>(source.c_str());
     ASSERT_THAT(signed_char_min.has_value(), Eq(true));
-    EXPECT_THAT(signed_char_min.value(), Eq(static_cast<signed char>(-128)));
+    EXPECT_THAT(signed_char_min.value(), Eq(std::numeric_limits<signed char>::min()));
 
     source = "127";
     auto signed_char_max = iox::convert::from_string<signed char>(source.c_str());
     ASSERT_THAT(signed_char_max.has_value(), Eq(true));
-    EXPECT_THAT(signed_char_max.value(), Eq(static_cast<signed char>(127)));
+    EXPECT_THAT(signed_char_max.value(), Eq(std::numeric_limits<signed char>::max()));
 }
 
 TEST_F(convert_test, fromString_SignedChar_EdgeCase_OutOfRange_Fail)
@@ -350,12 +350,12 @@ TEST_F(convert_test, fromString_SignedShort_EdgeCase_InRange_Success)
     std::string source = "-32768";
     auto short_min = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_min.has_value(), Eq(true));
-    EXPECT_THAT(short_min.value(), Eq(static_cast<short>(-32768)));
+    EXPECT_THAT(short_min.value(), Eq(std::numeric_limits<short>::min()));
 
     source = "32767";
     auto short_max = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_max.has_value(), Eq(true));
-    EXPECT_THAT(short_max.value(), Eq(static_cast<short>(32767)));
+    EXPECT_THAT(short_max.value(), Eq(std::numeric_limits<short>::max()));
 }
 
 TEST_F(convert_test, fromString_SignedShort_EdgeCase_OutOfRange_Fail)
@@ -378,12 +378,12 @@ TEST_F(convert_test, fromString_SignedInt_EdgeCase_InRange_Success)
     std::string source = "-2147483648";
     auto int_min = iox::convert::from_string<int>(source.c_str());
     ASSERT_THAT(int_min.has_value(), Eq(true));
-    EXPECT_THAT(int_min.value(), Eq(-2147483648));
+    EXPECT_THAT(int_min.value(), Eq(std::numeric_limits<int>::min()));
 
     source = "2147483647";
     auto int_max = iox::convert::from_string<int>(source.c_str());
     ASSERT_THAT(int_max.has_value(), Eq(true));
-    EXPECT_THAT(int_max.value(), Eq(2147483647));
+    EXPECT_THAT(int_max.value(), Eq(std::numeric_limits<int>::max()));
 }
 
 TEST_F(convert_test, fromString_SignedInt_EdgeCase_OutOfRange_Fail)
@@ -443,7 +443,7 @@ TEST_F(convert_test, fromString_SignedLongLong_EdgeCase_InRange_Success)
     source = "9223372036854775807";
     auto long_long_max = iox::convert::from_string<long long>(source.c_str());
     ASSERT_THAT(long_long_max.has_value(), Eq(true));
-    EXPECT_THAT(long_long_max.value(), Eq(9223372036854775807LL));
+    EXPECT_THAT(long_long_max.value(), Eq(std::numeric_limits<long long>::max()));
 }
 
 TEST_F(convert_test, fromString_SignedLongLong_EdgeCase_OutOfRange_Fail)
@@ -475,7 +475,7 @@ TEST_F(convert_test, fromString_UnSignedChar_EdgeCase_InRange_Success)
     source = "255";
     auto unchar_max = iox::convert::from_string<unsigned char>(source.c_str());
     ASSERT_THAT(unchar_max.has_value(), Eq(true));
-    EXPECT_THAT(unchar_max.value(), Eq(static_cast<unsigned char>(255)));
+    EXPECT_THAT(unchar_max.value(), Eq(std::numeric_limits<unsigned char>::max()));
 }
 
 TEST_F(convert_test, fromString_UnSignedChar_EdgeCase_OutOfRange_Fail)
@@ -503,7 +503,7 @@ TEST_F(convert_test, fromString_UnSignedShort_EdgeCase_InRange_Success)
     source = "65535";
     auto unshort_max = iox::convert::from_string<unsigned short>(source.c_str());
     ASSERT_THAT(unshort_max.has_value(), Eq(true));
-    EXPECT_THAT(unshort_max.value(), Eq(static_cast<unsigned short>(65535)));
+    EXPECT_THAT(unshort_max.value(), Eq(std::numeric_limits<unsigned short>::max()));
 }
 
 TEST_F(convert_test, fromString_UnSignedShort_EdgeCase_OutOfRange_Fail)
@@ -531,7 +531,7 @@ TEST_F(convert_test, fromString_UnSignedInt_EdgeCase_InRange_Success)
     source = "4294967295";
     auto unint_max = iox::convert::from_string<unsigned int>(source.c_str());
     ASSERT_THAT(unint_max.has_value(), Eq(true));
-    EXPECT_THAT(unint_max.value(), Eq(4294967295U));
+    EXPECT_THAT(unint_max.value(), Eq(std::numeric_limits<unsigned int>::max()));
 }
 
 TEST_F(convert_test, fromString_UnSignedInt_EdgeCase_OutOfRange_Fail)
@@ -590,7 +590,7 @@ TEST_F(convert_test, fromString_UnSignedLongLong_EdgeCase_InRange_Success)
     source = "18446744073709551615";
     auto unlong_long_max = iox::convert::from_string<unsigned long long>(source.c_str());
     ASSERT_THAT(unlong_long_max.has_value(), Eq(true));
-    EXPECT_THAT(unlong_long_max.value(), Eq(18446744073709551615ULL));
+    EXPECT_THAT(unlong_long_max.value(), Eq(std::numeric_limits<unsigned long long>::max()));
 }
 
 TEST_F(convert_test, fromString_UnSignedLongLong_EdgeCase_OutOfRange_Fail)

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -315,7 +315,7 @@ TEST_F(convert_test, fromString_LongInt_Fail)
 /// SINGED INTEGRAL EDGE CASES START
 /// inc: increment, dec: decrement
 
-TEST_F(convert_test, fromString_EdgeCase_SignedChar)
+TEST_F(convert_test, fromString_SignedChar_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3a70481e-ae86-4b96-92c4-44169700e93a");
 
@@ -324,60 +324,75 @@ TEST_F(convert_test, fromString_EdgeCase_SignedChar)
     ASSERT_THAT(signed_char_min.has_value(), Eq(true));
     EXPECT_THAT(signed_char_min.value(), Eq(static_cast<signed char>(-128)));
 
-    source = "-129";
-    auto signed_char_min_dec_1 = iox::convert::from_string<signed char>(source.c_str());
-    ASSERT_THAT(signed_char_min_dec_1.has_value(), Eq(false));
-
     source = "127";
     auto signed_char_max = iox::convert::from_string<signed char>(source.c_str());
     ASSERT_THAT(signed_char_max.has_value(), Eq(true));
     EXPECT_THAT(signed_char_max.value(), Eq(static_cast<signed char>(127)));
+}
+
+TEST_F(convert_test, fromString_SignedChar_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "23a3aa3d-954f-43f3-96e9-6b885bbb0c86");
+
+    std::string source = "-129";
+    auto signed_char_min_dec_1 = iox::convert::from_string<signed char>(source.c_str());
+    ASSERT_THAT(signed_char_min_dec_1.has_value(), Eq(false));
 
     source = "128";
     auto signed_char_max_inc_1 = iox::convert::from_string<signed char>(source.c_str());
     ASSERT_THAT(signed_char_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_SignedShort)
+TEST_F(convert_test, fromString_SignedShort_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "98e33efd-ba39-4b88-8307-358be30e4e73");
+    ::testing::Test::RecordProperty("TEST_ID", "68f802ce-feb5-46d9-a956-dd3ca1a3ce53");
 
     std::string source = "-32768";
     auto short_min = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_min.has_value(), Eq(true));
     EXPECT_THAT(short_min.value(), Eq(static_cast<short>(-32768)));
 
-    source = "-32769";
-    auto short_min_dec_1 = iox::convert::from_string<short>(source.c_str());
-    ASSERT_THAT(short_min_dec_1.has_value(), Eq(false));
-
     source = "32767";
     auto short_max = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_max.has_value(), Eq(true));
     EXPECT_THAT(short_max.value(), Eq(static_cast<short>(32767)));
+}
+
+TEST_F(convert_test, fromString_SignedShort_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "98e33efd-ba39-4b88-8307-358be30e4e73");
+
+    std::string source = "-32769";
+    auto short_min_dec_1 = iox::convert::from_string<short>(source.c_str());
+    ASSERT_THAT(short_min_dec_1.has_value(), Eq(false));
 
     source = "32768";
     auto short_max_inc_1 = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_SignedInt)
+TEST_F(convert_test, fromString_SignedInt_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "abf0fda5-044e-4f1b-bb1e-31b701578a3d");
+    ::testing::Test::RecordProperty("TEST_ID", "7333d0f9-dd48-4a88-85c9-2167d65633db");
 
     std::string source = "-2147483648";
     auto int_min = iox::convert::from_string<int>(source.c_str());
     ASSERT_THAT(int_min.has_value(), Eq(true));
     EXPECT_THAT(int_min.value(), Eq(-2147483648));
 
-    source = "-2147483649";
-    auto int_min_dec_1 = iox::convert::from_string<int>(source.c_str());
-    ASSERT_THAT(int_min_dec_1.has_value(), Eq(false));
-
     source = "2147483647";
     auto int_max = iox::convert::from_string<int>(source.c_str());
     ASSERT_THAT(int_max.has_value(), Eq(true));
     EXPECT_THAT(int_max.value(), Eq(2147483647));
+}
+
+TEST_F(convert_test, fromString_SignedInt_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "abf0fda5-044e-4f1b-bb1e-31b701578a3d");
+
+    std::string source = "-2147483649";
+    auto int_min_dec_1 = iox::convert::from_string<int>(source.c_str());
+    ASSERT_THAT(int_min_dec_1.has_value(), Eq(false));
 
     source = "2147483648";
     auto int_max_inc_1 = iox::convert::from_string<int>(source.c_str());
@@ -385,34 +400,39 @@ TEST_F(convert_test, fromString_EdgeCase_SignedInt)
 }
 
 // platform dependent (32/64 bit system only)
-TEST_F(convert_test, fromString_EdgeCase_SignedLong)
+TEST_F(convert_test, fromString_SignedLong_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "5dc4c773-6a51-42b6-ad94-7ec885263856");
-
-    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
 
     std::string source = std::to_string(std::numeric_limits<long>::min());
     auto long_min = iox::convert::from_string<long>(source.c_str());
     ASSERT_THAT(long_min.has_value(), Eq(true));
     EXPECT_THAT(long_min.value(), Eq(std::numeric_limits<long>::min()));
 
-    source = IS_32_BIT ? "-2147483649" : "-9223372036854775809";
-    auto long_min_dec_1 = iox::convert::from_string<long>(source.c_str());
-    ASSERT_THAT(long_min_dec_1.has_value(), Eq(false));
-
     source = std::to_string(std::numeric_limits<long>::max());
     auto long_max = iox::convert::from_string<long>(source.c_str());
     ASSERT_THAT(long_max.has_value(), Eq(true));
     EXPECT_THAT(long_max.value(), Eq(std::numeric_limits<long>::max()));
+}
+
+TEST_F(convert_test, fromString_SignedLong_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "fb349f9c-0800-4f0b-8940-9012f9946b77");
+
+    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
+
+    std::string source = IS_32_BIT ? "-2147483649" : "-9223372036854775809";
+    auto long_min_dec_1 = iox::convert::from_string<long>(source.c_str());
+    ASSERT_THAT(long_min_dec_1.has_value(), Eq(false));
 
     source = IS_32_BIT ? "2147483648" : "9223372036854775808";
     auto long_max_inc_1 = iox::convert::from_string<long>(source.c_str());
     ASSERT_THAT(long_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_SignedLongLong)
+TEST_F(convert_test, fromString_SignedLongLong_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "7c015ac0-06a7-407d-aa93-d39c50734951");
+    ::testing::Test::RecordProperty("TEST_ID", "1f1b0456-3b50-49ce-a69d-fe1d71a39230");
 
     std::string source = "-9223372036854775808";
     auto long_long_min = iox::convert::from_string<long long>(source.c_str());
@@ -420,14 +440,19 @@ TEST_F(convert_test, fromString_EdgeCase_SignedLongLong)
     // we don't use -9223372036854775808LL here for the compiler will parse it in way we don't want
     EXPECT_THAT(long_long_min.value(), Eq(std::numeric_limits<long long>::min()));
 
-    source = "-9223372036854775809";
-    auto long_long_min_dec_1 = iox::convert::from_string<long long>(source.c_str());
-    ASSERT_THAT(long_long_min_dec_1.has_value(), Eq(false));
-
     source = "9223372036854775807";
     auto long_long_max = iox::convert::from_string<long long>(source.c_str());
     ASSERT_THAT(long_long_max.has_value(), Eq(true));
     EXPECT_THAT(long_long_max.value(), Eq(9223372036854775807LL));
+}
+
+TEST_F(convert_test, fromString_SignedLongLong_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "7c015ac0-06a7-407d-aa93-d39c50734951");
+
+    std::string source = "-9223372036854775809";
+    auto long_long_min_dec_1 = iox::convert::from_string<long long>(source.c_str());
+    ASSERT_THAT(long_long_min_dec_1.has_value(), Eq(false));
 
     source = "9223372036854775808";
     auto long_long_max_inc_1 = iox::convert::from_string<long long>(source.c_str());
@@ -438,53 +463,63 @@ TEST_F(convert_test, fromString_EdgeCase_SignedLongLong)
 
 /// UNSINGED INTEGRAL EDGE CASES START
 
-TEST_F(convert_test, fromString_EdgeCase_UnSignedChar)
+TEST_F(convert_test, fromString_UnSignedChar_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "c11d74a1-be55-41fc-952f-519546eb04fe");
+    ::testing::Test::RecordProperty("TEST_ID", "4d2debf7-a6fb-40e1-b672-cb3520be98dd");
 
     std::string source = "0";
     auto unchar_min = iox::convert::from_string<unsigned char>(source.c_str());
     ASSERT_THAT(unchar_min.has_value(), Eq(true));
     EXPECT_THAT(unchar_min.value(), Eq(0));
 
-    source = "-1";
-    auto unchar_min_dec_1 = iox::convert::from_string<unsigned char>(source.c_str());
-    ASSERT_THAT(unchar_min_dec_1.has_value(), Eq(false));
-
     source = "255";
     auto unchar_max = iox::convert::from_string<unsigned char>(source.c_str());
     ASSERT_THAT(unchar_max.has_value(), Eq(true));
     EXPECT_THAT(unchar_max.value(), Eq(static_cast<unsigned char>(255)));
+}
+
+TEST_F(convert_test, fromString_UnSignedChar_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c11d74a1-be55-41fc-952f-519546eb04fe");
+
+    std::string source = "-1";
+    auto unchar_min_dec_1 = iox::convert::from_string<unsigned char>(source.c_str());
+    ASSERT_THAT(unchar_min_dec_1.has_value(), Eq(false));
 
     source = "256";
     auto unchar_max_inc_1 = iox::convert::from_string<unsigned char>(source.c_str());
     ASSERT_THAT(unchar_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_UnSignedShort)
+TEST_F(convert_test, fromString_UnSignedShort_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "f9196939-ae5d-4c27-85bf-b3b084343261");
+    ::testing::Test::RecordProperty("TEST_ID", "cf168594-e673-4dba-90b7-9b11a3edb967");
 
     std::string source = "0";
     auto unshort_min = iox::convert::from_string<unsigned short>(source.c_str());
     ASSERT_THAT(unshort_min.has_value(), Eq(true));
     EXPECT_THAT(unshort_min.value(), Eq(0));
 
-    source = "-1";
-    auto unshort_min_dec_1 = iox::convert::from_string<unsigned short>(source.c_str());
-    ASSERT_THAT(unshort_min_dec_1.has_value(), Eq(false));
-
     source = "65535";
     auto unshort_max = iox::convert::from_string<unsigned short>(source.c_str());
     ASSERT_THAT(unshort_max.has_value(), Eq(true));
     EXPECT_THAT(unshort_max.value(), Eq(static_cast<unsigned short>(65535)));
+}
+
+TEST_F(convert_test, fromString_UnSignedShort_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "f9196939-ae5d-4c27-85bf-b3b084343261");
+
+    std::string source = "-1";
+    auto unshort_min_dec_1 = iox::convert::from_string<unsigned short>(source.c_str());
+    ASSERT_THAT(unshort_min_dec_1.has_value(), Eq(false));
 
     source = "65536";
     auto unshort_max_inc_1 = iox::convert::from_string<unsigned short>(source.c_str());
     ASSERT_THAT(unshort_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_UnSignedInt)
+TEST_F(convert_test, fromString_UnSignedInt_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c2a832ef-3e86-4303-a98c-63c7b11ea789");
 
@@ -493,14 +528,19 @@ TEST_F(convert_test, fromString_EdgeCase_UnSignedInt)
     ASSERT_THAT(unint_min.has_value(), Eq(true));
     EXPECT_THAT(unint_min.value(), Eq(0));
 
-    source = "-1";
-    auto unint_min_dec_1 = iox::convert::from_string<unsigned int>(source.c_str());
-    ASSERT_THAT(unint_min_dec_1.has_value(), Eq(false));
-
     source = "4294967295";
     auto unint_max = iox::convert::from_string<unsigned int>(source.c_str());
     ASSERT_THAT(unint_max.has_value(), Eq(true));
     EXPECT_THAT(unint_max.value(), Eq(4294967295U));
+}
+
+TEST_F(convert_test, fromString_UnSignedInt_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "64216d84-c008-47fc-ab9b-0e8d77aeb6c2");
+
+    std::string source = "-1";
+    auto unint_min_dec_1 = iox::convert::from_string<unsigned int>(source.c_str());
+    ASSERT_THAT(unint_min_dec_1.has_value(), Eq(false));
 
     source = "4294967296";
     auto unint_max_inc_1 = iox::convert::from_string<unsigned int>(source.c_str());
@@ -508,48 +548,58 @@ TEST_F(convert_test, fromString_EdgeCase_UnSignedInt)
 }
 
 // platform dependent (32/64 bit system only)
-TEST_F(convert_test, fromString_EdgeCase_UnSignedLong)
+TEST_F(convert_test, fromString_UnSignedLong_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "6e74e284-7f13-4d77-8d3f-009df216828f");
-
-    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
+    ::testing::Test::RecordProperty("TEST_ID", "1aaac1ae-3d59-4443-8d88-bfe4e50569a8");
 
     std::string source = "0";
     auto unlong_min = iox::convert::from_string<unsigned long>(source.c_str());
     ASSERT_THAT(unlong_min.has_value(), Eq(true));
     EXPECT_THAT(unlong_min.value(), Eq(0));
 
-    source = "-1";
-    auto unlong_min_dec_1 = iox::convert::from_string<unsigned long>(source.c_str());
-    ASSERT_THAT(unlong_min_dec_1.has_value(), Eq(false));
-
     source = std::to_string(std::numeric_limits<unsigned long>::max());
     auto unlong_max = iox::convert::from_string<unsigned long>(source.c_str());
     ASSERT_THAT(unlong_max.has_value(), Eq(true));
     EXPECT_THAT(unlong_max.value(), Eq(std::numeric_limits<unsigned long>::max()));
+}
+
+TEST_F(convert_test, fromString_UnSignedLong_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6e74e284-7f13-4d77-8d3f-009df216828f");
+
+    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
+
+    std::string source = "-1";
+    auto unlong_min_dec_1 = iox::convert::from_string<unsigned long>(source.c_str());
+    ASSERT_THAT(unlong_min_dec_1.has_value(), Eq(false));
 
     source = IS_32_BIT ? "4294967296" : "18446744073709551616";
     auto unlong_max_inc_1 = iox::convert::from_string<unsigned long>(source.c_str());
     ASSERT_THAT(unlong_max_inc_1.has_value(), Eq(false));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_UnSignedLongLong)
+TEST_F(convert_test, fromString_UnSignedLongLong_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "96456d6f-2493-4db2-b5fa-f96f92ec64dd");
+    ::testing::Test::RecordProperty("TEST_ID", "b3c70efd-f875-45bd-b86c-126dc44d3238");
 
     std::string source = "0";
     auto unlong_long_min = iox::convert::from_string<unsigned long long>(source.c_str());
     ASSERT_THAT(unlong_long_min.has_value(), Eq(true));
     EXPECT_THAT(unlong_long_min.value(), Eq(0));
 
-    source = "-1";
-    auto unlong_long_min_dec_1 = iox::convert::from_string<unsigned long long>(source.c_str());
-    ASSERT_THAT(unlong_long_min_dec_1.has_value(), Eq(false));
-
     source = "18446744073709551615";
     auto unlong_long_max = iox::convert::from_string<unsigned long long>(source.c_str());
     ASSERT_THAT(unlong_long_max.has_value(), Eq(true));
     EXPECT_THAT(unlong_long_max.value(), Eq(18446744073709551615ULL));
+}
+
+TEST_F(convert_test, fromString_UnSignedLongLong_EdgeCase_OutOfRange_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "96456d6f-2493-4db2-b5fa-f96f92ec64dd");
+
+    std::string source = "-1";
+    auto unlong_long_min_dec_1 = iox::convert::from_string<unsigned long long>(source.c_str());
+    ASSERT_THAT(unlong_long_min_dec_1.has_value(), Eq(false));
 
     source = "18446744073709551616";
     auto unlong_long_max_inc_1 = iox::convert::from_string<unsigned long long>(source.c_str());
@@ -560,27 +610,14 @@ TEST_F(convert_test, fromString_EdgeCase_UnSignedLongLong)
 
 /// NORMAL FLOATING POINT TYPE EDGE CASES START
 
-TEST_F(convert_test, fromString_EdgeCase_Float)
+TEST_F(convert_test, fromString_Float_EdgeCase_InRange_Success)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "68d4f096-a93c-406b-b081-fe50e4b1a2c9");
+    ::testing::Test::RecordProperty("TEST_ID", "cf849d5d-d0ed-4447-89b8-d6b9f47287c7");
 
     std::string source = fp_to_string(std::numeric_limits<float>::min());
     auto float_min = iox::convert::from_string<float>(source.c_str());
     ASSERT_THAT(float_min.has_value(), Eq(true));
     EXPECT_THAT(float_min.value(), FloatEq(std::numeric_limits<float>::min()));
-
-    // strtof will trigger ERANGE if the input is a subnormal float, resulting in a nullopt return value.
-    // note that for MSVC, sub normal float is a valid input!
-    auto normal_float_min_eps = std::nextafter(std::numeric_limits<float>::min(), 0.0F);
-    source = fp_to_string(std::numeric_limits<float>::min() - normal_float_min_eps);
-    auto float_min_dec_eps = iox::convert::from_string<float>(source.c_str());
-#ifdef _MSC_VER
-    ASSERT_THAT(float_min_dec_eps.has_value(), Eq(true));
-    ASSERT_THAT(std::fpclassify(float_min_dec_eps.value()), Eq(FP_SUBNORMAL));
-    EXPECT_THAT(float_min_dec_eps.value(), FloatNear(0.0F, std::numeric_limits<float>::min()));
-#else
-    ASSERT_THAT(float_min_dec_eps.has_value(), Eq(false));
-#endif
 
     source = fp_to_string(std::numeric_limits<float>::lowest());
     auto float_lowest = iox::convert::from_string<float>(source.c_str());
@@ -593,25 +630,32 @@ TEST_F(convert_test, fromString_EdgeCase_Float)
     EXPECT_THAT(float_max.value(), FloatEq(std::numeric_limits<float>::max()));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_Double)
+TEST_F(convert_test, fromString_Float_EdgeCase_SubNormalFloat_ShouldFailExceptMsvc)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "af7ca2e6-ba7e-41f7-a321-5f68617d3566");
+    ::testing::Test::RecordProperty("TEST_ID", "68d4f096-a93c-406b-b081-fe50e4b1a2c9");
+
+    // strtof will trigger ERANGE if the input is a subnormal float, resulting in a nullopt return value.
+    // note that for MSVC, sub normal float is a valid input!
+    auto normal_float_min_eps = std::nextafter(std::numeric_limits<float>::min(), 0.0F);
+    std::string source = fp_to_string(std::numeric_limits<float>::min() - normal_float_min_eps);
+    auto float_min_dec_eps = iox::convert::from_string<float>(source.c_str());
+#ifdef _MSC_VER
+    ASSERT_THAT(float_min_dec_eps.has_value(), Eq(true));
+    ASSERT_THAT(std::fpclassify(float_min_dec_eps.value()), Eq(FP_SUBNORMAL));
+    EXPECT_THAT(float_min_dec_eps.value(), FloatNear(0.0F, std::numeric_limits<float>::min()));
+#else
+    ASSERT_THAT(float_min_dec_eps.has_value(), Eq(false));
+#endif
+}
+
+TEST_F(convert_test, fromString_Double_EdgeCase_InRange_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d5e5e5ad-92ed-4229-8128-4ee82059fbf7");
 
     std::string source = fp_to_string(std::numeric_limits<double>::min());
     auto double_min = iox::convert::from_string<double>(source.c_str());
     ASSERT_THAT(double_min.has_value(), Eq(true));
     EXPECT_THAT(double_min.value(), DoubleEq(std::numeric_limits<double>::min()));
-
-    auto normal_double_min_eps = std::nextafter(std::numeric_limits<double>::min(), 0.0);
-    source = fp_to_string(std::numeric_limits<double>::min() - normal_double_min_eps);
-    auto double_min_dec_eps = iox::convert::from_string<double>(source.c_str());
-#ifdef _MSC_VER
-    ASSERT_THAT(double_min_dec_eps.has_value(), Eq(true));
-    ASSERT_THAT(std::fpclassify(double_min_dec_eps.value()), Eq(FP_SUBNORMAL));
-    EXPECT_THAT(double_min_dec_eps.value(), DoubleNear(0.0L, std::numeric_limits<double>::min()));
-#else
-    ASSERT_THAT(double_min_dec_eps.has_value(), Eq(false));
-#endif
 
     source = fp_to_string(std::numeric_limits<double>::lowest());
     auto double_lowest = iox::convert::from_string<double>(source.c_str());
@@ -624,27 +668,31 @@ TEST_F(convert_test, fromString_EdgeCase_Double)
     EXPECT_THAT(double_max.value(), DoubleEq(std::numeric_limits<double>::max()));
 }
 
-TEST_F(convert_test, fromString_EdgeCase_LongDouble)
+TEST_F(convert_test, fromString_Double_EdgeCase_SubNormalDouble_ShouldFailExceptMsvc)
 {
-    ::testing::Test::RecordProperty("TEST_ID", "fb96e526-8fb6-4af9-87f0-dfd4193237a5");
+    ::testing::Test::RecordProperty("TEST_ID", "af7ca2e6-ba7e-41f7-a321-5f68617d3566");
+
+    auto normal_double_min_eps = std::nextafter(std::numeric_limits<double>::min(), 0.0);
+    std::string source = fp_to_string(std::numeric_limits<double>::min() - normal_double_min_eps);
+    auto double_min_dec_eps = iox::convert::from_string<double>(source.c_str());
+#ifdef _MSC_VER
+    ASSERT_THAT(double_min_dec_eps.has_value(), Eq(true));
+    ASSERT_THAT(std::fpclassify(double_min_dec_eps.value()), Eq(FP_SUBNORMAL));
+    EXPECT_THAT(double_min_dec_eps.value(), DoubleNear(0.0, std::numeric_limits<double>::min()));
+#else
+    ASSERT_THAT(double_min_dec_eps.has_value(), Eq(false));
+#endif
+}
+
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_InRange_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "cab1c90b-1de0-4654-bbea-4bb4e55e4fc3");
 
     std::string source = fp_to_string(std::numeric_limits<long double>::min());
     auto long_double_min = iox::convert::from_string<long double>(source.c_str());
     ASSERT_THAT(long_double_min.has_value(), Eq(true));
     // There's no LongDoubleEq
     EXPECT_THAT(long_double_min.value(), Eq(std::numeric_limits<long double>::min()));
-
-    auto normal_long_double_min_eps = std::nextafter(std::numeric_limits<long double>::min(), 0.0L);
-    source = fp_to_string(std::numeric_limits<long double>::min() - normal_long_double_min_eps);
-    auto long_double_min_dec_eps = iox::convert::from_string<long double>(source.c_str());
-#ifdef _MSC_VER
-    ASSERT_THAT(long_double_min_dec_eps.has_value(), Eq(true));
-    ASSERT_THAT(std::fpclassify(long_double_min_dec_eps.value()), Eq(FP_SUBNORMAL));
-    // There's no LongDoubleNear
-    EXPECT_TRUE(std::fabsl(long_double_min_dec_eps.value() - 0.0L) <= std::numeric_limits<long double>::min());
-#else
-    ASSERT_THAT(long_double_min_dec_eps.has_value(), Eq(false));
-#endif
 
     source = fp_to_string(std::numeric_limits<long double>::lowest());
     auto long_double_lowest = iox::convert::from_string<long double>(source.c_str());
@@ -657,11 +705,28 @@ TEST_F(convert_test, fromString_EdgeCase_LongDouble)
     EXPECT_THAT(long_double_max.value(), Eq(std::numeric_limits<long double>::max()));
 }
 
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_SubNormalLongDouble_ShouldFailExceptMsvc)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "fb96e526-8fb6-4af9-87f0-dfd4193237a5");
+
+    auto normal_long_double_min_eps = std::nextafter(std::numeric_limits<long double>::min(), 0.0L);
+    std::string source = fp_to_string(std::numeric_limits<long double>::min() - normal_long_double_min_eps);
+    auto long_double_min_dec_eps = iox::convert::from_string<long double>(source.c_str());
+#ifdef _MSC_VER
+    ASSERT_THAT(long_double_min_dec_eps.has_value(), Eq(true));
+    ASSERT_THAT(std::fpclassify(long_double_min_dec_eps.value()), Eq(FP_SUBNORMAL));
+    // There's no LongDoubleNear
+    EXPECT_TRUE(std::fabsl(long_double_min_dec_eps.value() - 0.0L) <= std::numeric_limits<long double>::min());
+#else
+    ASSERT_THAT(long_double_min_dec_eps.has_value(), Eq(false));
+#endif
+}
+
 /// NORMAL FLOATING POINT TYPE EDGE CASES END
 
 /// SPECIAL FLOATING POINT TYPE EDGE CASES START
 
-TEST_F(convert_test, fromString_EdgeCase_Float_NaN)
+TEST_F(convert_test, fromString_Float_EdgeCase_Nan_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "772bcbc3-d55b-464f-873f-82754ad543f3");
 
@@ -675,7 +740,7 @@ TEST_F(convert_test, fromString_EdgeCase_Float_NaN)
     }
 }
 
-TEST_F(convert_test, fromString_EdgeCase_Double_NaN)
+TEST_F(convert_test, fromString_Double_EdgeCase_Nan_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a27c8575-658c-465d-a1a2-4f2f6b9a723a");
 
@@ -689,7 +754,7 @@ TEST_F(convert_test, fromString_EdgeCase_Double_NaN)
     }
 }
 
-TEST_F(convert_test, fromString_EdgeCase_LongDouble_NaN)
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_Nan_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "486f4e78-6000-4401-bb66-62d26b1d0cce");
 
@@ -703,7 +768,7 @@ TEST_F(convert_test, fromString_EdgeCase_LongDouble_NaN)
     }
 }
 
-TEST_F(convert_test, fromString_EdgeCase_Float_Inf)
+TEST_F(convert_test, fromString_Float_EdgeCase_Inf_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "82dba3ae-5802-4fbc-aa91-15f4a2953573");
 
@@ -718,7 +783,7 @@ TEST_F(convert_test, fromString_EdgeCase_Float_Inf)
     }
 }
 
-TEST_F(convert_test, fromString_EdgeCase_Double_Inf)
+TEST_F(convert_test, fromString_Double_EdgeCase_Inf_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e4ccd01d-b1d1-433e-ba04-548dcc479bb1");
 
@@ -733,7 +798,7 @@ TEST_F(convert_test, fromString_EdgeCase_Double_Inf)
     }
 }
 
-TEST_F(convert_test, fromString_EdgeCase_LongDouble_Inf)
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_Inf_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "6b8a3284-5f20-4cd6-9958-a2abb348ebe2");
 

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -303,8 +303,31 @@ TEST_F(convert_test, fromString_LongInt_Fail)
     ASSERT_THAT(result.has_value(), Eq(false));
 }
 
-/// EDGE CASES START
+/// SINGED INTEGRAL EDGE CASES START
 /// inc: increment, dec: decrement
+
+TEST_F(convert_test, fromString_EdgeCase_SignedChar)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "3a70481e-ae86-4b96-92c4-44169700e93a");
+
+    std::string source = "-128";
+    auto signed_char_min = iox::convert::from_string<signed char>(source.c_str());
+    ASSERT_THAT(signed_char_min.has_value(), Eq(true));
+    EXPECT_THAT(signed_char_min.value(), Eq(static_cast<signed char>(-128)));
+
+    source = "-129";
+    auto signed_char_min_dec_1 = iox::convert::from_string<signed char>(source.c_str());
+    ASSERT_THAT(signed_char_min_dec_1.has_value(), Eq(false));
+
+    source = "127";
+    auto signed_char_max = iox::convert::from_string<signed char>(source.c_str());
+    ASSERT_THAT(signed_char_max.has_value(), Eq(true));
+    EXPECT_THAT(signed_char_max.value(), Eq(static_cast<signed char>(127)));
+
+    source = "128";
+    auto signed_char_max_inc_1 = iox::convert::from_string<signed char>(source.c_str());
+    ASSERT_THAT(signed_char_max_inc_1.has_value(), Eq(false));
+}
 
 TEST_F(convert_test, fromString_EdgeCase_SignedShort)
 {
@@ -313,7 +336,7 @@ TEST_F(convert_test, fromString_EdgeCase_SignedShort)
     std::string source = "-32768";
     auto short_min = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_min.has_value(), Eq(true));
-    EXPECT_THAT(short_min.value(), Eq(-32768));
+    EXPECT_THAT(short_min.value(), Eq(static_cast<short>(-32768)));
 
     source = "-32769";
     auto short_min_dec_1 = iox::convert::from_string<short>(source.c_str());
@@ -322,7 +345,7 @@ TEST_F(convert_test, fromString_EdgeCase_SignedShort)
     source = "32767";
     auto short_max = iox::convert::from_string<short>(source.c_str());
     ASSERT_THAT(short_max.has_value(), Eq(true));
-    EXPECT_THAT(short_max.value(), Eq(32767));
+    EXPECT_THAT(short_max.value(), Eq(static_cast<short>(32767)));
 
     source = "32768";
     auto short_max_inc_1 = iox::convert::from_string<short>(source.c_str());
@@ -352,6 +375,83 @@ TEST_F(convert_test, fromString_EdgeCase_SignedInt)
     ASSERT_THAT(int_max_inc_1.has_value(), Eq(false));
 }
 
+// platform dependent (32/64 bit system only)
+TEST_F(convert_test, fromString_EdgeCase_SignedLong)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "5dc4c773-6a51-42b6-ad94-7ec885263856");
+
+    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
+
+    std::string source = std::to_string(std::numeric_limits<long>::min());
+    auto long_min = iox::convert::from_string<long>(source.c_str());
+    ASSERT_THAT(long_min.has_value(), Eq(true));
+    EXPECT_THAT(long_min.value(), Eq(std::numeric_limits<long>::min()));
+
+    source = IS_32_BIT ? "-2147483649" : "-9223372036854775809";
+    auto long_min_dec_1 = iox::convert::from_string<long>(source.c_str());
+    ASSERT_THAT(long_min_dec_1.has_value(), Eq(false));
+
+    source = std::to_string(std::numeric_limits<long>::max());
+    auto long_max = iox::convert::from_string<long>(source.c_str());
+    ASSERT_THAT(long_max.has_value(), Eq(true));
+    EXPECT_THAT(long_max.value(), Eq(std::numeric_limits<long>::max()));
+
+    source = IS_32_BIT ? "2147483648" : "9223372036854775808";
+    auto long_max_inc_1 = iox::convert::from_string<long>(source.c_str());
+    ASSERT_THAT(long_max_inc_1.has_value(), Eq(false));
+}
+
+TEST_F(convert_test, fromString_EdgeCase_SignedLongLong)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "7c015ac0-06a7-407d-aa93-d39c50734951");
+
+    std::string source = "-9223372036854775808";
+    auto long_long_min = iox::convert::from_string<long long>(source.c_str());
+    ASSERT_THAT(long_long_min.has_value(), Eq(true));
+    // we don't use -9223372036854775808LL here for the compiler will parse it in way we don't want
+    EXPECT_THAT(long_long_min.value(), Eq(std::numeric_limits<long long>::min()));
+
+    source = "-9223372036854775809";
+    auto long_long_min_dec_1 = iox::convert::from_string<long long>(source.c_str());
+    ASSERT_THAT(long_long_min_dec_1.has_value(), Eq(false));
+
+    source = "9223372036854775807";
+    auto long_long_max = iox::convert::from_string<long long>(source.c_str());
+    ASSERT_THAT(long_long_max.has_value(), Eq(true));
+    EXPECT_THAT(long_long_max.value(), Eq(9223372036854775807LL));
+
+    source = "9223372036854775808";
+    auto long_long_max_inc_1 = iox::convert::from_string<long long>(source.c_str());
+    ASSERT_THAT(long_long_max_inc_1.has_value(), Eq(false));
+}
+
+/// SINGED INTEGRAL EDGE CASES END
+
+/// UNSINGED INTEGRAL EDGE CASES START
+
+TEST_F(convert_test, fromString_EdgeCase_UnSignedChar)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "c11d74a1-be55-41fc-952f-519546eb04fe");
+
+    std::string source = "0";
+    auto unchar_min = iox::convert::from_string<unsigned char>(source.c_str());
+    ASSERT_THAT(unchar_min.has_value(), Eq(true));
+    EXPECT_THAT(unchar_min.value(), Eq(0));
+
+    source = "-1";
+    auto unchar_min_dec_1 = iox::convert::from_string<unsigned char>(source.c_str());
+    ASSERT_THAT(unchar_min_dec_1.has_value(), Eq(false));
+
+    source = "255";
+    auto unchar_max = iox::convert::from_string<unsigned char>(source.c_str());
+    ASSERT_THAT(unchar_max.has_value(), Eq(true));
+    EXPECT_THAT(unchar_max.value(), Eq(static_cast<unsigned char>(255)));
+
+    source = "256";
+    auto unchar_max_inc_1 = iox::convert::from_string<unsigned char>(source.c_str());
+    ASSERT_THAT(unchar_max_inc_1.has_value(), Eq(false));
+}
+
 TEST_F(convert_test, fromString_EdgeCase_UnSignedShort)
 {
     ::testing::Test::RecordProperty("TEST_ID", "f9196939-ae5d-4c27-85bf-b3b084343261");
@@ -368,7 +468,7 @@ TEST_F(convert_test, fromString_EdgeCase_UnSignedShort)
     source = "65535";
     auto unshort_max = iox::convert::from_string<unsigned short>(source.c_str());
     ASSERT_THAT(unshort_max.has_value(), Eq(true));
-    EXPECT_THAT(unshort_max.value(), Eq(65535));
+    EXPECT_THAT(unshort_max.value(), Eq(static_cast<unsigned short>(65535)));
 
     source = "65536";
     auto unshort_max_inc_1 = iox::convert::from_string<unsigned short>(source.c_str());
@@ -391,14 +491,63 @@ TEST_F(convert_test, fromString_EdgeCase_UnSignedInt)
     source = "4294967295";
     auto unint_max = iox::convert::from_string<unsigned int>(source.c_str());
     ASSERT_THAT(unint_max.has_value(), Eq(true));
-    EXPECT_THAT(unint_max.value(), Eq(4294967295));
+    EXPECT_THAT(unint_max.value(), Eq(4294967295U));
 
     source = "4294967296";
     auto unint_max_inc_1 = iox::convert::from_string<unsigned int>(source.c_str());
     ASSERT_THAT(unint_max_inc_1.has_value(), Eq(false));
 }
 
-/// EDGE CASES END
+// platform dependent (32/64 bit system only)
+TEST_F(convert_test, fromString_EdgeCase_UnSignedLong)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6e74e284-7f13-4d77-8d3f-009df216828f");
+
+    constexpr bool IS_32_BIT{sizeof(long) != sizeof(long long)};
+
+    std::string source = "0";
+    auto unlong_min = iox::convert::from_string<unsigned long>(source.c_str());
+    ASSERT_THAT(unlong_min.has_value(), Eq(true));
+    EXPECT_THAT(unlong_min.value(), Eq(0));
+
+    source = "-1";
+    auto unlong_min_dec_1 = iox::convert::from_string<unsigned long>(source.c_str());
+    ASSERT_THAT(unlong_min_dec_1.has_value(), Eq(false));
+
+    source = std::to_string(std::numeric_limits<unsigned long>::max());
+    auto unlong_max = iox::convert::from_string<unsigned long>(source.c_str());
+    ASSERT_THAT(unlong_max.has_value(), Eq(true));
+    EXPECT_THAT(unlong_max.value(), Eq(std::numeric_limits<unsigned long>::max()));
+
+    source = IS_32_BIT ? "4294967296" : "18446744073709551616";
+    auto unlong_max_inc_1 = iox::convert::from_string<unsigned long>(source.c_str());
+    ASSERT_THAT(unlong_max_inc_1.has_value(), Eq(false));
+}
+
+TEST_F(convert_test, fromString_EdgeCase_UnSignedLongLong)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "96456d6f-2493-4db2-b5fa-f96f92ec64dd");
+
+    std::string source = "0";
+    auto unlong_long_min = iox::convert::from_string<unsigned long long>(source.c_str());
+    ASSERT_THAT(unlong_long_min.has_value(), Eq(true));
+    EXPECT_THAT(unlong_long_min.value(), Eq(0));
+
+    source = "-1";
+    auto unlong_long_min_dec_1 = iox::convert::from_string<unsigned long long>(source.c_str());
+    ASSERT_THAT(unlong_long_min_dec_1.has_value(), Eq(false));
+
+    source = "18446744073709551615";
+    auto unlong_long_max = iox::convert::from_string<unsigned long long>(source.c_str());
+    ASSERT_THAT(unlong_long_max.has_value(), Eq(true));
+    EXPECT_THAT(unlong_long_max.value(), Eq(18446744073709551615ULL));
+
+    source = "18446744073709551616";
+    auto unlong_long_max_inc_1 = iox::convert::from_string<unsigned long long>(source.c_str());
+    ASSERT_THAT(unlong_long_max_inc_1.has_value(), Eq(false));
+}
+
+/// UNSINGED INTEGRAL EDGE CASES END
 
 TEST_F(convert_test, fromString_cxxString)
 {

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -815,7 +815,7 @@ TEST_F(convert_test, fromString_LongDouble_EdgeCase_Inf_Success)
 
 /// SPECIAL FLOATING POINT TYPE EDGE CASES END
 
-TEST_F(convert_test, fromString_cxxString)
+TEST_F(convert_test, fromString_ioxString)
 {
     ::testing::Test::RecordProperty("TEST_ID", "dbf015bb-5f51-47e1-9d0e-0525f65e7803");
     std::string source = "hello";

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -313,6 +313,35 @@ TEST_F(convert_test, fromString_LongInt_Fail)
     ASSERT_THAT(result.has_value(), Eq(false));
 }
 
+TEST_F(convert_test, fromString_Integer_InvalidTrailingChar_Fail)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "6a70f10f-227b-4b0a-8149-e5ca3c793b5d");
+
+    using IntegerType = std::tuple<signed char,
+                                   short,
+                                   int,
+                                   long,
+                                   long long,
+                                   unsigned char,
+                                   unsigned short,
+                                   unsigned int,
+                                   unsigned long,
+                                   unsigned long long>;
+    std::vector<std::string> invalid_input = {"42a", "74 ", "-52-"};
+
+    // a lambda to iterate all invalid_input cases converting to type decltype(dummy)
+    auto expect_failure = [&invalid_input](auto dummy) {
+        using T = decltype(dummy);
+        for (const auto& v : invalid_input)
+        {
+            auto invalid_ret = iox::convert::from_string<T>(v.c_str());
+            ASSERT_THAT(invalid_ret.has_value(), Eq(false));
+        }
+    };
+
+    std::apply([&](auto... args) { (..., expect_failure(args)); }, IntegerType{});
+}
+
 /// SINGED INTEGRAL EDGE CASES START
 /// inc: increment, dec: decrement
 

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -23,6 +23,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <tuple>
 namespace
 {
 using namespace ::testing;
@@ -811,6 +812,81 @@ TEST_F(convert_test, fromString_LongDouble_EdgeCase_Inf_Success)
         ASSERT_THAT(inf_ret.has_value(), Eq(true));
         ASSERT_THAT(std::isinf(inf_ret.value()), Eq(true));
     }
+}
+
+TEST_F(convert_test, fromString_Float_EdgeCase_ZeroDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "4ac285f9-e107-4d74-8aca-5d87032794db");
+
+    std::vector<std::string> decimal_notation_vec = {"0", "-0", ".0", "-.0", "0.0", "-0.0", "0.", "-0."};
+
+    for (const auto& v : decimal_notation_vec)
+    {
+        auto decimal_ret = iox::convert::from_string<float>(v.c_str());
+        ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+        ASSERT_THAT(decimal_ret.value(), Eq(0.0F));
+    }
+}
+
+TEST_F(convert_test, fromString_Double_EdgeCase_ZeroDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "98938eaa-c472-4338-a153-5c2de9eb4940");
+
+    std::vector<std::string> decimal_notation_vec = {"0", "-0", ".0", "-.0", "0.0", "-0.0", "0.", "-0."};
+
+    for (const auto& v : decimal_notation_vec)
+    {
+        auto decimal_ret = iox::convert::from_string<double>(v.c_str());
+        ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+        ASSERT_THAT(decimal_ret.value(), Eq(0.0));
+    }
+}
+
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_ZeroDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "49fc0812-47c0-4815-8a15-a94a81493ea0");
+
+    std::vector<std::string> decimal_notation_vec = {"0", "-0", ".0", "-.0", "0.0", "-0.0", "0.", "-0."};
+
+    for (const auto& v : decimal_notation_vec)
+    {
+        auto decimal_ret = iox::convert::from_string<long double>(v.c_str());
+        ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+        ASSERT_THAT(decimal_ret.value(), Eq(0.0L));
+    }
+}
+
+TEST_F(convert_test, fromString_Float_EdgeCase_OtherDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "278ff5af-28bd-4c11-839e-160e148c5a64");
+
+    std::string source = ".1";
+
+    auto decimal_ret = iox::convert::from_string<float>(source.c_str());
+    ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+    ASSERT_THAT(decimal_ret.value(), Eq(0.1F));
+}
+
+TEST_F(convert_test, fromString_Double_EdgeCase_OtherDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "a8539f9a-1c7a-4d81-9a88-ef8a6630f065");
+
+    std::string source = ".1";
+
+    auto decimal_ret = iox::convert::from_string<double>(source.c_str());
+    ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+    ASSERT_THAT(decimal_ret.value(), Eq(0.1));
+}
+
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_OtherDecimalNotation_Success)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "d71ec687-aaab-45d5-aee5-2ec9a51602d0");
+
+    std::string source = ".1";
+
+    auto decimal_ret = iox::convert::from_string<long double>(source.c_str());
+    ASSERT_THAT(decimal_ret.has_value(), Eq(true));
+    ASSERT_THAT(decimal_ret.value(), Eq(0.1L));
 }
 
 /// SPECIAL FLOATING POINT TYPE EDGE CASES END

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -339,7 +339,7 @@ TEST_F(convert_test, fromString_Integer_InvalidTrailingChar_Fail)
         }
     };
 
-    std::apply([&](auto... args) { (..., expect_failure(args)); }, IntegerType{});
+    std::apply([&expect_failure](auto... args) { (..., expect_failure(args)); }, IntegerType{});
 }
 
 /// SINGED INTEGRAL EDGE CASES START


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Note: The items in **bold** indicate that they have already been implemented.

### Signed Integral Types

1. **`signed char`**
    - **`CHAR_MIN`** (-128)
    - **`CHAR_MIN - 1`** (-129)
    - **`CHAR_MAX`** (127)
    - **`CHAR_MAX + 1`** (128)
2. **`signed short` [tested]**
    - **`SHRT_MIN`** (-32768)
    - **`SHRT_MIN - 1`** (-32769)
    - **`SHRT_MAX`** (32767)
    - **`SHRT_MAX + 1`** (32768)
3. **`signed int` [tested]**
    - **`INT_MIN`** (-2147483648)
    - **`INT_MIN - 1`** (-2147483649)
    - **`INT_MAX`** (2147483647)
    - **`INT_MAX + 1`** (2147483648)
4. **`signed long`**
    - **`LONG_MIN`** (-2147483648 / -9223372036854775808)
    - **`LONG_MIN - 1`** (-2147483649 / -9223372036854775809)
    - **`LONG_MAX`** (2147483647 / 9223372036854775807)
    - **`LONG_MAX + 1`** (2147483648 / 9223372036854775808)
5. **`signed long long`**
    - **`LLONG_MIN`** (-9223372036854775808)
    - **`LLONG_MIN - 1`** (-9223372036854775809)
    - **`LLONG_MAX`** (9223372036854775807)
    - **`LLONG_MAX + 1`** (9223372036854775808)

### Unsigned Integral Types

1. **`unsigned char`**
    - **`0`**
    - **`-1`**
    - **`UCHAR_MAX`** (255)
    - **`UCHAR_MAX + 1`** (256)
2. **`unsigned short` [tested]**
    - **`0`**
    - **`-1`**
    - **`USHRT_MAX`** (65535)
    - **`USHRT_MAX + 1`** (65536)
3. **`unsigned int` [tested]**
    - **`0`**
    - **`-1`**
    - **`UINT_MAX`** (4294967295)
    - **`UINT_MAX + 1`** (4294967296)
4. **`unsigned long`**
    - **`0`**
    - **`-1`**
    - **`ULONG_MAX`** (4294967295 / 18446744073709551615)
    - **`ULONG_MAX + 1`** (4294967296 / 18446744073709551616)
5. **`unsigned long long`**
    - **`0`**
    - **`-1`**
    - **`ULLONG_MAX`** (18446744073709551615)
    - **`ULLONG_MAX + 1`** (18446744073709551616)

### Floating Point Type

1. **`float`**
    - **`FLT_MIN`** (using `numeric_limits`)
    - **`FLT_MIN - epsilon`** (using `numeric_limits`) -> should failed
    - **`std::numeric_limits<float>::lowest()`** (using `numeric_limits`)
    - `std::numeric_limits<float>::lowest() - epsilon` (Not Impl)
    - **`FLT_MAX`** (using `numeric_limits`)
    - `FLT_MAX + epsilon` (Not Impl)
    - **`NAN`**
    - **`INF`**
    - **`-INF`**
2. **`double`**
    - **`DBL_MIN`** (using `numeric_limits`)
    - **`DBL_MIN - epsilon`** (using `numeric_limits`) -> should failed
    - **`std::numeric_limits<double>::lowest()`** (using `numeric_limits`)
    - `std::numeric_limits<double>::lowest() - epsilon` (Not Impl)
    - **`DBL_MAX`** (using `numeric_limits`)
    - `DBL_MAX + epsilon` (Not Impl)
    - **`NAN`**
    - **`INF`**
    - **`-INF`**
3. **`long double`**
    - **`LDBL_MIN`** (using `numeric_limits`)
    - **`LDBL_MIN - epsilon`** (using `numeric_limits`) -> should failed
    - **`std::numeric_limits<long double>::lowest()`** (using `numeric_limits`)
    - `std::numeric_limits<long double>::lowest() - epsilon` (Not Impl)
    - **`LDBL_MAX`** (using `numeric_limits`)
    - `LDBL_MAX + epsilon` (Not Impl)
    - **`NAN`**
    - **`INF`**
    - **`-INF`**

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2055 
