### PR TITLE
iox-#1032 Add stringified condition to the error output

### DIFF
--- a/iceoryx_hoofs/reporting/include/iox/assertions.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/assertions.hpp
@@ -48,31 +48,33 @@
 //* Instead a special internal error type is used.
 //************************************************************************************************
 
-/// @brief only for debug builds: report fatal assert violation if expr evaluates to false
+/// @brief only for debug builds: report fatal assert violation if expression evaluates to false
 /// @note for conditions that should not happen with correct use
-/// @param expr boolean expression that must hold
+/// @param condition boolean expression that must hold
 /// @param message message to be forwarded in case of violation
-#define IOX_ASSERT(expr, message)                                                                                      \
-    if (iox::er::Configuration::CHECK_ASSERT && !(expr))                                                               \
+#define IOX_ASSERT(condition, message)                                                                                 \
+    if (iox::er::Configuration::CHECK_ASSERT && !(condition))                                                          \
     {                                                                                                                  \
         iox::er::forwardFatalError(iox::er::Violation::createAssertViolation(),                                        \
                                    iox::er::ASSERT_VIOLATION,                                                          \
                                    IOX_CURRENT_SOURCE_LOCATION,                                                        \
+                                   #condition,                                                                         \
                                    message);                                                                           \
     }                                                                                                                  \
     [] {}() // the empty lambda forces a semicolon on the caller side
 
-/// @brief report fatal enforce violation if expr evaluates to false
+/// @brief report fatal enforce violation if expression evaluates to false
 /// @note for conditions that may actually happen during correct use
-/// @param expr boolean expression that must hold
+/// @param condition boolean expression that must hold
 /// @param message message to be forwarded in case of violation
-#define IOX_ENFORCE(expr, message)                                                                                     \
-    if (!(expr))                                                                                                       \
+#define IOX_ENFORCE(condition, message)                                                                                \
+    if (!(condition))                                                                                                  \
     {                                                                                                                  \
         iox::er::forwardFatalError(iox::er::Violation::createEnforceViolation(),                                       \
                                    iox::er::ENFORCE_VIOLATION,                                                         \
                                    IOX_CURRENT_SOURCE_LOCATION,                                                        \
-                                   message); /* @todo iox-#1032 add strigified 'expr' as '#expr' */                    \
+                                   #condition,                                                                         \
+                                   message);                                                                           \
     }                                                                                                                  \
     [] {}() // the empty lambda forces a semicolon on the caller side
 

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_reporting_impl.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_reporting_impl.hpp
@@ -68,20 +68,34 @@ template <class Message>
     panic();
 }
 
-/// @todo iox-#1032 add a 'StringifiedCondition' template parameter
+namespace detail
+{
+inline log::LogStream& logStringifiedCondition(log::LogStream& stream, const char* stringifiedCondition)
+{
+    if (stringifiedCondition != nullptr && strnlen(stringifiedCondition, 1) != 0)
+    {
+        stream << "Conditiopn: \"" << stringifiedCondition << "\" ";
+    }
+    return stream;
+}
+} // namespace detail
 
 // Report any error, general version.
 template <class Kind, class Error>
-inline void report(const SourceLocation& location, Kind, const Error& error)
+inline void report(const SourceLocation& location, Kind, const Error& error, const char* stringifiedCondition)
 {
     auto code = toCode(error);
     auto module = toModule(error);
     auto moduleName = toModuleName(error);
     auto errorName = toErrorName(error);
 
-    IOX_ERROR_INTERNAL_LOG(location,
-                           "[" << errorName << " (code = " << code.value << ")] in module [" << moduleName
-                               << " (id = " << module.value << ")]");
+    IOX_ERROR_INTERNAL_LOG(
+        location,
+        [stringifiedCondition](auto& stream) -> auto& {
+            return detail::logStringifiedCondition(stream, stringifiedCondition);
+        } << "["
+          << errorName << " (code = " << code.value << ")] in module [" << moduleName << " (id = " << module.value
+          << ")]");
     auto& h = ErrorHandler::get();
     h.onReportError(ErrorDescriptor(location, code, module));
 }
@@ -92,16 +106,21 @@ inline void report(const SourceLocation& location, Kind, const Error& error)
 // Here the logging is subtly different and does not easily allow to factor out common parts.
 
 template <class Error>
