### PR TITLE
iox-#2241 Fix span iterator constructor

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -127,6 +127,7 @@
 - Add missing type aliases that conform with STL container types [#2220](https://github.com/eclipse-iceoryx/iceoryx/issues/2220)
 - Fix `const` value assignment in `iox::optional` [\#2224](https://github.com/eclipse-iceoryx/iceoryx/issues/2224)
 - Generated files cause recompilation even without any changes [#2210](https://github.com/eclipse-iceoryx/iceoryx/issues/2210)
+- Fix span_iterator constructor to prevent assertion when iterating over spans [#2216](https://github.com/eclipse-iceoryx/iceoryx/issues/2216)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_span.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_span.cpp
@@ -382,4 +382,19 @@ TEST(span_test, GetSpanDataAsWritableBytes)
     EXPECT_EQ(0, vec[0]);
 }
 
+TEST(span_test, IterateOverSpan)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "87924274-b774-467e-8ffc-a66a46596cbe");
+    std::vector<int32_t> vector = {1, 1, 13, 3, 5, 8};
+    span<int32_t, 6> static_sut(vector.data(), vector.size());
+
+    // Sum the values in the span as a simple test
+    int32_t sum{0U};
+    for (const auto& val : static_sut)
+    {
+        sum += val;
+    }
+    EXPECT_EQ(sum, 31);
+}
+
 } // namespace

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/span_iterator.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/span_iterator.hpp
@@ -52,7 +52,7 @@ class span_iterator final
         , m_current(current)
     {
         assert(m_begin <= m_end);
-        assert(m_begin <= m_current && m_current < m_end);
+        assert(m_begin <= m_current && m_current <= m_end);
     }
 
     explicit constexpr operator span_iterator<const T>() const noexcept


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes an incorrect assert which prevented the creation of the end iterator of a span

Fixes https://github.com/eclipse-iceoryx/iceoryx/issues/2241

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2241 
