### PR TITLE
iox-#2011 Solve a warning when building in Release mode.

### DIFF
--- a/iceoryx_posh/source/popo/publisher_options.cpp
+++ b/iceoryx_posh/source/popo/publisher_options.cpp
@@ -36,7 +36,7 @@ PublisherOptions::deserialize(const cxx::Serialization& serialized) noexcept
     using ConsumerTooSlowPolicyUT = std::underlying_type_t<ConsumerTooSlowPolicy>;
 
     PublisherOptions publisherOptions;
-    ConsumerTooSlowPolicyUT subscriberTooSlowPolicy;
+    ConsumerTooSlowPolicyUT subscriberTooSlowPolicy{0};
 
     auto deserializationSuccessful = serialized.extract(publisherOptions.historyCapacity,
                                                         publisherOptions.nodeName,

--- a/iceoryx_posh/source/popo/subscriber_options.cpp
+++ b/iceoryx_posh/source/popo/subscriber_options.cpp
@@ -37,7 +37,7 @@ SubscriberOptions::deserialize(const cxx::Serialization& serialized) noexcept
     using QueueFullPolicyUT = std::underlying_type_t<QueueFullPolicy>;
 
     SubscriberOptions subscriberOptions;
-    QueueFullPolicyUT queueFullPolicy;
+    QueueFullPolicyUT queueFullPolicy{0};
 
     auto deserializationSuccessful = serialized.extract(subscriberOptions.queueCapacity,
                                                         subscriberOptions.historyRequest,


### PR DESCRIPTION
When building the `iceoryx_hoofs` package from the `release_2.0` branch in Release mode (`-DCMAKE_BUILD_TYPE=Release`), with gcc 13, we get warnings like the following:

```
In file included from /home/ubuntu/rolling_ws/src/eclipse-iceoryx/iceoryx/iceoryx_posh/source/popo/subscriber_options.cpp:17:
In constructor ‘iox::popo::SubscriberOptions::SubscriberOptions(iox::popo::SubscriberOptions&&)’,
    inlined from ‘bool iox::cxx::variant<Types>::emplace_at_index(CTorArguments&& ...) [with long unsigned int TypeIndex = 0; CTorArguments = {iox::popo::SubscriberOptions}; Types = {iox::popo::SubscriberOptions, iox::cxx::Serialization::Error}]’ at /home/ubuntu/rolling_ws/install/iceoryx_hoofs/include/iceoryx/v2.0.6/iceoryx_hoofs/internal/cxx/variant.inl:174:5,
    inlined from ‘constexpr iox::cxx::variant<Types>::variant(const iox::cxx::in_place_index<N>&, CTorArguments&& ...) [with long unsigned int N = 0; CTorArguments = {iox::popo::SubscriberOptions}; Types = {iox::popo::SubscriberOptions, iox::cxx::Serialization::Error}]’ at /home/ubuntu/rolling_ws/install/iceoryx_hoofs/include/iceoryx/v2.0.6/iceoryx_hoofs/internal/cxx/variant.inl:42:24,
    inlined from ‘iox::cxx::expected<ValueType, ErrorType>::expected(iox::cxx::success<ValueType>&&) [with ValueType = iox::popo::SubscriberOptions; ErrorType = iox::cxx::Serialization::Error]’ at /home/ubuntu/rolling_ws/install/iceoryx_hoofs/include/iceoryx/v2.0.6/iceoryx_hoofs/internal/cxx/expected.inl:93:7,
    inlined from ‘static iox::cxx::expected<iox::popo::SubscriberOptions, iox::cxx::Serialization::Error> iox::popo::SubscriberOptions::deserialize(const iox::cxx::Serialization&)’ at /home/ubuntu/rolling_ws/src/eclipse-iceoryx/iceoryx/iceoryx_posh/source/popo/subscriber_options.cpp:56:61:
/home/ubuntu/rolling_ws/src/eclipse-iceoryx/iceoryx/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp:32:8: warning: ‘queueFullPolicy’ may be used uninitialized [-Wmaybe-uninitialized]
   32 | struct SubscriberOptions
      |        ^~~~~~~~~~~~~~~~~
/home/ubuntu/rolling_ws/src/eclipse-iceoryx/iceoryx/iceoryx_posh/source/popo/subscriber_options.cpp: In static member function ‘static iox::cxx::expected<iox::popo::SubscriberOptions, iox::cxx::Serialization::Error> iox::popo::SubscriberOptions::deserialize(const iox::cxx::Serialization&)’:
/home/ubuntu/rolling_ws/src/eclipse-iceoryx/iceoryx/iceoryx_posh/source/popo/subscriber_options.cpp:40:23: note: ‘queueFullPolicy’ was declared here
   40 |     QueueFullPolicyUT queueFullPolicy;
      |       
```

This change avoids the warning by just always assigning a zero.  However, this isn't really a serious attempt at a fix, but more of a way to start a discussion.  I noticed that the `main` branch compiles without warnings, but does *not* have this zero in place.  That said, I do not understand the mechanism that is being used there, so I'm having trouble tracking down the difference between the `main` branch and this one.  Any thoughts on the "correct" way to fix this?

(skipping the rest of the checklist for now until we decide what to do here)


## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Relates to #2011 
