### PR TITLE
iox-#2440 Fix race condition that can cause failed chunk management a…

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -156,6 +156,7 @@
 - Fix windows performance issue [#2377](https://github.com/eclipse-iceoryx/iceoryx/issues/2377)
 - Max Client and Server cannot be configured independently of Max Publisher and Subscriber [#2394](https://github.com/eclipse-iceoryx/iceoryx/issues/2394)
 - Fix call to non-existing `getService` in channel.inl [#2426](https://github.com/eclipse-iceoryx/iceoryx/issues/2426)
+- Fix chunk management race condition causing failed management allocation [#2440](https://github.com/eclipse-iceoryx/iceoryx/issues/2440)
 
 **Refactoring:**
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/memory_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/memory_manager.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 - 2020 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2025 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +72,10 @@ class MemoryManager
     /// @param[in] chunkSettings for the requested chunk
     /// @return a SharedChunk if successful, otherwise a MemoryManager::Error
     expected<SharedChunk, Error> getChunk(const ChunkSettings& chunkSettings) noexcept;
+
+    /// @brief Release a chunk back to the mempools
+    /// @param[in] chunkManagement Management for the chunk
+    static void freeChunk(ChunkManagement& chunkManagement) noexcept;
 
     uint32_t getNumberOfMemPools() const noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_chunk.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/shared_chunk.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2025 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -64,7 +65,6 @@ class SharedChunk
   private:
     void decrementReferenceCounter() noexcept;
     void incrementReferenceCounter() noexcept;
-    void freeChunk() noexcept;
 
   private:
     ChunkManagement* m_chunkManagement{nullptr};

--- a/iceoryx_posh/source/mepoo/shared_chunk.cpp
+++ b/iceoryx_posh/source/mepoo/shared_chunk.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
 // Copyright (c) 2021 - 2022 by Apex.AI Inc. All rights reserved.
+// Copyright (c) 2025 by Latitude AI. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +17,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "iceoryx_posh/internal/mepoo/shared_chunk.hpp"
+#include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 
 namespace iox
 {
@@ -54,15 +56,9 @@ void SharedChunk::decrementReferenceCounter() noexcept
     if ((m_chunkManagement != nullptr)
         && (m_chunkManagement->m_referenceCounter.fetch_sub(1U, std::memory_order_relaxed) == 1U))
     {
-        freeChunk();
+        MemoryManager::freeChunk(*m_chunkManagement);
+        m_chunkManagement = nullptr;
     }
-}
-
-void SharedChunk::freeChunk() noexcept
-{
-    m_chunkManagement->m_mempool->freeChunk(static_cast<void*>(m_chunkManagement->m_chunkHeader.get()));
-    m_chunkManagement->m_chunkManagementPool->freeChunk(m_chunkManagement);
-    m_chunkManagement = nullptr;
 }
 
 SharedChunk& SharedChunk::operator=(const SharedChunk& rhs) noexcept


### PR DESCRIPTION
…llocation

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

As described in #2440, the race condition exists between the `MemoryManager` acquiring chunks for payloads before acquiring chunks for management, and the `SharedChunk` releasing chunks for payloads before releasing chunks for management.

The `MemoryManager` relies upon the assumption that if a payload allocation succeeded, the management allocation will succeed. This assumption proves to be false however for a brief moment when `SharedChunk::releaseChunk` releases the payload chunk but has not yet released the management chunk. 

The changes in this pull request resolve the issue by switching the order of release such that the management chunk is released before the payload chunk. This properly uploads the invariant that the number of management chunks is always greater than or equal to the number of payload chunks - since for any given payload/management pair the lifetime of the management chunk is contained within the lifetime of the payload chunk.

With regards to testing - there isn't any formal way to prove these changes resolve the issue nor prevent a new issue, other than running the stress tests.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2440
