### PR TITLE
iox-2343 Add Findacl.cmake to setup libacl dependency

### DIFF
--- a/doc/website/release-notes/iceoryx-unreleased.md
+++ b/doc/website/release-notes/iceoryx-unreleased.md
@@ -76,6 +76,7 @@
 - Make iceoryx resource prefix a compile time option [#2272](https://github.com/eclipse-iceoryx/iceoryx/issues/2272)
 - Improve introspection-client interface by adding the number of ports in parentheses [#2299](https://github.com/eclipse-iceoryx/iceoryx/issues/2299)
 - Add std::atomic abstraction [#2329](https://github.com/eclipse-iceoryx/iceoryx/issues/2329)
+- Add Findacl.cmake module for ACL library detection [#2343](https://github.com/eclipse-iceoryx/iceoryx/issues/2343)
 - Port iceoryx to bzlmod [#2325](https://github.com/eclipse-iceoryx/iceoryx/issues/2325)
 - Make ACL support optional [#1176](https://github.com/eclipse-iceoryx/iceoryx/issues/1176)
 - Implement subscriber/publisher options in introspection [#2076](https://github.com/eclipse-iceoryx/iceoryx/issues/2076)

--- a/iceoryx_platform/CMakeLists.txt
+++ b/iceoryx_platform/CMakeLists.txt
@@ -120,6 +120,7 @@ install(
 
 install(
     FILES
+        cmake/Findacl.cmake
         cmake/IceoryxConfigureOptionMacro.cmake
         cmake/IceoryxPackageHelper.cmake
         cmake/IceoryxPlatform.cmake

--- a/iceoryx_platform/CMakeLists.txt
+++ b/iceoryx_platform/CMakeLists.txt
@@ -60,6 +60,7 @@ else()
 endif()
 
 set(PREFIX iceoryx/v${CMAKE_PROJECT_VERSION})
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/IceoryxConfigureOptionMacro.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/iceoryxversions.cmake")
 
@@ -83,7 +84,8 @@ file ( GLOB_RECURSE ICEORYX_PLATFORM_FILES
 
 if(IOX_PLATFORM_FEATURE_ACL)
     set(IOX_CFG_FEATURE_ACL "1")
-    set(ACL_LIB acl)
+    find_package(acl REQUIRED)
+    set(ACL_LIB acl::libacl)
 else()
     set(IOX_CFG_FEATURE_ACL "0")
     set(ACL_LIB)

--- a/iceoryx_platform/cmake/Config.cmake.in
+++ b/iceoryx_platform/cmake/Config.cmake.in
@@ -17,6 +17,11 @@
 
 include(CMakeFindDependencyMacro)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+if(@IOX_PLATFORM_FEATURE_ACL@)
+  find_dependency(acl)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 check_required_components("@PROJECT_NAME@")

--- a/iceoryx_platform/cmake/Findacl.cmake
+++ b/iceoryx_platform/cmake/Findacl.cmake
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 by Functionhx <2994114386@qq.com>. All rights reserved.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#[=======================================================================[.rst:
+Findacl
+-------
+
+Finds the ACL (Access Control Lists) library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported target, if found:
+
+``acl::libacl``
+  The ACL library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``acl_FOUND``
+  True if the ACL library was found
+``acl_INCLUDE_DIRS``
+  Include directories for ACL headers
+``acl_LIBRARIES``
+  Libraries to link against
+
+#]=======================================================================]
+
+find_path(
+  acl_INCLUDE_DIR
+  NAMES sys/acl.h
+  DOC "ACL include directory"
+)
+
+find_library(
+  acl_LIBRARY
+  NAMES acl
+  DOC "ACL library"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(acl
+  REQUIRED_VARS acl_LIBRARY acl_INCLUDE_DIR
+)
+
+set(acl_INCLUDE_DIRS "${acl_INCLUDE_DIR}")
+set(acl_LIBRARIES "${acl_LIBRARY}")
+
+if(acl_FOUND AND NOT TARGET acl::libacl)
+  add_library(acl::libacl UNKNOWN IMPORTED)
+  set_target_properties(acl::libacl PROPERTIES
+    IMPORTED_LOCATION "${acl_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${acl_INCLUDE_DIR}"
+  )
+endif()
+
+mark_as_advanced(acl_INCLUDE_DIR acl_LIBRARY)


### PR DESCRIPTION
## Notes for Reviewer
Simple CMake find module to replace hardcoded -lacl. Tested with non-standard install prefixes.

## Pre-Review Checklist for the PR Author

1. [x] Code follows the coding style of CONTRIBUTING.md
1. [x] Tests follow the best practice for testing
1. [x] Changelog updated in the unreleased section
1. [x] Branch follows the naming format (iox-2343-find-acl-cmake-module)
1. [x] Commits messages are according to this guideline
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed (except task-list-completed)
1. [x] Assign PR to reviewer

## References

Fixes #2343.
Replaces #2536 (closed due to branch rename).

## Checklist for the PR Reviewer

- [x] Consider a second reviewer for complex new features or larger refactorings
- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] All touched (C/C++) source code files from iceoryx_hoofs have been added to ./clang-tidy-diff-scans.txt
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues