### PR TITLE
iox-#2011 Rename 'string.cpp' to fix the clang-tidy check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -183,7 +183,7 @@ jobs:
           retention-days: 30
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./lcov_results/unittest/lcov/iceoryx_lcov_result_unit.info
           name: iceoryx
@@ -191,9 +191,10 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./lcov_results/unittest_timing/lcov/iceoryx_lcov_result_unit-timing.info
           name: iceoryx
           flags: unittests_timing
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/iceoryx_platform/generic/source/string_.cpp
+++ b/iceoryx_platform/generic/source/string_.cpp
@@ -14,6 +14,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// NOTE: This file is called 'string_.cpp' due to issues with clang-tidy. When the file is called 'string.cpp'
+// clang-tidy assumes to be the translation unit for 'iox/string.hpp' tries to check that header with the wrong
+// translation unit which leads to an error not finding the includes in 'iox/string.hpp'
+
 #include "iceoryx_platform/string.hpp"
 
 #ifndef IOX_PLATFORM_OVERRIDE_STRING_ALL


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The `string.cpp` file in the platform abstraction confuses clang-tidy to use the wrong translation unit for the `iox/string.hpp` check. By renaming the file to `string_.cpp` the problem vanishes.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

-  Relates to #2011
