### PR TITLE
iox-#2209 Refactor ssize_t to iox_ssize_t for Windows compatibility

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -104,17 +104,17 @@ jobs:
     needs: pre-flight-check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Unix (FreeBSD) test
-      id: Test
-      uses: vmactions/freebsd-vm@v1
-      with:
-        release: "14.0"
-        copyback: false
-        prepare: pkg install -y cmake git ncurses bash wget bison
-        run: |
-         git config --global --add safe.directory /home/runner/work/iceoryx/iceoryx
-         ./tools/ci/build-test-freebsd.sh
+      - uses: actions/checkout@v4
+      - name: Unix (FreeBSD) test
+        id: Test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "14.0"
+          copyback: false
+          prepare: pkg install -y cmake git ncurses bash wget bison
+          run: |
+            git config --global --add safe.directory /home/runner/work/iceoryx/iceoryx
+            ./tools/ci/build-test-freebsd.sh
 
   run-integration-test:
     # prevent stuck jobs consuming runners for 6 hours

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -138,7 +138,7 @@
 - 'iox::string' tests can exceed the translation unit compilation timeout [#2278](https://github.com/eclipse-iceoryx/iceoryx/issues/2278)
 -  Building iceoryx with bazel on Windows is broken [#2320](https://github.com/eclipse-iceoryx/iceoryx/issues/2320)
 - Fix wrong memory orders in SpscSoFi [#2177](https://github.com/eclipse-iceoryx/iceoryx/issues/2177)
--
+- ssize_t: redefinition; different basic types [#2209](https://github.com/eclipse-iceoryx/iceoryx/issues/2209)
 
 **Refactoring:**
 

--- a/iceoryx_platform/win/include/iceoryx_platform/acl.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/acl.hpp
@@ -83,7 +83,7 @@ inline int acl_add_perm(acl_permset_t permset_d, acl_perm_t perm)
     return 0;
 }
 
-inline char* acl_to_text(acl_t acl, ssize_t* len_p)
+inline char* acl_to_text(acl_t acl, iox_ssize_t* len_p)
 {
     return nullptr;
 }

--- a/iceoryx_platform/win/include/iceoryx_platform/mqueue.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/mqueue.hpp
@@ -52,12 +52,12 @@ inline int mq_close(mqd_t mqdes)
 //{
 //}
 
-inline ssize_t mq_receive(mqd_t mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio)
+inline iox_ssize_t mq_receive(mqd_t mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio)
 {
     return 0;
 }
 
-inline ssize_t
+inline iox_ssize_t
 mq_timedreceive(mqd_t mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio, const struct timespec* abs_timeout)
 {
     return 0;

--- a/iceoryx_platform/win/include/iceoryx_platform/socket.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/socket.hpp
@@ -30,9 +30,9 @@ using sa_family_t = int;
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
 int iox_socket(int domain, int type, int protocol);
 int iox_setsockopt(int sockfd, int level, int optname, const void* optval, socklen_t optlen);
-ssize_t
+iox_ssize_t
 iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
-ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
+iox_ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen);
 int iox_connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen);
 int iox_closesocket(int sockfd);
 

--- a/iceoryx_platform/win/include/iceoryx_platform/types.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/types.hpp
@@ -23,8 +23,10 @@ using iox_gid_t = int;
 using iox_uid_t = int;
 #if defined(_MSC_VER)
 using mode_t = int;
-using ssize_t = size_t;
+using iox_ssize_t = int;
 using pid_t = int;
+#elif defined(__MINGW32__) || defined(__MINGW64__)
+using iox_ssize_t = ssize_t;
 #endif
 using nlink_t = int;
 using blksize_t = int;

--- a/iceoryx_platform/win/include/iceoryx_platform/unistd.hpp
+++ b/iceoryx_platform/win/include/iceoryx_platform/unistd.hpp
@@ -35,7 +35,6 @@
 #endif
 
 using iox_off_t = long;
-using iox_ssize_t = int;
 
 #define IOX_F_OK 0
 #define IOX_X_OK 1
@@ -54,5 +53,6 @@ iox_ssize_t iox_read(int fd, void* buf, size_t count);
 iox_ssize_t iox_write(int fd, const void* buf, size_t count);
 iox_gid_t iox_getgid(void);
 iox_uid_t iox_geteuid(void);
+
 
 #endif // IOX_HOOFS_WIN_PLATFORM_UNISTD_HPP

--- a/iceoryx_platform/win/source/socket.cpp
+++ b/iceoryx_platform/win/source/socket.cpp
@@ -16,6 +16,7 @@
 
 #include "iceoryx_platform/socket.hpp"
 #include "iceoryx_platform/logging.hpp"
+#include "iceoryx_platform/types.hpp"
 #include <cstdio>
 
 int iox_bind(int sockfd, const struct sockaddr* addr, socklen_t addrlen)
@@ -36,14 +37,14 @@ int iox_setsockopt(int sockfd, int level, int optname, const void* optval, sockl
     return 0;
 }
 
-ssize_t
+iox_ssize_t
 iox_sendto(int sockfd, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
 {
     IOX_PLATFORM_LOG(IOX_PLATFORM_LOG_LEVEL_ERROR, "'iox_sendto' is not implemented in windows!");
     return 0;
 }
 
-ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
+iox_ssize_t iox_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* src_addr, socklen_t* addrlen)
 {
     IOX_PLATFORM_LOG(IOX_PLATFORM_LOG_LEVEL_ERROR, "'iox_recvfrom' is not implemented in windows!");
     return 0;

--- a/iceoryx_platform/win/source/unistd.cpp
+++ b/iceoryx_platform/win/source/unistd.cpp
@@ -20,6 +20,7 @@
 #include "iceoryx_platform/mman.hpp"
 #include "iceoryx_platform/win32_errorHandling.hpp"
 
+
 int iox_ftruncate(int fildes, off_t length)
 {
     internal_iox_shm_set_size(fildes, length);


### PR DESCRIPTION
This change updates the ssize_t type to iox_ssize_t in Windows-specific files to resolve a compatibility issue. It ensures consistent type usage and includes the necessary headers for type definitions.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2209 

@elBoberido  I don't have windows to check the build :(