### PR TITLE
Fix 'covert::from_string' test on aarch64 platform

### DIFF
--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -69,16 +69,7 @@ class convert_test : public Test
     {
     }
     template <typename T>
-    std::string fp_to_string(T value)
-    {
-        static_assert(std::is_floating_point<T>::value, "requires floating point type");
-
-        std::ostringstream oss;
-        oss << std::scientific << std::setprecision(std::numeric_limits<T>::digits10) << value;
-        return oss.str();
-    }
-    template <typename T>
-    std::string fp_to_string(T value, uint16_t digits)
+    std::string fp_to_string(T value, uint16_t digits = std::numeric_limits<T>::digits10)
     {
         static_assert(std::is_floating_point<T>::value, "requires floating point type");
 
@@ -703,7 +694,7 @@ TEST_F(convert_test, fromString_Float_EdgeCase_InRange_Success)
     EXPECT_THAT(float_max.value(), FloatEq(std::numeric_limits<float>::max()));
 }
 
-TEST_F(convert_test, fromString_Float_EdgeCase_SubNormalFloat_ShouldFailExceptMsvc)
+TEST_F(convert_test, fromString_Float_EdgeCase_SubNormalFloat_ShouldFail)
 {
     ::testing::Test::RecordProperty("TEST_ID", "68d4f096-a93c-406b-b081-fe50e4b1a2c9");
 
@@ -737,7 +728,7 @@ TEST_F(convert_test, fromString_Double_EdgeCase_InRange_Success)
     EXPECT_THAT(double_max.value(), DoubleEq(std::numeric_limits<double>::max()));
 }
 
-TEST_F(convert_test, fromString_Double_EdgeCase_SubNormalDouble_ShouldFailExceptMsvc)
+TEST_F(convert_test, fromString_Double_EdgeCase_SubNormalDouble_ShouldFail)
 {
     ::testing::Test::RecordProperty("TEST_ID", "af7ca2e6-ba7e-41f7-a321-5f68617d3566");
 
@@ -774,7 +765,7 @@ TEST_F(convert_test, fromString_LongDouble_EdgeCase_InRange_Success)
     EXPECT_THAT(LongDouble::Eq(long_double_max.value(), std::numeric_limits<long double>::max()), Eq(true));
 }
 
-TEST_F(convert_test, fromString_LongDouble_EdgeCase_SubNormalLongDouble_ShouldFailExceptMsvc)
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_SubNormalLongDouble_ShouldFail)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb96e526-8fb6-4af9-87f0-dfd4193237a5");
 

--- a/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_convert.cpp
@@ -30,6 +30,35 @@ using namespace ::testing;
 
 using NumberType = iox::convert::NumberType;
 
+class LongDouble
+{
+  public:
+    static bool Eq(long double a, long double b)
+    {
+        IOX_LOG(DEBUG, "a: " << a << ", b: " << b);
+
+        long double min_val = std::min(std::fabs(a), std::fabs(b));
+        long double epsilon = std::fabs(min_val - std::nextafter(min_val, static_cast<long double>(0)));
+
+        IOX_LOG(DEBUG, "epsilon from min_val: " << epsilon);
+        IOX_LOG(DEBUG, "abs min_val: " << min_val);
+
+        if (epsilon <= 0 || epsilon < std::numeric_limits<long double>::min())
+        {
+            epsilon = std::numeric_limits<long double>::min();
+        }
+        IOX_LOG(DEBUG, "epsilon: " << epsilon);
+
+        long double abs_diff = std::fabs(a - b);
+        IOX_LOG(DEBUG, "fabs result: " << abs_diff);
+
+        bool is_equal = abs_diff <= epsilon;
+        IOX_LOG(DEBUG, "<< a and b " << ((is_equal) ? "IS" : "IS NOT") << " considered equal! >>");
+
+        return is_equal;
+    }
+};
+
 class convert_test : public Test
 {
   public:
@@ -42,30 +71,20 @@ class convert_test : public Test
     template <typename T>
     std::string fp_to_string(T value)
     {
-        static_assert(std::is_floating_point<T>::value, "fp_to_string requires floating point type");
+        static_assert(std::is_floating_point<T>::value, "requires floating point type");
 
         std::ostringstream oss;
-        oss << std::scientific << std::setprecision(get_digits<T>()) << value;
+        oss << std::scientific << std::setprecision(std::numeric_limits<T>::digits10) << value;
         return oss.str();
     }
-
-  private:
-    // see https://github.com/eclipse-iceoryx/iceoryx/pull/2155
     template <typename T>
-    constexpr static uint32_t get_digits()
+    std::string fp_to_string(T value, uint16_t digits)
     {
-        if constexpr (std::is_same_v<T, float>)
-        {
-            return 9;
-        }
-        else if (std::is_same_v<T, double> || std::is_same_v<T, long double>)
-        {
-            return 19;
-        }
-        else
-        {
-            static_assert("T should be floating point");
-        }
+        static_assert(std::is_floating_point<T>::value, "requires floating point type");
+
+        std::ostringstream oss;
+        oss << std::scientific << std::setprecision(digits) << value;
+        return oss.str();
     }
 };
 
