### PR TITLE
fix - attempt to use a deleted function

### DIFF
--- a/iceoryx_binding_c/CMakeLists.txt
+++ b/iceoryx_binding_c/CMakeLists.txt
@@ -24,9 +24,6 @@ find_package(iceoryx_platform REQUIRED)
 find_package(iceoryx_hoofs REQUIRED)
 find_package(iceoryx_posh REQUIRED)
 
-include(IceoryxPackageHelper)
-include(IceoryxPlatform)
-include(IceoryxPlatformSettings)
 
 if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)
     option(BUILD_SHARED_LIBS "Create shared libraries by default" ON)

--- a/iceoryx_examples/iceperf/CMakeLists.txt
+++ b/iceoryx_examples/iceperf/CMakeLists.txt
@@ -26,9 +26,6 @@ find_package(iceoryx_posh CONFIG REQUIRED)
 find_package(iceoryx_binding_c CONFIG REQUIRED)
 find_package(iceoryx_hoofs CONFIG REQUIRED)
 
-include(IceoryxPackageHelper)
-include(IceoryxPlatform)
-include(IceoryxPlatformSettings)
 
 iox_add_executable(
     TARGET      iceperf-bench-leader

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -23,10 +23,6 @@ project(iceoryx_hoofs VERSION ${IOX_VERSION_STRING})
 
 find_package(iceoryx_platform REQUIRED)
 
-include(IceoryxPackageHelper)
-include(IceoryxPlatform)
-include(IceoryxPlatformSettings)
-
 include(cmake/IceoryxHoofsDeployment.cmake)
 
 if(CMAKE_SYSTEM_NAME MATCHES Linux OR CMAKE_SYSTEM_NAME MATCHES Darwin)

--- a/iceoryx_platform/cmake/Config.cmake.in
+++ b/iceoryx_platform/cmake/Config.cmake.in
@@ -19,5 +19,8 @@
 include(CMakeFindDependencyMacro)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceoryxPackageHelper.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceoryxPlatform.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceoryxPlatformSettings.cmake")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 check_required_components("@PROJECT_NAME@")

--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -36,9 +36,6 @@ if(TOML_CONFIG)
     find_package(cpptoml REQUIRED)
 endif()
 
-include(IceoryxPackageHelper)
-include(IceoryxPlatform)
-include(IceoryxPlatformSettings)
 
 include(cmake/IceoryxPoshDeployment.cmake)
 

--- a/iceoryx_posh/cmake/Config.cmake.in
+++ b/iceoryx_posh/cmake/Config.cmake.in
@@ -23,5 +23,7 @@ find_dependency(iceoryx_platform)
 find_dependency(iceoryx_hoofs)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/IceoryxPoshDeployment.cmake")
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 check_required_components("@PROJECT_NAME@")

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl
@@ -184,7 +184,7 @@ inline uint64_t ChunkDistributor<ChunkDistributorDataType>::deliverToAllStoredQu
             typename MemberType_t::LockGuard_t lock(*getMembers());
             QueueContainer remainingQueues;
             using QueueContainerValue = typename QueueContainer::value_type;
-            auto greaterThan = [](QueueContainerValue& a, QueueContainerValue& b) -> bool {
+            auto greaterThan = [](const QueueContainerValue& a, const QueueContainerValue& b) -> bool {
                 return reinterpret_cast<uint64_t>(a.get()) > reinterpret_cast<uint64_t>(b.get());
             };
             std::sort(getMembers()->m_queues.begin(), getMembers()->m_queues.end(), greaterThan);


### PR DESCRIPTION
I got a compilation issue while building for Raspberry Pi 4 using Yocto.
attempt to use a deleted function in file chunk_distributor.inl
`note: in instantiation of function template specialization 'std::__lower_bound_onesided<std::_ClassicAlgPolicy, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>> *, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>> *, iox::RelativePointer<iox::popo::ChunkQueueData<iox::DefaultChunkQueueConfig, iox::popo::ThreadSafePolicy>>, const std::__identity, (lambda at XXXX/git/iceoryx_posh/include/iceoryx_posh/internal/popo/building_blocks/chunk_distributor.inl:187:32)>' requested here 104 |         std::__lower_bound_onesided<_AlgPolicy>(__first1, __last1, *__first2, __comp, __proj);`
Environment:
Compiler: clang