### PR TITLE
iox-#2082 Always initialize members in 'iox::vector(count)'

### DIFF
--- a/iceoryx_hoofs/container/include/iox/detail/vector.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/vector.inl
@@ -55,14 +55,10 @@ inline vector<T, Capacity>::vector(const uint64_t count) noexcept
     }
 
     m_size = std::min(count, Capacity);
-    // If the type is a trivial class without member initialization the constructor would not initialize the data
-    if constexpr (!(std::is_trivial<T>::value && std::is_class<T>::value))
+    for (uint64_t i{0U}; i < m_size; ++i)
     {
-        for (uint64_t i{0U}; i < m_size; ++i)
-        {
-            // AXIVION Next Line AutosarC++19_03-A18.5.2, FaultDetection-IndirectAssignmentOverflow : False positive, it is a placement new. Size guaranteed by T.
-            new (&at_unchecked(i)) T();
-        }
+        // AXIVION Next Line AutosarC++19_03-A18.5.2, FaultDetection-IndirectAssignmentOverflow : False positive, it is a placement new. Size guaranteed by T.
+        new (&at_unchecked(i)) T();
     }
 }
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR reverts one change from a previous PR where under some conditions the elements with the 'iox::vector(count)' ctor were not initialized. In order to keep the old behavior and follow our philosophy to always initialize except when stated otherwise, this change is reverted with this PR.

See also https://github.com/eclipse-iceoryx/iceoryx/issues/2082#issuecomment-1848453718

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes #2082 