@@ -198,11 +217,13 @@ TEST_F(convert_test, fromString_Double_Fail)
 TEST_F(convert_test, fromString_LongDouble_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2864fbae-ef1c-48ab-97f2-745baadc4dc5");
+    constexpr long double VERIFY = 121.01L;
     std::string source = "121.01";
-    constexpr long double VERIFY = 121.01;
+
     auto result = iox::convert::from_string<long double>(source.c_str());
     ASSERT_THAT(result.has_value(), Eq(true));
-    EXPECT_THAT(static_cast<double>(result.value()), DoubleEq(static_cast<double>(VERIFY)));
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    EXPECT_THAT(LongDouble::Eq(VERIFY, result.value()), Eq(true));
 }
 
 TEST_F(convert_test, fromString_LongDouble_Fail)
@@ -486,7 +507,6 @@ TEST_F(convert_test, fromString_SignedLongLong_EdgeCase_InRange_Success)
     std::string source = "-9223372036854775808";
     auto long_long_min = iox::convert::from_string<long long>(source.c_str());
     ASSERT_THAT(long_long_min.has_value(), Eq(true));
-    // we don't use -9223372036854775808LL here for the compiler will parse it in way we don't want
     EXPECT_THAT(long_long_min.value(), Eq(std::numeric_limits<long long>::min()));
 
     source = "9223372036854775807";
