### PR TITLE
iox-#2011 Move FreeBSD back to GitHub actions

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -219,6 +219,7 @@ arch_linux_x64_test_task:
 #
 
 freebsd_x64_build_task:
+  only_if: false # deactivated for now due to limited compute credits
   depends_on: preflight_check
   freebsd_instance:
     image_family: freebsd-14-0
@@ -237,6 +238,7 @@ freebsd_x64_build_task:
     <<: *IOX_PREPARE_TEST_BINARIES_FOR_CACHE
 
 freebsd_x64_test_task:
+  only_if: false # deactivated for now due to limited compute credits
   depends_on: freebsd_x64_build
   freebsd_instance:
     image_family: freebsd-14-0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -89,6 +89,25 @@ jobs:
       - run: ./tools/ci/build-test-windows.ps1 -toolchain MinGW
         shell: powershell
 
+  # uses ubuntu to run freebsd in a virtualbox
+  build-test-unix-with-freebsd:
+    # prevent stuck jobs consuming runners for 6 hours
+    timeout-minutes: 60
+    needs: pre-flight-check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Unix (FreeBSD) test
+      id: Test
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: "14.0"
+        copyback: false
+        prepare: pkg install -y cmake git ncurses bash wget bison
+        run: |
+         git config --global --add safe.directory /home/runner/work/iceoryx/iceoryx
+         ./tools/ci/build-test-freebsd.sh
+
   run-integration-test:
     # prevent stuck jobs consuming runners for 6 hours
     timeout-minutes: 60
@@ -189,6 +208,7 @@ jobs:
           name: iceoryx
           flags: unittests
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

In order to safe credits on Cirrus CI, the FreeBSD build is moved back to github.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Relates to #2011