### PR TITLE
iox-#2480 Fix gcc 8 compile error

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -159,6 +159,7 @@
 - Max Client and Server cannot be configured independently of Max Publisher and Subscriber [#2394](https://github.com/eclipse-iceoryx/iceoryx/issues/2394)
 - Fix call to non-existing `getService` in channel.inl [#2426](https://github.com/eclipse-iceoryx/iceoryx/issues/2426)
 - Fix chunk management race condition causing failed management allocation [#2440](https://github.com/eclipse-iceoryx/iceoryx/issues/2440)
+- Fix compile error with GCC 8 [#2480](https://github.com/eclipse-iceoryx/iceoryx/issues/2480)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/reporting/include/iox/assertions.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/assertions.hpp
@@ -80,7 +80,8 @@
 
 /// @brief panic if control flow reaches this code at runtime
 #define IOX_UNREACHABLE()                                                                                              \
-    iox::er::forwardPanic(IOX_CURRENT_SOURCE_LOCATION, "Reached code that was supposed to be unreachable.")
+    iox::er::detail::unreachable_wrapped(                                                                              \
+        true, true, IOX_CURRENT_SOURCE_LOCATION, "Reached code that was supposed to be unreachable.")
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/iceoryx_hoofs/reporting/include/iox/assertions.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/assertions.hpp
@@ -80,8 +80,8 @@
 
 /// @brief panic if control flow reaches this code at runtime
 #define IOX_UNREACHABLE()                                                                                              \
-    iox::er::detail::unreachable_wrapped(                                                                              \
-        true, true, IOX_CURRENT_SOURCE_LOCATION, "Reached code that was supposed to be unreachable.")
+    iox::er::detail::unreachable_wrapped<void, void>(IOX_CURRENT_SOURCE_LOCATION,                                      \
+                                                     "Reached code that was supposed to be unreachable.")
 
 // NOLINTEND(cppcoreguidelines-macro-usage)
 

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/error_forwarding.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/error_forwarding.hpp
@@ -48,19 +48,13 @@ namespace detail
 {
 // workaround for gcc 8 bug
 // see also https://github.com/eclipse-iceoryx/iceoryx2/issues/855
-template <typename T, typename Message>
-[[noreturn]] constexpr inline void unreachable_wrapped(T t1, T t2, const SourceLocation& location, Message&& msg)
+template <typename T1, typename T2, typename Message>
+[[noreturn]] constexpr inline void unreachable_wrapped(const SourceLocation& location, Message&& msg)
 {
-#if (defined(__GNUC__) && (__GNUC__ >= 8 && __GNUC__ <= 8) && !defined(__clang__))
-    if (t1 == t2)
+    if (std::is_same<T1, T2>::value)
     {
         forwardPanic(location, std::forward<Message>(msg));
     }
-#else
-    static_cast<void>(t1);
-    static_cast<void>(t2);
-    forwardPanic(location, std::forward<Message>(msg));
-#endif
 }
 } // namespace detail
 

--- a/iceoryx_hoofs/reporting/include/iox/error_reporting/source_location.hpp
+++ b/iceoryx_hoofs/reporting/include/iox/error_reporting/source_location.hpp
@@ -23,7 +23,7 @@ namespace er
 {
 struct SourceLocation
 {
-    SourceLocation(const char* file, int line, const char* function)
+    constexpr SourceLocation(const char* file, int line, const char* function)
         : file(file)
         , line(line)
         , function(function)


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This fixes a compile error for the iceoryx2 C++ bindings when used with gcc 8

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

- Closes #2480 
