### PR TITLE
iox-eclipse-iceoryx#1963 support for iox::string in MessageQueue

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -58,6 +58,7 @@
 - Fast POD data in `iox::vector` [#2082](https://github.com/eclipse-iceoryx/iceoryx/issues/2082)
 - MinGW support for Windows [#2150](https://github.com/eclipse-iceoryx/iceoryx/issues/2150)
 - Add support for `iox::string` in `UnixDomainSocket` and created `unix_domain_socket.inl` [#2040](https://github.com/eclipse-iceoryx/iceoryx/issues/2040)
+- Add support for `iox::string` in `MessageQueue` and created `message_queue.inl` [#1963](https://github.com/eclipse-iceoryx/iceoryx/issues/1963)
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/message_queue.inl
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/message_queue.inl
@@ -1,0 +1,213 @@
+// Copyright 2024, Eclipse Foundation and the iceoryx contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_HOOFS_POSIX_IPC_MESSAGE_QUEUE_INL
+#define IOX_HOOFS_POSIX_IPC_MESSAGE_QUEUE_INL
+
+#include "iox/duration.hpp"
+#include "iox/message_queue.hpp"
+#include "iox/not_null.hpp"
+#include "iox/posix_call.hpp"
+
+namespace iox
+{
+template <typename Type, MessageQueue::Termination Terminator>
+expected<void, PosixIpcChannelError>
+MessageQueue::timedSendImpl(not_null<const Type*> msg, uint64_t msgSize, const units::Duration& timeout) const noexcept
+{
+    uint64_t msgSizeToSend = msgSize;
+    if constexpr (Terminator == Termination::NULL_TERMINATOR)
+    {
+        msgSizeToSend += NULL_TERMINATOR_SIZE;
+    }
+
+    if (msgSizeToSend > static_cast<uint64_t>(m_attributes.mq_msgsize))
+    {
+        IOX_LOG(ERROR, "the message which should be sent to the message queue '" << m_name << "' is too long");
+        return err(PosixIpcChannelError::MESSAGE_TOO_LONG);
+    }
+
+    timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
+    auto mqCall = IOX_POSIX_CALL(mq_timedsend)(m_mqDescriptor, msg, msgSizeToSend, 1U, &timeOut)
+                      .failureReturnValue(ERROR_CODE)
+                      // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
+                      .ignoreErrnos(TIMEOUT_ERRNO)
+                      .evaluate();
+
+    if (mqCall.has_error())
+    {
+        return err(errnoToEnum(mqCall.error().errnum));
+    }
+
+    if (mqCall->errnum == TIMEOUT_ERRNO)
+    {
+        return err(errnoToEnum(ETIMEDOUT));
+    }
+
+    return ok();
+}
+
+template <typename Type, MessageQueue::Termination Terminator>
+expected<void, PosixIpcChannelError> MessageQueue::sendImpl(not_null<const Type*> msg, uint64_t msgSize) const noexcept
+{
+    uint64_t msgSizeToSend = msgSize;
+    if constexpr (Terminator == Termination::NULL_TERMINATOR)
+    {
+        msgSizeToSend += NULL_TERMINATOR_SIZE;
+    }
+
+    if (msgSizeToSend > static_cast<uint64_t>(m_attributes.mq_msgsize))
+    {
+        IOX_LOG(ERROR, "the message which should be sent to the message queue '" << m_name << "' is too long");
+        return err(PosixIpcChannelError::MESSAGE_TOO_LONG);
+    }
+
+    auto mqCall =
+        IOX_POSIX_CALL(mq_send)(m_mqDescriptor, msg, msgSizeToSend, 1U).failureReturnValue(ERROR_CODE).evaluate();
+
+    if (mqCall.has_error())
+    {
+        return err(errnoToEnum(mqCall.error().errnum));
+    }
+
+    if (mqCall->errnum == TIMEOUT_ERRNO)
+    {
+        return err(errnoToEnum(ETIMEDOUT));
+    }
+
+    return ok();
+}
+
+template <typename Type, MessageQueue::Termination Terminator>
+expected<uint64_t, PosixIpcChannelError>
+MessageQueue::timedReceiveImpl(not_null<Type*> msg, uint64_t maxMsgSize, const units::Duration& timeout) const noexcept
+{
+    timespec timeOut = timeout.timespec(units::TimeSpecReference::Epoch);
+    auto mqCall = IOX_POSIX_CALL(mq_timedreceive)(m_mqDescriptor, msg, maxMsgSize, nullptr, &timeOut)
+                      .failureReturnValue(ERROR_CODE)
+                      // don't use the suppressErrorMessagesForErrnos method since QNX used EINTR instead of ETIMEDOUT
+                      .ignoreErrnos(TIMEOUT_ERRNO)
+                      .evaluate();
+
+    if (mqCall.has_error())
+    {
+        return err(errnoToEnum(mqCall.error().errnum));
+    }
+
+    if (mqCall->errnum == TIMEOUT_ERRNO)
+    {
+        return err(errnoToEnum(ETIMEDOUT));
+    }
+
+    return receiveVerification<Type, Terminator>(msg, static_cast<uint64_t>(mqCall->value));
+}
+
+template <typename Type, MessageQueue::Termination Terminator>
+expected<uint64_t, PosixIpcChannelError> MessageQueue::receiveImpl(not_null<Type*> msg,
+                                                                   uint64_t maxMsgSize) const noexcept
+{
+    auto mqCall =
+        IOX_POSIX_CALL(mq_receive)(m_mqDescriptor, msg, maxMsgSize, nullptr).failureReturnValue(ERROR_CODE).evaluate();
+
+    if (mqCall.has_error())
+    {
+        return err(errnoToEnum(mqCall.error().errnum));
+    }
+
+    if (mqCall->errnum == TIMEOUT_ERRNO)
+    {
+        return err(errnoToEnum(ETIMEDOUT));
+    }
+
+    return receiveVerification<Type, Terminator>(msg, static_cast<uint64_t>(mqCall->value));
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> MessageQueue::send(const iox::string<N>& buf) const noexcept
+{
+    return sendImpl<char, Termination::NULL_TERMINATOR>(buf.c_str(), buf.size());
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> MessageQueue::timedSend(const iox::string<N>& buf,
+                                                             const units::Duration& timeout) const noexcept
+{
+    return timedSendImpl<char, Termination::NULL_TERMINATOR>(buf.c_str(), buf.size(), timeout);
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> MessageQueue::receive(iox::string<N>& buf) const noexcept
+{
+    static_assert(N <= MAX_MESSAGE_SIZE, "Size exceeds transmission limit!");
+
+    auto result = expected<uint64_t, PosixIpcChannelError>(in_place, uint64_t(0));
+    buf.unsafe_raw_access([&](auto* str, const auto info) -> uint64_t {
+        result = receiveImpl<char, Termination::NULL_TERMINATOR>(str, info.total_size);
+        if (result.has_error())
+        {
+            return 0;
+        }
+        return result.value();
+    });
+    if (result.has_error())
+    {
+        return err(result.error());
+    }
+    return ok();
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> MessageQueue::timedReceive(iox::string<N>& buf,
+                                                                const units::Duration& timeout) const noexcept
+{
+    static_assert(N <= MAX_MESSAGE_SIZE, "Size exceeds transmission limit!");
+
+    auto result = expected<uint64_t, PosixIpcChannelError>(in_place, uint64_t(0));
+    buf.unsafe_raw_access([&](auto* str, const auto info) -> uint64_t {
+        result = timedReceiveImpl<char, Termination::NULL_TERMINATOR>(str, info.total_size, timeout);
+        if (result.has_error())
+        {
+            return 0;
+        }
+        return result.value();
+    });
+    if (result.has_error())
+    {
+        return err(result.error());
+    }
+    return ok();
+}
+
+template <typename Type, MessageQueue::Termination Terminator>
+expected<uint64_t, PosixIpcChannelError> MessageQueue::receiveVerification(not_null<Type*> msg,
+                                                                           uint64_t msgLenght) const noexcept
+{
+    if constexpr (Terminator == Termination::NULL_TERMINATOR)
+    {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        if (msg[msgLenght - NULL_TERMINATOR_SIZE] != 0)
+        {
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            msg[0] = 0;
+            return err(PosixIpcChannelError::INTERNAL_LOGIC_ERROR);
+        }
+        return ok<uint64_t>(msgLenght - NULL_TERMINATOR_SIZE);
+    }
+
+    return ok<uint64_t>(msgLenght);
+}
+} // namespace iox
+
+#endif


### PR DESCRIPTION
By default, the MessageQueue class relies on std::string objects to send and receive data, as defined by its interface. However, this approach can potentially lead to dynamic memory allocation when handling larger data payloads that exceed the stack space optimization (SSO) limit.

To address this issue, an alternative API has been introduced that enables data transmission and reception using iox::string. This approach allows for direct data manipulation within stack memory, effectively eliminating the need for dynamic memory allocation.

## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Reference: https://github.com/eclipse-iceoryx/iceoryx/issues/1693
