### PR TITLE
iox-#2224 Fix const value assignment in optional

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -125,6 +125,7 @@
 - Fix wrong memory orders in SpscFiFo [#2167](https://github.com/eclipse-iceoryx/iceoryx/issues/2167)
 - Implement missing copy assignment for expected [#2216](https://github.com/eclipse-iceoryx/iceoryx/issues/2216)
 - Add missing type aliases that conform with STL container types [#2220](https://github.com/eclipse-iceoryx/iceoryx/issues/2220)
+- Fix `const` value assignment in `iox::optional` [\#2224](https://github.com/eclipse-iceoryx/iceoryx/issues/2224)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_optional.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_optional.cpp
@@ -280,6 +280,30 @@ TEST_F(Optional_test, CopyAssignmentFromNoValueToNoValue)
     ASSERT_THAT(sut2.has_value(), Eq(false));
 }
 
+TEST_F(Optional_test, DirectCopyAssignmentWithNoValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "8dddd1c5-e59b-4f3c-9e6c-6fa9ac1daa86");
+    iox::optional<TestClass> sut;
+    const TestClass value{4711, 1337};
+
+    sut = value;
+    ASSERT_THAT(sut.has_value(), Eq(true));
+    EXPECT_THAT(sut->value, Eq(4711));
+    EXPECT_THAT(sut->secondValue, Eq(1337));
+}
+
+TEST_F(Optional_test, DirectCopyAssignmentWithValue)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "66fa19ab-0a08-48d3-824c-7b259e6f15b0");
+    iox::optional<TestClass> sut{TestClass{7474, 33331}};
+    TestClass value{4711, 1337};
+
+    sut = value;
+    ASSERT_THAT(sut.has_value(), Eq(true));
+    EXPECT_THAT(sut->value, Eq(4711));
+    EXPECT_THAT(sut->secondValue, Eq(1337));
+}
+
 TEST_F(Optional_test, MoveCTorWithValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a7694c42-fb4d-4c53-930b-f0be78127027");

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
@@ -169,11 +169,11 @@ optional<T>::operator=(U&& newValue) noexcept
 {
     if (m_hasValue)
     {
-        value() = std::forward<T>(newValue);
+        value() = std::forward<U>(newValue);
     }
     else
     {
-        construct_value(std::forward<T>(newValue));
+        construct_value(std::forward<U>(newValue));
     }
     return *this;
 }

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -793,7 +793,7 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
         {
             prettyPrint("### MemPool Status ###\n\n", PrettyOptions::highlight);
 
-            memPoolSubscriber->take().and_then([&](auto& sample) { memPoolSample = sample; });
+            memPoolSubscriber->take().and_then([&](auto& sample) { memPoolSample = std::move(sample); });
 
             if (memPoolSample)
             {
@@ -812,7 +812,7 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
         if (introspectionSelection.process == true)
         {
             prettyPrint("### Processes ###\n\n", PrettyOptions::highlight);
-            processSubscriber->take().and_then([&](auto& sample) { processSample = sample; });
+            processSubscriber->take().and_then([&](auto& sample) { processSample = std::move(sample); });
 
             if (processSample)
             {
@@ -827,12 +827,12 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriod,
         // print port information
         if (introspectionSelection.port == true)
         {
-            portSubscriber->take().and_then([&](auto& sample) { portSample = sample; });
+            portSubscriber->take().and_then([&](auto& sample) { portSample = std::move(sample); });
 
-            portThroughputSubscriber->take().and_then([&](auto& sample) { portThroughputSample = sample; });
+            portThroughputSubscriber->take().and_then([&](auto& sample) { portThroughputSample = std::move(sample); });
 
             subscriberPortChangingDataSubscriber->take().and_then(
-                [&](auto& sample) { subscriberPortChangingDataSamples = sample; });
+                [&](auto& sample) { subscriberPortChangingDataSamples = std::move(sample); });
 
             if (portSample && portThroughputSample && subscriberPortChangingDataSamples)
             {


### PR DESCRIPTION
Fixes the forwarding reference type in `iox::optional::operator=` when performing a direct assignment of the underlying value such that assigning `const` values is supported.

## Pre-Review Checklist for the PR Author

1. [ ] ~Add a second reviewer for complex new features or larger refactorings~
1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] All touched (C/C++) source code files from `iceoryx_hoofs` are added to `./clang-tidy-diff-scans.txt`
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

- Closes [#2224](https://github.com/eclipse-iceoryx/iceoryx/issues/2224)