@@ -663,32 +683,33 @@ TEST_F(convert_test, fromString_Float_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cf849d5d-d0ed-4447-89b8-d6b9f47287c7");
 
-    std::string source = fp_to_string(std::numeric_limits<float>::min());
+    // the number larger than numeric_limits<long double>::digits10 that will pass all tests for all platforms
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MIN{7};
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MAX{7};
+
+    std::string source = fp_to_string(std::numeric_limits<float>::min(), PLATFORM_DIGIT_WORKAROUND_MIN);
     auto float_min = iox::convert::from_string<float>(source.c_str());
     ASSERT_THAT(float_min.has_value(), Eq(true));
     EXPECT_THAT(float_min.value(), FloatEq(std::numeric_limits<float>::min()));
 
-    source = fp_to_string(std::numeric_limits<float>::lowest());
+    source = fp_to_string(std::numeric_limits<float>::lowest(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto float_lowest = iox::convert::from_string<float>(source.c_str());
     ASSERT_THAT(float_lowest.has_value(), Eq(true));
     EXPECT_THAT(float_lowest.value(), FloatEq(std::numeric_limits<float>::lowest()));
 
-    source = fp_to_string(std::numeric_limits<float>::max());
+    source = fp_to_string(std::numeric_limits<float>::max(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto float_max = iox::convert::from_string<float>(source.c_str());
     ASSERT_THAT(float_max.has_value(), Eq(true));
     EXPECT_THAT(float_max.value(), FloatEq(std::numeric_limits<float>::max()));
 }
 
-TEST_F(convert_test, fromString_Float_EdgeCase_SubNormalFloat_ShouldFail)
+TEST_F(convert_test, fromString_Float_EdgeCase_SubNormalFloat_ShouldFailExceptMsvc)
 {
     ::testing::Test::RecordProperty("TEST_ID", "68d4f096-a93c-406b-b081-fe50e4b1a2c9");
 
     auto normal_float_min_eps = std::nextafter(std::numeric_limits<float>::min(), 0.0F);
     std::string source = fp_to_string(std::numeric_limits<float>::min() - normal_float_min_eps);
     auto float_min_dec_eps = iox::convert::from_string<float>(source.c_str());
-#ifdef _WIN32
-    GTEST_SKIP() << "@todo iox-#2055 temporarily skipped";
-#else
     ASSERT_THAT(float_min_dec_eps.has_value(), Eq(false));
 }
 
@@ -696,32 +717,33 @@ TEST_F(convert_test, fromString_Double_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d5e5e5ad-92ed-4229-8128-4ee82059fbf7");
 
-    std::string source = fp_to_string(std::numeric_limits<double>::min());
+    // the number larger than numeric_limits<double>::digits10 that will pass all tests for all platforms
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MIN{19};
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MAX{18};
+
+    std::string source = fp_to_string(std::numeric_limits<double>::min(), PLATFORM_DIGIT_WORKAROUND_MIN);
     auto double_min = iox::convert::from_string<double>(source.c_str());
     ASSERT_THAT(double_min.has_value(), Eq(true));
     EXPECT_THAT(double_min.value(), DoubleEq(std::numeric_limits<double>::min()));
 
-    source = fp_to_string(std::numeric_limits<double>::lowest());
+    source = fp_to_string(std::numeric_limits<double>::lowest(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto double_lowest = iox::convert::from_string<double>(source.c_str());
     ASSERT_THAT(double_lowest.has_value(), Eq(true));
     EXPECT_THAT(double_lowest.value(), DoubleEq(std::numeric_limits<double>::lowest()));
 
-    source = fp_to_string(std::numeric_limits<double>::max());
+    source = fp_to_string(std::numeric_limits<double>::max(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto double_max = iox::convert::from_string<double>(source.c_str());
     ASSERT_THAT(double_max.has_value(), Eq(true));
     EXPECT_THAT(double_max.value(), DoubleEq(std::numeric_limits<double>::max()));
 }
 
-TEST_F(convert_test, fromString_Double_EdgeCase_SubNormalDouble_ShouldFailExcept)
+TEST_F(convert_test, fromString_Double_EdgeCase_SubNormalDouble_ShouldFailExceptMsvc)
 {
     ::testing::Test::RecordProperty("TEST_ID", "af7ca2e6-ba7e-41f7-a321-5f68617d3566");
 
     auto normal_double_min_eps = std::nextafter(std::numeric_limits<double>::min(), 0.0);
     std::string source = fp_to_string(std::numeric_limits<double>::min() - normal_double_min_eps);
     auto double_min_dec_eps = iox::convert::from_string<double>(source.c_str());
-#ifdef _WIN32
-    GTEST_SKIP() << "@todo iox-#2055 temporarily skipped";
-#else
     ASSERT_THAT(double_min_dec_eps.has_value(), Eq(false));
 }
 
@@ -729,33 +751,36 @@ TEST_F(convert_test, fromString_LongDouble_EdgeCase_InRange_Success)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cab1c90b-1de0-4654-bbea-4bb4e55e4fc3");
 
-    std::string source = fp_to_string(std::numeric_limits<long double>::min());
+    // the number larger than numeric_limits<long double>::digits10 that will pass all tests for all platforms
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MIN{36};
+    constexpr uint16_t PLATFORM_DIGIT_WORKAROUND_MAX{34};
+
+    std::string source = fp_to_string(std::numeric_limits<long double>::min(), PLATFORM_DIGIT_WORKAROUND_MIN);
     auto long_double_min = iox::convert::from_string<long double>(source.c_str());
     ASSERT_THAT(long_double_min.has_value(), Eq(true));
-    // There's no LongDoubleEq
-    EXPECT_THAT(long_double_min.value(), Eq(std::numeric_limits<long double>::min()));
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    EXPECT_THAT(LongDouble::Eq(long_double_min.value(), std::numeric_limits<long double>::min()), Eq(true));
 
-    source = fp_to_string(std::numeric_limits<long double>::lowest());
+    source = fp_to_string(std::numeric_limits<long double>::lowest(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto long_double_lowest = iox::convert::from_string<long double>(source.c_str());
     ASSERT_THAT(long_double_lowest.has_value(), Eq(true));
-    EXPECT_THAT(long_double_lowest.value(), Eq(std::numeric_limits<long double>::lowest()));
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    EXPECT_THAT(LongDouble::Eq(long_double_lowest.value(), std::numeric_limits<long double>::lowest()), Eq(true));
 
-    source = fp_to_string(std::numeric_limits<long double>::max());
+    source = fp_to_string(std::numeric_limits<long double>::max(), PLATFORM_DIGIT_WORKAROUND_MAX);
     auto long_double_max = iox::convert::from_string<long double>(source.c_str());
     ASSERT_THAT(long_double_max.has_value(), Eq(true));
-    EXPECT_THAT(long_double_max.value(), Eq(std::numeric_limits<long double>::max()));
+    // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+    EXPECT_THAT(LongDouble::Eq(long_double_max.value(), std::numeric_limits<long double>::max()), Eq(true));
 }
 
-TEST_F(convert_test, fromString_LongDouble_EdgeCase_SubNormalLongDouble_ShouldFail)
+TEST_F(convert_test, fromString_LongDouble_EdgeCase_SubNormalLongDouble_ShouldFailExceptMsvc)
 {
     ::testing::Test::RecordProperty("TEST_ID", "fb96e526-8fb6-4af9-87f0-dfd4193237a5");
 
     auto normal_long_double_min_eps = std::nextafter(std::numeric_limits<long double>::min(), 0.0L);
     std::string source = fp_to_string(std::numeric_limits<long double>::min() - normal_long_double_min_eps);
     auto long_double_min_dec_eps = iox::convert::from_string<long double>(source.c_str());
-#ifdef _WIN32
-    GTEST_SKIP() << "@todo iox-#2055 temporarily skipped";
-#else
     ASSERT_THAT(long_double_min_dec_eps.has_value(), Eq(false));
 }
 
@@ -888,7 +913,8 @@ TEST_F(convert_test, fromString_LongDouble_EdgeCase_ZeroDecimalNotation_Success)
     {
         auto decimal_ret = iox::convert::from_string<long double>(v.c_str());
         ASSERT_THAT(decimal_ret.has_value(), Eq(true));
-        ASSERT_THAT(decimal_ret.value(), Eq(0.0L));
+        // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+        ASSERT_THAT(LongDouble::Eq(decimal_ret.value(), 0.0L), Eq(true));
     }
 }
 

--- a/iceoryx_hoofs/utility/include/iox/detail/convert.inl
+++ b/iceoryx_hoofs/utility/include/iox/detail/convert.inl
@@ -363,7 +363,6 @@ inline bool convert::is_within_range(const SourceType& source_val) noexcept
     {
         return true;
     }
-    // is_arithmetic_v
     if constexpr (std::is_floating_point_v<SourceType>)
     {
         // special cases for floating point
@@ -371,8 +370,13 @@ inline bool convert::is_within_range(const SourceType& source_val) noexcept
         {
             return true;
         }
+#ifdef _MSC_VER
+        if (!std::isnormal(source_val) && (source_val != 0.0))
+        {
+            return false;
+        }
+#endif
     }
-
     // out of range (upper bound)
     if (source_val > std::numeric_limits<TargetType>::max())
     {
@@ -381,7 +385,6 @@ inline bool convert::is_within_range(const SourceType& source_val) noexcept
                            << std::numeric_limits<TargetType>::max());
         return false;
     }
-
     // out of range (lower bound)
     if (source_val < std::numeric_limits<TargetType>::lowest())
     {

--- a/iceoryx_hoofs/utility/include/iox/detail/convert.inl
+++ b/iceoryx_hoofs/utility/include/iox/detail/convert.inl
@@ -366,16 +366,16 @@ inline bool convert::is_within_range(const SourceType& source_val) noexcept
     if constexpr (std::is_floating_point_v<SourceType>)
     {
         // special cases for floating point
+        // can be nan or inf
         if (std::isnan(source_val) || std::isinf(source_val))
         {
             return true;
         }
-#ifdef _MSC_VER
+        // should be normal or zero
         if (!std::isnormal(source_val) && (source_val != 0.0))
         {
             return false;
         }
-#endif
     }
     // out of range (upper bound)
     if (source_val > std::numeric_limits<TargetType>::max())


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
It seems that there's some unknown issue on aarch64. I disable the specific test and will try to fix it in the following commits.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- #2055 
