### PR TITLE
iox-#1051 Move publish subscribe port type definitions to pub_sub_port_types.hpp

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp
@@ -17,19 +17,44 @@
 #define IOX_POSH_POPO_PORTS_PUB_SUB_PORT_TYPES_HPP
 
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
+#include "iceoryx_posh/internal/popo/building_blocks/chunk_sender_data.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
+#include "iceoryx_posh/popo/enum_trigger_type.hpp"
 
 namespace iox
 {
 namespace popo
 {
-/// @todo iox-#1051 move definitions for publish subscribe communication here
+// ==================== Subscriber types ====================
 
 using SubscriberChunkQueueData_t = ChunkQueueData<DefaultChunkQueueConfig, ThreadSafePolicy>;
 
 using SubscriberChunkReceiverData_t =
     ChunkReceiverData<MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, SubscriberChunkQueueData_t>;
+
+// ==================== Publisher types ====================
+
+using PublisherChunkQueueData_t = SubscriberChunkQueueData_t;
+
+using PublisherChunkDistributorData_t =
+    ChunkDistributorData<DefaultChunkDistributorConfig, ThreadSafePolicy, ChunkQueuePusher<PublisherChunkQueueData_t>>;
+
+using PublisherChunkSenderData_t =
+    ChunkSenderData<MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY, PublisherChunkDistributorData_t>;
+
+// ==================== Event and State enums ====================
+
+enum class SubscriberEvent : EventEnumIdentifier
+{
+    DATA_RECEIVED
+};
+
+enum class SubscriberState : StateEnumIdentifier
+{
+    HAS_DATA
+};
 
 } // namespace popo
 } // namespace iox

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
@@ -20,11 +20,8 @@
 #include "iceoryx_posh/capro/service_description.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
-#include "iceoryx_posh/internal/popo/building_blocks/chunk_distributor_data.hpp"
-#include "iceoryx_posh/internal/popo/building_blocks/chunk_sender_data.hpp"
-#include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
-#include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
+#include "iceoryx_posh/internal/popo/ports/pub_sub_port_types.hpp"
 #include "iceoryx_posh/mepoo/memory_info.hpp"
 #include "iceoryx_posh/popo/publisher_options.hpp"
 #include "iox/atomic.hpp"
@@ -44,11 +41,9 @@ struct PublisherPortData : public BasePortData
                       const PublisherOptions& publisherOptions,
                       const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
-    using ChunkQueueData_t = SubscriberPortData::ChunkQueueData_t;
-    using ChunkDistributorData_t =
-        ChunkDistributorData<DefaultChunkDistributorConfig, ThreadSafePolicy, ChunkQueuePusher<ChunkQueueData_t>>;
-    using ChunkSenderData_t =
-        ChunkSenderData<MAX_CHUNKS_ALLOCATED_PER_PUBLISHER_SIMULTANEOUSLY, ChunkDistributorData_t>;
+    using ChunkQueueData_t = PublisherChunkQueueData_t;
+    using ChunkDistributorData_t = PublisherChunkDistributorData_t;
+    using ChunkSenderData_t = PublisherChunkSenderData_t;
 
     ChunkSenderData_t m_chunkSenderData;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -40,10 +40,8 @@ struct SubscriberPortData : public BasePortData
                        const SubscriberOptions& subscriberOptions,
                        const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
-    /// @todo iox-#1051 remove these aliases here and only depend on pub_sub_port_types.hpp
-    ///       (move relevant types and constants there)
-    using ChunkQueueData_t = iox::popo::SubscriberChunkQueueData_t;
-    using ChunkReceiverData_t = iox::popo::SubscriberChunkReceiverData_t;
+    using ChunkQueueData_t = SubscriberChunkQueueData_t;
+    using ChunkReceiverData_t = SubscriberChunkReceiverData_t;
 
     ChunkReceiverData_t m_chunkReceiverData;
 


### PR DESCRIPTION
## Summary

This PR consolidates publish/subscribe port related type definitions into `pub_sub_port_types.hpp`, following the established pattern of `client_server_port_types.hpp`.

Fixes #1051

## Changes

### `pub_sub_port_types.hpp`
- Added `PublisherChunkQueueData_t`, `PublisherChunkDistributorData_t`, and `PublisherChunkSenderData_t` type aliases
- Added `SubscriberEvent` and `SubscriberState` enums (following `ClientEvent`/`ClientState` pattern)
- Added necessary includes for chunk distributor and sender data
- Removed TODO comment

### `publisher_port_data.hpp`
- Updated to use types from `pub_sub_port_types.hpp` instead of defining them locally
- Removed redundant includes (`chunk_distributor_data.hpp`, `chunk_sender_data.hpp`, `locking_policy.hpp`, `subscriber_port_data.hpp`)
- Simplified type aliases to reference the new centralized definitions

### `subscriber_port_data.hpp`
- Removed TODO comment for iox-#1051
- Simplified type aliases (removed redundant `iox::popo::` namespace prefix)

## Benefits

- **Reduced dependency issues**: `publisher_port_data.hpp` no longer depends on `subscriber_port_data.hpp`
- **Single point of definition**: All pub/sub communication types are now in one file
- **Improved discoverability**: Easier to find and understand pub/sub type definitions
- **Consistent with existing patterns**: Follows the same structure as `client_server_port_types.hpp`

## Testing

- [ ] Compile test - CI will verify
- [ ] Existing tests should pass unchanged (no runtime behavior changes)

Signed-off-by: Nivesh Dandyan <niveshdandyan@gmail.com>