### PR TITLE
Fix macOS RPATH handling and install rules for Iceoryx platform modules

### DIFF
--- a/iceoryx_binding_c/CMakeLists.txt
+++ b/iceoryx_binding_c/CMakeLists.txt
@@ -114,6 +114,15 @@ endif()
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
 
+# Ensure dependent dylibs can be found via @rpath on macOS
+if(APPLE)
+  set_target_properties(iceoryx_binding_c PROPERTIES
+    INSTALL_RPATH "@loader_path/../lib"
+    BUILD_WITH_INSTALL_RPATH TRUE
+    MACOSX_RPATH ON
+  )
+endif()
+
 #
 ########## build test executables ##########
 #

--- a/iceoryx_hoofs/CMakeLists.txt
+++ b/iceoryx_hoofs/CMakeLists.txt
@@ -241,6 +241,35 @@ install(
     DESTINATION ${DESTINATION_CONFIGDIR}
 )
 
+# Add after existing install() commands
+install(EXPORT iceoryx_platformTargets
+  FILE iceoryx_platformTargets.cmake
+  NAMESPACE iceoryx::
+  DESTINATION lib/cmake/iceoryx_platform
+)
+
+include(CMakePackageConfigHelpers)
+# Add this before configure_package_config_file
+get_filename_component(ICEORYX_PLATFORM_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/platform/include" ABSOLUTE)
+configure_package_config_file(
+  cmake/iceoryx_platformConfig.cmake.in
+  iceoryx_platformConfig.cmake
+  INSTALL_DESTINATION lib/cmake/iceoryx_platform
+  PATH_VARS ICEORYX_PLATFORM_INCLUDE_DIRS
+)
+
+write_basic_package_version_file(
+  iceoryx_platformConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/iceoryx_platformConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/iceoryx_platformConfigVersion.cmake"
+  DESTINATION lib/cmake/iceoryx_platform
+)
+
 if(BUILD_TEST)
     add_subdirectory(test)
 endif(BUILD_TEST)

--- a/iceoryx_hoofs/cmake/iceoryx_platformConfig.cmake.in
+++ b/iceoryx_hoofs/cmake/iceoryx_platformConfig.cmake.in
@@ -1,0 +1,13 @@
+# iceoryx_platformConfig.cmake.in
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(iceoryx_hoofs)
+
+include("${CMAKE_CURRENT_LIST_DIR}/iceoryx_platformTargets.cmake")
+
+# Add platform-specific include paths
+get_filename_component(ICEORYX_PLATFORM_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include/iceoryx_hoofs/platform" ABSOLUTE)
+set(ICEORYX_PLATFORM_INCLUDE_DIRS ${ICEORYX_PLATFORM_INCLUDE_DIRS} CACHE PATH "Iceoryx platform include directories")
+set_and_check(ICEORYX_PLATFORM_INCLUDE_DIRS "@PACKAGE_ICEORYX_PLATFORM_INCLUDE_DIRS@")

--- a/iceoryx_hoofs/platform/CMakeLists.txt
+++ b/iceoryx_hoofs/platform/CMakeLists.txt
@@ -52,6 +52,31 @@ set_target_properties(iceoryx_platform PROPERTIES
 
 target_link_libraries(iceoryx_platform PRIVATE ${ICEORYX_SANITIZER_FLAGS})
 
+# Add right after target_link_libraries(iceoryx_platform PRIVATE ${ICEORYX_SANITIZER_FLAGS})
+
+# Add installation rules for all platforms
+install(TARGETS iceoryx_platform
+  EXPORT iceoryx_platformTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+# Add platform-specific installation for headers
+install(DIRECTORY ${ICEORYX_PLATFORM}/include/
+  DESTINATION include/iceoryx_hoofs/platform
+)
+
+# macOS-specific RPATH handling
+if(APPLE)
+  set_target_properties(iceoryx_platform PROPERTIES
+    INSTALL_RPATH "@loader_path/../lib;@loader_path/../../iceoryx_hoofs/lib"
+    MACOSX_RPATH ON
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
+endif()
+
 target_compile_options(iceoryx_platform PRIVATE ${ICEORYX_WARNINGS} ${ICEORYX_SANITIZER_FLAGS})
 
 if(LINUX)


### PR DESCRIPTION
## Notes for Reviewer
This PR improves compatibility with MacOS by correctly setting RPATH and install properties in key CMakeLists.txt files for iceoryx_binding_c and iceoryx_hoofs, particularly addressing dynamic linking of the iceoryx_platform module.

Changes include:

Added explicit INSTALL_RPATH and BUILD_RPATH for MacOS

Fixed missing install rule for iceoryx_platform

Ensured proper MACOSX_RPATH behavior

Tested with ros2_rolling and colcon build using --symlink-install on MacOS 12.7.6 x86_64 with SIP enabled.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [ ] Tests follow the [best practice for testing][testing]
+ [x] N/A - No new runtime logic added; changes affect CMake install and RPATH only
1. [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
+ [x] Added to unreleased changelog in `doc/website/release-notes/iceoryx-unreleased.md`
1. [ ] Branch follows the naming format (`iox-123-this-is-a-branch`)
+ [x] N/A - Patch relates to platform compatibility, not linked to an existing issue ID
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
+ [x] N/A - This resolves a platform compatibility gap but has no tracked upstream issue
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [ ] Consider a second reviewer for complex new features or larger refactorings
- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References
Relates to MacOS build compatibility for ROS2 Rolling and downstream packages using colcon with symlink-install.

- Targets compatibility with MacOS 12.7.6 (x86_64)
- Apple SIP remains enabled during testing
- All patched files build cleanly with `colcon build --symlink-install`
- No runtime logic or public API modified — strictly build system compatibility

- Closes **TBD**
