### PR TITLE
iox-#2011 Silence some warnings when building with GCC 13.

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -12,6 +12,8 @@
 
 **Refactoring:**
 
+- Silence warnings when building with GCC 13 [\#2011](https://github.com/eclipse-iceoryx/iceoryx/issues/2011)
+
 **New API features:**
 
 **API Breaking Changes:**

--- a/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_queue.inl
+++ b/iceoryx_hoofs/include/iceoryx_hoofs/internal/cxx/variant_queue.inl
@@ -17,6 +17,7 @@
 #ifndef IOX_HOOFS_CXX_VARIANT_QUEUE_INL
 #define IOX_HOOFS_CXX_VARIANT_QUEUE_INL
 
+#include "iceoryx_hoofs/cxx/variant_queue.hpp"
 #include "iceoryx_hoofs/error_handling/error_handling.hpp"
 
 namespace iox
@@ -48,6 +49,11 @@ inline VariantQueue<ValueType, Capacity>::VariantQueue(const VariantQueueTypes t
     }
     }
 }
+
+#if (defined(__GNUC__) && __GNUC__ >= 13 && !defined(__clang__))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 
 template <typename ValueType, uint64_t Capacity>
 optional<ValueType> VariantQueue<ValueType, Capacity>::push(const ValueType& value) noexcept
@@ -89,6 +95,10 @@ optional<ValueType> VariantQueue<ValueType, Capacity>::push(const ValueType& val
 
     return cxx::nullopt;
 }
+
+#if (defined(__GNUC__) && __GNUC__ >= 13 && !defined(__clang__))
+#pragma GCC diagnostic pop
+#endif
 
 template <typename ValueType, uint64_t Capacity>
 inline optional<ValueType> VariantQueue<ValueType, Capacity>::pop() noexcept

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -132,6 +132,11 @@ inline bool ChunkDistributor<ChunkDistributorDataType>::hasStoredQueues() const 
     return !getMembers()->m_queues.empty();
 }
 
+#if (defined(__GNUC__) && __GNUC__ >= 13 && !defined(__clang__))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
 template <typename ChunkDistributorDataType>
 inline uint64_t ChunkDistributor<ChunkDistributorDataType>::deliverToAllStoredQueues(mepoo::SharedChunk chunk) noexcept
 {
@@ -208,6 +213,10 @@ inline uint64_t ChunkDistributor<ChunkDistributorDataType>::deliverToAllStoredQu
 
     return numberOfQueuesTheChunkWasDeliveredTo;
 }
+
+#if (defined(__GNUC__) && __GNUC__ >= 13 && !defined(__clang__))
+#pragma GCC diagnostic pop
+#endif
 
 template <typename ChunkDistributorDataType>
 inline bool ChunkDistributor<ChunkDistributorDataType>::pushToQueue(cxx::not_null<ChunkQueueData_t* const> queue,


### PR DESCRIPTION
GCC 13 (which is in Ubuntu 24.04) introduced a number of false positive warnings when using -Warray-bounds and -Wstring-op; see:

* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114758
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111118
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110807
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110498

In my testing, these only show up when building with optimizations, i.e. CMAKE_BUILD_TYPE=RelWithDebInfo.

This commit silences those warnings across the two functions that cause the problem, and make the build completely clean.

## Notes for Reviewer

This should fix the yellow builds in e.g. https://ci.ros2.org/view/packaging/job/packaging_linux/3451/
Note that this targets the `release_2.0` branch, since that is what ROS 2 is currently using.  If you'd like me to target another branch and then backport, I'm happy to do that instead.

<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [N/A] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [N/A] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [N/A] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Relates to #2011 
