### PR TITLE
iox-#2274 Fix clang-tidy-18 warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,7 @@ concurrency-*,
 performance-*,
 hicpp-*,
 
--cppcoreguidelines-avoid-do-while
+-cppcoreguidelines-avoid-do-while,
 -cppcoreguidelines-non-private-member-variables-in-classes,
 
 -hicpp-named-parameter,
@@ -30,13 +30,16 @@ hicpp-*,
 -readability-identifier-length,
 -readability-redundant-access-specifiers,
 -readability-redundant-declaration,
+-readability-redundant-inline-specifier,
 -readability-static-accessed-through-instance,
 
 -readability-identifier-naming,
 -readability-use-anyofallof,
 -readability-named-parameter,
 
--cert-dcl21-cpp
+-performance-avoid-endl,
+
+-cert-dcl21-cpp,
 
 '
 
@@ -98,6 +101,9 @@ hicpp-*,
 #        // in cpp file
 #        void bar(Foo& foo) {...}
 #
+# * rule: readability-redundant-inline-specifier
+#   justicfication: there are many false positives
+#
 # * rule: readability-use-anyofallof
 #   justification: requires C++20 and std::ranges but we only use C++17
 #
@@ -131,6 +137,12 @@ hicpp-*,
 #       // dispatch site
 #       Tag1 tag;
 #       foo(tag); // calls (1)
+#
+# * rule: performance-avoid-endl
+#   justification: 'iostream' is only used in a few places where the logger either cannot be used, likt the platform layer, or
+#                  we want to print immediatelly something on the screen like the command line parser or the examples. In this
+#                  cases we would immediatelly after the '\n' calls 'std::flush'. Therefore we keep using 'std::endl' in this
+#                  limited places.
 #
 ## Those warnings should be enabled
 ## They are disabled since they require a heavy API refactoring and when we enable it we clutter the code with // NOLINT comments

--- a/.clang-tidy-diff-scans.txt
+++ b/.clang-tidy-diff-scans.txt
@@ -1,7 +1,7 @@
 ./iceoryx_hoofs/**/*
 
