### PR TITLE
iox-#2011 Use cmake mechanism to suppress the output of 'git apply'

### DIFF
--- a/iceoryx_posh/cmake/cpptoml/CMakeLists.txt
+++ b/iceoryx_posh/cmake/cpptoml/CMakeLists.txt
@@ -73,9 +73,11 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 execute_process(
-    COMMAND git apply -R -p1 --ignore-space-change --whitespace=nowarn --quiet --check
+    COMMAND git apply -R -p1 --ignore-space-change --whitespace=nowarn --check
     INPUT_FILE "${CMAKE_CURRENT_LIST_DIR}/0001-cpptoml-cmake-version.patch"
     WORKING_DIRECTORY "${SOURCE_DIR}"
+    OUTPUT_QUIET
+    ERROR_QUIET
     RESULT_VARIABLE result)
 if(result)
     message(STATUS "Applying patch for minimal cmake version to cpptoml")


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The git version on the ROS CI does not support the `quiet` option. This PR make use of cmake mechanisms to suppress to output of 'git apply'. See also #2263 and https://github.com/eclipse-iceoryx/iceoryx/pull/2262#issuecomment-2061430077

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Relates to #2011
