### PR TITLE
iox-#1693 support for iox::string in NamedPipe

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -59,6 +59,8 @@
 - MinGW support for Windows [#2150](https://github.com/eclipse-iceoryx/iceoryx/issues/2150)
 - Add support for `iox::string` in `UnixDomainSocket` and created `unix_domain_socket.inl` [#2040](https://github.com/eclipse-iceoryx/iceoryx/issues/2040)
 - Add support for `iox::string` in `MessageQueue` and created `message_queue.inl` [#1963](https://github.com/eclipse-iceoryx/iceoryx/issues/1963)
+- Add support for `iox::string` in `NamedPipe` and created `named_pipe.inl` [#1693](https://github.com/eclipse-iceoryx/iceoryx/issues/1693)
+
 
 **Bugfixes:**
 

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/named_pipe.inl
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/named_pipe.inl
@@ -1,0 +1,128 @@
+// Copyright 2024, Eclipse Foundation and the iceoryx contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+#ifndef IOX_HOOFS_POSIX_IPC_NAMED_PIPE_INL
+#define IOX_HOOFS_POSIX_IPC_NAMED_PIPE_INL
+
+#include "iox/duration.hpp"
+#include "iox/into.hpp"
+#include "iox/named_pipe.hpp"
+
+namespace iox
+{
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::trySend(const iox::string<N>& message) const noexcept
+{
+    static_assert(N <= MAX_MESSAGE_SIZE, "Size exceeds transmission limit!");
+
+    auto result = m_data->sendSemaphore().tryWait();
+    IOX_EXPECTS(!result.has_error());
+
+    if (*result)
+    {
+        IOX_DISCARD_RESULT(m_data->messages.push(message));
+        IOX_EXPECTS(!m_data->receiveSemaphore().post().has_error());
+        return ok();
+    }
+    return err(PosixIpcChannelError::TIMEOUT);
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::send(const iox::string<N>& message) const noexcept
+{
+    static_assert(N <= MAX_MESSAGE_SIZE, "Size exceeds transmission limit!");
+
+    IOX_EXPECTS(!m_data->sendSemaphore().wait().has_error());
+    IOX_DISCARD_RESULT(m_data->messages.push(message));
+    IOX_EXPECTS(!m_data->receiveSemaphore().post().has_error());
+
+    return ok();
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::timedSend(const iox::string<N>& message,
+                                                          const units::Duration& timeout) const noexcept
+{
+    static_assert(N <= MAX_MESSAGE_SIZE, "Size exceeds transmission limit!");
+
+    auto result = m_data->sendSemaphore().timedWait(timeout);
+    IOX_EXPECTS(!result.has_error());
+
+    if (*result == SemaphoreWaitState::NO_TIMEOUT)
+    {
+        IOX_DISCARD_RESULT(m_data->messages.push(message));
+        IOX_EXPECTS(!m_data->receiveSemaphore().post().has_error());
+        return ok();
+    }
+    return err(PosixIpcChannelError::TIMEOUT);
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::receive(iox::string<N>& message) const noexcept
+{
+    IOX_EXPECTS(!m_data->receiveSemaphore().wait().has_error());
+    auto msg = m_data->messages.pop();
+    if (msg.has_value())
+    {
+        IOX_EXPECTS(!m_data->sendSemaphore().post().has_error());
+        message = *msg;
+        return ok();
+    }
+    return err(PosixIpcChannelError::INTERNAL_LOGIC_ERROR);
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::tryReceive(iox::string<N>& message) const noexcept
+{
+    auto result = m_data->receiveSemaphore().tryWait();
+    IOX_EXPECTS(!result.has_error());
+
+    if (*result)
+    {
+        auto msg = m_data->messages.pop();
+        if (msg.has_value())
+        {
+            IOX_EXPECTS(!m_data->sendSemaphore().post().has_error());
+            message = *msg;
+        }
+        return err(PosixIpcChannelError::INTERNAL_LOGIC_ERROR);
+    }
+
+    return err(PosixIpcChannelError::TIMEOUT);
+}
+
+template <uint64_t N>
+expected<void, PosixIpcChannelError> NamedPipe::timedReceive(iox::string<N>& message,
+                                                             const units::Duration& timeout) const noexcept
+{
+    auto result = m_data->receiveSemaphore().timedWait(timeout);
+    IOX_EXPECTS(!result.has_error());
+
+    if (*result == SemaphoreWaitState::NO_TIMEOUT)
+    {
+        auto msg = m_data->messages.pop();
+        if (msg.has_value())
+        {
+            IOX_EXPECTS(!m_data->sendSemaphore().post().has_error());
+            message = *msg;
+            return ok();
+        }
+        return err(PosixIpcChannelError::INTERNAL_LOGIC_ERROR);
+    }
+    return err(PosixIpcChannelError::TIMEOUT);
+}
+} // namespace iox
+
+#endif

--- a/iceoryx_hoofs/posix/ipc/include/iox/named_pipe.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/named_pipe.hpp
@@ -104,6 +104,55 @@ class NamedPipe
     /// @return on success a string containing the message, otherwise an error which describes the failure
     expected<std::string, PosixIpcChannelError> timedReceive(const units::Duration& timeout) const noexcept;
 
+    /// @brief tries to send a message via the named pipe. if the pipe is full PosixIpcChannelError::TIMEOUT is returned
+    /// @tparam N capacity of the iox::string
+    /// @param[in] message the message to send
+    /// @return on failure an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> trySend(const iox::string<N>& message) const noexcept;
+
+    /// @brief sends a message via the named pipe. if the pipe is full this call is blocking until the message could be
+    ///        delivered
+    /// @tparam N capacity of the iox::string, is not allowed to be longer then MAX_MESSAGE_SIZE
+    /// @param[in] message the message which should be sent
+    /// @return success when message was sent otherwise an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> send(const iox::string<N>& message) const noexcept;
+
+    /// @brief sends a message via the named pipe.
+    /// @tparam N capacity of the iox::string, is not allowed to be longer then MAX_MESSAGE_SIZE
+    /// @param[in] message the message which should be sent
+    /// @param[in] timeout the timeout on how long this method should retry to send the message
+    /// @return success when message was sent otherwise an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> timedSend(const iox::string<N>& message,
+                                                   const units::Duration& timeout) const noexcept;
+
+    /// @brief tries to receive a message via the named pipe. if the pipe is empty PosixIpcChannelError::TIMEOUT is
+    /// returned
+    /// @tparam N capacity of the iox::string
+    /// @param[in] message the message to receive
+    /// @return on success a string containing the message, otherwise an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> tryReceive(iox::string<N>& message) const noexcept;
+
+    /// @brief receives a message via the named pipe. if the pipe is empty this call is blocking until a message was
+    ///        received
+    /// @tparam N capacity of the iox::string
+    /// @param[in] message the message to receive
+    /// @return on success a string containing the message, otherwise an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> receive(iox::string<N>& message) const noexcept;
+
+    /// @brief receives a message via the named pipe.
+    /// @tparam N capacity of the iox::string
+    /// @param[in] message the message to receive
+    /// @param[in] timeout the timeout on how long this method should retry to receive a message
+    /// @return on success a string containing the message, otherwise an error which describes the failure
+    template <uint64_t N>
+    expected<void, PosixIpcChannelError> timedReceive(iox::string<N>& message,
+                                                      const units::Duration& timeout) const noexcept;
+
   private:
     friend class NamedPipeBuilder;
 
@@ -175,5 +224,8 @@ class NamedPipeBuilder
 };
 
 } // namespace iox
+
+#include "detail/named_pipe.inl"
+
 
 #endif // IOX_HOOFS_POSIX_IPC_NAMED_PIPE_HPP


### PR DESCRIPTION
By default, the NamedPipe class relies on std::string objects to send and receive data, as defined by its interface. However, this approach can potentially lead to dynamic memory allocation when handling larger data payloads that exceed the stack space optimization (SSO) limit.

To address this issue, an alternative API has been introduced that enables data transmission and reception using iox::string. This approach allows for direct data manipulation within stack memory, effectively eliminating the need for dynamic memory allocation.

## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes https://github.com/eclipse-iceoryx/iceoryx/issues/1693