-./iceoryx_posh/include/iox/**/*
-./iceoryx_posh/source/posh/**/*
+./iceoryx_posh/experimental/include/iox/**/*
+./iceoryx_posh/experimental/source/**/*
 
 # IMPORTANT:
 #    after the first # everything is considered a comment, add new files and

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -217,6 +217,7 @@
 - Split `iceoryx_hoofs` into logical modules [#1391](https://github.com/eclipse-iceoryx/iceoryx/issues/1391)
 - Create a flat include structure for `iceoryx_hoofs` [#1593](https://github.com/eclipse-iceoryx/iceoryx/issues/1593)
 - Handle 'strerror_r' idiosyncrasies in the platform layer [#1616](https://github.com/eclipse-iceoryx/iceoryx/issues/1616)
+- Fix new clang-tidy-18 warnings [#2274](https://github.com/eclipse-iceoryx/iceoryx/issues/2274)
 
 **Workflow:**
 

--- a/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
+++ b/iceoryx_hoofs/buffer/include/iox/detail/stack.inl
@@ -47,6 +47,7 @@ inline stack<T, Capacity>& stack<T, Capacity>::copy(const stack& rhs) noexcept
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) false positive, the elements are moved
 inline stack<T, Capacity>& stack<T, Capacity>::move(stack&& rhs) noexcept
 {
     uint64_t i{0};

--- a/iceoryx_hoofs/cli/include/iox/cli/arguments.hpp
+++ b/iceoryx_hoofs/cli/include/iox/cli/arguments.hpp
@@ -37,7 +37,7 @@ namespace cli
 class Arguments
 {
   public:
-    enum class Error
+    enum class Error : uint8_t
     {
         UNABLE_TO_CONVERT_VALUE,
         NO_SUCH_VALUE

--- a/iceoryx_hoofs/concurrent/buffer/include/iox/detail/mpmc_lockfree_queue/mpmc_lockfree_queue.inl
+++ b/iceoryx_hoofs/concurrent/buffer/include/iox/detail/mpmc_lockfree_queue/mpmc_lockfree_queue.inl
@@ -59,6 +59,7 @@ inline bool MpmcLockFreeQueue<ElementType, Capacity>::tryPush(const ElementType&
 }
 
 template <typename ElementType, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline bool MpmcLockFreeQueue<ElementType, Capacity>::tryPush(ElementType&& value) noexcept
 {
     uint64_t index{0};
@@ -120,6 +121,7 @@ inline iox::optional<ElementType> MpmcLockFreeQueue<ElementType, Capacity>::push
 }
 
 template <typename ElementType, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline iox::optional<ElementType> MpmcLockFreeQueue<ElementType, Capacity>::push(ElementType&& value) noexcept
 {
     return pushImpl(std::forward<ElementType>(value));

--- a/iceoryx_hoofs/concurrent/buffer/include/iox/detail/mpmc_lockfree_queue/mpmc_resizeable_lockfree_queue.inl
+++ b/iceoryx_hoofs/concurrent/buffer/include/iox/detail/mpmc_lockfree_queue/mpmc_resizeable_lockfree_queue.inl
@@ -53,8 +53,10 @@ inline bool MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::setCapacity(c
 
 template <typename ElementType, uint64_t MaxCapacity>
 template <typename Function, typename>
-inline bool MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::setCapacity(const uint64_t newCapacity,
-                                                                               Function&& removeHandler) noexcept
+inline bool MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::setCapacity(
+    const uint64_t newCapacity,
+    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) false positive, this is used as a universal reference
+    Function&& removeHandler) noexcept
 {
     if (newCapacity > MAX_CAPACITY)
     {
@@ -121,9 +123,10 @@ MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::increaseCapacity(const ui
 
 template <typename ElementType, uint64_t MaxCapacity>
 template <typename Function>
-inline uint64_t
-MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::decreaseCapacity(const uint64_t toDecrease,
-                                                                        Function&& removeHandler) noexcept
+inline uint64_t MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::decreaseCapacity(
+    const uint64_t toDecrease,
+    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) false positive, this is used as a universal reference
+    Function&& removeHandler) noexcept
 {
     uint64_t decreased = 0U;
     while (decreased < toDecrease)
@@ -191,6 +194,7 @@ iox::optional<ElementType> inline MpmcResizeableLockFreeQueue<ElementType, MaxCa
 
 template <typename ElementType, uint64_t MaxCapacity>
 inline iox::optional<ElementType>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 MpmcResizeableLockFreeQueue<ElementType, MaxCapacity>::push(ElementType&& value) noexcept
 {
     return pushImpl(std::forward<ElementType>(value));

--- a/iceoryx_hoofs/container/include/iox/detail/forward_list.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/forward_list.inl
@@ -354,6 +354,7 @@ inline bool forward_list<T, Capacity>::push_front(const T& data) noexcept
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline bool forward_list<T, Capacity>::push_front(T&& data) noexcept
 {
     auto sizeBeforePush = m_size;
@@ -380,8 +381,10 @@ inline typename forward_list<T, Capacity>::iterator forward_list<T, Capacity>::i
 }
 
 template <typename T, uint64_t Capacity>
-inline typename forward_list<T, Capacity>::iterator forward_list<T, Capacity>::insert_after(const_iterator citer,
-                                                                                            T&& data) noexcept
+inline typename forward_list<T, Capacity>::iterator forward_list<T, Capacity>::insert_after(
+    const_iterator citer,
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
+    T&& data) noexcept
 {
     return emplace_after(citer, std::forward<T>(data));
 }

--- a/iceoryx_hoofs/container/include/iox/detail/list.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/list.inl
@@ -24,18 +24,18 @@
 
 namespace iox
 {
-/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
-/// into the list
-/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+// NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
+// into the list
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list() noexcept
 {
     init();
 }
 
-/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
-/// into the list
-/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+// NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
+// into the list
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list(const list& rhs) noexcept
 {
@@ -43,9 +43,9 @@ inline list<T, Capacity>::list(const list& rhs) noexcept
     *this = rhs;
 }
 
-/// @NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
-/// into the list
-/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+// NOLINTJUSTIFICATION m_data fields are explicitly initialized whenever a new element is inserted
+// into the list
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 template <typename T, uint64_t Capacity>
 inline list<T, Capacity>::list(list&& rhs) noexcept
 {
@@ -371,6 +371,7 @@ inline bool list<T, Capacity>::push_front(const T& data) noexcept
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline bool list<T, Capacity>::push_front(T&& data) noexcept
 {
     auto sizeBeforePush = m_size;
@@ -394,6 +395,7 @@ inline bool list<T, Capacity>::push_back(const T& data) noexcept
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline bool list<T, Capacity>::push_back(T&& data) noexcept
 {
     auto sizeBeforePush = m_size;
@@ -427,6 +429,7 @@ inline typename list<T, Capacity>::iterator list<T, Capacity>::insert(const_iter
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline typename list<T, Capacity>::iterator list<T, Capacity>::insert(const_iterator citer, T&& data) noexcept
 {
     return emplace(citer, std::forward<T>(data));
@@ -466,9 +469,9 @@ template <bool IsConstIterator>
 inline typename list<T, Capacity>::template IteratorBase<IsConstIterator>&
 list<T, Capacity>::IteratorBase<IsConstIterator>::operator=(const IteratorBase<false>& rhs) noexcept
 {
-    /// @NOLINTJUSTIFICATION ensure that this and rhs are not the same object without taking the type into account
-    ///                      required since it is possible to assign a non const iterator to a const iterator
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTJUSTIFICATION ensure that this and rhs are not the same object without taking the type into account
+    //                      required since it is possible to assign a non const iterator to a const iterator
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     if (reinterpret_cast<const void*>(this) != reinterpret_cast<const void*>(&rhs))
     {
         m_list = rhs.m_list;
@@ -594,9 +597,9 @@ inline const typename list<T, Capacity>::size_type& list<T, Capacity>::getPrevId
 template <typename T, uint64_t Capacity>
 inline typename list<T, Capacity>::size_type& list<T, Capacity>::getPrevIdx(const size_type idx) noexcept
 {
-    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
-    /// restored
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    // NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    // restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<size_type&>(const_cast<const list<T, Capacity>*>(this)->getPrevIdx(idx));
 }
 
@@ -608,9 +611,9 @@ inline const typename list<T, Capacity>::size_type& list<T, Capacity>::getNextId
 template <typename T, uint64_t Capacity>
 inline typename list<T, Capacity>::size_type& list<T, Capacity>::getNextIdx(const size_type idx) noexcept
 {
-    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
-    /// restored
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    // NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    // restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<size_type&>(const_cast<const list<T, Capacity>*>(this)->getNextIdx(idx));
 }
 
@@ -656,17 +659,17 @@ inline const T* list<T, Capacity>::getDataPtrFromIdx(const size_type idx) const 
 {
     IOX_ENFORCE(isValidElementIdx(idx), "invalid list element");
 
-    /// @NOLINTJUSTIFICATION provide type safe access to the encapsulated untyped m_data array
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTJUSTIFICATION provide type safe access to the encapsulated untyped m_data array
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return &(reinterpret_cast<const T*>(&m_data)[idx]);
 }
 
 template <typename T, uint64_t Capacity>
 inline T* list<T, Capacity>::getDataPtrFromIdx(const size_type idx) noexcept
 {
-    /// @NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
-    /// restored
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    // NOLINTJUSTIFICATION const_cast avoids code duplication, is safe since the constness of the return value is
+    // restored
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
     return const_cast<T*>(const_cast<const list<T, Capacity>*>(this)->getDataPtrFromIdx(idx));
 }
 

--- a/iceoryx_hoofs/container/include/iox/detail/vector.inl
+++ b/iceoryx_hoofs/container/include/iox/detail/vector.inl
@@ -247,6 +247,7 @@ inline bool vector<T, Capacity>::push_back(const T& value) noexcept
 }
 
 template <typename T, uint64_t Capacity>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline bool vector<T, Capacity>::push_back(T&& value) noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A18.9.2: we use idiomatic perfect forwarding

--- a/iceoryx_hoofs/container/include/iox/fixed_position_container.hpp
+++ b/iceoryx_hoofs/container/include/iox/fixed_position_container.hpp
@@ -38,7 +38,7 @@ template <typename T, uint64_t CAPACITY>
 class FixedPositionContainer final
 {
   private:
-    enum class IterMutability
+    enum class IterMutability : uint8_t
     {
         ITER_MUT,
         ITER_CONST

--- a/iceoryx_hoofs/container/include/iox/list.hpp
+++ b/iceoryx_hoofs/container/include/iox/list.hpp
@@ -275,9 +275,9 @@ class list
 
         /// @brief construct a const_iterator from an iterator
         /// @param[in] iter is the iterator which will deliver list and index info for the const_iterator
-        /// @NOLINTJUSTIFICATION conversion from non const iterator to const iterator follows the
-        ///                      STL behavior and should be allowed
-        /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
+        // NOLINTJUSTIFICATION conversion from non const iterator to const iterator follows the
+        //                     STL behavior and should be allowed
+        // NOLINTNEXTLINE(hicpp-explicit-conversions)
         IteratorBase(const IteratorBase<false>& iter) noexcept;
 
         /// @brief assigns a const_iterator from an iterator; needs to be implemented because the copy c'tor is also

--- a/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
+++ b/iceoryx_hoofs/design/include/iox/move_and_copy_helper.hpp
@@ -17,13 +17,14 @@
 #ifndef IOX_HOOFS_DESIGN_MOVE_AND_COPY_HELPER_HPP
 #define IOX_HOOFS_DESIGN_MOVE_AND_COPY_HELPER_HPP
 
+#include <cstdint>
 #include <functional>
 #include <utility>
 
 namespace iox
 {
 
-enum class MoveAndCopyOperations
+enum class MoveAndCopyOperations : uint8_t
 {
     CopyConstructor,
     CopyAssignment,

--- a/iceoryx_hoofs/design/include/iox/newtype.hpp
+++ b/iceoryx_hoofs/design/include/iox/newtype.hpp
@@ -78,7 +78,7 @@ class NewType : public Policies<Derived, NewType<Derived, T, Policies...>>...
 {
   protected:
     /// 'ProtectedConstructor_t' is a compile time variable to select the correct constructors
-    /// @NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
+    // NOLINTNEXTLINE(hicpp-named-parameter, readability-named-parameter)
     constexpr NewType(newtype::internal::ProtectedConstructor_t, const T& rhs) noexcept;
 
     /// @brief copy constructor
@@ -156,7 +156,7 @@ class NewType : public Policies<Derived, NewType<Derived, T, Policies...>>...
 // AXIVION Next Construct AutosarC++19_03-M16.0.6 : brackets around macro parameter would lead in this case to compile
 // time failures
 // AXIVION Next Construct AutosarC++19_03-A16.0.1 : macro is used to reduce boilerplate code for 'NewType'
-/// @NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_NEW_TYPE(TypeName, Type, ...)                                                                              \
     struct TypeName : public iox::NewType<TypeName, Type, __VA_ARGS__>                                                 \
     {                                                                                                                  \

--- a/iceoryx_hoofs/filesystem/include/iox/file_reader.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/file_reader.hpp
@@ -18,6 +18,7 @@
 #ifndef IOX_HOOFS_FILESYSTEM_FILE_READER_HPP
 #define IOX_HOOFS_FILESYSTEM_FILE_READER_HPP
 
+#include <cstdint>
 #include <fstream>
 
 namespace iox
@@ -40,7 +41,7 @@ class FileReader
   public:
     /// Error handling strategy. Ignore continues execution as if nothing happened. Inform continues, but prints an
     /// error message. Terminate causes the process to exit.
-    enum class ErrorMode
+    enum class ErrorMode : uint8_t
     {
         Ignore,
         Inform,

--- a/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
+++ b/iceoryx_hoofs/filesystem/include/iox/filesystem.hpp
@@ -40,7 +40,7 @@ constexpr char ASCII_UNDERSCORE{'_'};
 } // namespace internal
 // AXIVION ENABLE STYLE AutosarC++19_03-A3.9.1
 
-enum class RelativePathComponents : std::uint32_t
+enum class RelativePathComponents : uint8_t
 {
     REJECT,
     ACCEPT
@@ -91,7 +91,7 @@ template <uint64_t StringCapacity>
 bool doesEndWithPathSeparator(const string<StringCapacity>& name) noexcept;
 
 
-enum class AccessMode : uint64_t
+enum class AccessMode : uint8_t
 {
     READ_ONLY = 0U,
     READ_WRITE = 1U,
@@ -99,7 +99,7 @@ enum class AccessMode : uint64_t
 };
 
 /// @brief describes how the shared memory is opened or created
-enum class OpenMode : uint64_t
+enum class OpenMode : uint8_t
 {
     /// @brief creates the shared memory, if it exists already the construction will fail
     EXCLUSIVE_CREATE = 0U,

--- a/iceoryx_hoofs/functional/include/iox/detail/function_ref.inl
+++ b/iceoryx_hoofs/functional/include/iox/detail/function_ref.inl
@@ -29,6 +29,7 @@ template <class ReturnType, class... ArgTypes>
 template <typename CallableType, typename>
 // AXIVION Next Construct AutosarC++19_03-A12.1.5 : Other c'tors can't be used as delegating c'tor
 // AXIVION Next Construct AutosarC++19_03-A8.4.6 : Only ArgTypes needs to be forwarded
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
 inline function_ref<ReturnType(ArgTypes...)>::function_ref(CallableType&& callable) noexcept
     // AXIVION Next Construct AutosarC++19_03-A5.2.4, AutosarC++19_03-A5.2.3, CertC++-EXP55 : Type-safety ensured by
     // casting back on call

--- a/iceoryx_hoofs/functional/include/iox/detail/storable_function.hpp
+++ b/iceoryx_hoofs/functional/include/iox/detail/storable_function.hpp
@@ -58,14 +58,14 @@ class storable_function<Capacity, signature<ReturnType, Args...>> final
     // the storable function should implicitly behave like any generic constructor, adding
     // explicit would require a static_cast. Furthermore, the storable_functor stores a copy
     // which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
-    /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     storable_function(const Functor& functor) noexcept;
 
     /// @brief construct from function pointer (including static functions)
-    /// @NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
-    ///                      explicit would require a static_cast. Furthermore, the storable_functor stores a copy
-    ///                      which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
-    /// @NOLINTNEXTLINE(hicpp-explicit-conversions)
+    // NOLINTJUSTIFICATION the storable function should implicitly behave like any generic constructor, adding
+    //                     explicit would require a static_cast. Furthermore, the storable_functor stores a copy
+    //                     which avoids implicit misbehaviors or ownership problems caused by implicit conversion.
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
     storable_function(ReturnType (*function)(Args...)) noexcept;
 
     /// @brief construct from object reference and member function

--- a/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
+++ b/iceoryx_hoofs/legacy/include/iceoryx_hoofs/posix_wrapper/posix_call.hpp
@@ -56,9 +56,9 @@ PosixCallBuilder<ReturnType, FunctionArguments...> createPosixCallBuilder(Return
 } // namespace internal
 
 /// @deprecated use 'IOX_POSIX_CALL' from 'iox/posix_call.hpp' instead of 'iox::posix::posixCall'
-/// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
-///                     name
-/// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
+//                     name
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define posixCall(f)                                                                                                   \
     internal::createPosixCallBuilder(                                                                                  \
         &(f),                                                                                                          \

--- a/iceoryx_hoofs/memory/include/iox/detail/scope_guard.inl
+++ b/iceoryx_hoofs/memory/include/iox/detail/scope_guard.inl
@@ -66,6 +66,7 @@ inline ScopeGuardWithVariableCapacity<CleanupCapacity>& ScopeGuardWithVariableCa
 template <uint64_t CleanupCapacity>
 inline typename ScopeGuardWithVariableCapacity<CleanupCapacity>::CleanupFunction
 ScopeGuardWithVariableCapacity<CleanupCapacity>::release(
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) false positive
     ScopeGuardWithVariableCapacity<CleanupCapacity>&& scopeGuard) noexcept
 {
     IOX_ENFORCE(scopeGuard.m_cleanupFunction.has_value(),

--- a/iceoryx_hoofs/memory/include/iox/detail/static_storage.hpp
+++ b/iceoryx_hoofs/memory/include/iox/detail/static_storage.hpp
@@ -37,9 +37,9 @@ namespace iox
 ///       optimized_storage would have a dynamic memory fallback when static memory is
 ///       insufficent.
 template <uint64_t Capacity, uint64_t Align = 1>
-/// @NOLINTJUSTIFICATION static_storage provides uninitialized memory, correct initialization is the users
-///                      responsibility whenever memory with "allocate" is acquired
-/// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+// NOLINTJUSTIFICATION static_storage provides uninitialized memory, correct initialization is the users
+//                     responsibility whenever memory with "allocate" is acquired
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 class static_storage final
 {
   public:
@@ -96,8 +96,8 @@ class static_storage final
     static constexpr uint64_t allocation_size() noexcept;
 
   private:
-    /// AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the static_storage
-    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the static_storage
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     alignas(Align) uint8_t m_bytes[Capacity];
     void* m_ptr{nullptr};
 

--- a/iceoryx_hoofs/memory/include/iox/detail/unique_ptr.inl
+++ b/iceoryx_hoofs/memory/include/iox/detail/unique_ptr.inl
@@ -90,8 +90,9 @@ inline const T* unique_ptr<T>::get() const noexcept
 template <typename T>
 inline T* unique_ptr<T>::release(unique_ptr&& ptrToBeReleased) noexcept
 {
-    auto* const ptr{ptrToBeReleased.m_ptr};
-    ptrToBeReleased.m_ptr = nullptr;
+    auto owned = std::move(ptrToBeReleased);
+    auto* const ptr{owned.m_ptr};
+    owned.m_ptr = nullptr;
     return ptr;
 }
 

--- a/iceoryx_hoofs/posix/design/include/iox/detail/posix_call.inl
+++ b/iceoryx_hoofs/posix/design/include/iox/detail/posix_call.inl
@@ -27,8 +27,8 @@ namespace detail
 {
 template <typename ReturnType, typename... FunctionArguments>
 inline PosixCallBuilder<ReturnType, FunctionArguments...>
-/// NOLINTJUSTIFICATION this function is never used directly, only be the macro IOX_POSIX_CALL
-/// NOLINTNEXTLINE(readability-function-size)
+// NOLINTJUSTIFICATION this function is never used directly, only be the macro IOX_POSIX_CALL
+// NOLINTNEXTLINE(readability-function-size)
 createPosixCallBuilder(ReturnType (*IOX_POSIX_CALL)(FunctionArguments...),
                        const char* posixFunctionName,
                        const char* file,
@@ -40,9 +40,9 @@ createPosixCallBuilder(ReturnType (*IOX_POSIX_CALL)(FunctionArguments...),
 }
 
 template <typename ReturnType>
-/// NOLINTJUSTIFICATION used only internally, the function and file name are provided by
-///                     compiler macros and are of type char*
-/// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+// NOLINTJUSTIFICATION used only internally, the function and file name are provided by
+//                     compiler macros and are of type char*
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 inline PosixCallDetails<ReturnType>::PosixCallDetails(const char* posixFunctionName,
                                                       const char* file,
                                                       int line,
@@ -73,8 +73,8 @@ inline string<POSIX_CALL_ERROR_STRING_SIZE> errorLiteralToString(const char* msg
 template <typename T>
 inline string<POSIX_CALL_ERROR_STRING_SIZE> PosixCallResult<T>::getHumanReadableErrnum() const noexcept
 {
-    /// NOLINTJUSTIFICATION needed by POSIX function which is wrapped here
-    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION needed by POSIX function which is wrapped here
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
     char buffer[POSIX_CALL_ERROR_STRING_SIZE];
     return string<POSIX_CALL_ERROR_STRING_SIZE>(TruncateToCapacity,
                                                 iox_gnu_strerror_r(errnum, &buffer[0], POSIX_CALL_ERROR_STRING_SIZE));

--- a/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/file_management_interface.hpp
@@ -29,7 +29,7 @@
 namespace iox
 {
 /// @brief Describes failures when acquiring details about a file.
-enum class FileStatError
+enum class FileStatError : uint8_t
 {
     IoFailure,
     FileTooLarge,
@@ -38,7 +38,7 @@ enum class FileStatError
 };
 
 /// @brief Describes failures when setting the owner of a file
-enum class FileSetOwnerError
+enum class FileSetOwnerError : uint8_t
 {
     IoFailure,
     Interrupt,
@@ -50,7 +50,7 @@ enum class FileSetOwnerError
 };
 
 /// @brief Describes failures when setting the permissions of a file
-enum class FileSetPermissionError
+enum class FileSetPermissionError : uint8_t
 {
     PermissionDenied,
     ReadOnlyFilesystem,

--- a/iceoryx_hoofs/posix/design/include/iox/posix_call.hpp
+++ b/iceoryx_hoofs/posix/design/include/iox/posix_call.hpp
@@ -207,9 +207,9 @@ class [[nodiscard]] PosixCallBuilder
 ///        // when your posix call signals failure by returning the errno value instead of setting the errno use
 ///        // .returnValueMatchesErrno() instead of .successReturnValue(_)
 /// @endcode
-/// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
-///                     name
-/// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+// NOLINTJUSTIFICATION a template or constexpr function does not have access to source code origin file, line, function
+//                     name
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define IOX_POSIX_CALL(f)                                                                                              \
     iox::detail::createPosixCallBuilder(                                                                               \
         &(f),                                                                                                          \

--- a/iceoryx_hoofs/posix/filesystem/include/iox/detail/posix_acl.hpp
+++ b/iceoryx_hoofs/posix/filesystem/include/iox/detail/posix_acl.hpp
@@ -56,6 +56,7 @@ class PosixAcl
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
     enum class Category : std::underlying_type<acl_tag_t>::type
 #else
+    // NOLINTNEXTLINE(performance-enum-size) required for compatibility with ACL API
     enum class Category : acl_tag_t
 #endif
     {
@@ -72,6 +73,7 @@ class PosixAcl
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
     enum class Permission : std::underlying_type<acl_perm_t>::type
 #else
+    // NOLINTNEXTLINE(performance-enum-size) required for compatibility with ACL API
     enum class Permission : acl_perm_t
 #endif
     {

--- a/iceoryx_hoofs/posix/filesystem/include/iox/file.hpp
+++ b/iceoryx_hoofs/posix/filesystem/include/iox/file.hpp
@@ -25,7 +25,7 @@
 namespace iox
 {
 /// @brief Describes failures which can occur when a file is opened or created.
-enum class FileCreationError
+enum class FileCreationError : uint8_t
 {
     PermissionDenied,
     Interrupt,
@@ -43,7 +43,7 @@ enum class FileCreationError
 };
 
 /// @brief Describes failures which can occur when a file is read.
-enum class FileReadError
+enum class FileReadError : uint8_t
 {
     OffsetFailure,
     Interrupt,
@@ -56,7 +56,7 @@ enum class FileReadError
 };
 
 /// @brief Describes failures which can occur when a file is written to.
-enum class FileWriteError
+enum class FileWriteError : uint8_t
 {
     OffsetFailure,
     OperationWouldBlock,
@@ -72,7 +72,7 @@ enum class FileWriteError
 };
 
 /// @brief Describes failures which can occur when the files metadata is accessed.
-enum class FileAccessError
+enum class FileAccessError : uint8_t
 {
     InsufficientPermissions,
     TooManySymbolicLinksEncountered,
@@ -82,7 +82,7 @@ enum class FileAccessError
 };
 
 /// @brief Describes failures which can occur when a file is removed.
-enum class FileRemoveError
+enum class FileRemoveError : uint8_t
 {
     PermissionDenied,
     CurrentlyInUse,
@@ -95,7 +95,7 @@ enum class FileRemoveError
 };
 
 /// @brief Describes failures which can occur when a file offset is changed.
-enum class FileOffsetError
+enum class FileOffsetError : uint8_t
 {
     FileOffsetOverflow,
     OffsetBeyondFileLimits,

--- a/iceoryx_hoofs/posix/filesystem/include/iox/file_lock.hpp
+++ b/iceoryx_hoofs/posix/filesystem/include/iox/file_lock.hpp
@@ -25,7 +25,7 @@
 
 namespace iox
 {
-enum class FileLockError
+enum class FileLockError : uint8_t
 {
     INVALID_FILE_NAME,
     INVALID_PATH,
@@ -59,8 +59,8 @@ class FileLock
 {
   public:
     static constexpr int32_t INVALID_FD = -1;
-    /// NOLINTJUSTIFICATION Required as a safe and null terminated compile time string literal
-    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION Required as a safe and null terminated compile time string literal
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static constexpr const char LOCK_FILE_SUFFIX[] = ".lock";
     static constexpr uint64_t PATH_SEPARATOR_LENGTH = 1U;
     static constexpr uint64_t LOCK_FILE_SUFFIX_LENGTH = sizeof(LOCK_FILE_SUFFIX) / sizeof(char);
@@ -87,10 +87,11 @@ class FileLock
     ~FileLock() noexcept;
 
   private:
+    // NOLINTNEXTLINE(performance-enum-size) int32_t required for values from from file.h
     enum class LockOperation : int32_t
     {
-        /// NOLINTJUSTIFICATION abstracted in enum as value so that the user does not have to use bit operations
-        /// NOLINTNEXTLINE(hicpp-signed-bitwise)
+        // NOLINTJUSTIFICATION abstracted in enum as value so that the user does not have to use bit operations
+        // NOLINTNEXTLINE(hicpp-signed-bitwise)
         LOCK = LOCK_EX | LOCK_NB,
         UNLOCK = LOCK_UN
     };

--- a/iceoryx_hoofs/posix/filesystem/source/file_lock.cpp
+++ b/iceoryx_hoofs/posix/filesystem/source/file_lock.cpp
@@ -27,8 +27,8 @@
 
 namespace iox
 {
-/// NOLINTJUSTIFICATION see declaration
-/// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTJUSTIFICATION see declaration
+// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char FileLock::LOCK_FILE_SUFFIX[];
 
 expected<FileLock, FileLockError> FileLockBuilder::create() noexcept

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_memory_map.hpp
@@ -30,7 +30,7 @@ namespace iox
 namespace detail
 {
 
-enum class PosixMemoryMapError
+enum class PosixMemoryMapError : uint8_t
 {
     ACCESS_FAILED,
     UNABLE_TO_LOCK,
@@ -47,6 +47,7 @@ enum class PosixMemoryMapError
 };
 
 /// @brief Flags defining how the mapped data should be handled
+// NOLINTNEXTLINE(performance-enum-size) int32_t required for POSIX API
 enum class PosixMemoryMapFlags : int32_t
 {
     /// @brief changes are shared

--- a/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_shared_memory.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/detail/posix_shared_memory.hpp
@@ -34,7 +34,7 @@ using shm_handle_t = int;
 namespace detail
 {
 
-enum class PosixSharedMemoryError
+enum class PosixSharedMemoryError : uint8_t
 {
     EMPTY_NAME,
     INVALID_FILE_NAME,

--- a/iceoryx_hoofs/posix/ipc/include/iox/message_queue.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/message_queue.hpp
@@ -143,7 +143,7 @@ class MessageQueue
     sanitizeIpcChannelName(const PosixIpcChannelName_t& name) noexcept;
     expected<void, PosixIpcChannelError> destroy() noexcept;
 
-    enum class Termination
+    enum class Termination : uint8_t
     {
         NONE,
         NULL_TERMINATOR
@@ -175,9 +175,9 @@ class MessageQueue
     static constexpr int TIMEOUT_ERRNO = ETIMEDOUT;
 #endif
     // read/write permissions
-    /// NOLINTJUSTIFICATION used inside the wrapper so that the user does not have to use this
-    ///                     construct from outside
-    /// NOLINTNEXTLINE(hicpp-signed-bitwise)
+    // NOLINTJUSTIFICATION used inside the wrapper so that the user does not have to use this
+    //                     construct from outside
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
     static constexpr mode_t FILE_MODE{S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH};
 };
 

--- a/iceoryx_hoofs/posix/ipc/include/iox/named_pipe.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/named_pipe.hpp
@@ -50,8 +50,8 @@ class NamedPipe
     static constexpr uint64_t NULL_TERMINATOR_SIZE = 0U;
     static constexpr units::Duration CYCLE_TIME = units::Duration::fromMilliseconds(10);
 
-    /// NOLINTJUSTIFICATION used as safe compile time string literal
-    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION used as safe compile time string literal
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static constexpr const char NAMED_PIPE_PREFIX[] = "iox_np_";
 
     using Builder_t = NamedPipeBuilder;

--- a/iceoryx_hoofs/posix/ipc/include/iox/posix_shared_memory_object.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/posix_shared_memory_object.hpp
@@ -32,7 +32,7 @@
 namespace iox
 {
 
-enum class PosixSharedMemoryObjectError
+enum class PosixSharedMemoryObjectError : uint8_t
 {
     SHARED_MEMORY_CREATION_FAILED,
     MAPPING_SHARED_MEMORY_FAILED,
@@ -41,7 +41,7 @@ enum class PosixSharedMemoryObjectError
     INTERNAL_LOGIC_FAILURE,
 };
 
-enum class PosixSharedMemoryAllocationError
+enum class PosixSharedMemoryAllocationError : uint8_t
 {
     REQUESTED_MEMORY_AFTER_FINALIZED_ALLOCATION,
     NOT_ENOUGH_MEMORY,

--- a/iceoryx_hoofs/posix/ipc/include/iox/unix_domain_socket.hpp
+++ b/iceoryx_hoofs/posix/ipc/include/iox/unix_domain_socket.hpp
@@ -146,7 +146,7 @@ class UnixDomainSocket
                                                                     const sockaddr_un& sockAddr,
                                                                     PosixIpcChannelSide channelSide) noexcept;
 
-    enum class Termination
+    enum class Termination : uint8_t
     {
         NONE,
         NULL_TERMINATOR

--- a/iceoryx_hoofs/posix/ipc/source/message_queue.cpp
+++ b/iceoryx_hoofs/posix/ipc/source/message_queue.cpp
@@ -207,8 +207,8 @@ expected<mqd_t, PosixIpcChannelError> MessageQueue::open(const PosixIpcChannelNa
         int32_t openFlags = O_RDWR;
         if (channelSide == PosixIpcChannelSide::SERVER)
         {
-            /// NOLINTJUSTIFICATION used in internal implementation which wraps the posix functionality
-            /// NOLINTNEXTLINE(hicpp-signed-bitwise)
+            // NOLINTJUSTIFICATION used in internal implementation which wraps the posix functionality
+            // NOLINTNEXTLINE(hicpp-signed-bitwise)
             openFlags |= O_CREAT;
         }
 

--- a/iceoryx_hoofs/posix/ipc/source/named_pipe.cpp
+++ b/iceoryx_hoofs/posix/ipc/source/named_pipe.cpp
@@ -27,8 +27,8 @@
 
 namespace iox
 {
-/// NOLINTJUSTIFICATION see declaration in header
-/// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTJUSTIFICATION see declaration in header
+// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr const char NamedPipe::NAMED_PIPE_PREFIX[];
 constexpr units::Duration NamedPipe::CYCLE_TIME;
 constexpr units::Duration NamedPipe::NamedPipeData::WAIT_FOR_INIT_SLEEP_TIME;

--- a/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/posix/ipc/source/posix_shared_memory_object.cpp
@@ -34,14 +34,14 @@ namespace detail
 {
 constexpr uint64_t SIGBUS_ERROR_MESSAGE_LENGTH = 1024U + platform::IOX_MAX_SHM_NAME_LENGTH;
 
-/// NOLINTJUSTIFICATION global variables are only accessible from within this compilation unit
-/// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
-///
-/// NOLINTJUSTIFICATION c array required to print a signal safe error message in memsetSigbusHandler
-/// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTJUSTIFICATION global variables are only accessible from within this compilation unit
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+//
+// NOLINTJUSTIFICATION c array required to print a signal safe error message in memsetSigbusHandler
+// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 static char sigbusErrorMessage[SIGBUS_ERROR_MESSAGE_LENGTH];
 static std::mutex sigbusHandlerMutex;
-/// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 static void memsetSigbusHandler(int) noexcept
 {

--- a/iceoryx_hoofs/posix/sync/include/iox/detail/semaphore_interface.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/detail/semaphore_interface.hpp
@@ -23,7 +23,7 @@
 
 namespace iox
 {
-enum class SemaphoreError
+enum class SemaphoreError : uint8_t
 {
     INVALID_NAME,
     INVALID_SEMAPHORE_HANDLE,
@@ -37,7 +37,7 @@ enum class SemaphoreError
     UNDEFINED
 };
 
-enum class SemaphoreWaitState
+enum class SemaphoreWaitState : uint8_t
 {
     TIMEOUT,
     NO_TIMEOUT,

--- a/iceoryx_hoofs/posix/sync/include/iox/mutex.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/mutex.hpp
@@ -25,7 +25,7 @@
 
 namespace iox
 {
-enum class MutexCreationError
+enum class MutexCreationError : uint8_t
 {
     MUTEX_ALREADY_INITIALIZED,
     INSUFFICIENT_MEMORY,
@@ -38,7 +38,7 @@ enum class MutexCreationError
     UNKNOWN_ERROR
 };
 
-enum class MutexLockError
+enum class MutexLockError : uint8_t
 {
     PRIORITY_MISMATCH,
     MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED,
@@ -47,13 +47,13 @@ enum class MutexLockError
     UNKNOWN_ERROR
 };
 
-enum class MutexUnlockError
+enum class MutexUnlockError : uint8_t
 {
     NOT_OWNED_BY_THREAD,
     UNKNOWN_ERROR
 };
 
-enum class MutexTryLockError
+enum class MutexTryLockError : uint8_t
 {
     PRIORITY_MISMATCH,
     MAXIMUM_NUMBER_OF_RECURSIVE_LOCKS_EXCEEDED,
@@ -61,7 +61,7 @@ enum class MutexTryLockError
     UNKNOWN_ERROR
 };
 
-enum class MutexTryLock
+enum class MutexTryLock : uint8_t
 {
     LOCK_SUCCEEDED,
     FAILED_TO_ACQUIRE_LOCK
@@ -144,6 +144,7 @@ class mutex
 };
 
 /// @brief Describes the type of mutex.
+// NOLINTNEXTLINE(performance-enum-size) int32_t required for POSIX API
 enum class MutexType : int32_t
 {
     /// @brief Behavior without error detection and multiple locks from within
@@ -163,6 +164,7 @@ enum class MutexType : int32_t
 
 /// @brief Describes how the priority of a mutex owning thread changes when another thread
 ///        with an higher priority would like to acquire the mutex.
+// NOLINTNEXTLINE(performance-enum-size) int32_t required for POSIX API
 enum class MutexPriorityInheritance : int32_t
 {
     /// @brief No priority setting.
@@ -178,6 +180,7 @@ enum class MutexPriorityInheritance : int32_t
 };
 
 /// @brief Defines the behavior when a mutex owning thread is terminated
+// NOLINTNEXTLINE(performance-enum-size) int32_t required for POSIX API
 enum class MutexThreadTerminationBehavior : int32_t
 {
     /// @brief The mutex stays locked, is unlockable and no longer usable.

--- a/iceoryx_hoofs/posix/sync/include/iox/signal_handler.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/signal_handler.hpp
@@ -26,6 +26,7 @@ using SignalHandlerCallback_t = void (*)(int);
 
 /// @brief Corresponds to the SIG* macros defined in signal.h. The integer values
 ///        are equal to the corresponding macro value.
+// NOLINTNEXTLINE(performance-enum-size) int required for POSIX API
 enum class PosixSignal : int
 {
     BUS = SIGBUS,
@@ -37,7 +38,7 @@ enum class PosixSignal : int
     ///            and sigaction returns the errno EINVAL
 };
 
-enum class SignalGuardError
+enum class SignalGuardError : uint8_t
 {
     INVALID_SIGNAL_ENUM_VALUE,
     UNDEFINED_ERROR_IN_SYSTEM_CALL

--- a/iceoryx_hoofs/posix/sync/include/iox/thread.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/thread.hpp
@@ -37,7 +37,7 @@ using ThreadName_t = string<MAX_THREAD_NAME_LENGTH>;
 bool setThreadName(const ThreadName_t& name) noexcept;
 ThreadName_t getThreadName() noexcept;
 
-enum class ThreadError
+enum class ThreadError : uint8_t
 {
     INSUFFICIENT_MEMORY,
     INSUFFICIENT_PERMISSIONS,
@@ -54,9 +54,9 @@ enum class ThreadError
 /// optional<Thread> myThread;
 /// ThreadBuilder().create(myThread, callable).expect("Couldn't create a thread.");
 /// @endcode
-/// NOLINTJUSTIFICATION m_threadHandle is always initialized during create in the ThreadBuilder hence it is impossible
-/// to create a Thread without an initialized m_threadHandle
-/// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
+// NOLINTJUSTIFICATION m_threadHandle is always initialized during create in the ThreadBuilder hence it is impossible
+// to create a Thread without an initialized m_threadHandle
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 class Thread
 {
   public:

--- a/iceoryx_hoofs/posix/sync/include/iox/unnamed_semaphore.hpp
+++ b/iceoryx_hoofs/posix/sync/include/iox/unnamed_semaphore.hpp
@@ -25,10 +25,10 @@
 namespace iox
 {
 /// @brief A unnamed posix semaphore.
-/// NOLINTJUSTIFICATION m_handle is always initialized during create in the UnnamedSemaphoreBuilder
-///                     hence it is impossible to create a UnnamedSemaphore without an initialized
-///                     m_handle
-/// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+// NOLINTJUSTIFICATION m_handle is always initialized during create in the UnnamedSemaphoreBuilder
+//                     hence it is impossible to create a UnnamedSemaphore without an initialized
+//                     m_handle
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
 class UnnamedSemaphore final : public detail::SemaphoreInterface<UnnamedSemaphore>
 {
   public:

--- a/iceoryx_hoofs/posix/sync/source/mutex.cpp
+++ b/iceoryx_hoofs/posix/sync/source/mutex.cpp
@@ -165,6 +165,11 @@ struct MutexAttributes
                                                   << "] of the Scheduler::FIFO.");
                 return err(MutexCreationError::INVALID_PRIORITY_CEILING_VALUE);
             }
+            default:
+                IOX_LOG(
+                    ERROR,
+                    "This should never happen. An unknown error occurred while setting up the mutex priority ceiling.");
+                return err(MutexCreationError::UNKNOWN_ERROR);
             }
         }
 

--- a/iceoryx_hoofs/posix/sync/source/named_semaphore.cpp
+++ b/iceoryx_hoofs/posix/sync/source/named_semaphore.cpp
@@ -96,11 +96,11 @@ tryOpenExistingSemaphore(optional<NamedSemaphore>& uninitializedSemaphore, const
     return ok(false);
 }
 
-/// NOLINTJUSTIFICATION used only internally in this file. Furthermore the problem cannot be avoided since
-///                     those arguments are required by the posix function sem_open. One could call it
-///                     before this function and provide the result but this would increase code complexity
-///                     even further. The cognitive complexity results from the expanded log macro
-/// NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
+// NOLINTJUSTIFICATION used only internally in this file. Furthermore the problem cannot be avoided since
+//                     those arguments are required by the posix function sem_open. One could call it
+//                     before this function and provide the result but this would increase code complexity
+//                     even further. The cognitive complexity results from the expanded log macro
+// NOLINTNEXTLINE(readability-function-size,readability-function-cognitive-complexity)
 static expected<void, SemaphoreError> createSemaphore(optional<NamedSemaphore>& uninitializedSemaphore,
                                                       const NamedSemaphore::Name_t& name,
                                                       const OpenMode openMode,

--- a/iceoryx_hoofs/posix/sync/source/signal_watcher.cpp
+++ b/iceoryx_hoofs/posix/sync/source/signal_watcher.cpp
@@ -31,8 +31,8 @@ void internalSignalHandler(int) noexcept
         {
             // we use write since internalSignalHandler can be called from within a
             // signal handler and write is signal safe
-            /// NOLINTJUSTIFICATION used as safe and null terminated compile time string literal
-            /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+            // NOLINTJUSTIFICATION used as safe and null terminated compile time string literal
+            // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
             constexpr const char MSG[] = "Unable to increment semaphore in signal handler";
             auto result = write(STDERR_FILENO, &MSG[0], strlen(&MSG[0]));
             IOX_DISCARD_RESULT(result);

--- a/iceoryx_hoofs/posix/sync/source/thread.cpp
+++ b/iceoryx_hoofs/posix/sync/source/thread.cpp
@@ -80,7 +80,6 @@ expected<void, ThreadError> ThreadBuilder::create(optional<Thread>& uninitialize
 Thread::Thread(const ThreadName_t& name, const callable_t& callable) noexcept
     : m_threadHandle{}
     , m_callable{callable}
-    , m_isThreadConstructed{false}
     , m_threadName{name}
 {
 }

--- a/iceoryx_hoofs/posix/utility/include/iox/detail/posix_scheduler.hpp
+++ b/iceoryx_hoofs/posix/utility/include/iox/detail/posix_scheduler.hpp
@@ -26,6 +26,7 @@ namespace iox
 namespace detail
 {
 /// @brief Defines all supported scheduler
+// NOLINTNEXTLINE(performance-enum-size) int32_t required for POSIX API
 enum class Scheduler : int32_t
 {
     FIFO = SCHED_FIFO

--- a/iceoryx_hoofs/primitives/include/iox/attributes.hpp
+++ b/iceoryx_hoofs/primitives/include/iox/attributes.hpp
@@ -26,6 +26,7 @@ namespace internal
 /// on gcc and this approach solves it cleanly.
 template <typename T>
 // AXIVION Next Construct AutosarC++19_03-M0.1.8 : No side effects are the intended behavior of the function
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) intended for this function
 inline void IOX_DISCARD_RESULT_IMPL(T&&) noexcept
 {
 }

--- a/iceoryx_hoofs/primitives/include/iox/type_traits.hpp
+++ b/iceoryx_hoofs/primitives/include/iox/type_traits.hpp
@@ -74,7 +74,7 @@ struct is_invocable
     // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     // This is chosen if Callable(ArgTypes) does not resolve to a valid type.
     template <typename C, typename... As>
-    /// @NOLINTNEXTLINE(cert-dcl50-cpp)
+    // NOLINTNEXTLINE(cert-dcl50-cpp)
     static constexpr std::false_type test(...) noexcept
     {
         return {};
@@ -102,7 +102,7 @@ struct is_invocable_r
     // AXIVION Next Construct AutosarC++19_03-A8.4.1 : we require a SFINEA failure case where all
     // parameter types (non invokable ones) are allowed, this can be achieved with variadic arguments
     template <typename C, typename... As>
-    /// @NOLINTNEXTLINE(cert-dcl50-cpp)
+    // NOLINTNEXTLINE(cert-dcl50-cpp)
     static constexpr std::false_type test(...) noexcept
     {
         return {};

--- a/iceoryx_hoofs/primitives/source/type_traits.cpp
+++ b/iceoryx_hoofs/primitives/source/type_traits.cpp
@@ -18,8 +18,8 @@
 
 namespace iox
 {
-/// NOLINTJUSTIFICATION See definitions in header file.
-/// NOLINTBEGIN(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
+// NOLINTJUSTIFICATION See definitions in header file.
+// NOLINTBEGIN(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
 constexpr const char TypeInfo<int8_t>::NAME[];
 constexpr const char TypeInfo<int16_t>::NAME[];
 constexpr const char TypeInfo<int32_t>::NAME[];
@@ -33,5 +33,5 @@ constexpr const char TypeInfo<char>::NAME[];
 constexpr const char TypeInfo<float>::NAME[];
 constexpr const char TypeInfo<double>::NAME[];
 constexpr const char TypeInfo<long double>::NAME[];
-/// NOLINTEND(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
+// NOLINTEND(hicpp-avoid-c-arrays, cppcoreguidelines-avoid-c-arrays)
 } // namespace iox

--- a/iceoryx_hoofs/reporting/include/iox/detail/hoofs_error_reporting.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/detail/hoofs_error_reporting.hpp
@@ -45,6 +45,7 @@ namespace iox
 
 // DO NOT TOUCH THE ENUM, you can doodle around with the lines above!!!
 
+// NOLINTNEXTLINE(performance-enum-size) the type is required for error handling
 enum class HoofsError : iox::er::ErrorCode::type
 {
     IOX_HOOFS_ERRORS(IOX_CREATE_ERROR_ENUM)

--- a/iceoryx_hoofs/reporting/include/iox/detail/log/building_blocks/console_logger.inl
+++ b/iceoryx_hoofs/reporting/include/iox/detail/log/building_blocks/console_logger.inl
@@ -35,6 +35,7 @@ inline constexpr uint32_t ConsoleLogger::bufferSize(const char (&)[N]) noexcept
 }
 
 template <typename T>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) intended for this function
 inline constexpr void ConsoleLogger::unused(T&&) noexcept
 {
 }

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_handler_interface.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_handler_interface.hpp
@@ -46,8 +46,8 @@ struct ErrorDescriptor
 };
 
 /// @brief Defines the dynamic error handling interface (i.e. changeable at runtime).
-/// NOLINTJUSTIFICATION abstract interface
-/// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
+// NOLINTJUSTIFICATION abstract interface
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions, hicpp-special-member-functions)
 class ErrorHandlerInterface
 {
   public:

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_reporting_impl.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/custom/default/error_reporting_impl.hpp
@@ -62,6 +62,7 @@ namespace er
 // note that Message is generic as the logger technically accepts more general loggable constructs
 // beyond const char*
 template <class Message>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) false positive, this is used as a universal reference
 [[noreturn]] inline void panic(const SourceLocation& location, Message&& msg)
 {
     IOX_ERROR_INTERNAL_LOG_PANIC(location, "[PANIC] " << msg);

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/source_location.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/source_location.hpp
@@ -38,7 +38,7 @@ struct SourceLocation
 } // namespace er
 } // namespace iox
 
-/// NOLINTNEXTLINE(cppcoreguidelines-macro-usage) macro is required for use of location intrinsics (__FILE__ etc.)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage) macro is required for use of location intrinsics (__FILE__ etc.)
 #define IOX_CURRENT_SOURCE_LOCATION                                                                                    \
     iox::er::SourceLocation                                                                                            \
     {                                                                                                                  \

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/violation.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/violation.hpp
@@ -34,7 +34,8 @@ namespace er
 // By default, there are only error codes and violations.
 // Custom errors can be added but must satisfy the minimal interface.
 
-enum class ViolationErrorCode : uint32_t
+// NOLINTNEXTLINE(performance-enum-size) the type is required for error handling
+enum class ViolationErrorCode : iox::er::ErrorCode::type
 {
     ASSERT_VIOLATION,
     ENFORCE_VIOLATION

--- a/iceoryx_hoofs/test/.clang-tidy
+++ b/iceoryx_hoofs/test/.clang-tidy
@@ -5,7 +5,7 @@ InheritParentConfig:  true
 
 Checks: '
 -cert-err58-cpp,
--cppcoreguidelines-avoid-const-or-ref-data-members
+-cppcoreguidelines-avoid-const-or-ref-data-members,
 -cppcoreguidelines-avoid-magic-numbers,
 -cppcoreguidelines-avoid-non-const-global-variables,
 -cppcoreguidelines-owning-memory,

--- a/iceoryx_hoofs/test/moduletests/error_reporting/module_a/errors.hpp
+++ b/iceoryx_hoofs/test/moduletests/error_reporting/module_a/errors.hpp
@@ -30,6 +30,7 @@ using ModuleId = iox::er::ModuleId;
 
 constexpr ModuleId MODULE_ID{666};
 
+// NOLINTNEXTLINE(performance-enum-size) the type is required for error handling
 enum class Code : ErrorCode::type
 {
     Unknown = 42,

--- a/iceoryx_hoofs/test/moduletests/error_reporting/module_b/errors.hpp
+++ b/iceoryx_hoofs/test/moduletests/error_reporting/module_b/errors.hpp
@@ -30,6 +30,7 @@ using ModuleId = iox::er::ModuleId;
 
 constexpr ModuleId MODULE_ID{13};
 
+// NOLINTNEXTLINE(performance-enum-size) the type is required for error handling
 enum class Code : ErrorCode::type
 {
     Unknown = 24,

--- a/iceoryx_hoofs/test/moduletests/test_buffer_stack.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_buffer_stack.cpp
@@ -26,8 +26,8 @@ using namespace ::testing;
 
 struct CompareOrder
 {
-    /// NOLINTJUSTIFICATION only used in this test case
-    /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    // NOLINTJUSTIFICATION only used in this test case
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     CompareOrder(uint32_t a, uint32_t b, uint32_t c) noexcept
         : a(a)
         , b(b)
@@ -52,8 +52,8 @@ class TestClass
     static std::vector<CompareOrder> dTorOrder;
 
     TestClass() noexcept = default;
-    /// NOLINTJUSTIFICATION only used in this test case
-    /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+    // NOLINTJUSTIFICATION only used in this test case
+    // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
     TestClass(const uint32_t a, const uint32_t b, const uint32_t c) noexcept
         : m_a(a)
         , m_b(b)

--- a/iceoryx_hoofs/test/moduletests/test_concurrent_smart_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_concurrent_smart_lock.cpp
@@ -177,8 +177,8 @@ TEST_F(smart_lock_test, MoveConstructionOfUnderlyinObjectWorks)
     SmartLockTester tester(CTOR_VALUE);
     m_sut.emplace(ForwardArgsToCTor, std::move(tester));
     EXPECT_THAT((*m_sut)->getA(), Eq(CTOR_VALUE));
-    /// NOLINTJUSTIFICATION we want to test defined behavior of a moved smart_lock
-    /// NOLINTNEXTLINE(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
+    // NOLINTJUSTIFICATION we want to test defined behavior of a moved smart_lock
+    // NOLINTNEXTLINE(bugprone-use-after-move,hicpp-invalid-access-moved,clang-analyzer-cplusplus.Move)
     EXPECT_TRUE(tester.isMoved());
 }
 
@@ -331,7 +331,7 @@ void threadSafeOperationTest(smart_lock_test* test, const std::function<void()> 
 TEST_F(smart_lock_test, ThreadSafeAccessThroughArrowOperator)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e6cfd20a-4450-46f7-80ca-b87f75a0462e");
-    threadSafeOperationTest(this, [=] { (*m_sut)->incrementA(); });
+    threadSafeOperationTest(this, [this] { (*m_sut)->incrementA(); });
 
     EXPECT_THAT((*m_sut)->getA(), Eq(NUMBER_OF_RUNS_PER_THREAD * NUMBER_OF_THREADS));
 }
@@ -340,14 +340,14 @@ TEST_F(smart_lock_test, ThreadSafeAccessThroughConstArrowOperator)
 {
     ::testing::Test::RecordProperty("TEST_ID", "c0dedded-cf07-47dc-9032-e5de3db859d2");
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) used to explitly test const arrow operator
-    threadSafeOperationTest(this, [=] { (const_cast<const SutType_t&>(*m_sut))->constIncrementA(); });
+    threadSafeOperationTest(this, [this] { (const_cast<const SutType_t&>(*m_sut))->constIncrementA(); });
     EXPECT_THAT((*m_sut)->getA(), Eq(NUMBER_OF_RUNS_PER_THREAD * NUMBER_OF_THREADS));
 }
 
 TEST_F(smart_lock_test, ThreadSafeAccessThroughScopedGuard)
 {
     ::testing::Test::RecordProperty("TEST_ID", "2ffb9ba4-4df3-4851-8976-20f15a3bfa4b");
-    threadSafeOperationTest(this, [=] {
+    threadSafeOperationTest(this, [this] {
         auto guard = (*m_sut).get_scope_guard();
         guard->incrementA();
     });
@@ -357,7 +357,7 @@ TEST_F(smart_lock_test, ThreadSafeAccessThroughScopedGuard)
 TEST_F(smart_lock_test, ThreadSafeAccessThroughConstScopedGuard)
 {
     ::testing::Test::RecordProperty("TEST_ID", "dc2efd41-4c0a-4ac0-93ed-f8e9195e0dfd");
-    threadSafeOperationTest(this, [=] {
+    threadSafeOperationTest(this, [this] {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) used to explitly test const get_scope_guard()
         auto guard = const_cast<const SutType_t&>(*m_sut).get_scope_guard();
         guard->incrementA();
@@ -368,21 +368,21 @@ TEST_F(smart_lock_test, ThreadSafeAccessThroughConstScopedGuard)
 TEST_F(smart_lock_test, ThreadSafeCopyCTor)
 {
     ::testing::Test::RecordProperty("TEST_ID", "23b27eda-17de-42b9-bdbc-81e7bae15fd6");
-    threadSafeOperationTest(this, [=] { SutType_t someCopy(*m_sut); });
+    threadSafeOperationTest(this, [this] { SutType_t someCopy(*m_sut); });
     EXPECT_THAT((*m_sut)->getB(), Eq(NUMBER_OF_RUNS_PER_THREAD * NUMBER_OF_THREADS));
 }
 
 TEST_F(smart_lock_test, ThreadSafeMoveCTor)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e7368392-ff41-44a7-ad58-9d3b17637dd6");
-    threadSafeOperationTest(this, [=] { SutType_t movedSut(std::move(*m_sut)); });
+    threadSafeOperationTest(this, [this] { SutType_t movedSut(std::move(*m_sut)); });
     EXPECT_THAT((*m_sut)->getB(), Eq(NUMBER_OF_RUNS_PER_THREAD * NUMBER_OF_THREADS));
 }
 
 TEST_F(smart_lock_test, ThreadSafeCopyAssignment)
 {
     ::testing::Test::RecordProperty("TEST_ID", "a9964501-9c88-4250-a1d5-e266171a670c");
-    threadSafeOperationTest(this, [=] {
+    threadSafeOperationTest(this, [this] {
         SutType_t someCopy;
         someCopy = *m_sut;
     });
@@ -392,7 +392,7 @@ TEST_F(smart_lock_test, ThreadSafeCopyAssignment)
 TEST_F(smart_lock_test, ThreadSafeMoveAssignment)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3f89e951-bf93-4230-b749-ec91416785ae");
-    threadSafeOperationTest(this, [=] {
+    threadSafeOperationTest(this, [this] {
         SutType_t someMovedSut;
         someMovedSut = std::move(*m_sut);
     });

--- a/iceoryx_hoofs/test/moduletests/test_container_list.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_container_list.cpp
@@ -1525,8 +1525,8 @@ TEST_F(list_test, CopyConstructorWithEmptyList)
 {
     ::testing::Test::RecordProperty("TEST_ID", "65409af0-bd13-4011-bdd7-e1b6aa0d4703");
     list<TestListElement, TESTLISTCAPACITY> sut11;
-    /// @NOLINTJUSTIFICATION the test should explicitly test the copy constructor
-    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    // NOLINTJUSTIFICATION the test should explicitly test the copy constructor
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     list<TestListElement, TESTLISTCAPACITY> sut12(sut11);
     EXPECT_THAT(stats.copyCTor, Eq(0U));
     EXPECT_THAT(sut12.size(), Eq(0U));
@@ -2319,8 +2319,8 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
     ::testing::Test::RecordProperty("TEST_ID", "ce16f50e-8da5-497c-abd5-a3af4ebd78d2");
     uint64_t i = 0U;
     using TestFwdList = list<TestListElement, TESTLISTCAPACITY>;
-    /// @NOLINTJUSTIFICATION required temporary memory buffer for the memcpy test
-    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION required temporary memory buffer for the memcpy test
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     alignas(TestFwdList) uint8_t otherSutBuffer[sizeof(TestFwdList)];
     uint8_t* otherSutPtr = &otherSutBuffer[0];
 
@@ -2333,8 +2333,8 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
             sut1.emplace_front(static_cast<int64_t>(j));
         }
 
-        /// @NOLINTJUSTIFICATION the list is trivially copyable and this test verifies this with memcpy
-        /// @NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
+        // NOLINTJUSTIFICATION the list is trivially copyable and this test verifies this with memcpy
+        // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
         memcpy(otherSutPtr, &sut1, sizeof(sut1));
 
         // overwrite copied-from list before it's being destroyed
@@ -2346,9 +2346,9 @@ TEST_F(list_test, ListIsCopyableViaMemcpy)
         }
     }
 
-    /// @NOLINTJUSTIFICATION we need to verify that list is in fact trivially copyable and stored in otherSubBuffer
-    /// therefore we need to cast it
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTJUSTIFICATION we need to verify that list is in fact trivially copyable and stored in otherSubBuffer
+    // therefore we need to cast it
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     for (auto& listElement : *reinterpret_cast<TestFwdList*>(otherSutPtr))
     {
         --i;

--- a/iceoryx_hoofs/test/moduletests/test_container_vector.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_container_vector.cpp
@@ -1340,11 +1340,8 @@ TEST_F(vector_test, SizeIncreaseWithResizeAndDefaultCTorWorks)
     class DefaultCTor
     {
       public:
-        DefaultCTor()
-            : m_a{1231}
-        {
-        }
-        int m_a;
+        DefaultCTor() = default;
+        int m_a{1231};
     };
     vector<DefaultCTor, 10U> sut;
 

--- a/iceoryx_hoofs/test/moduletests/test_filesystem_filesystem.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_filesystem_filesystem.cpp
@@ -601,8 +601,10 @@ TEST(filesystem_test_isValidPathEntry, StringWithRelativeComponentsIsInvalidWhen
 
 // BEGIN AccessMode and OpenMode tests
 
-constexpr AccessMode INVALID_ACCESS_MODE = static_cast<AccessMode>(std::numeric_limits<uint64_t>::max());
-constexpr OpenMode INVALID_OPEN_MODE = static_cast<OpenMode>(std::numeric_limits<uint64_t>::max());
+constexpr AccessMode INVALID_ACCESS_MODE =
+    static_cast<AccessMode>(std::numeric_limits<std::underlying_type_t<AccessMode>>::max());
+constexpr OpenMode INVALID_OPEN_MODE =
+    static_cast<OpenMode>(std::numeric_limits<std::underlying_type_t<OpenMode>>::max());
 
 TEST(TypesTest, ConvertToOflagFromAccessModeWorks)
 {

--- a/iceoryx_hoofs/test/moduletests/test_functional_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_functional_function.cpp
@@ -307,8 +307,8 @@ TEST_F(function_test, CopyCtorCopiesStoredFunctor)
     test_function f(functor);
     Functor::resetCounts();
 
-    /// @NOLINTJUSTIFICATION the copy constructor is tested here
-    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    // NOLINTJUSTIFICATION the copy constructor is tested here
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     test_function sut(f);
 
     EXPECT_EQ(Functor::numCopied, 1U);
@@ -364,8 +364,8 @@ TEST_F(function_test, CopyCtorCopiesStoredFreeFunction)
 {
     ::testing::Test::RecordProperty("TEST_ID", "8f95a82a-c879-48b1-aa56-316bf15b983a");
     test_function f(freeFunction);
-    /// @NOLINTJUSTIFICATION the copy constructor is tested here
-    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    // NOLINTJUSTIFICATION the copy constructor is tested here
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     test_function sut(f);
 
     EXPECT_EQ(sut(1), f(1));
@@ -539,8 +539,8 @@ TEST_F(function_test, CallWithValueArgumentsWorks)
     const int32_t initial = 73;
     Arg arg(initial);
 
-    /// @NOLINTJUSTIFICATION value argument is tested here
-    /// @NOLINTNEXTLINE(performance-unnecessary-value-param)
+    // NOLINTJUSTIFICATION value argument is tested here
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     auto lambda = [](const Arg a) { return a.value + 1; };
     function<int32_t(Arg&), 128> sut(lambda);
 
@@ -555,8 +555,9 @@ TEST_F(function_test, CallWithRValueReferenceArgumentsWorks)
     const int32_t initial = 73;
     Arg arg(initial);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) this is okay for this test
     auto lambda = [](Arg&& a) { return a.value + 1; };
-    function<int32_t(Arg &&), 128> sut(lambda);
+    function<int32_t(Arg&&), 128> sut(lambda);
 
     auto result = sut(std::move(arg));
 
@@ -573,8 +574,8 @@ TEST_F(function_test, CallWithMixedArgumentsWorks)
 
     constexpr int32_t sum = 10;
 
-    /// @NOLINTJUSTIFICATION value argument is tested here
-    /// @NOLINTNEXTLINE(performance-unnecessary-value-param)
+    // NOLINTJUSTIFICATION value argument is tested here
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved, performance-unnecessary-value-param)
     auto lambda = [](Arg& a1, const Arg& a2, Arg&& a3, Arg a4) { return a1.value + a2.value + a3.value + a4.value; };
     function<int32_t(Arg&, const Arg&, Arg&&, Arg), 128> sut(lambda);
 

--- a/iceoryx_hoofs/test/moduletests/test_functional_function.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_functional_function.cpp
@@ -557,7 +557,7 @@ TEST_F(function_test, CallWithRValueReferenceArgumentsWorks)
 
     // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) this is okay for this test
     auto lambda = [](Arg&& a) { return a.value + 1; };
-    function<int32_t(Arg&&), 128> sut(lambda);
+    function<int32_t(Arg &&), 128> sut(lambda);
 
     auto result = sut(std::move(arg));
 

--- a/iceoryx_hoofs/test/moduletests/test_memory_relative_pointer.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_relative_pointer.cpp
@@ -65,27 +65,25 @@ typedef testing::Types<uint8_t, int8_t, double> Types;
 
 TYPED_TEST_SUITE(RelativePointer_test, Types, );
 
+// NOLINTJUSTIFICATION Pointer arithmetic needed for tests
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
+
 /// @todo iox-#1745 the tests should be reworked
 TYPED_TEST(RelativePointer_test, ConstrTests)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cae7b4d4-86eb-42f6-b938-90a76f01bea5");
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
                   segment_id_t{1U}, reinterpret_cast<TypeParam*>(this->memoryPartition[0]), SHARED_MEMORY_SIZE),
               true);
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
                   segment_id_t{2U}, reinterpret_cast<TypeParam*>(this->memoryPartition[1]), SHARED_MEMORY_SIZE),
               true);
-    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
     auto* ptr0 = this->partitionPtr(0U);
     auto* ptr1 = this->partitionPtr(1U);
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0 + offset);
 
         RelativePointer<TypeParam> rp;
@@ -96,18 +94,15 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
     }
 
     {
-        // No pointer arithmetic involved hence reinterpret_cast can be avoided
-        auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr0));
+        auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0);
         RelativePointer<TypeParam> rp(typedPtr);
-        EXPECT_EQ(rp.getOffset(), 0);
+        EXPECT_EQ(rp.getOffset(), 0U);
         EXPECT_EQ(rp.getId(), 1U);
         EXPECT_NE(rp, nullptr);
     }
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -117,8 +112,6 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1U;
-        // Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -127,18 +120,15 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
     }
 
     {
-        // No pointer arithmetic involved hence reinterpret_cast can be avoided
-        auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr1));
+        auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1);
         RelativePointer<TypeParam> rp(typedPtr);
-        EXPECT_EQ(rp.getOffset(), 0);
+        EXPECT_EQ(rp.getOffset(), 0U);
         EXPECT_EQ(rp.getId(), 2U);
         EXPECT_NE(rp, nullptr);
     }
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -148,8 +138,6 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
         EXPECT_EQ(rp.getOffset(), offset);
@@ -164,8 +152,6 @@ TYPED_TEST(RelativePointer_test, ConstrTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp(typedPtr);
         EXPECT_TRUE(rp);
@@ -178,20 +164,16 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
     auto* ptr0 = this->partitionPtr(0U);
     auto* ptr1 = this->partitionPtr(1U);
 
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
                   segment_id_t{1U}, reinterpret_cast<TypeParam*>(ptr0), SHARED_MEMORY_SIZE),
               true);
     EXPECT_EQ(RelativePointer<TypeParam>::registerPtrWithId(
                   segment_id_t{2U}, reinterpret_cast<TypeParam*>(ptr1), SHARED_MEMORY_SIZE),
               true);
-    // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
     {
         RelativePointer<TypeParam> rp;
-        // No pointer arithmetic involved hence reinterpret_cast can be avoided
-        auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr0));
+        auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0);
         rp = typedPtr;
         EXPECT_EQ(rp.getOffset(), 0U);
         EXPECT_EQ(rp.getId(), 1U);
@@ -200,8 +182,6 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
@@ -212,8 +192,6 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr0 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
@@ -224,18 +202,15 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
 
     {
         RelativePointer<TypeParam> rp;
-        // No pointer arithmetic involved hence reinterpret_cast can be avoided
-        auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr1));
+        auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1);
         rp = typedPtr;
-        EXPECT_EQ(rp.getOffset(), 0);
+        EXPECT_EQ(rp.getOffset(), 0U);
         EXPECT_EQ(rp.getId(), 2U);
         EXPECT_TRUE(rp);
     }
 
     {
         auto offset = SHARED_MEMORY_SIZE / 2U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
@@ -246,8 +221,6 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE - 1U;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
@@ -264,8 +237,6 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorTests)
 
     {
         auto offset = SHARED_MEMORY_SIZE + 1;
-        // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
         auto* typedPtr = reinterpret_cast<TypeParam*>(ptr1 + offset);
         RelativePointer<TypeParam> rp;
         rp = typedPtr;
@@ -277,19 +248,14 @@ TYPED_TEST(RelativePointer_test, IdAndOffsetAreTranslatedToRawPointerCorrectly)
 {
     ::testing::Test::RecordProperty("TEST_ID", "9a29a074-d68d-4431-88b9-bdd26b1a41f7");
     auto* ptr = this->partitionPtr(0U);
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(ptr);
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     EXPECT_EQ(rp1.getOffset(), reinterpret_cast<std::ptrdiff_t>(typedPtr));
     EXPECT_EQ(rp1.getId(), 1U);
 
     int offset = SHARED_MEMORY_SIZE / 2U;
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
     RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1U});
     EXPECT_EQ(rp2.getOffset(), offset);
@@ -301,16 +267,13 @@ TYPED_TEST(RelativePointer_test, GetOffsetReturnsCorrectOffset)
 {
     ::testing::Test::RecordProperty("TEST_ID", "0b493337-ee55-498a-9cac-8bb5741f72f0");
     auto* ptr = this->partitionPtr(0U);
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(ptr);
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
     EXPECT_EQ(UntypedRelativePointer::getOffset(segment_id_t{1U}, typedPtr), 0U);
 
     int offset = SHARED_MEMORY_SIZE / 2U;
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
     RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1U});
     EXPECT_EQ(UntypedRelativePointer::getOffset(segment_id_t{1U}, addressAtOffset), offset);
@@ -320,15 +283,12 @@ TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
 {
     ::testing::Test::RecordProperty("TEST_ID", "4fadf89f-69c0-4058-8995-a98e2e3334b2");
     auto* ptr = this->partitionPtr(0U);
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     EXPECT_EQ(rp1.registerPtrWithId(segment_id_t{1U}, typedPtr), true);
     EXPECT_EQ(UntypedRelativePointer::getPtr(segment_id_t{1U}, 0), typedPtr);
 
     uint64_t offset = SHARED_MEMORY_SIZE / 2U;
-    // NOLINTJUSTIFICATION Pointer arithmetic needed for tests
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
     auto* addressAtOffset = reinterpret_cast<TypeParam*>(ptr + offset);
     RelativePointer<TypeParam> rp2(addressAtOffset, segment_id_t{1});
     EXPECT_EQ(UntypedRelativePointer::getPtr(segment_id_t{1U}, offset), addressAtOffset);
@@ -337,8 +297,7 @@ TYPED_TEST(RelativePointer_test, GetPtrReturnsAddressWithCorrectOffset)
 TYPED_TEST(RelativePointer_test, RegisteringAndUnregisteringRelativePointerWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "3f08ab46-c778-468a-bab1-ecd71aa800f4");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
 
@@ -353,8 +312,7 @@ TYPED_TEST(RelativePointer_test, UnRegisteringOneRelativePointerWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "cc09122e-74e8-4d24-83ec-6500471becac");
     auto* ptr = this->partitionPtr(0U);
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(ptr));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(ptr);
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
 
@@ -366,10 +324,8 @@ TYPED_TEST(RelativePointer_test, UnRegisteringOneRelativePointerWorks)
 TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e793b3e8-5077-499d-b628-608ecfd91b9e");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
-    auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
+    auto* typedPtr0 = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
+    auto* typedPtr1 = reinterpret_cast<TypeParam*>(this->partitionPtr(1U));
 
     RelativePointer<TypeParam> rp1(typedPtr0, segment_id_t{1U});
     RelativePointer<TypeParam> rp2(typedPtr1, segment_id_t{9999U});
@@ -384,9 +340,8 @@ TYPED_TEST(RelativePointer_test, UnregisteringAllRelativePointerWorks)
 TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
 {
     ::testing::Test::RecordProperty("TEST_ID", "87521383-6aea-4b43-a182-3a21499be710");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr0 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
-    auto* typedPtr1 = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(1U)));
+    auto* typedPtr0 = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
+    auto* typedPtr1 = reinterpret_cast<TypeParam*>(this->partitionPtr(1U));
 
     RelativePointer<TypeParam> rp1(typedPtr0, segment_id_t{1U});
     RelativePointer<TypeParam> rp2(typedPtr1, segment_id_t{10000U});
@@ -398,8 +353,7 @@ TYPED_TEST(RelativePointer_test, RegisterPtrWithIdFailsWhenTooLarge)
 TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
 {
     ::testing::Test::RecordProperty("TEST_ID", "40e649bc-b159-45ab-891f-2194a0dcf0e6");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     EXPECT_EQ(rp1.getBasePtr(segment_id_t{1U}), nullptr);
@@ -410,8 +364,7 @@ TYPED_TEST(RelativePointer_test, BasePointerIsSameAfterRegistering)
 TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAndOffset)
 {
     ::testing::Test::RecordProperty("TEST_ID", "98e2eb78-ee5d-4d87-9753-5ac42b90b9d6");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
 
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
     // NOLINTJUSTIFICATION Copy needed for tests
@@ -426,8 +379,7 @@ TYPED_TEST(RelativePointer_test, AssignmentOperatorResultsInSameBasePointerIdAnd
 TYPED_TEST(RelativePointer_test, DereferencingOperatorResultsInSameValue)
 {
     ::testing::Test::RecordProperty("TEST_ID", "d8c1105e-1041-418f-9327-27958f788119");
-    // No pointer arithmetic involved hence reinterpret_cast can be avoided
-    auto* typedPtr = static_cast<TypeParam*>(static_cast<void*>(this->partitionPtr(0U)));
+    auto* typedPtr = reinterpret_cast<TypeParam*>(this->partitionPtr(0U));
 
     *typedPtr = static_cast<TypeParam>(88);
     RelativePointer<TypeParam> rp1(typedPtr, segment_id_t{1U});
@@ -462,11 +414,8 @@ TYPED_TEST(RelativePointer_test, MemoryRemappingWorks)
     EXPECT_EQ(*base2, 73U);
 
     int offset = BLOCK_SIZE / 2U;
-    // NOLINTJUSTIFICATION pointer arithmetic needed for tests
-    // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-bounds-pointer-arithmetic)
     auto* adr1 = reinterpret_cast<int*>(base1 + offset);
     auto* adr2 = reinterpret_cast<int*>(base2 + offset);
-    // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast, cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
     // int write
     *adr1 = 12;
@@ -535,5 +484,7 @@ TYPED_TEST(RelativePointer_test, DefaultConstructedRelativePtrIsNull)
     EXPECT_FALSE(rp1);
     EXPECT_FALSE(rp2);
 }
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
 
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_memory_static_storage.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_memory_static_storage.cpp
@@ -33,8 +33,8 @@ using namespace iox;
 template <uint32_t Size, uint32_t Align = 1U>
 struct alignas(Align) Bytes
 {
-    /// @NOLINTJUSTIFICATION required to provide raw memory in tests
-    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION required to provide raw memory in tests
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     uint8_t data[Size] = {};
 
     void set(uint8_t value)
@@ -46,8 +46,8 @@ struct alignas(Align) Bytes
     {
         for (uint32_t i = 0; i < Size; ++i)
         {
-            /// @NOLINTJUSTIFICATION verify content of memory
-            /// @NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+            // NOLINTJUSTIFICATION verify content of memory
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
             if (data[i] != value)
             {
                 return false;
@@ -207,8 +207,8 @@ TEST(static_storage_test, AllocationIsAligned)
 {
     ::testing::Test::RecordProperty("TEST_ID", "645c0194-7aea-4f9c-b379-212fbcaa05f7");
     static_storage<17, 2> sut;
-    /// @NOLINTJUSTIFICATION required for testing
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTJUSTIFICATION required for testing
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto p = reinterpret_cast<uintptr_t>(sut.allocate(16, 4));
     EXPECT_EQ(p % 4, 0);
 }
@@ -218,8 +218,8 @@ TEST(static_storage_test, TypedAllocationIsAligned)
     ::testing::Test::RecordProperty("TEST_ID", "bb990529-2721-4db8-8b17-02719021210e");
     using Data = Bytes<4, 8>;
     static_storage<17, 2> sut;
-    /// @NOLINTJUSTIFICATION required for testing
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    // NOLINTJUSTIFICATION required for testing
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     auto p = reinterpret_cast<uintptr_t>(sut.allocate<Data>());
     EXPECT_EQ(p % 8, 0);
 }

--- a/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_file_lock.cpp
@@ -24,11 +24,11 @@ namespace
 using namespace ::testing;
 using namespace iox;
 
-/// NOLINTJUSTIFICATION compile time string literal used only in tests
-/// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTJUSTIFICATION compile time string literal used only in tests
+// NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 constexpr char TEST_NAME[] = "TestProcess";
 constexpr char ANOTHER_TEST_NAME[] = "AnotherTestProcess";
-/// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+// NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 
 
 /// @req

--- a/iceoryx_hoofs/test/moduletests/test_posix_filesystem_posix_acl.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_filesystem_posix_acl.cpp
@@ -55,8 +55,8 @@ struct PwUidResult
 {
     static constexpr uint64_t BUFFER_SIZE{2048U};
     passwd pwd;
-    /// NOLINTJUSTIFICATION required as memory buffer for the getpwuid_r result
-    /// NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION required as memory buffer for the getpwuid_r result
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     char buff[BUFFER_SIZE];
 };
 
@@ -256,7 +256,6 @@ TEST_F(PosixAcl_test, addNameInWrongPlace)
     ::testing::Test::RecordProperty("TEST_ID", "2d2dbb0d-1fb6-4569-8651-d341a4525ea6");
     auto name = iox_getpwuid(geteuid());
     ASSERT_TRUE(name);
-    std::string currentUserName(name->pwd.pw_name);
 
     m_accessController.addPermissionEntry(PosixAcl::Category::GROUP, PosixAcl::Permission::READ);
     m_accessController.addPermissionEntry(PosixAcl::Category::OTHERS, PosixAcl::Permission::NONE);

--- a/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_posix_call.cpp
@@ -23,8 +23,8 @@ using namespace ::testing;
 
 namespace
 {
-/// NOLINTJUSTIFICATION only used in testing
-/// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+// NOLINTJUSTIFICATION only used in testing
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 int testFunction(int returnValue, int errnoValue)
 {
     errno = errnoValue;

--- a/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_shared_memory_object.cpp
@@ -81,7 +81,7 @@ TEST_F(SharedMemoryObject_Test, AllocateMemoryInSharedMemoryAndReadIt)
 
     for (uint64_t i = 0; i < MEMORY_SIZE; ++i)
     {
-        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         data_ptr[i] = static_cast<uint8_t>(i * 2 + 1);
     }
 
@@ -96,7 +96,7 @@ TEST_F(SharedMemoryObject_Test, AllocateMemoryInSharedMemoryAndReadIt)
 
     for (uint64_t i = 0; i < MEMORY_SIZE; ++i)
     {
-        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         EXPECT_THAT(data_ptr2[i], Eq(static_cast<uint8_t>(i) * 2 + 1));
     }
 }
@@ -141,7 +141,7 @@ TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)
 
     for (uint64_t i = 0; i < MEMORY_SIZE; ++i)
     {
-        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         data_ptr[i] = i * 2 + 1;
     }
 
@@ -158,7 +158,7 @@ TEST_F(SharedMemoryObject_Test, OpenSutMapsAllMemoryIntoProcess)
 
     for (uint64_t i = 0; i < MEMORY_SIZE; ++i)
     {
-        /// NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         EXPECT_THAT(data_ptr2[i], Eq(i * 2 + 1));
     }
 }

--- a/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_signal_handler.cpp
@@ -62,8 +62,8 @@ class SignalHandler_test : public Test
     {
         struct sigaction action = {};
         sigemptyset(&action.sa_mask);
-        /// NOLINTJUSTIFICATION sigaction is a posix system construct, no other way to assign members
-        /// NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
+        // NOLINTJUSTIFICATION sigaction is a posix system construct, no other way to assign members
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)
         action.sa_handler = callback;
         action.sa_flags = 0;
 

--- a/iceoryx_hoofs/test/moduletests/test_posix_sync_signal_watcher.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_posix_sync_signal_watcher.cpp
@@ -81,8 +81,8 @@ TEST_F(SignalWatcher_test, SignalIsTriggeredWhenSIGTERMWasTriggeredBefore)
 }
 
 void unblocksWhenSignalWasRaisedForWaiters(SignalWatcher_test& test,
-                                           /// NOLINTJUSTIFICATION only used inside this test
-                                           /// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+                                           // NOLINTJUSTIFICATION only used inside this test
+                                           // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
                                            const int signal,
                                            const uint32_t numberOfWaiters,
                                            const std::function<void()>& wait)

--- a/iceoryx_hoofs/test/moduletests/test_primitives_type_traits.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_primitives_type_traits.cpp
@@ -258,8 +258,8 @@ TEST(TypeTraitsTest, NonCharArraysAreIdentifiedCorrectly)
     ::testing::Test::RecordProperty("TEST_ID", "40359de0-2ccd-422a-b1d4-da4b4f12a172");
 
     EXPECT_FALSE(is_char_array<int>::value);
-    /// @NOLINTJUSTIFICATION we want test explicitly the c arrays case
-    /// @NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION we want test explicitly the c arrays case
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     EXPECT_FALSE(is_char_array<int[10]>::value);
     EXPECT_FALSE(is_char_array<iox::string<11>>::value);
     EXPECT_FALSE(is_char_array<char>::value);
@@ -269,10 +269,10 @@ TEST(TypeTraitsTest, CharArraysAreIdentifiedCorrectly)
 {
     ::testing::Test::RecordProperty("TEST_ID", "e1c115d9-80c4-4bc9-97d0-338112dfe1d3");
 
-    /// @NOLINTJUSTIFICATION we want test explicitly the c arrays case
-    /// @NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION we want test explicitly the c arrays case
+    // NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     EXPECT_TRUE(is_char_array<char[1]>::value);
     EXPECT_TRUE(is_char_array<char[10]>::value);
-    /// @NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
 }
 } // namespace

--- a/iceoryx_hoofs/test/moduletests/test_reporting_console_logger.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_reporting_console_logger.cpp
@@ -35,50 +35,13 @@ class LoggerSUT : public iox::log::ConsoleLogger
     using iox::log::ConsoleLogger::logString;
 };
 
-/// @todo iox-#1755 this test will be done via the integration tests with launch testing once "RouDi is ready for
-/// clients" will be printed via the logger
-#if 0
 TEST(ConsoleLogger_test, TestOutput)
 {
     ::testing::Test::RecordProperty("TEST_ID", "67f1dac5-b425-414a-9690-268ecb06c1ee");
 
-    constexpr const char* LOG_FILE_NAME{"iceoryx_console_logger_output_test.txt"};
-    constexpr const char* LOG_MESSAGE{"All glory to the hypnotoad!"};
-
-    // #### redirect stdout ####
-    // to be able to check if the logger writes to stdout we need to redirect the output to a file
-    // save original stdout
-    auto stdoutOriginal = dup(STDOUT_FILENO);
-
-    int logFd = open(LOG_FILE_NAME, O_CREAT | O_WRONLY | O_TRUNC, 0664);
-    ASSERT_GE(logFd, 0);
-    ASSERT_GE(dup2(logFd, STDOUT_FILENO), 0);
-    // #### redirect stdout ####
-
-    LoggerSUT sut;
-    // createLogMessageHeader is intentionally not called;
-    // it creates a timestamp which needs to be removed anyway;
-    // logString is sufficient to ensure that the output works
-    sut.logString(LOG_MESSAGE);
-    sut.flush();
-
-    // #### restore stdout ####
-    close(logFd);
-
-    ASSERT_GE(dup2(stdoutOriginal, STDOUT_FILENO), 0);
-    // #### restore stdout ####
-
-    std::fstream fileStream;
-    fileStream.open(LOG_FILE_NAME, std::fstream::in);
-    ASSERT_TRUE(fileStream.is_open());
-    std::string logString;
-    ASSERT_TRUE(std::getline(fileStream, logString));
-
-    // assure that there a no further strings
-    EXPECT_THAT(logString, StrEq(LOG_MESSAGE));
-    ASSERT_FALSE(std::getline(fileStream, logString));
+    GTEST_SKIP() << "This is tested via the integration tests by launch testing waiting for the 'RouDi is ready for "
+                    "clients' string";
 }
-#endif
 
 /// @note the actual log API is tested via the LogStream tests
 

--- a/iceoryx_hoofs/test/moduletests/test_utility_into.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_into.cpp
@@ -20,13 +20,13 @@
 
 namespace
 {
-enum class A
+enum class A : uint8_t
 {
     A1 = 13,
     A2
 };
 
-enum class B
+enum class B : uint8_t
 {
     B1 = 42,
     B2

--- a/iceoryx_hoofs/test/moduletests/test_utility_unique_id.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_utility_unique_id.cpp
@@ -71,8 +71,8 @@ TEST(UniqueId_test, CopyConstructingUniqueIdsWorks)
     auto id = UniqueId();
     auto idValue = static_cast<UniqueId::value_type>(id);
 
-    /// @NOLINTJUSTIFICATION we test the copy constructor here
-    /// @NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+    // NOLINTJUSTIFICATION we test the copy constructor here
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     auto sut{id};
     auto sutValue = static_cast<UniqueId::value_type>(sut);
 

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_optional.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_optional.cpp
@@ -549,6 +549,7 @@ struct TestStructForInPlaceConstruction
     {
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) intended for the test
     explicit TestStructForInPlaceConstruction(int8_t&& val)
         : val(static_cast<int8_t>(DEFAULT_MULTIPLICATOR * val))
     {

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_string.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_string.cpp
@@ -1423,8 +1423,6 @@ TYPED_TEST(stringTyped_test, CompareOperatorsWithDifferentStringWithDifferentSiz
     }
     testCharArray[STRINGCAP] = '\0';
 
-    const std::string testStdString = &testCharArray[0];
-
     // compare with greater string
     std::string temp1(STRINGCAP + 5U, 'M');
     string<STRINGCAP + 5U> sutGreater;
@@ -2399,7 +2397,6 @@ TYPED_TEST(stringTyped_test, AppendStringContainingNullWorks)
 
     string<RESULT_CAPACITY> sut("i");
     const string<RESULT_CAPACITY> testCxxString(TruncateToCapacity, expectedString.substr(1).c_str(), 6U);
-    const std::string testStdString = expectedString.substr(1);
 
     // append iox::string
     sut.append(TruncateToCapacity, testCxxString);
@@ -3267,11 +3264,11 @@ TEST(stringTyped_test, NonCxxStringsAreIdentifiedCorrectly)
     ::testing::Test::RecordProperty("TEST_ID", "898fdeb7-2b35-4d33-8db4-ed3b9447a1da");
 
     EXPECT_FALSE(is_iox_string<int>::value);
-    /// @NOLINTJUSTIFICATION we want test explicitly the c arrays case
-    /// @NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTJUSTIFICATION we want test explicitly the c arrays case
+    // NOLINTBEGIN(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     EXPECT_FALSE(is_iox_string<int[10]>::value);
     EXPECT_FALSE(is_iox_string<char[11]>::value);
-    /// @NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    // NOLINTEND(hicpp-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     EXPECT_FALSE(is_iox_string<char>::value);
 }
 
@@ -3296,8 +3293,8 @@ TYPED_TEST(stringTyped_test, UncheckedAtWorks)
     for (uint64_t i = 0; i < this->testSubject.size(); ++i)
     {
         EXPECT_THAT(this->testSubject.unchecked_at(i), Eq(static_cast<char>('a' + i % 3)));
-        /// @NOLINTJUSTIFICATION we explicitly test the const version
-        /// @NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        // NOLINTJUSTIFICATION we explicitly test the const version
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
         EXPECT_THAT(const_cast<const decltype(this->testSubject)&>(this->testSubject).unchecked_at(i),
                     Eq(static_cast<char>('a' + i % 3)));
     }

--- a/iceoryx_hoofs/test/moduletests/test_vocabulary_variant.cpp
+++ b/iceoryx_hoofs/test/moduletests/test_vocabulary_variant.cpp
@@ -65,7 +65,6 @@ class variant_Test : public Test
     {
       public:
         DoubleDelete()
-            : doDtorCall{true}
         {
             ctorCalls++;
         }
@@ -116,7 +115,7 @@ class variant_Test : public Test
         static int ctorCalls;
 
       private:
-        bool doDtorCall;
+        bool doDtorCall{true};
     };
 
     iox::variant<int, float, ComplexClass> sut;

--- a/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/watch_dog.hpp
+++ b/iceoryx_hoofs/testing/include/iceoryx_hoofs/testing/watch_dog.hpp
@@ -64,7 +64,7 @@ class Watchdog
     {
         reset();
 
-        m_watchdog = std::thread([=] {
+        m_watchdog = std::thread([this, actionOnFailure] {
             m_watchdogSemaphore->timedWait(m_timeToWait)
                 .and_then([&](auto& result) {
                     if (result == iox::SemaphoreWaitState::TIMEOUT)

--- a/iceoryx_hoofs/utility/include/iox/detail/convert.hpp
+++ b/iceoryx_hoofs/utility/include/iox/detail/convert.hpp
@@ -25,6 +25,7 @@
 
 #include <climits>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -49,7 +50,7 @@ namespace iox
 class convert
 {
   public:
-    enum class NumberType
+    enum class NumberType : uint8_t
     {
         INTEGER,
         UNSIGNED_INTEGER,

--- a/iceoryx_hoofs/utility/include/iox/detail/convert.inl
+++ b/iceoryx_hoofs/utility/include/iox/detail/convert.inl
@@ -88,8 +88,8 @@ inline iox::optional<char> convert::from_string<char>(const char* v) noexcept
         return iox::nullopt;
     }
 
-    /// @NOLINTJUSTIFICATION encapsulated in abstraction
-    /// @NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    // NOLINTJUSTIFICATION encapsulated in abstraction
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return iox::optional<char>(v[0]);
 }
 

--- a/iceoryx_hoofs/utility/include/iox/detail/serialization.hpp
+++ b/iceoryx_hoofs/utility/include/iox/detail/serialization.hpp
@@ -108,7 +108,7 @@ class Serialization
     bool getNth(const unsigned int index, T& t) const noexcept;
 
     /// @brief This is an error which can be used for 'iox::expected' on a custom deserialization when 'extract' fails
-    enum class Error
+    enum class Error : uint8_t
     {
         DESERIALIZATION_FAILED, ///< indicates a failed deserialization
     };

--- a/iceoryx_hoofs/utility/include/iox/detail/unique_id.hpp
+++ b/iceoryx_hoofs/utility/include/iox/detail/unique_id.hpp
@@ -44,9 +44,9 @@ class UniqueId : public NewType<UniqueId,
     UniqueId() noexcept;
 
   private:
-    /// @NOLINTJUSTIFICATION only accessible by this class. the global variable is required to
-    ///                      generate a unique id from it incrementing value
-    /// @NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+    // NOLINTJUSTIFICATION only accessible by this class. the global variable is required to
+    //                     generate a unique id from it incrementing value
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
     static std::atomic<value_type> m_IdCounter; // initialized in corresponding cpp file
 };
 

--- a/iceoryx_hoofs/utility/source/unique_id.cpp
+++ b/iceoryx_hoofs/utility/source/unique_id.cpp
@@ -19,8 +19,8 @@
 namespace iox
 {
 // start with 1, just in case we want to use 0 for a special purpose later on
-/// @NOLINTJUSTIFICATION see argument in header
-/// @NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTJUSTIFICATION see argument in header
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::atomic<uint64_t> UniqueId::m_IdCounter{1U};
 
 UniqueId::UniqueId() noexcept

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected.inl
@@ -71,6 +71,7 @@ inline expected<ValueType, ErrorType>::expected(const detail::ok<ValueType>& suc
 }
 
 template <typename ValueType, typename ErrorType>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) the underlying value is moved
 inline expected<ValueType, ErrorType>::expected(detail::ok<ValueType>&& successValue) noexcept
     : m_store(in_place, std::move(successValue.value))
 {
@@ -83,6 +84,7 @@ inline expected<ValueType, ErrorType>::expected(const detail::err<ErrorType>& er
 }
 
 template <typename ValueType, typename ErrorType>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) the underlying value is moved
 inline expected<ValueType, ErrorType>::expected(detail::err<ErrorType>&& errorValue) noexcept
     : m_store(unexpect, std::move(errorValue.value))
 {

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/expected_helper.hpp
@@ -58,6 +58,7 @@ struct ok
 
     // AXIVION Next Construct AutosarC++19_03-A18.9.2 : For universal references std::forward must be used
     template <typename U = T, typename = enable_if_not_lvalue_referece_t<U>>
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
     explicit ok(T&& t) noexcept
         : value(std::forward<T>(t))
     {
@@ -94,6 +95,7 @@ struct err
 
     // AXIVION Next Construct AutosarC++19_03-A18.9.2 : For universal references std::forward must be used
     template <typename U = T, typename = enable_if_not_lvalue_referece_t<U>>
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
     explicit err(T&& t) noexcept
         : value(std::forward<T>(t))
     {
@@ -122,6 +124,7 @@ class expected_storage
     }
 
     template <typename... Targs>
+    // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
     explicit expected_storage(unexpect_t, Targs&&... args)
         : data(in_place_index<ERROR_INDEX>(), std::forward<Targs>(args)...)
     {
@@ -172,6 +175,7 @@ class expected_storage<void, ErrorType>
     expected_storage() noexcept = delete;
 
     template <typename... Targs>
+    // NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) Targs is not used but required for template meta-programming
     explicit expected_storage(in_place_t, Targs&&...)
         : data(in_place_index<VALUE_INDEX>(), DUMMY_VALUE)
     {

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/optional.inl
@@ -43,6 +43,7 @@ inline optional<T>::optional() noexcept
 // m_data is set inside construct_value
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init, hicpp-member-init)
 template <typename T>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) perfect forwarding is used
 inline optional<T>::optional(T&& value) noexcept
 {
     // AXIVION Next Construct AutosarC++19_03-A18.9.2 : Perfect forwarding is intended here and
@@ -244,7 +245,8 @@ inline T& optional<T>::value() & noexcept
     // during compile time and the type is unchangeable during the lifetime of the object.
     // All accesses to the underlying data is done via the same static type and therefore the
     // casts are always valid
-    return *static_cast<T*>(static_cast<void*>(&m_data));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return *reinterpret_cast<T*>(&m_data);
 }
 
 template <typename T>
@@ -263,7 +265,8 @@ inline T&& optional<T>::value() && noexcept
     // during compile time and the type is unchangeable during the lifetime of the object.
     // All accesses to the underlying data is done via the same static type and therefore the
     // casts are always valid
-    return std::move(*static_cast<T*>(static_cast<void*>(&m_data)));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return std::move(*reinterpret_cast<T*>(&m_data));
 }
 
 template <typename T>

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/span.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/span.inl
@@ -159,9 +159,7 @@ inline constexpr span<T, DYNAMIC_EXTENT> span<T, Extent>::last(uint64_t count) c
 
 template <typename T, uint64_t Extent>
 template <uint64_t Offset, uint64_t Count>
-inline constexpr span<T,
-                      (Count != DYNAMIC_EXTENT ? Count : (Extent != DYNAMIC_EXTENT ? Extent - Offset : DYNAMIC_EXTENT))>
-span<T, Extent>::subspan() const noexcept
+inline constexpr span<T, detail::subspan_capacity<Offset, Count, Extent>()> span<T, Extent>::subspan() const noexcept
 {
     static_assert(Offset <= Extent, "Offset must not exceed Extent");
     static_assert(Count == DYNAMIC_EXTENT || Count <= Extent - Offset, "Count must not exceed Extent - Offset");

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/string.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/string.inl
@@ -338,6 +338,7 @@ inline string<Capacity>& string<Capacity>::copy(const string<N>& rhs) noexcept
 
 template <uint64_t Capacity>
 template <uint64_t N>
+// NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved) false positive, the underlying data is moved
 inline string<Capacity>& string<Capacity>::move(string<N>&& rhs) noexcept
 {
     static_assert(N <= Capacity,

--- a/iceoryx_hoofs/vocabulary/include/iox/detail/variant.inl
+++ b/iceoryx_hoofs/vocabulary/include/iox/detail/variant.inl
@@ -157,7 +157,8 @@ variant<Types...>::operator=(T&& rhs) noexcept
     if (!has_bad_variant_element_access<T>())
     {
         // AXIVION Next Construct AutosarC++19_03-M5.2.8: conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
-        auto storage = static_cast<T*>(static_cast<void*>(&m_storage));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        auto storage = reinterpret_cast<T*>(&m_storage);
         *storage = std::forward<T>(rhs);
     }
     else
@@ -216,7 +217,8 @@ variant<Types...>::unsafe_get_at_index_unchecked() noexcept
     using T = typename internal::get_type_at_index<0, TypeIndex, Types...>::type;
 
     // AXIVION Next Construct AutosarC++19_03-M5.2.8 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
-    return static_cast<T*>(static_cast<void*>(&m_storage));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<T*>(&m_storage);
 }
 
 template <typename... Types>
@@ -250,7 +252,8 @@ inline const T* variant<Types...>::get() const noexcept
         return nullptr;
     }
     // AXIVION Next Construct AutosarC++19_03-M5.2.8 : conversion to typed pointer is intentional, it is correctly aligned and points to sufficient memory for a T by design
-    return static_cast<const T*>(static_cast<const void*>(&m_storage));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<const T*>(&m_storage);
 }
 
 template <typename... Types>

--- a/iceoryx_hoofs/vocabulary/include/iox/semantic_string.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/semantic_string.hpp
@@ -26,7 +26,7 @@ namespace iox
 {
 /// @brief Defines errors which can occur when modifying or creating a
 ///         SemanticString
-enum class SemanticStringError
+enum class SemanticStringError : uint8_t
 {
     ContainsInvalidCharacters,
     ContainsInvalidContent,

--- a/iceoryx_hoofs/vocabulary/include/iox/span.hpp
+++ b/iceoryx_hoofs/vocabulary/include/iox/span.hpp
@@ -36,6 +36,25 @@ namespace iox
 // constants
 constexpr uint64_t DYNAMIC_EXTENT = std::numeric_limits<uint64_t>::max();
 
+namespace detail
+{
+template <uint64_t Offset, uint64_t Count, uint64_t Extent>
+static constexpr uint64_t subspan_capacity()
+{
+    if (Count != DYNAMIC_EXTENT)
+    {
+        return Count;
+    }
+
+    if (Extent != DYNAMIC_EXTENT)
+    {
+        return Extent - Offset;
+    }
+
+    return DYNAMIC_EXTENT;
+}
+} // namespace detail
+
 // Specialization/ implementation of C++17's std::size() and std::data()
 
 /// @brief Returns a pointer to the block of memory containing the elements of the range.
@@ -343,8 +362,7 @@ class span final : public detail::span_storage<Extent>
     /// @tparam Count number of elements in the returned span
     /// @return the subspan
     template <uint64_t Offset, uint64_t Count = DYNAMIC_EXTENT>
-    constexpr span<T, (Count != DYNAMIC_EXTENT ? Count : (Extent != DYNAMIC_EXTENT ? Extent - Offset : DYNAMIC_EXTENT))>
-    subspan() const noexcept;
+    constexpr span<T, detail::subspan_capacity<Offset, Count, Extent>()> subspan() const noexcept;
 
     /// @brief obtains a subspan with dynamic extend
     /// @param offset in the returned span

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/detail/publisher.inl
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/detail/publisher.inl
@@ -37,8 +37,11 @@ inline expected<unique_ptr<Publisher<T, H>>, PublisherBuilderError> PublisherBui
     {
         return err(PublisherBuilderError::OUT_OF_RESOURCES);
     }
-    return ok(unique_ptr<Publisher<T, H>>{new Publisher<T, H>{iox::PublisherPortUserType{publisher_port_data}},
-                                          [&](auto* const pub) { delete pub; }});
+    return ok(unique_ptr<Publisher<T, H>>{
+        new (std::nothrow) Publisher<T, H>{iox::PublisherPortUserType{publisher_port_data}}, [&](auto* const pub) {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) raw pointer is required by the unique_ptr API
+            delete pub;
+        }});
 }
 
 inline expected<unique_ptr<UntypedPublisher>, PublisherBuilderError> PublisherBuilder::create() noexcept
@@ -49,8 +52,11 @@ inline expected<unique_ptr<UntypedPublisher>, PublisherBuilderError> PublisherBu
     {
         return err(PublisherBuilderError::OUT_OF_RESOURCES);
     }
-    return ok(unique_ptr<UntypedPublisher>{new UntypedPublisher{iox::PublisherPortUserType{publisher_port_data}},
-                                           [&](auto* const pub) { delete pub; }});
+    return ok(unique_ptr<UntypedPublisher>{
+        new (std::nothrow) UntypedPublisher{iox::PublisherPortUserType{publisher_port_data}}, [&](auto* const pub) {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) raw pointer is required by the unique_ptr API
+            delete pub;
+        }});
 }
 
 } // namespace iox::posh::experimental

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/detail/subscriber.inl
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/detail/subscriber.inl
@@ -42,8 +42,11 @@ inline expected<unique_ptr<Subscriber<T, H>>, SubscriberBuilderError> Subscriber
     {
         return err(SubscriberBuilderError::OUT_OF_RESOURCES);
     }
-    return ok(unique_ptr<Subscriber<T, H>>{new Subscriber<T, H>{iox::SubscriberPortUserType{subscriber_port_data}},
-                                           [&](auto* const sub) { delete sub; }});
+    return ok(unique_ptr<Subscriber<T, H>>{
+        new (std::nothrow) Subscriber<T, H>{iox::SubscriberPortUserType{subscriber_port_data}}, [&](auto* const sub) {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) raw pointer is required by the unique_ptr API
+            delete sub;
+        }});
 }
 
 inline expected<unique_ptr<UntypedSubscriber>, SubscriberBuilderError> SubscriberBuilder::create() noexcept
@@ -59,8 +62,11 @@ inline expected<unique_ptr<UntypedSubscriber>, SubscriberBuilderError> Subscribe
     {
         return err(SubscriberBuilderError::OUT_OF_RESOURCES);
     }
-    return ok(unique_ptr<UntypedSubscriber>{new UntypedSubscriber{iox::SubscriberPortUserType{subscriber_port_data}},
-                                            [&](auto* const sub) { delete sub; }});
+    return ok(unique_ptr<UntypedSubscriber>{
+        new (std::nothrow) UntypedSubscriber{iox::SubscriberPortUserType{subscriber_port_data}}, [&](auto* const sub) {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) raw pointer is required by the unique_ptr API
+            delete sub;
+        }});
 }
 
 } // namespace iox::posh::experimental

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/detail/wait_set.inl
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/detail/wait_set.inl
@@ -35,8 +35,11 @@ inline expected<unique_ptr<WaitSet<Capacity>>, WaitSetBuilderError> WaitSetBuild
     {
         return err(WaitSetBuilderError::OUT_OF_RESOURCES);
     }
-    return ok(unique_ptr<WaitSet<Capacity>>{new WaitSet<Capacity>{*condition_variable_data},
-                                            [&](auto* const ws) { delete ws; }});
+    return ok(unique_ptr<WaitSet<Capacity>>{new (std::nothrow) WaitSet<Capacity>{*condition_variable_data},
+                                            [&](auto* const ws) {
+                                                // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) raw pointer is required by the unique_ptr API
+                                                delete ws;
+                                            }});
 }
 
 } // namespace iox::posh::experimental

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/node.hpp
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/node.hpp
@@ -37,7 +37,7 @@ using capro::ServiceDescription;
 
 class Node;
 
-enum class NodeBuilderError
+enum class NodeBuilderError : uint8_t
 {
     INVALID_OR_NO_DOMAIN_ID,
     IPC_CHANNEL_CREATION_FAILED,

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/publisher.hpp
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/publisher.hpp
@@ -34,7 +34,7 @@ using iox::popo::ConsumerTooSlowPolicy;
 using iox::popo::Publisher;
 using iox::popo::UntypedPublisher;
 
-enum class PublisherBuilderError
+enum class PublisherBuilderError : uint8_t
 {
     OUT_OF_RESOURCES,
 };

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/subscriber.hpp
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/subscriber.hpp
@@ -33,7 +33,7 @@ using iox::popo::QueueFullPolicy;
 using iox::popo::Subscriber;
 using iox::popo::UntypedSubscriber;
 
-enum class SubscriberBuilderError
+enum class SubscriberBuilderError : uint8_t
 {
     OUT_OF_RESOURCES,
 };

--- a/iceoryx_posh/experimental/include/iox/posh/experimental/wait_set.hpp
+++ b/iceoryx_posh/experimental/include/iox/posh/experimental/wait_set.hpp
@@ -30,7 +30,7 @@ namespace iox::posh::experimental
 template <uint64_t Capacity = MAX_NUMBER_OF_ATTACHMENTS_PER_WAITSET>
 using WaitSet = iox::popo::WaitSet<Capacity>;
 
-enum class WaitSetBuilderError
+enum class WaitSetBuilderError : uint8_t
 {
     OUT_OF_RESOURCES,
 };


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

To prevent issues with the upcoming Ubuntu 24.04 release which has clang-tidy-18, this PR fixes all the new warnings introduced between clang-tidy-15 and clang-tidy-18

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2274 
