### PR TITLE
iox-#2513 Increase MaxNumberOfGroups from 888 to 1024

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,5 +3,6 @@ https://github.com/eclipse-iceoryx/iceoryx/tree/vx.x.x
 https://www.misra.org.uk/
 https://www.gnu.org/software/screen/
 https://www.etas.com/
+https://medium.com/@pjbgf/title-testing-code-ocd-and-the-aaa-pattern-df453975ab80
 
 iceoryx-dev@eclipse.org

--- a/doc/aspice_swe3_4/swe_docu_guidelines.md
+++ b/doc/aspice_swe3_4/swe_docu_guidelines.md
@@ -1,4 +1,4 @@
-# [ASPICE](http://www.automotivespice.com/) example [WIP]
+# [ASPICE](https://vda-qmc.de/en/automotive-spice/) example [WIP]
 
 ## Purpose
 

--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -161,6 +161,7 @@
 - Fix chunk management race condition causing failed management allocation [#2440](https://github.com/eclipse-iceoryx/iceoryx/issues/2440)
 - Fix compile error with GCC 8 [#2480](https://github.com/eclipse-iceoryx/iceoryx/issues/2480)
 - Fix cmake cache inconsistency [#2485](https://github.com/eclipse-iceoryx/iceoryx/issues/2485)
+- Increase `PosixUser::MAX_NUMBER_OF_GROUPS` from 888 to 1024 to support systems with many supplementary groups [#2513](https://github.com/eclipse-iceoryx/iceoryx/issues/2513)
 
 **Refactoring:**
 

--- a/iceoryx_hoofs/posix/auth/include/iox/posix_user.hpp
+++ b/iceoryx_hoofs/posix/auth/include/iox/posix_user.hpp
@@ -32,7 +32,7 @@ class PosixUser
 {
   public:
     // Increase from 888 to 1024 to support systems with many supplementary groups
-    // (e.g. Nvidia Tegra boards where `id -G | wc -w` returns 1000+).
+    // (e.g. Nvidia Tegra boards where 'id -G | wc -w' returns 1000+).
     // When the group count exceeds MAX_NUMBER_OF_GROUPS, iox_getgrouplist fails
     // with "Could not obtain group list", causing RouDi to deny the node a
     // writable SHM segment, which crashes the node with:

--- a/iceoryx_hoofs/posix/auth/include/iox/posix_user.hpp
+++ b/iceoryx_hoofs/posix/auth/include/iox/posix_user.hpp
@@ -31,7 +31,13 @@ namespace iox
 class PosixUser
 {
   public:
-    static constexpr uint64_t MAX_NUMBER_OF_GROUPS = 888;
+    // Increase from 888 to 1024 to support systems with many supplementary groups
+    // (e.g. Nvidia Tegra boards where `id -G | wc -w` returns 1000+).
+    // When the group count exceeds MAX_NUMBER_OF_GROUPS, iox_getgrouplist fails
+    // with "Could not obtain group list", causing RouDi to deny the node a
+    // writable SHM segment, which crashes the node with:
+    //   POSH__RUNTIME_NO_WRITABLE_SHM_SEGMENT / EXPECTS_ENSURES_FAILED
+    static constexpr uint64_t MAX_NUMBER_OF_GROUPS = 1024;
     using groupVector_t = vector<PosixGroup, MAX_NUMBER_OF_GROUPS>;
 
     using userName_t = string<platform::MAX_USER_NAME_LENGTH>;


### PR DESCRIPTION
## Notes for Reviewer

Increases `PosixUser::MAX_NUMBER_OF_GROUPS` from 888 to 1024 in `iceoryx_hoofs/posix/auth/include/iox/posix_user.hpp`.

The default value of 888 is too low for systems with many supplementary groups (e.g. Nvidia Tegra boards where `id -G | wc -w` returns 1000+). When the group count exceeds `MAX_NUMBER_OF_GROUPS`, `iox_getgrouplist` fails with _"Could not obtain group list"_, causing RouDi to deny the node a writable SHM segment, which crashes the node with:

```
POSH__RUNTIME_NO_WRITABLE_SHM_SEGMENT / EXPECTS_ENSURES_FAILED
```

1024 aligns with the Linux kernel's `NGROUPS_MAX` default and gives headroom for such embedded platforms.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of [CONTRIBUTING.md][contributing]
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Branch follows the naming format (`iox-123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except `task-list-completed`)
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[contributing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/CONTRIBUTING.md#coding-style
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx/blob/main/doc/website/release-notes/iceoryx-unreleased.md

## Checklist for the PR Reviewer

- [ ] Consider a second reviewer for complex new features or larger refactorings
- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] All touched (C/C++) source code files from `iceoryx_hoofs` have been added to `./clang-tidy-diff-scans.txt`
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

- Closes #2513