### PR TITLE
iox-#2011 Add patch to use cmake 3.16 for cpptoml

### DIFF
--- a/iceoryx_posh/cmake/cpptoml/0001-cpptoml-cmake-version.patch
+++ b/iceoryx_posh/cmake/cpptoml/0001-cpptoml-cmake-version.patch
@@ -1,0 +1,8 @@
+--- a/CMakeLists.txt	2024-03-26 12:09:54.921829374 +0000
++++ b/CMakeLists.txt	2024-03-26 12:09:59.552800904 +0000
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.16)
+ project(cpptoml)
+
+ set(cpptoml_VERSION 0.4.0)

--- a/iceoryx_posh/cmake/cpptoml/CMakeLists.txt
+++ b/iceoryx_posh/cmake/cpptoml/CMakeLists.txt
@@ -72,6 +72,15 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
     set(cpptoml_DIR ${cpptoml_DIR} CACHE PATH "" FORCE)
 endif()
 
+execute_process(
+    COMMAND git apply -p1 --ignore-space-change --whitespace=nowarn
+    INPUT_FILE "${CMAKE_CURRENT_LIST_DIR}/0001-cpptoml-cmake-version.patch"
+    WORKING_DIRECTORY "${SOURCE_DIR}"
+    RESULT_VARIABLE result)
+if(result)
+    message(WARNING "CMake step [patch] for '${PROJECT_NAME}' failed! Error code: ${result}! Build of '${PROJECT_NAME}' might fail")
+endif()
+
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" "-DENABLE_LIBCXX=off" "-DCPPTOML_BUILD_EXAMPLES=off" "-DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}" "${SOURCE_DIR}" ${CMAKE_ADDITIONAL_OPTIONS}
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${BUILD_DIR} )


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR add a patch to the CMakeLists.txt of cpptoml in order to prevent warnings with newer cmake versions. It is based on #2232 for the v2.0 branch.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Relates to #2011
