### PR TITLE
Include <chrono> for system_clock

### DIFF
--- a/iceoryx_platform/win/source/time.cpp
+++ b/iceoryx_platform/win/source/time.cpp
@@ -16,6 +16,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_platform/time.hpp"
+#include <chrono>
 
 static std::chrono::nanoseconds getNanoSeconds(const timespec& value)
 {


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by microsoft/STL#5105, which revealed a conformance issue in `iceoryx`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\iceoryx\src\v2.0.6-c8abea20ae.clean\iceoryx_platform\win\source\time.cpp(42): error C2039: 'system_clock': is not a member of 'std::chrono'
```