-inline void report(const SourceLocation& location, iox::er::FatalKind kind, const Error& error)
+inline void
+report(const SourceLocation& location, iox::er::FatalKind kind, const Error& error, const char* stringifiedCondition)
 {
     auto code = toCode(error);
     auto module = toModule(error);
     auto moduleName = toModuleName(error);
     auto errorName = toErrorName(error);
 
-    IOX_ERROR_INTERNAL_LOG_FATAL(location,
-                                 "[" << kind.name << "] [" << errorName << " (code = " << code.value << ")] in module ["
-                                     << moduleName << " (id = " << module.value << ")]");
+    IOX_ERROR_INTERNAL_LOG_FATAL(
+        location,
+        [stringifiedCondition](auto& stream) -> auto& {
+            return detail::logStringifiedCondition(stream, stringifiedCondition);
+        } << "["
+          << kind.name << "] [" << errorName << " (code = " << code.value << ")] in module [" << moduleName
+          << " (id = " << module.value << ")]");
     auto& h = ErrorHandler::get();
     h.onReportError(ErrorDescriptor(location, code, module));
 }
@@ -113,17 +132,29 @@ enum class NoMessage
 };
 
 template <class Kind, class Error, class Message>
-inline void report(const SourceLocation& location, Kind kind, const Error& error, Message&& msg)
+inline void
+// NOLINTNEXTLINE(readability-function-size) Not used directly but via a macro which hides the number of parameter away
+report(const SourceLocation& location, Kind kind, const Error& error, const char* stringifiedCondition, Message&& msg)
 {
     auto code = toCode(error);
     auto module = toModule(error);
     if constexpr (std::is_same<NoMessage, Message>::value)
     {
-        IOX_ERROR_INTERNAL_LOG_FATAL(location, "[" << kind.name << "]");
+        IOX_ERROR_INTERNAL_LOG_FATAL(
+            location,
+            [stringifiedCondition](auto& stream) -> auto& {
+                return detail::logStringifiedCondition(stream, stringifiedCondition);
+            } << "["
+              << kind.name << "]");
     }
     else
     {
-        IOX_ERROR_INTERNAL_LOG_FATAL(location, "[" << kind.name << "] " << std::forward<Message>(msg));
+        IOX_ERROR_INTERNAL_LOG_FATAL(
+            location,
+            [stringifiedCondition](auto& stream) -> auto& {
+                return detail::logStringifiedCondition(stream, stringifiedCondition);
+            } << "["
+              << kind.name << "] " << std::forward<Message>(msg));
     }
     auto& h = ErrorHandler::get();
     h.onReportViolation(ErrorDescriptor(location, code, module));
@@ -131,28 +162,43 @@ inline void report(const SourceLocation& location, Kind kind, const Error& error
 } // namespace detail
 
 template <class Error>
-inline void report(const SourceLocation& location, iox::er::AssertViolationKind kind, const Error& error)
+inline void report(const SourceLocation& location,
+                   iox::er::AssertViolationKind kind,
+                   const Error& error,
+                   const char* stringifiedCondition)
 {
-    detail::report(location, kind, error, detail::NoMessage{});
+    detail::report(location, kind, error, stringifiedCondition, detail::NoMessage{});
 }
 
 template <class Error>
-inline void report(const SourceLocation& location, iox::er::EnforceViolationKind kind, const Error& error)
+inline void report(const SourceLocation& location,
+                   iox::er::EnforceViolationKind kind,
+                   const Error& error,
+                   const char* stringifiedCondition)
 {
-    detail::report(location, kind, error, detail::NoMessage{});
+    detail::report(location, kind, error, stringifiedCondition, detail::NoMessage{});
 }
 
 template <class Error, class Message>
-inline void report(const SourceLocation& location, iox::er::AssertViolationKind kind, const Error& error, Message&& msg)
+// NOLINTNEXTLINE(readability-function-size) Not used directly but via a macro which hides the number of parameter away
+inline void report(const SourceLocation& location,
+                   iox::er::AssertViolationKind kind,
+                   const Error& error,
+                   const char* stringifiedCondition,
+                   Message&& msg)
 {
-    detail::report(location, kind, error, std::forward<Message>(msg));
+    detail::report(location, kind, error, stringifiedCondition, std::forward<Message>(msg));
 }
 
 template <class Error, class Message>
-inline void
-report(const SourceLocation& location, iox::er::EnforceViolationKind kind, const Error& error, Message&& msg)
+// NOLINTNEXTLINE(readability-function-size) Not used directly but via a macro which hides the number of parameter away
+inline void report(const SourceLocation& location,
+                   iox::er::EnforceViolationKind kind,
+                   const Error& error,
+                   const char* stringifiedCondition,
+                   Message&& msg)
 {
-    detail::report(location, kind, error, std::forward<Message>(msg));
+    detail::report(location, kind, error, stringifiedCondition, std::forward<Message>(msg));
 }
 
 } // namespace er

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/error_forwarding.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/error_forwarding.hpp
@@ -45,45 +45,56 @@ template <typename Message>
 }
 
 /// @brief Forwards a fatal error and does not return.
