### PR TITLE
iox-#2426 Fix comparison operator in channel.inl

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -146,7 +146,7 @@
 - Fix span span constructor assert when using begin/end constructor [#2253](https://github.com/eclipse-iceoryx/iceoryx/issues/2253)
 - Listener examples need to take all samples in the callback [#2251](https://github.com/eclipse-iceoryx/iceoryx/issues/2251)
 - 'iox::string' tests can exceed the translation unit compilation timeout [#2278](https://github.com/eclipse-iceoryx/iceoryx/issues/2278)
--  Building iceoryx with bazel on Windows is broken [#2320](https://github.com/eclipse-iceoryx/iceoryx/issues/2320)
+- Building iceoryx with bazel on Windows is broken [#2320](https://github.com/eclipse-iceoryx/iceoryx/issues/2320)
 - Fix wrong memory orders in SpscSoFi [#2177](https://github.com/eclipse-iceoryx/iceoryx/issues/2177)
 - ssize_t: redefinition; different basic types [#2209](https://github.com/eclipse-iceoryx/iceoryx/issues/2209)
 - Fix bazel build on macos [#2345](https://github.com/eclipse-iceoryx/iceoryx/issues/2345)
@@ -155,6 +155,7 @@
 - Depend on @ncurses when building with Bazel [#2372](https://github.com/eclipse-iceoryx/iceoryx/issues/2372)
 - Fix windows performance issue [#2377](https://github.com/eclipse-iceoryx/iceoryx/issues/2377)
 - Max Client and Server cannot be configured independently of Max Publisher and Subscriber [#2394](https://github.com/eclipse-iceoryx/iceoryx/issues/2394)
+- Fix call to non-existing `getService` in channel.inl [#2426](https://github.com/eclipse-iceoryx/iceoryx/issues/2426)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/gateway/channel.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/channel.hpp
@@ -22,7 +22,6 @@
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iox/expected.hpp"
 #include "iox/fixed_position_container.hpp"
-#include "iox/optional.hpp"
 
 #include <memory>
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
@@ -50,7 +50,7 @@ template <typename IceoryxTerminal, typename ExternalTerminal>
 constexpr inline bool Channel<IceoryxTerminal, ExternalTerminal>::operator==(
     const Channel<IceoryxTerminal, ExternalTerminal>& rhs) const noexcept
 {
-    return m_service == rhs.getService();
+    return m_service == rhs.getServiceDescription();
 }
 
 template <typename IceoryxTerminal, typename ExternalTerminal>

--- a/iceoryx_posh/test/moduletests/test_gw_channel.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_channel.cpp
@@ -62,4 +62,18 @@ TEST_F(ChannelTest, ReturnsErrorIfPoolExhausted)
     EXPECT_FALSE(channel.has_error());
 }
 
+TEST_F(ChannelTest, ComparisonWorks)
+{
+    ::testing::Test::RecordProperty("TEST_ID", "535de22b-575d-467c-810a-6beced4d4144");
+    auto channel1 = iox::gw::Channel<StubbedIceoryxTerminal, StubbedExternalTerminal>::create(
+        {"", "", ""}, StubbedIceoryxTerminal::Options());
+    ASSERT_FALSE(channel1.has_error());
+    EXPECT_TRUE(channel1 == channel1);
+
+    auto channel2 = iox::gw::Channel<StubbedIceoryxTerminal, StubbedExternalTerminal>::create(
+        {"Service", "", ""}, StubbedIceoryxTerminal::Options());
+    ASSERT_FALSE(channel2.has_error());
+    EXPECT_FALSE(channel1 == channel2);
+}
+
 } // namespace


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR replaces the call to the non-existing `getService` in the comparison operator of `Channel` with `getServiceDescription`. Another option would be to remove the comparison operator completely

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2426 
