### PR TITLE
 fix - attempt to use a deleted function in file chunk_distributor.inl

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -184,7 +184,7 @@ inline uint64_t ChunkDistributor<ChunkDistributorDataType>::deliverToAllStoredQu
             typename MemberType_t::LockGuard_t lock(*getMembers());
             QueueContainer remainingQueues;
             using QueueContainerValue = typename QueueContainer::value_type;
-            auto greaterThan = [](QueueContainerValue& a, QueueContainerValue& b) -> bool {
+            auto greaterThan = [](const QueueContainerValue& a, const QueueContainerValue& b) -> bool {
                 return reinterpret_cast<uint64_t>(a.get()) > reinterpret_cast<uint64_t>(b.get());
             };
             std::sort(getMembers()->m_queues.begin(), getMembers()->m_queues.end(), greaterThan);


### PR DESCRIPTION

I got a compilation issue while building for Raspberry Pi 4 using Yocto.
attempt to use a deleted function in file **chunk_distributor.inl**
`
 note: in instantiation of function template specialization 'std::__lower_bound_onesided<std::_ClassicAlgPolicy, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>> *, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>> *, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>>, const std::__identity, (lambda at XXXX/git/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl:187:32)>' requested here
  104 |         std::__lower_bound_onesided<_AlgPolicy>(__first1, __last1, *__first2, __comp, __proj);
`
Environment:
Compiler: clang