-/// @param location the location of the error
 /// @param error the error
 /// @param kind the kind of error (category)
+/// @param location the location of the error
+/// @param stringifiedCondition the condition as string if a macro with a condition was used; an empty string otherwise
 template <typename Error, typename Kind>
-[[noreturn]] inline void forwardFatalError(Error&& error, Kind&& kind, const SourceLocation& location)
+[[noreturn]] inline void
+forwardFatalError(Error&& error, Kind&& kind, const SourceLocation& location, const char* stringifiedCondition)
 {
     using K = typename std::remove_const<typename std::remove_reference<Kind>::type>::type;
     static_assert(IsFatal<K>::value, "Must forward a fatal error!");
 
-    report(location, std::forward<Kind>(kind), std::forward<Error>(error));
+    report(location, std::forward<Kind>(kind), std::forward<Error>(error), stringifiedCondition);
     panic(location);
     abort();
 }
 
 /// @brief Forwards a non-fatal error.
-/// @param location the location of the error
 /// @param error the error
 /// @param kind the kind of error (category)
+/// @param location the location of the error
+/// @param stringifiedCondition the condition as string if a macro with a condition was used; an empty string otherwise
 template <typename Error, typename Kind>
-inline void forwardNonFatalError(Error&& error, Kind&& kind, const SourceLocation& location)
+inline void
+forwardNonFatalError(Error&& error, Kind&& kind, const SourceLocation& location, const char* stringifiedCondition)
 {
     using K = typename std::remove_const<typename std::remove_reference<Kind>::type>::type;
     static_assert(!IsFatal<K>::value, "Must forward a non-fatal error!");
 
-    report(location, std::forward<Kind>(kind), std::forward<Error>(error));
+    report(location, std::forward<Kind>(kind), std::forward<Error>(error), stringifiedCondition);
 }
 
 /// @brief Forwards a fatal error and a message and does not return.
-/// @param location the location of the error
 /// @param error the error
 /// @param kind the kind of error (category)
+/// @param location the location of the error
+/// @param stringifiedCondition the condition as string if a macro with a condition was used; an empty string otherwise
 /// @param msg the message to be forwarded
 template <typename Error, typename Kind, typename Message>
-[[noreturn]] inline void forwardFatalError(Error&& error, Kind&& kind, const SourceLocation& location, Message&& msg)
+// NOLINTNEXTLINE(readability-function-size) Not used directly but via a macro which hides the number of parameter away
+[[noreturn]] inline void forwardFatalError(
+    Error&& error, Kind&& kind, const SourceLocation& location, const char* stringifiedCondition, Message&& msg)
 {
     using K = typename std::remove_const<typename std::remove_reference<Kind>::type>::type;
     static_assert(IsFatal<K>::value, "Must forward a fatal error!");
 
-    report(location, std::forward<Kind>(kind), std::forward<Error>(error), std::forward<Message>(msg));
+    report(location,
+           std::forward<Kind>(kind),
+           std::forward<Error>(error),
+           stringifiedCondition,
+           std::forward<Message>(msg));
     panic(location);
     abort();
 }

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/macros.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/macros.hpp
@@ -41,34 +41,31 @@
 /// @param error error object (or code)
 /// @param kind kind of error, must be non-fatal
 #define IOX_REPORT(error, kind)                                                                                        \
-    iox::er::forwardNonFatalError(iox::er::toError(error), kind, IOX_CURRENT_SOURCE_LOCATION)
+    iox::er::forwardNonFatalError(iox::er::toError(error), kind, IOX_CURRENT_SOURCE_LOCATION, "")
 
 /// @brief report fatal error
 /// @param error error object (or code)
 #define IOX_REPORT_FATAL(error)                                                                                        \
-    iox::er::forwardFatalError(iox::er::toError(error), iox::er::FATAL, IOX_CURRENT_SOURCE_LOCATION)
+    iox::er::forwardFatalError(iox::er::toError(error), iox::er::FATAL, IOX_CURRENT_SOURCE_LOCATION, "")
 
 /// @brief report error of some non-fatal kind if expr evaluates to true
-/// @param expr boolean expression
+/// @param condition boolean expression
 /// @param error error object (or code)
 /// @param kind kind of error, must be non-fatal
