### PR TITLE
iox-#2372: Depend on @ncurses when building with Bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,3 +14,4 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
+bazel_dep(name = "ncurses", version = "6.4.20221231")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,4 +14,5 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(name = "googletest", version = "1.15.2", dev_dependency = True)
+
 bazel_dep(name = "ncurses", version = "6.4.20221231")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -25,3 +25,13 @@ load_repositories()
 load("//bazel:setup_repositories.bzl", "setup_repositories")
 
 setup_repositories()
+
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+# This sets up some common toolchains for building targets. For more details, please see
+# https://bazelbuild.github.io/rules_foreign_cc/0.12.0/flatten.html#rules_foreign_cc_dependencies
+rules_foreign_cc_dependencies()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()

--- a/bazel/load_repositories.bzl
+++ b/bazel/load_repositories.bzl
@@ -20,6 +20,7 @@ load("//bazel/bazelbuild:repositories.bzl", "load_com_github_bazelbuild_rules_cc
 load("//bazel/buildifier_prebuilt:repositories.bzl", "load_buildifier_prebuilt_repositories")
 load("//bazel/cpptoml:repositories.bzl", "load_cpptoml_repositories")
 load("//bazel/googletest:repositories.bzl", "load_googletest_repositories")
+load("//bazel/ncurses:repositories.bzl", "load_ncurses_repositories")
 load("//bazel/skylib:repositories.bzl", "load_bazel_skylib_repositories")
 
 def load_repositories():
@@ -31,3 +32,4 @@ def load_repositories():
     load_buildifier_prebuilt_repositories()
     load_googletest_repositories()
     load_cpptoml_repositories()
+    load_ncurses_repositories()

--- a/bazel/ncurses/ncurses.BUILD
+++ b/bazel/ncurses/ncurses.BUILD
@@ -1,3 +1,19 @@
+# Copyright (c) 2024 by Fernride GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 
 filegroup(

--- a/bazel/ncurses/ncurses.BUILD
+++ b/bazel/ncurses/ncurses.BUILD
@@ -1,0 +1,23 @@
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+filegroup(
+    name = "all_srcs",
+    srcs = glob(["**"]),
+)
+
+configure_make(
+    name = "ncurses",
+    args = ["-j"],
+    configure_options = [
+        "--without-debug",
+        "--without-ada",
+        "--without-tests",
+        "--enable-overwrite",
+    ],
+    lib_source = ":all_srcs",
+    out_static_libs = [
+        "libncurses.a",
+        "libcurses.a",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/ncurses/repositories.bzl
+++ b/bazel/ncurses/repositories.bzl
@@ -1,3 +1,21 @@
+# Copyright (c) 2024 by Fernride GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""This module prepares the ncurses dependency."""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 

--- a/bazel/ncurses/repositories.bzl
+++ b/bazel/ncurses/repositories.bzl
@@ -1,0 +1,19 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def load_ncurses_repositories():
+    maybe(
+        http_archive,
+        name = "rules_foreign_cc",
+        sha256 = "a2e6fb56e649c1ee79703e99aa0c9d13c6cc53c8d7a0cbb8797ab2888bbc99a3",
+        strip_prefix = "rules_foreign_cc-0.12.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/releases/download/0.12.0/rules_foreign_cc-0.12.0.tar.gz",
+    )
+    maybe(
+        http_archive,
+        name = "ncurses",
+        url = "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.3.tar.gz",
+        sha256 = "97fc51ac2b085d4cde31ef4d2c3122c21abc217e9090a43a30fc5ec21684e059",
+        strip_prefix = "ncurses-6.3",
+        build_file = "//bazel/ncurses:ncurses.BUILD",
+    )

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -144,6 +144,7 @@
 - ssize_t: redefinition; different basic types [#2209](https://github.com/eclipse-iceoryx/iceoryx/issues/2209)
 - Fix bazel build on macos [#2345](https://github.com/eclipse-iceoryx/iceoryx/issues/2345)
 - Fix Bzlmod module name typo [#2364](https://github.com/eclipse-iceoryx/iceoryx/issues/2364)
+- Depend on @ncurses when building with Bazel [#2372](https://github.com/eclipse-iceoryx/iceoryx/issues/2372)
 
 **Refactoring:**
 

--- a/tools/introspection/BUILD.bazel
+++ b/tools/introspection/BUILD.bazel
@@ -23,7 +23,6 @@ cc_library(
         "source/introspection_app.cpp",
     ],
     hdrs = glob(["include/iceoryx_introspection/**"]),
-    linkopts = ["-lncurses"],
     strip_include_prefix = "include",
     #Windows does not offer ncurses, therefore we do not build the lib
     target_compatible_with = select({
@@ -33,6 +32,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//iceoryx_posh",
+        "@ncurses",
     ],
 )
 

--- a/tools/introspection/include/iceoryx_introspection/introspection_app.hpp
+++ b/tools/introspection/include/iceoryx_introspection/introspection_app.hpp
@@ -20,8 +20,8 @@
 #include "iceoryx_platform/getopt.hpp"
 #include "iceoryx_posh/popo/subscriber.hpp"
 
+#include <curses.h>
 #include <map>
-#include <ncurses.h>
 #include <vector>
 
 namespace iox


### PR DESCRIPTION
## Notes for Reviewer

Depend on third-party `@ncurses` when building with Bazel. This is easy with Bzlmod, but I went the hard path and made it work for legacy Workspace as well.

Testing:
```console
❯ bazel run //tools/introspection:iox-introspection-client --enable_bzlmod --noenable_workspace -- --version
INFO: Analyzed target //tools/introspection:iox-introspection-client (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //tools/introspection:iox-introspection-client up-to-date:
  bazel-bin/tools/introspection/iox-introspection-client
INFO: Elapsed time: 0.061s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/introspection/iox-introspection-client --version
Latest official iceoryx release version: 2.95.3
❯ bazel run //tools/introspection:iox-introspection-client --noenable_bzlmod --enable_workspace -- --version
INFO: Analyzed target //tools/introspection:iox-introspection-client (71 packages loaded, 3237 targets configured).
INFO: Found 1 target...
Target //tools/introspection:iox-introspection-client up-to-date:
  bazel-bin/tools/introspection/iox-introspection-client
INFO: Elapsed time: 8.044s, Critical Path: 2.81s
INFO: 138 processes: 8 internal, 130 linux-sandbox.
INFO: Build completed successfully, 138 total actions
INFO: Running command line: bazel-bin/tools/introspection/iox-introspection-client --version
Latest official iceoryx release version: 2.95.3
```

Note also the change from `ncurses.h` vs `curses.h`. There is some background info in https://stackoverflow.com/questions/59555474/difference-between-the-headers-ncurses-h-and-curses-h
The issue is mostly that `ncurses.h` isn't available in the current BCR ncurses.
There are no implementation differences iiuc.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2372 