-#define IOX_REPORT_IF(expr, error, kind)                                                                               \
-    if (expr)                                                                                                          \
+#define IOX_REPORT_IF(condition, error, kind)                                                                          \
+    if (condition)                                                                                                     \
     {                                                                                                                  \
-        iox::er::forwardNonFatalError(                                                                                 \
-            iox::er::toError(error),                                                                                   \
-            kind,                                                                                                      \
-            IOX_CURRENT_SOURCE_LOCATION); /* @todo iox-#1032 add strigified 'expr' as '#expr' */                       \
+        iox::er::forwardNonFatalError(iox::er::toError(error), kind, IOX_CURRENT_SOURCE_LOCATION, #condition);         \
     }                                                                                                                  \
     [] {}() // the empty lambda forces a semicolon on the caller side
 
 /// @brief report fatal error if expr evaluates to true
-/// @param expr boolean expression
+/// @param condition boolean expression
 /// @param error error object (or code)
-#define IOX_REPORT_FATAL_IF(expr, error)                                                                               \
-    if (expr)                                                                                                          \
+#define IOX_REPORT_FATAL_IF(condition, error)                                                                          \
+    if (condition)                                                                                                     \
     {                                                                                                                  \
-        iox::er::forwardFatalError(iox::er::toError(error), iox::er::FATAL, IOX_CURRENT_SOURCE_LOCATION);              \
+        iox::er::forwardFatalError(iox::er::toError(error), iox::er::FATAL, IOX_CURRENT_SOURCE_LOCATION, #condition);  \
     }                                                                                                                  \
     [] {}() // the empty lambda forces a semicolon on the caller side
 

--- a/iceoryx_hoofs/test/moduletests/error_reporting/test_custom_error_reporting.cpp
+++ b/iceoryx_hoofs/test/moduletests/error_reporting/test_custom_error_reporting.cpp
@@ -88,7 +88,10 @@ TEST_F(ErrorReporting_test, reportNonFatalErrorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "1a1cec1b-5297-487a-bb95-e80af99886b6");
 
-    auto f = []() { report(IOX_CURRENT_SOURCE_LOCATION, RUNTIME_ERROR, ERROR); };
+    auto f = []() {
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, RUNTIME_ERROR, ERROR, STRINGIFIED_CONDITION);
+    };
 
     iox::testing::runInTestThread(f);
 
@@ -100,7 +103,10 @@ TEST_F(ErrorReporting_test, reportFatalErrorWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "");
 
-    auto f = []() { report(IOX_CURRENT_SOURCE_LOCATION, FATAL, ERROR); };
+    auto f = []() {
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, FATAL, ERROR, STRINGIFIED_CONDITION);
+    };
 
     iox::testing::runInTestThread(f);
 
@@ -116,7 +122,8 @@ TEST_F(ErrorReporting_test, reportAssertViolatonWorks)
 
     auto f = []() {
         auto v = Violation::createAssertViolation();
-        report(IOX_CURRENT_SOURCE_LOCATION, ASSERT_VIOLATION, v);
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, ASSERT_VIOLATION, v, STRINGIFIED_CONDITION);
     };
 
     iox::testing::runInTestThread(f);
@@ -131,7 +138,8 @@ TEST_F(ErrorReporting_test, reportAssertViolatonWithMessageWorks)
 
     auto f = []() {
         auto v = Violation::createAssertViolation();
-        report(IOX_CURRENT_SOURCE_LOCATION, ASSERT_VIOLATION, v, "message");
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, ASSERT_VIOLATION, v, STRINGIFIED_CONDITION, "message");
     };
 
     iox::testing::runInTestThread(f);
@@ -145,7 +153,8 @@ TEST_F(ErrorReporting_test, reportEnforceViolatonWorks)
 
     auto f = []() {
         auto v = Violation::createEnforceViolation();
-        report(IOX_CURRENT_SOURCE_LOCATION, ENFORCE_VIOLATION, v);
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, ENFORCE_VIOLATION, v, STRINGIFIED_CONDITION);
     };
 
     iox::testing::runInTestThread(f);
@@ -160,7 +169,8 @@ TEST_F(ErrorReporting_test, reportEnforceViolatonWithMessageWorks)
 
     auto f = []() {
         auto v = Violation::createEnforceViolation();
-        report(IOX_CURRENT_SOURCE_LOCATION, ENFORCE_VIOLATION, v, "message");
+        constexpr const char* STRINGIFIED_CONDITION{""};
+        report(IOX_CURRENT_SOURCE_LOCATION, ENFORCE_VIOLATION, v, STRINGIFIED_CONDITION, "message");
     };
 
     iox::testing::runInTestThread(f);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Add a second reviewer for complex new features or larger refactorings
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

Similar to the output of `Expects`/`Ensures`, this PR adds a stringified condition to the error string fo `IOX_ENFORCE`, `IOX_ASSERT` and `IOX_REPORT_IF`.

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Relates to #1032
